### PR TITLE
Improve packaging and add configuration defaults

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,1 +1,30 @@
+from pathlib import Path
 from setuptools import setup, find_packages
+
+# Read requirements from the provided requirements.txt
+requirements_path = Path(__file__).parent / "requirements.txt"
+if requirements_path.exists():
+    with open(requirements_path) as f:
+        requirements = [line.strip() for line in f if line.strip() and not line.startswith('#')]
+else:
+    requirements = []
+
+# Import version from the package if available
+version = "0.0.0"
+try:
+    from src.deepthought import __version__ as package_version
+    version = package_version
+except Exception:
+    pass
+
+setup(
+    name="deepthought-rethought",
+    version=version,
+    packages=find_packages("src"),
+    package_dir={"": "src"},
+    install_requires=requirements,
+    description="DeepThought reThought - experimental AI framework",
+    license="MIT",
+    url="https://github.com/d0tTino/DeepThought-ReThought",
+    python_requires=">=3.8",
+)

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -1,1 +1,19 @@
-# Configuration module for DeepThought reThought
+# Basic configuration for DeepThought reThought
+# Provides defaults for connecting to NATS and JetStream.
+
+from dataclasses import dataclass, field
+import os
+
+@dataclass
+class NATSSettings:
+    """Configuration for NATS connectivity."""
+    url: str = os.getenv("NATS_URL", "nats://localhost:4222")
+    stream_name: str = os.getenv("NATS_STREAM_NAME", "deepthought_events")
+
+@dataclass
+class Settings:
+    """Application wide settings."""
+    nats: NATSSettings = field(default_factory=NATSSettings)
+
+# Module level singleton for convenience
+settings = Settings()


### PR DESCRIPTION
## Summary
- extend `setup.py` with setuptools metadata and dependencies
- implement `src/deepthought/config.py` with basic NATS settings

## Testing
- `pip install nats-py pytest-asyncio`
- `pytest -q` *(fails: nats server not available)*

------
https://chatgpt.com/codex/tasks/task_e_6840baf2d3dc83268d80972966abde48