### PR TITLE
Implement basic memory and LLM modules

### DIFF
--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -8,6 +8,15 @@ including input handling, memory, LLM processing, and output handling components
 from .input_handler import InputHandler
 from .output_handler import OutputHandler
 from .memory_stub import MemoryStub
+from .memory_basic import BasicMemory
 from .llm_stub import LLMStub
+from .llm_basic import BasicLLM
 
-__all__ = ["InputHandler", "OutputHandler", "MemoryStub", "LLMStub"] 
+__all__ = [
+    "InputHandler",
+    "OutputHandler",
+    "MemoryStub",
+    "LLMStub",
+    "BasicMemory",
+    "BasicLLM",
+]

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -1,0 +1,96 @@
+import json
+import logging
+from datetime import datetime, timezone
+from typing import List
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+from transformers import AutoTokenizer, AutoModelForCausalLM
+import torch
+from ..eda.events import EventSubjects, ResponseGeneratedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+class BasicLLM:
+    """Simple LLM module using a small HuggingFace model."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, model_name: str = "distilgpt2"):
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self._model = AutoModelForCausalLM.from_pretrained(model_name)
+        logger.info("BasicLLM initialized with model %s", model_name)
+
+    def _build_prompt(self, facts: List[str]) -> str:
+        prompt = "\n".join(facts) + "\nResponse:" if facts else "Response:"
+        return prompt
+
+    async def _handle_memory_event(self, msg: Msg) -> None:
+        input_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            input_id = data.get("input_id", "unknown")
+            retrieved = data.get("retrieved_knowledge", {})
+            if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
+                knowledge = retrieved.get("retrieved_knowledge", {})
+            else:
+                knowledge = retrieved
+            facts = knowledge.get("facts", [])
+            logger.info("BasicLLM received memory event ID %s", input_id)
+
+            prompt = self._build_prompt([str(f) for f in facts])
+            inputs = self._tokenizer(prompt, return_tensors="pt")
+            with torch.no_grad():
+                outputs = self._model.generate(**inputs, max_length=inputs["input_ids"].shape[1] + 20)
+            generated = self._tokenizer.decode(outputs[0], skip_special_tokens=True)
+            response_text = generated[len(prompt):].strip()
+
+            payload = ResponseGeneratedPayload(
+                final_response=response_text,
+                input_id=input_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                confidence=0.5,
+            )
+            await self._publisher.publish(
+                EventSubjects.RESPONSE_GENERATED, payload, use_jetstream=True, timeout=10.0
+            )
+            logger.info("BasicLLM published RESPONSE_GENERATED for %s", input_id)
+            await msg.ack()
+        except Exception as e:
+            logger.error("Error in BasicLLM handler: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+    async def start_listening(self, durable_name: str = "llm_basic_listener") -> bool:
+        if not self._subscriber:
+            logger.error("Subscriber not initialized for BasicLLM.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.MEMORY_RETRIEVED,
+                handler=self._handle_memory_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("BasicLLM subscribed to %s", EventSubjects.MEMORY_RETRIEVED)
+            return True
+        except Exception as e:
+            logger.error("BasicLLM failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop_listening(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("BasicLLM stopped listening.")
+        else:
+            logger.warning("Cannot stop listening - no subscriber available.")

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -1,0 +1,99 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import List, Dict, Any
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+class BasicMemory:
+    """File-backed memory module storing past inputs."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, memory_file: str = "memory.json"):
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._memory_file = memory_file
+        if not os.path.exists(self._memory_file):
+            with open(self._memory_file, "w", encoding="utf-8") as f:
+                json.dump([], f)
+        logger.info("BasicMemory initialized with file %s", self._memory_file)
+
+    def _read_memory(self) -> List[Dict[str, Any]]:
+        try:
+            with open(self._memory_file, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+
+    def _write_memory(self, data: List[Dict[str, Any]]) -> None:
+        with open(self._memory_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    async def _handle_input_event(self, msg: Msg) -> None:
+        input_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            input_id = data.get("input_id", "unknown")
+            user_input = data.get("user_input", "")
+            logger.info("BasicMemory received input event ID %s", input_id)
+
+            history = self._read_memory()
+            history.append({"timestamp": datetime.now(timezone.utc).isoformat(), "user_input": user_input})
+            self._write_memory(history)
+
+            last_entries = history[-3:]
+            facts = [entry["user_input"] for entry in last_entries]
+            memory_data = {"facts": facts, "source": "basic_memory"}
+            payload = MemoryRetrievedPayload(
+                retrieved_knowledge={"retrieved_knowledge": memory_data},
+                input_id=input_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0
+            )
+            logger.info("BasicMemory published memory event ID %s", input_id)
+            await msg.ack()
+        except Exception as e:
+            logger.error("Error in BasicMemory handler: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+    async def start_listening(self, durable_name: str = "memory_basic_listener") -> bool:
+        if not self._subscriber:
+            logger.error("Subscriber not initialized for BasicMemory.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("BasicMemory subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            return True
+        except Exception as e:
+            logger.error("BasicMemory failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop_listening(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("BasicMemory stopped listening.")
+        else:
+            logger.warning("Cannot stop listening - no subscriber available.")


### PR DESCRIPTION
## Summary
- add BasicMemory file-backed module
- add BasicLLM using a small HuggingFace model
- export new modules
- refactor integration test to use BasicMemory and BasicLLM

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nats')*

------
https://chatgpt.com/codex/tasks/task_e_6844d3f112608326978f0d10ba3ce11c