### PR TITLE
Add social graph bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ python setup_jetstream.py
 
 This step is necessary before running the tests below.
 
+## Social Graph Bot Example
+
+An example Discord bot demonstrating social graph logging is available at `examples/social_graph_bot.py`. It records user interactions in a SQLite database, monitors channel activity, and forwards data to a Prism endpoint implemented in `examples/prism_server.py`.
+
+
 ## Testing
 
 Tests are implemented using the `pytest` framework. To run the tests:

--- a/examples/prism_server.py
+++ b/examples/prism_server.py
@@ -1,0 +1,12 @@
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route('/receive_data', methods=['POST'])
+def receive_data():
+    data = request.json
+    print(f"Received from bot: {data}")
+    return 'Data received', 200
+
+if __name__ == '__main__':
+    app.run(port=5000)

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1,0 +1,90 @@
+import asyncio
+import random
+import aiohttp
+import aiosqlite
+import discord
+
+DB_PATH = 'social_graph.db'
+
+async def init_db():
+    """Initialize the SQLite database for tracking interactions."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                user_id TEXT,
+                target_id TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await db.commit()
+
+async def log_interaction(user_id: int, target_id: int) -> None:
+    """Insert a user interaction record into the database."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
+            (str(user_id), str(target_id)),
+        )
+        await db.commit()
+
+async def send_to_prism(data: dict) -> None:
+    """Send collected data to a Prism endpoint."""
+    async with aiohttp.ClientSession() as session:
+        await session.post("http://localhost:5000/receive_data", json=data)
+
+async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
+    """Periodically monitor a channel and prompt activity if quiet."""
+    await bot.wait_until_ready()
+    channel = bot.get_channel(channel_id)
+    while not bot.is_closed():
+        # Fetch the last 10 messages
+        messages = [m async for m in channel.history(limit=10)]
+        if not messages:
+            await channel.send("The channel is quiet... Let's start a conversation!")
+        await asyncio.sleep(300)  # check every 5 minutes
+
+class SocialGraphBot(discord.Client):
+    """Discord bot that records interactions and demonstrates simple awareness."""
+
+    def __init__(self, *args, monitor_channel_id: int, **kwargs):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        super().__init__(*args, intents=intents, **kwargs)
+        self.monitor_channel_id = monitor_channel_id
+
+    async def setup_hook(self) -> None:
+        await init_db()
+        self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author == self.user:
+            return
+
+        # Log the interaction
+        await log_interaction(message.author.id, message.channel.id)
+
+        await asyncio.sleep(random.uniform(1, 3))  # simulate thinking
+        await message.channel.send("I'm pondering your message...")
+
+        await send_to_prism({
+            "user_id": str(message.author.id),
+            "channel_id": str(message.channel.id),
+            "content": message.content,
+        })
+
+
+def run(token: str, monitor_channel_id: int) -> None:
+    """Run the SocialGraphBot."""
+    bot = SocialGraphBot(monitor_channel_id=monitor_channel_id)
+    bot.run(token)
+
+if __name__ == "__main__":
+    import os
+    token = os.getenv("DISCORD_TOKEN")
+    channel_id = int(os.getenv("MONITOR_CHANNEL", "0"))
+    if not token or channel_id == 0:
+        print("Please set DISCORD_TOKEN and MONITOR_CHANNEL environment variables.")
+    else:
+        run(token, channel_id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,7 @@ scipy
 evaluate
 nats-py
 pytest-asyncio
+aiosqlite
+aiohttp
+flask
+discord.py


### PR DESCRIPTION
## Summary
- add an example Flask endpoint in `prism_server.py`
- add a Discord social graph bot example showing SQLite logging, channel monitoring, and Prism integration
- document the example in README
- include necessary dependencies in `requirements.txt`

## Testing
- `pip install nats-py pytest-asyncio`
- `nats-server -js` *(background)*
- `python setup_jetstream.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840c6a9022883269f31a591f36d5340