### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
 
       - run: pip install -r requirements-ci.txt
       - run: pip install -e . --no-deps
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure
       - run: flake8 src tests
       - env:
           PYTHONPATH: src

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+        args: [--line-length=120]
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: [--profile=black, --line-length=120]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ PYTHONPATH=src pytest tests/
     ```
     The default settings are configured in [.flake8](.flake8).
 
+5.  Install and run the `pre-commit` hooks to automatically format and lint
+    your changes:
+    ```bash
+    pip install pre-commit
+    pre-commit install
+    ```
+    To run all hooks manually:
+    ```bash
+    pre-commit run --all-files
+    ```
+    The configuration is provided in [.pre-commit-config.yaml](.pre-commit-config.yaml).
+
 ## Continuous Integration
 
 The project includes a GitHub Actions workflow that runs `flake8` and


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` configuring black, isort and flake8
- document pre-commit usage in the README
- run pre-commit as part of CI

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -v`
- `pre-commit run --files README.md .pre-commit-config.yaml .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6849a658c8b8832698ca1f0f789254ea