### PR TITLE
Fix timezone in NATS example

### DIFF
--- a/examples/nats_simple_demo.py
+++ b/examples/nats_simple_demo.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import uuid
 import datetime
+from datetime import timezone
 
 import nats
 
@@ -34,7 +35,7 @@ async def run_test():
         # Publish a test message
         test_data = {
             "test_id": str(uuid.uuid4()),
-            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "timestamp": datetime.datetime.now(timezone.utc).isoformat(),
             "message": "Hello NATS!"
         }
         


### PR DESCRIPTION
## Summary
- use timezone aware timestamps in `nats_simple_demo.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nats')*

------
https://chatgpt.com/codex/tasks/task_e_6842eba70e9883269534ad61a3e576b7