### PR TITLE
Handle flat memory payloads in LLMStub

### DIFF
--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -27,7 +27,11 @@ class LLMStub:
         try:
             data = json.loads(msg.data.decode())
             input_id = data.get("input_id", "unknown")
-            knowledge = data.get("retrieved_knowledge", {}).get("retrieved_knowledge", {})
+            retrieved = data.get("retrieved_knowledge", {})
+            if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
+                knowledge = retrieved.get("retrieved_knowledge", {})
+            else:
+                knowledge = retrieved
             facts = knowledge.get("facts", [])
             logger.info(f"LLMStub received memory event ID {input_id}")
 

--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -49,9 +49,16 @@ def create_stub(monkeypatch, publisher_cls=DummyPublisher):
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_success(monkeypatch):
+@pytest.mark.parametrize(
+    "knowledge",
+    [
+        {"retrieved_knowledge": {"facts": ["f1"]}},
+        {"facts": ["f1"]},
+    ],
+)
+async def test_handle_memory_success(monkeypatch, knowledge):
     stub = create_stub(monkeypatch)
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"retrieved_knowledge": {"facts": ["f1"]}}, input_id="abc")
+    payload = MemoryRetrievedPayload(retrieved_knowledge=knowledge, input_id="abc")
     msg = DummyMsg(payload.to_json())
     await stub._handle_memory_event(msg)
 


### PR DESCRIPTION
## Summary
- relax LLMStub knowledge parsing for flat payloads
- update unit test to cover nested and flat structures

## Testing
- `pytest tests/unit/modules/test_llm_stub.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6842eba805e08326b3078bed6e69d2d1