### PR TITLE
Add minimal CI requirements file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - run: pip install -r requirements.txt
-      - run: pip install flake8 pytest
+      - run: pip install -r requirements-ci.txt
       - run: flake8 src tests
       - run: pytest -v

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Users would typically incorporate these scripts into their Unity projects and us
         ```bash
         pip install -r requirements.txt
         ```
+    *   A trimmed-down `requirements-ci.txt` is included for CI jobs and only
+        contains the packages needed for testing and linting.
 4.  **Initialize JetStream:**
     *   Run the `setup_jetstream.py` script to create the necessary JetStream streams:
         ```bash
@@ -168,6 +170,7 @@ The project includes a GitHub Actions workflow that runs `flake8` and
 the test suite whenever code changes are detected. Detection is handled by
 [`scripts/check_code_changes.py`](scripts/check_code_changes.py), which
 inspects diffs and skips CI when only documentation or comments change.
+The workflow installs its dependencies from `requirements-ci.txt`.
 
 ## Contributing
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,10 @@
+nats-py
+networkx
+aiosqlite
+pytest
+pytest-asyncio
+flake8
+pydantic-settings
+aiohttp
+discord.py
+textblob


### PR DESCRIPTION
## Summary
- add `requirements-ci.txt` for lightweight testing deps
- install CI deps from the new file
- document the difference between `requirements.txt` and `requirements-ci.txt`

## Testing
- `flake8 src tests`
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_68498eae551083268db4d28f0f137bd3