### PR TITLE
Add knowledge graph memory module

### DIFF
--- a/src/deepthought/graph/__init__.py
+++ b/src/deepthought/graph/__init__.py
@@ -1,0 +1,5 @@
+"""Graph utilities for DeepThought."""
+
+from .connector import GraphConnector
+
+__all__ = ["GraphConnector"]

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -1,0 +1,44 @@
+"""Minimal Memgraph connector using pymgclient."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+import mgclient
+
+
+class GraphConnector:
+    """Wrapper around mgclient to execute Cypher queries."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 7687,
+        username: str = "",
+        password: str = "",
+    ) -> None:
+        self._params = {
+            "host": host,
+            "port": port,
+            "username": username,
+            "password": password,
+        }
+        self._connection: Optional[mgclient.Connection] = None
+
+    def connect(self) -> mgclient.Connection:
+        """Establish connection if not already connected."""
+        if not self._connection:
+            self._connection = mgclient.connect(**self._params)
+        return self._connection
+
+    def close(self) -> None:
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+
+    def execute(self, query: str, params: Optional[Dict[str, Any]] = None) -> list:
+        conn = self.connect()
+        cur = conn.cursor()
+        cur.execute(query, params or {})
+        rows = cur.fetchall()
+        cur.close()
+        return rows

--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -10,6 +10,7 @@ from .output_handler import OutputHandler
 from .memory_stub import MemoryStub
 from .memory_basic import BasicMemory
 from .memory_graph import GraphMemory
+from .memory_kg import KnowledgeGraphMemory
 from .llm_stub import LLMStub
 
 # BasicLLM has heavy optional dependencies (transformers/torch). Import it lazily
@@ -36,5 +37,6 @@ __all__ = [
     "LLMStub",
     "BasicMemory",
     "GraphMemory",
+    "KnowledgeGraphMemory",
     "BasicLLM",
 ]

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -1,0 +1,103 @@
+"""Knowledge graph memory module using a Memgraph backend."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import List, Tuple
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+from ..graph import GraphConnector
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphMemory:
+    """Parse user input into a graph stored in Memgraph."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, connector: GraphConnector) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._connector = connector
+
+    def _parse_input(self, text: str) -> Tuple[List[str], List[Tuple[str, str]]]:
+        words = [w for w in text.strip().split() if w]
+        nodes = list(dict.fromkeys(words))
+        edges = [(words[i], words[i + 1]) for i in range(len(words) - 1)]
+        return nodes, edges
+
+    def _store(self, nodes: List[str], edges: List[Tuple[str, str]]) -> None:
+        for name in nodes:
+            self._connector.execute("MERGE (:Entity {name: $name})", {"name": name})
+        for src, dst in edges:
+            self._connector.execute(
+                "MATCH (a:Entity {name: $src}), (b:Entity {name: $dst}) MERGE (a)-[:NEXT]->(b)",
+                {"src": src, "dst": dst},
+            )
+
+    async def _handle_input_event(self, msg: Msg) -> None:
+        input_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            input_id = data.get("input_id", "unknown")
+            user_input = data.get("user_input", "")
+            logger.info("KnowledgeGraphMemory received input %s", input_id)
+
+            nodes, edges = self._parse_input(user_input)
+            self._store(nodes, edges)
+
+            payload = MemoryRetrievedPayload(
+                retrieved_knowledge={"retrieved_knowledge": {"facts": [], "source": "knowledge_graph"}},
+                input_id=input_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            await msg.ack()
+        except Exception as e:  # pragma: no cover - error path
+            logger.error("Error in KnowledgeGraphMemory: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+    async def start_listening(self, durable_name: str = "knowledge_graph_listener") -> bool:
+        if not self._subscriber:
+            logger.error("Subscriber not initialized for KnowledgeGraphMemory.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("KnowledgeGraphMemory subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            return True
+        except Exception as e:  # pragma: no cover - network failure
+            logger.error("KnowledgeGraphMemory failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop_listening(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("KnowledgeGraphMemory stopped listening.")
+        else:  # pragma: no cover - defensive
+            logger.warning("Cannot stop listening - no subscriber available.")

--- a/tests/unit/modules/test_memory_kg.py
+++ b/tests/unit/modules/test_memory_kg.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+import pytest
+
+import deepthought.modules.memory_kg as memory_kg
+from deepthought.eda.events import InputReceivedPayload
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+class DummyConnector:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.executed = []
+
+    def execute(self, query, params=None):
+        if self.fail:
+            raise RuntimeError("boom")
+        self.executed.append((query, params))
+        return []
+
+
+def create_memory(monkeypatch, connector):
+    monkeypatch.setattr(memory_kg, "Publisher", DummyPublisher)
+    monkeypatch.setattr(memory_kg, "Subscriber", DummySubscriber)
+    return memory_kg.KnowledgeGraphMemory(DummyNATS(), DummyJS(), connector)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_creates_nodes_edges(monkeypatch):
+    connector = DummyConnector()
+    mem = create_memory(monkeypatch, connector)
+    payload = InputReceivedPayload(user_input="hello world", input_id="7")
+    msg = DummyMsg(payload.to_json())
+    await mem._handle_input_event(msg)
+
+    assert msg.acked
+    pub = mem._publisher
+    assert pub.published
+    node_queries = [q for q, _ in connector.executed if "MERGE (:Entity" in q]
+    edge_queries = [q for q, _ in connector.executed if "MERGE (a)-[:NEXT]->(b)" in q]
+    assert len(node_queries) == 2
+    assert len(edge_queries) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_input_error(monkeypatch):
+    connector = DummyConnector(fail=True)
+    mem = create_memory(monkeypatch, connector)
+    payload = InputReceivedPayload(user_input="fail", input_id="8")
+    msg = DummyMsg(payload.to_json())
+    await mem._handle_input_event(msg)
+
+    assert msg.acked
+    assert connector.executed == []


### PR DESCRIPTION
## Summary
- add `GraphConnector` for Memgraph
- implement `KnowledgeGraphMemory` module
- export new module and connector
- add unit tests for knowledge graph memory

## Testing
- `ruff check src/deepthought/graph/connector.py src/deepthought/modules/memory_kg.py tests/unit/modules/test_memory_kg.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68477280d5388326aa39d4086dbb97a5