### PR TITLE
Handle optional BasicLLM deps in tests

### DIFF
--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -132,7 +132,10 @@ async def test_full_module_flow():
             os.remove(MEMORY_FILE)
         input_handler = InputHandler(nc, js)
         memory_module = BasicMemory(nc, js, memory_file=MEMORY_FILE)
-        llm_module = BasicLLM(nc, js)
+        try:
+            llm_module = BasicLLM(nc, js)
+        except ImportError:
+            pytest.skip("BasicLLM dependencies not installed")
         output_handler = OutputHandler(nc, js, output_callback=output_callback)
         logger.info("Modules initialized.")
         

--- a/tests/unit/modules/test_basic_llm_optional.py
+++ b/tests/unit/modules/test_basic_llm_optional.py
@@ -2,10 +2,11 @@ import pytest
 from deepthought import modules
 
 
-def test_basic_llm_placeholder():
+def test_basic_llm_instantiation():
+    """Instantiate BasicLLM or skip if optional deps are missing."""
     BasicLLM = modules.BasicLLM
-    if BasicLLM.__module__ != "deepthought.modules.llm_basic":
-        with pytest.raises(ImportError):
-            BasicLLM(None, None)
-    else:
-        pytest.skip("BasicLLM dependencies available; placeholder not used")
+    try:
+        instance = BasicLLM(None, None)
+    except ImportError:
+        pytest.skip("BasicLLM dependencies not installed")
+    assert instance is not None


### PR DESCRIPTION
## Summary
- adjust optional BasicLLM unit test to skip when dependencies missing
- skip integration test if BasicLLM dependencies are absent

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6845fe955ed48326a64cb7fd26277189