### PR TITLE
Switch to model_validate for settings

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -51,7 +51,7 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
                 data = yaml.safe_load(f)
             else:
                 data = json.load(f)
-        return Settings.parse_obj(data)
+        return Settings.model_validate(data)
     return Settings()
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 
 from deepthought.config import load_settings
 
@@ -31,3 +32,20 @@ def test_file_load(tmp_path):
     assert settings.db.port == 123
     assert settings.model_path == "file/model"
     assert settings.memory_file == "filemem.json"
+
+
+def test_yaml_file_load(tmp_path):
+    data = {
+        "nats_url": "nats://yaml:4222",
+        "db": {"user": "yamluser", "password": "p", "host": "dbyaml", "port": 456},
+        "model_path": "yaml/model",
+        "memory_file": "yaml.json",
+    }
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(yaml.safe_dump(data))
+
+    settings = load_settings(str(cfg))
+    assert settings.nats_url == "nats://yaml:4222"
+    assert settings.db.port == 456
+    assert settings.model_path == "yaml/model"
+    assert settings.memory_file == "yaml.json"


### PR DESCRIPTION
## Summary
- use `Settings.model_validate` instead of `parse_obj`
- test that YAML config files load correctly

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c875d327c8326acf0a0e8bb7925c8