### PR TITLE
Update README with codex_setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ PYTHONPATH=src pytest tests/
     ```
     The configuration is provided in [.pre-commit-config.yaml](.pre-commit-config.yaml).
 
+6.  Alternatively, run the helper script that mirrors the CI workflow and
+    automates setup:
+    ```bash
+    ./scripts/codex_setup.sh
+    ```
+    This script installs dependencies, starts a local NATS server, sets up
+    JetStream, and executes flake8 and pytest **only when code has changed**.
+
 ## Continuous Integration
 
 The project includes a GitHub Actions workflow that runs `flake8` and


### PR DESCRIPTION
## Summary
- document the `scripts/codex_setup.sh` helper in the Testing section

## Testing
- `pre-commit` and pytest were skipped because only docs were updated

------
https://chatgpt.com/codex/tasks/task_e_684af043014483268d14fa534869cbb8