### PR TITLE
Add pip upgrade step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,16 @@ jobs:
           python-version: '3.x'
       - id: requirements-hash
         run: echo "hash=$(pip hash requirements-ci.txt | awk 'NR==2 {print \$1}' | cut -d: -f2)" >> "$GITHUB_OUTPUT"
-      - name: Cache pip packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ steps.requirements-hash.outputs.hash }}
-          restore-keys: |
-            pip-
-      - run: pip install -r requirements-ci.txt
-      - run: pip install -e . --no-deps
+        - name: Cache pip packages
+          uses: actions/cache@v3
+          with:
+            path: ~/.cache/pip
+            key: pip-${{ steps.requirements-hash.outputs.hash }}
+            restore-keys: |
+              pip-
+        - run: python -m pip install --upgrade pip
+        - run: pip install -r requirements-ci.txt
+        - run: pip install -e . --no-deps
       - run: pre-commit run --all-files
       - name: Setup JetStream
         run: python setup_jetstream.py


### PR DESCRIPTION
## Summary
- upgrade pip before installing CI requirements

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac85e06fc8326b93e39ea3cc4baab