### PR TITLE
Add NATS start script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ An example Discord bot demonstrating social graph logging is available at `examp
 Tests are implemented using the `pytest` framework. To run the tests:
 
 1.  Ensure a NATS server with JetStream enabled is running and accessible (see [Running a Local NATS Server](#running-a-local-nats-server)).
+    * You can start one quickly by running:
+      ```bash
+      ./scripts/start_nats.sh
+      ```
     * If no server is available, tests that require NATS will be skipped automatically.
 2.  Navigate to the root directory of the project.
 3.  Run pytest with the project root added to `PYTHONPATH` so the `src` modules

--- a/scripts/start_nats.sh
+++ b/scripts/start_nats.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Start a local NATS server with JetStream using Docker.
+# The server will be exposed on ports 4222 (client) and 8222 (monitoring).
+# A container named 'dtr_nats' will be created in detached mode.
+
+set -e
+
+CONTAINER_NAME="dtr_nats"
+IMAGE="nats:latest"
+
+# Run the container in detached mode
+# --rm ensures it is cleaned up when stopped
+# -js enables JetStream
+
+exec docker run --rm -d --name "$CONTAINER_NAME" -p 4222:4222 -p 8222:8222 "$IMAGE" -js
+


### PR DESCRIPTION
## Summary
- add `scripts/start_nats.sh` to launch NATS with JetStream via Docker
- mention the helper script in README testing instructions

## Testing
- `pip install nats-py pytest pytest-asyncio aiosqlite aiohttp`
- `pip install "discord.py>=2.3.2"`
- `pip install textblob`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448b09a16c8326af391f7ab545c549