### PR TITLE
Implement theory tracking & deep reflection queue

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import json
+import logging
 import random
 from datetime import timezone
 
@@ -7,12 +9,16 @@ import aiohttp
 import aiosqlite
 import discord
 from textblob import TextBlob
+from typing import List, Tuple
+
+logger = logging.getLogger(__name__)
 
 DB_PATH = 'social_graph.db'
 
 # Configuration values
 MAX_BOT_SPEAKERS = int(os.getenv("MAX_BOT_SPEAKERS", "2"))
 IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
+REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
 
 # Candidate prompts used when the bot speaks after a period of silence
 idle_response_candidates = [
@@ -45,6 +51,29 @@ async def init_db():
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS theories (
+                subject_id TEXT,
+                theory TEXT,
+                confidence REAL,
+                updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY(subject_id, theory)
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS queued_tasks (
+                task_id INTEGER PRIMARY KEY,
+                user_id TEXT,
+                context TEXT,
+                prompt TEXT,
+                status TEXT DEFAULT 'pending',
+                created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
         await db.commit()
 
 async def log_interaction(user_id: int, target_id: int) -> None:
@@ -56,10 +85,122 @@ async def log_interaction(user_id: int, target_id: int) -> None:
         )
         await db.commit()
 
+
+async def recall_user(user_id: int):
+    """Retrieve memories for a given user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT topic, memory FROM memories WHERE user_id = ?", (str(user_id),)
+        ) as cur:
+            return await cur.fetchall()
+
 async def send_to_prism(data: dict) -> None:
     """Send collected data to a Prism endpoint."""
-    async with aiohttp.ClientSession() as session:
-        await session.post("http://localhost:5000/receive_data", json=data)
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.post(
+                "http://localhost:5000/receive_data", json=data, timeout=5
+            )
+    except Exception as exc:
+        logger.warning("Failed to send data to Prism: %s", exc)
+
+
+async def store_theory(subject_id: int, theory: str, confidence: float) -> None:
+    """Persist an inferred theory about a user."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            """
+            INSERT INTO theories (subject_id, theory, confidence)
+            VALUES (?, ?, ?)
+            ON CONFLICT(subject_id, theory) DO UPDATE SET
+                confidence=excluded.confidence,
+                updated=CURRENT_TIMESTAMP
+            """,
+            (str(subject_id), theory, confidence),
+        )
+        await db.commit()
+
+
+async def get_theories(subject_id: int):
+    """Retrieve stored theories about a subject."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        async with db.execute(
+            "SELECT theory, confidence FROM theories WHERE subject_id=?",
+            (str(subject_id),),
+        ) as cur:
+            return await cur.fetchall()
+
+
+async def queue_deep_reflection(user_id: int, context: dict, prompt: str) -> int:
+    """Add a deep reflection task to the queue."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        cur = await db.execute(
+            "INSERT INTO queued_tasks (user_id, context, prompt) VALUES (?, ?, ?)",
+            (str(user_id), json.dumps(context), prompt),
+        )
+        await db.commit()
+        return cur.lastrowid
+
+
+def generate_reflection(prompt: str) -> str:
+    """Return a simple reflection string based on sentiment analysis."""
+    blob = TextBlob(prompt)
+    polarity = blob.sentiment.polarity
+    if polarity > 0.1:
+        mood = "positive"
+    elif polarity < -0.1:
+        mood = "negative"
+    else:
+        mood = "neutral"
+    return f"Your message felt {mood}."
+
+
+async def process_deep_reflections(bot: discord.Client) -> None:
+    """Background task to process queued reflections."""
+    await bot.wait_until_ready()
+    while not bot.is_closed():
+        async with aiosqlite.connect(DB_PATH) as db:
+            async with db.execute(
+                "SELECT task_id, user_id, context, prompt FROM queued_tasks WHERE status='pending'"
+            ) as cur:
+                rows = await cur.fetchall()
+            if not rows:
+                logger.debug("No queued reflections to process")
+            for task_id, user_id, ctx_json, prompt in rows:
+                context = json.loads(ctx_json)
+                channel = bot.get_channel(int(context.get("channel_id")))
+                msg_id = context.get("message_id")
+                ref = None
+                if channel and msg_id:
+                    try:
+                        ref = await channel.fetch_message(int(msg_id))
+                    except Exception:
+                        ref = None
+                if channel:
+                    await asyncio.sleep(2)
+                    reflection = generate_reflection(prompt)
+                    logger.info(f"Posting deep reflection for task {task_id}")
+                    await channel.send(
+                        f"After some thought... {reflection}",
+                        reference=ref,
+                    )
+                await db.execute(
+                    "UPDATE queued_tasks SET status='done' WHERE task_id=?",
+                    (task_id,),
+                )
+            await db.commit()
+        await asyncio.sleep(REFLECTION_CHECK_SECONDS)
+
+
+def evaluate_triggers(message: discord.Message) -> List[Tuple[str, float]]:
+    """Return a list of (theory, confidence) pairs inferred from a message."""
+    theories: List[Tuple[str, float]] = []
+    if message.created_at.hour == 2:
+        theories.append(("insomniac", 0.7))
+    lower = message.content.lower()
+    if lower.startswith("i agree") or lower.startswith("you're right"):
+        theories.append(("social chameleon", 0.6))
+    return theories
 
 
 async def who_is_active(channel: discord.TextChannel, limit: int = 20):
@@ -110,6 +251,7 @@ class SocialGraphBot(discord.Client):
     async def setup_hook(self) -> None:
         await init_db()
         self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        self.loop.create_task(process_deep_reflections(self))
 
     async def on_message(self, message: discord.Message) -> None:
         if message.author == self.user:
@@ -137,6 +279,16 @@ class SocialGraphBot(discord.Client):
         memories = await recall_user(message.author.id)
         if memories:
             logger.info(f"Recalling memories for {message.author.id}: {memories}")
+
+        for theory, conf in evaluate_triggers(message):
+            await store_theory(message.author.id, theory, conf)
+            await message.channel.send("Some patterns... are best left unspoken.")
+
+        await queue_deep_reflection(
+            message.author.id,
+            {"channel_id": message.channel.id, "message_id": message.id},
+            message.content,
+        )
 
 
 def run(token: str, monitor_channel_id: int) -> None:

--- a/tests/test_theories_queue.py
+++ b/tests/test_theories_queue.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+import os
+
+import aiosqlite
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+@pytest.mark.asyncio
+async def test_store_theory(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    sg.DB_PATH = str(db_file)
+    await sg.init_db()
+    await sg.store_theory("u1", "insomniac", 0.5)
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute("SELECT theory FROM theories WHERE subject_id=?", ("u1",)) as cur:
+            row = await cur.fetchone()
+    assert row[0] == "insomniac"
+
+
+@pytest.mark.asyncio
+async def test_store_theory_update(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    sg.DB_PATH = str(db_file)
+    await sg.init_db()
+    await sg.store_theory("u1", "insomniac", 0.5)
+    await sg.store_theory("u1", "insomniac", 0.8)
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute(
+            "SELECT confidence FROM theories WHERE subject_id=? AND theory=?",
+            ("u1", "insomniac"),
+        ) as cur:
+            row = await cur.fetchone()
+    assert row[0] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_queue_deep_reflection(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    sg.DB_PATH = str(db_file)
+    await sg.init_db()
+    task_id = await sg.queue_deep_reflection("u2", {"channel_id": 1}, "hello")
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute("SELECT status FROM queued_tasks WHERE task_id=?", (task_id,)) as cur:
+            row = await cur.fetchone()
+    assert row[0] == "pending"
+
+
+def test_evaluate_triggers():
+    class Dummy:
+        def __init__(self, content, hour):
+            from datetime import datetime, timezone
+
+            self.content = content
+            self.created_at = datetime(2025, 1, 1, hour, tzinfo=timezone.utc)
+
+    m1 = Dummy("I agree with you", 1)
+    assert ("social chameleon", 0.6) in sg.evaluate_triggers(m1)
+    m2 = Dummy("hello", 2)
+    assert ("insomniac", 0.7) in sg.evaluate_triggers(m2)
+


### PR DESCRIPTION
## Summary
- store theories about users
- queue deep reflections for later processing
- add async background handler
- extend SocialGraphBot with theory triggers and queueing
- refine reflection loop and send-to-Prism errors
- test storing theories and queueing reflections

## Testing
- `pip install -e .`
- `pytest tests/test_theories_queue.py -q`
- `pytest -q` *(fails: nats server unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6840eed1f6e88326aac8d7f762a93029