### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,7 @@ jobs:
       - run: flake8 src tests
       - env:
           PYTHONPATH: src
-        run: pytest -v
+        run: pytest --cov=src --cov-report=xml
+      - uses: codecov/codecov-action@v3
+        with:
+          files: coverage.xml

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -2,6 +2,7 @@ nats-py
 networkx
 aiosqlite
 pytest
+pytest-cov
 pytest-asyncio
 flake8
 pydantic-settings


### PR DESCRIPTION
## Summary
- add `pytest-cov` to CI requirements
- collect coverage in GitHub Actions and upload to Codecov

## Testing
- `flake8 src tests`
- `pytest --cov=src --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_6849a6596d508326b4d5359e9b66fbe3