### PR TITLE
Fix nested memory payload

### DIFF
--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -1,7 +1,7 @@
 # File: src/deepthought/modules/input_handler.py
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 # Assuming eda modules are in parent dir relative to modules dir
@@ -21,7 +21,8 @@ class InputHandler:
     async def process_input(self, user_input: str) -> str:
         """Process input and publish via JetStream."""
         input_id = str(uuid.uuid4())
-        timestamp = datetime.utcnow().isoformat()
+        # Use timezone-aware UTC timestamp
+        timestamp = datetime.now(timezone.utc).isoformat()
         payload = InputReceivedPayload(
             user_input=user_input, input_id=input_id, timestamp=timestamp
         )

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
@@ -34,10 +34,11 @@ class LLMStub:
             await asyncio.sleep(0.5) # Simulate work
 
             facts_str = ", ".join(map(str, facts))
-            response = f"Based on: {facts_str}, this is a stub response. [TS: {datetime.utcnow().isoformat()}]"
+            # Use timezone-aware UTC timestamps
+            response = f"Based on: {facts_str}, this is a stub response. [TS: {datetime.now(timezone.utc).isoformat()}]"
             payload = ResponseGeneratedPayload(
                 final_response=response, input_id=input_id,
-                timestamp=datetime.utcnow().isoformat(), confidence=0.95
+                timestamp=datetime.now(timezone.utc).isoformat(), confidence=0.95
             )
 
             logger.info(f"LLMStub: Publishing RESPONSE_GENERATED for input_id: {input_id}")

--- a/src/deepthought/modules/memory_stub.py
+++ b/src/deepthought/modules/memory_stub.py
@@ -2,7 +2,7 @@
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
@@ -32,16 +32,17 @@ class MemoryStub:
 
             await asyncio.sleep(0.1) # Simulate work
 
+            # Align with LLMStub expectation which looks for a nested
+            # "retrieved_knowledge" block within the event payload.
             memory_data = {
-                "retrieved_knowledge": {
-                    "facts": ["Fact1", f"User asked: {user_input}"],
-                    "source": "memory_stub"
-                }
+                "facts": ["Fact1", f"User asked: {user_input}"],
+                "source": "memory_stub",
             }
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge=memory_data,
+                retrieved_knowledge={"retrieved_knowledge": memory_data},
                 input_id=input_id,
-                timestamp=datetime.utcnow().isoformat()
+                # Use timezone-aware UTC timestamp
+                timestamp=datetime.now(timezone.utc).isoformat()
             )
 
             # Publish result via JetStream

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from types import SimpleNamespace
+from datetime import datetime, timezone
 
 from deepthought.modules.input_handler import InputHandler
 from deepthought.eda.events import EventSubjects
@@ -34,6 +35,10 @@ async def test_process_input_success():
     payload = json.loads(data.decode())
     assert payload["user_input"] == "hello"
     assert payload["input_id"] == input_id
+    # Timestamp should be timezone-aware UTC
+    ts = payload["timestamp"]
+    parsed = datetime.fromisoformat(ts)
+    assert parsed.tzinfo == timezone.utc
 
 class FailingJS(DummyJS):
     async def publish(self, subject, data, timeout=10.0):

--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -3,6 +3,7 @@ import pytest
 
 import deepthought.modules.llm_stub as llm_stub
 from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload
+from datetime import datetime, timezone
 
 class DummyNATS:
     def __init__(self):
@@ -60,6 +61,10 @@ async def test_handle_memory_success(monkeypatch):
     subject, sent_payload = pub.published[0]
     assert subject == EventSubjects.RESPONSE_GENERATED
     assert sent_payload.input_id == "abc"
+    # Timestamp should be timezone-aware UTC
+    ts = sent_payload.timestamp
+    parsed = datetime.fromisoformat(ts)
+    assert parsed.tzinfo == timezone.utc
     assert msg.acked
 
 

--- a/tests/unit/modules/test_memory_stub.py
+++ b/tests/unit/modules/test_memory_stub.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 import pytest
+from datetime import datetime, timezone
 
 import deepthought.modules.memory_stub as memory_stub
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
@@ -60,6 +61,14 @@ async def test_handle_input_success(monkeypatch):
     subject, sent_payload = pub.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "123"
+    # Verify the nested retrieved_knowledge structure expected by LLMStub
+    assert "retrieved_knowledge" in sent_payload.retrieved_knowledge
+    facts = sent_payload.retrieved_knowledge["retrieved_knowledge"].get("facts")
+    assert facts and "User asked: hi" in facts
+    # Timestamp should be timezone-aware UTC
+    ts = sent_payload.timestamp
+    parsed = datetime.fromisoformat(ts)
+    assert parsed.tzinfo == timezone.utc
     assert msg.acked
 
 


### PR DESCRIPTION
## Summary
- ensure MemoryStub publishes nested `retrieved_knowledge`
- test for nested payload structure
- use timezone-aware timestamps for consistency
- add tests validating timestamp timezone awareness

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d26388bc8326b295a7e0e3953c7a