### PR TITLE
Fix GraphMemory integration test constant

### DIFF
--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -10,7 +10,19 @@ from .output_handler import OutputHandler
 from .memory_stub import MemoryStub
 from .memory_basic import BasicMemory
 from .memory_graph import GraphMemory
-from .memory_kg import KnowledgeGraphMemory
+# KnowledgeGraphMemory requires mgclient which may be optional
+try:  # pragma: no cover - optional dependency may be missing
+    from .memory_kg import KnowledgeGraphMemory  # type: ignore
+except Exception as exc:  # pragma: no cover - optional dependency may be missing
+    _missing_kg_err = exc
+
+    class KnowledgeGraphMemory:  # type: ignore
+        """Placeholder that raises if instantiated when mgclient is missing."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise ImportError(
+                "KnowledgeGraphMemory requires optional dependency mgclient"
+            ) from _missing_kg_err
 from .llm_stub import LLMStub
 
 # ProductionLLM depends on additional optional packages (transformers, torch, peft)

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -263,7 +263,6 @@ async def test_full_module_flow_graph_memory():
         final_response_received_event = asyncio.Event()
         responses = {}
         test_input_id = None
-        graph_memory_file = tempfile.mktemp(suffix=".json")
 
         def output_callback(input_id, response):
             nonlocal test_input_id
@@ -272,10 +271,10 @@ async def test_full_module_flow_graph_memory():
                 final_response_received_event.set()
 
         logger.info("Initializing modules (GraphMemory)...")
-        if os.path.exists(graph_memory_file):
-            os.remove(graph_memory_file)
+        if os.path.exists(GRAPH_MEMORY_FILE):
+            os.remove(GRAPH_MEMORY_FILE)
         input_handler = InputHandler(nc, js)
-        memory_module = GraphMemory(nc, js, graph_file=graph_memory_file)
+        memory_module = GraphMemory(nc, js, graph_file=GRAPH_MEMORY_FILE)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:
             llm_module = llm_cls(nc, js)
@@ -308,7 +307,7 @@ async def test_full_module_flow_graph_memory():
         assert final_response_received_event.is_set()
         assert test_input_id in responses
 
-        with open(graph_memory_file, "r", encoding="utf-8") as f:
+        with open(GRAPH_MEMORY_FILE, "r", encoding="utf-8") as f:
             graph_json = json.load(f)
         assert graph_json
 
@@ -323,8 +322,8 @@ async def test_full_module_flow_graph_memory():
             stubs_to_stop.append(output_handler.stop_listening())
         if stubs_to_stop:
             await asyncio.gather(*stubs_to_stop, return_exceptions=True)
-        if os.path.exists(graph_memory_file):
-            os.remove(graph_memory_file)
+        if os.path.exists(GRAPH_MEMORY_FILE):
+            os.remove(GRAPH_MEMORY_FILE)
         if nc and nc.is_connected:
             await nc.drain()
             logger.info("NATS connection closed.")


### PR DESCRIPTION
## Summary
- avoid importing mgclient by catching ImportError when initializing `KnowledgeGraphMemory`
- use a single `GRAPH_MEMORY_FILE` constant in the GraphMemory integration test

## Testing
- `pytest tests/test_module_integration.py -k test_full_module_flow_graph_memory -vv`

------
https://chatgpt.com/codex/tasks/task_e_6848345407308326af30fc8bc96cbda7