### PR TITLE
Remove redundant flake8 step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
       - run: pre-commit run --all-files
       - name: Setup JetStream
         run: python setup_jetstream.py
-      - run: flake8 src tests
       - env:
           PYTHONPATH: src
         run: pytest --cov=src --cov-report=xml


### PR DESCRIPTION
## Summary
- delete the explicit `flake8 src tests` job step since `pre-commit` already runs flake8

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac85d37c08326bb1d78e898be7625