### PR TITLE
Fix BasicLLM optional placeholder

### DIFF
--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -10,7 +10,23 @@ from .output_handler import OutputHandler
 from .memory_stub import MemoryStub
 from .memory_basic import BasicMemory
 from .llm_stub import LLMStub
-from .llm_basic import BasicLLM
+
+# BasicLLM has heavy optional dependencies (transformers/torch). Import it lazily
+# so modules that do not require those packages can still be used.
+try:  # pragma: no cover - optional dependency
+    from .llm_basic import BasicLLM  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency may be missing
+
+    _missing_deps_err = exc
+
+    class BasicLLM:  # type: ignore
+        """Placeholder that raises if instantiated when deps are missing."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise ImportError(
+                "BasicLLM requires optional dependencies (transformers, torch)"
+            ) from _missing_deps_err
+
 
 __all__ = [
     "InputHandler",

--- a/tests/unit/modules/test_basic_llm_optional.py
+++ b/tests/unit/modules/test_basic_llm_optional.py
@@ -1,0 +1,11 @@
+import pytest
+from deepthought import modules
+
+
+def test_basic_llm_placeholder():
+    BasicLLM = modules.BasicLLM
+    if BasicLLM.__module__ != "deepthought.modules.llm_basic":
+        with pytest.raises(ImportError):
+            BasicLLM(None, None)
+    else:
+        pytest.skip("BasicLLM dependencies available; placeholder not used")


### PR DESCRIPTION
## Summary
- avoid failing imports when transformers/torch missing by providing a BasicLLM placeholder class
- always export `BasicLLM` and remove runtime `__getattr__`
- add unit test confirming the placeholder raises ImportError
- refine BasicLLM placeholder to include original import error

## Testing
- `PYTHONPATH=src pytest -q`
- `black --check src/deepthought/modules/__init__.py src/deepthought/modules/llm_stub.py src/deepthought/modules/memory_stub.py src/deepthought/modules/output_handler.py tests/unit/modules/test_basic_llm_optional.py`


------
https://chatgpt.com/codex/tasks/task_e_6844f745e3cc8326938d50582f5e6283