### PR TITLE
Update README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ Tests are implemented using the `pytest` framework. To run the tests:
 1.  Ensure a NATS server with JetStream enabled is running and accessible (see [Running a Local NATS Server](#running-a-local-nats-server)).
     * If no server is available, tests that require NATS will be skipped automatically.
 2.  Navigate to the root directory of the project.
-3.  Run pytest:
+3.  Run pytest with the project root added to `PYTHONPATH` so the `src` modules
+    are discoverable:
     ```bash
-    pytest
+    PYTHONPATH=src pytest
     ```
     Or, to run tests from a specific directory:
     ```bash
-    pytest tests/
+    PYTHONPATH=src pytest tests/
     ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- document setting `PYTHONPATH=src` when running tests

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'nats')*

------
https://chatgpt.com/codex/tasks/task_e_6842eba545908326937d06b070b25ec4