### PR TITLE
Add BasicMemory and BasicLLM unit tests

### DIFF
--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -1,0 +1,127 @@
+import importlib
+import json
+import sys
+import types
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import pytest
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+class DummyTensor:
+    def __init__(self, length):
+        self._shape = (1, length)
+
+    @property
+    def shape(self):
+        return self._shape
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.prompt = ""
+
+    @classmethod
+    def from_pretrained(cls, name):
+        return cls()
+
+    def __call__(self, prompt, return_tensors=None):
+        self.prompt = prompt
+        return {"input_ids": DummyTensor(len(prompt.split()))}
+
+    def decode(self, _data, skip_special_tokens=True):
+        return self.prompt + " generated"
+
+
+class DummyModel:
+    @classmethod
+    def from_pretrained(cls, name):
+        return cls()
+
+    def generate(self, **kwargs):
+        return [DummyTensor(1)]
+
+
+def create_llm(monkeypatch):
+    tf = types.ModuleType("transformers")
+    tf.AutoTokenizer = DummyTokenizer
+    tf.AutoModelForCausalLM = DummyModel
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    def no_grad():
+        return _NoGrad()
+
+    torch_mod.no_grad = no_grad
+    monkeypatch.setitem(sys.modules, "transformers", tf)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    import deepthought.modules.llm_basic as llm_basic
+    importlib.reload(llm_basic)
+    monkeypatch.setattr(llm_basic, "Publisher", DummyPublisher)
+    monkeypatch.setattr(llm_basic, "Subscriber", DummySubscriber)
+    return llm_basic.BasicLLM(DummyNATS(), DummyJS(), model_name="dummy")
+
+
+from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event(monkeypatch):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="abc")
+    msg = DummyMsg(payload.to_json())
+    await llm._handle_memory_event(msg)
+
+    assert msg.acked
+    pub = llm._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert sent_payload.input_id == "abc"
+    assert sent_payload.final_response == "generated"
+    ts = sent_payload.timestamp
+    assert datetime.fromisoformat(ts).tzinfo == timezone.utc

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -1,0 +1,93 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import os
+import pytest
+
+import deepthought.modules.memory_basic as memory_basic
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class FailingPublisher(DummyPublisher):
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        raise RuntimeError("boom")
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+def create_memory(monkeypatch, memory_file, publisher_cls=DummyPublisher):
+    monkeypatch.setattr(memory_basic, "Publisher", publisher_cls)
+    monkeypatch.setattr(memory_basic, "Subscriber", DummySubscriber)
+    return memory_basic.BasicMemory(DummyNATS(), DummyJS(), memory_file=memory_file)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_success(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.json"
+    mem = create_memory(monkeypatch, mem_file)
+    payload = InputReceivedPayload(user_input="hello", input_id="42")
+    msg = DummyMsg(payload.to_json())
+    await mem._handle_input_event(msg)
+
+    assert msg.acked
+    pub = mem._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.MEMORY_RETRIEVED
+    assert sent_payload.input_id == "42"
+    with open(mem_file, "r", encoding="utf-8") as f:
+        history = json.load(f)
+    assert history[-1]["user_input"] == "hello"
+    ts = sent_payload.timestamp
+    assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_handle_input_error(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.json"
+    mem = create_memory(monkeypatch, mem_file, FailingPublisher)
+    payload = InputReceivedPayload(user_input="boom", input_id="99")
+    msg = DummyMsg(payload.to_json())
+    await mem._handle_input_event(msg)
+
+    assert msg.acked  # Even on error, ack() should be called
+    assert mem._publisher.published == []
+    with open(mem_file, "r", encoding="utf-8") as f:
+        history = json.load(f)
+    assert history[-1]["user_input"] == "boom"


### PR DESCRIPTION
## Summary
- add tests for BasicMemory storing data and publishing events
- add tests for BasicLLM verifying generation workflow with mocked HF classes

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845fe95f43083269156eddf2c2c680b