### PR TITLE
Add unit tests for module handlers

### DIFF
--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -1,0 +1,48 @@
+import json
+import pytest
+from types import SimpleNamespace
+
+from deepthought.modules.input_handler import InputHandler
+from deepthought.eda.events import EventSubjects
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+        self.published = []
+
+    async def publish(self, subject, data):
+        self.published.append((subject, data))
+
+class DummyJS:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, data, timeout=10.0):
+        self.published.append((subject, data))
+        return SimpleNamespace(seq=1, stream="test")
+
+@pytest.mark.asyncio
+async def test_process_input_success():
+    js = DummyJS()
+    nc = DummyNATS()
+    handler = InputHandler(nc, js)
+    input_id = await handler.process_input("hello")
+
+    assert js.published
+    subject, data = js.published[0]
+    assert subject == EventSubjects.INPUT_RECEIVED
+    payload = json.loads(data.decode())
+    assert payload["user_input"] == "hello"
+    assert payload["input_id"] == input_id
+
+class FailingJS(DummyJS):
+    async def publish(self, subject, data, timeout=10.0):
+        raise RuntimeError("publish error")
+
+@pytest.mark.asyncio
+async def test_process_input_error():
+    js = FailingJS()
+    nc = DummyNATS()
+    handler = InputHandler(nc, js)
+    with pytest.raises(RuntimeError):
+        await handler.process_input("boom")

--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+import pytest
+
+import deepthought.modules.llm_stub as llm_stub
+from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+class DummyJS:
+    pass
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+class FailingPublisher(DummyPublisher):
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        raise RuntimeError("boom")
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+def create_stub(monkeypatch, publisher_cls=DummyPublisher):
+    monkeypatch.setattr(llm_stub, "Publisher", publisher_cls)
+    monkeypatch.setattr(llm_stub, "Subscriber", DummySubscriber)
+    return llm_stub.LLMStub(DummyNATS(), DummyJS())
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_success(monkeypatch):
+    stub = create_stub(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"retrieved_knowledge": {"facts": ["f1"]}}, input_id="abc")
+    msg = DummyMsg(payload.to_json())
+    await stub._handle_memory_event(msg)
+
+    pub = stub._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert sent_payload.input_id == "abc"
+    assert msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_error(monkeypatch):
+    stub = create_stub(monkeypatch, FailingPublisher)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"retrieved_knowledge": {}}, input_id="x")
+    msg = DummyMsg(payload.to_json())
+    await stub._handle_memory_event(msg)
+
+    assert not msg.acked

--- a/tests/unit/modules/test_memory_stub.py
+++ b/tests/unit/modules/test_memory_stub.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+import pytest
+
+import deepthought.modules.memory_stub as memory_stub
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+class DummyJS:
+    pass
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+class FailingPublisher(DummyPublisher):
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        raise RuntimeError("boom")
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+def create_stub(monkeypatch, publisher_cls=DummyPublisher):
+    monkeypatch.setattr(memory_stub, "Publisher", publisher_cls)
+    monkeypatch.setattr(memory_stub, "Subscriber", DummySubscriber)
+    return memory_stub.MemoryStub(DummyNATS(), DummyJS())
+
+
+@pytest.mark.asyncio
+async def test_handle_input_success(monkeypatch):
+    stub = create_stub(monkeypatch)
+    payload = InputReceivedPayload(user_input="hi", input_id="123")
+    msg = DummyMsg(payload.to_json())
+    await stub._handle_input_event(msg)
+
+    pub = stub._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.MEMORY_RETRIEVED
+    assert sent_payload.input_id == "123"
+    assert msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_input_error(monkeypatch):
+    stub = create_stub(monkeypatch, FailingPublisher)
+    payload = InputReceivedPayload(user_input="fail", input_id="9")
+    msg = DummyMsg(payload.to_json())
+    await stub._handle_input_event(msg)
+
+    assert not msg.acked

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,0 +1,64 @@
+import asyncio
+from types import SimpleNamespace
+import pytest
+
+import deepthought.modules.output_handler as output_handler
+from deepthought.eda.events import EventSubjects, ResponseGeneratedPayload
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+class DummyJS:
+    pass
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+def create_handler(monkeypatch, callback=None):
+    monkeypatch.setattr(output_handler, "Subscriber", DummySubscriber)
+    return output_handler.OutputHandler(DummyNATS(), DummyJS(), callback)
+
+
+@pytest.mark.asyncio
+async def test_handle_response_success(monkeypatch):
+    received = {}
+    def cb(iid, resp):
+        received['id'] = iid
+        received['resp'] = resp
+
+    handler = create_handler(monkeypatch, cb)
+    payload = ResponseGeneratedPayload(final_response="ok", input_id="42")
+    msg = DummyMsg(payload.to_json())
+    await handler._handle_response_event(msg)
+
+    assert handler.get_response("42") == "ok"
+    assert received['id'] == "42"
+    assert received['resp'] == "ok"
+    assert msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_response_error(monkeypatch):
+    handler = create_handler(monkeypatch)
+    msg = DummyMsg("not json")
+    await handler._handle_response_event(msg)
+
+    assert handler.get_all_responses() == {}
+    assert not msg.acked


### PR DESCRIPTION
## Summary
- add minimal unit tests for InputHandler, MemoryStub, LLMStub, and OutputHandler
- use dummy NATS and JetStream implementations so tests do not require a live server

## Testing
- `PYTHONPATH=src pytest tests/unit/modules -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d062723c83269dbf1be4d3c7eedc