### PR TITLE
Fix CI matrix fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
     if: needs.detect_changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
     steps:


### PR DESCRIPTION
## Summary
- disable fail-fast in matrix strategy in `lint_and_test`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac85ea2b083268ddd46b0a756e66e