### PR TITLE
Make NATS URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ export DT_MEMORY_FILE=/tmp/my_memory.json
 If unset, the default `memory.json` in the current directory is used.
 Settings can also be loaded from a configuration file by setting the `DT_CONFIG_FILE` environment variable.
 
+Specify the NATS server address with the `NATS_URL` environment variable. If not set,
+`nats://localhost:4222` is used by default:
+
+```bash
+export NATS_URL=nats://my-nats:4222
+```
+
 ## Running a Local NATS Server
 
 If you don't already have a NATS server running locally, you can start one easily.

--- a/nats_deepthought_script.py
+++ b/nats_deepthought_script.py
@@ -14,6 +14,9 @@ import uuid
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
+# NATS server URL used for the test script
+NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
+
 # Add the src directory to the path for imports before loading project modules
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "src")))
 
@@ -76,7 +79,7 @@ async def test_subject(nc, subject, payload):
 
 async def run_test():
     print("Connecting to NATS server...")
-    nc = await nats.connect("nats://localhost:4222")
+    nc = await nats.connect(NATS_URL)
     print(f"Connected to NATS server at {nc.connected_url.netloc}")
 
     try:


### PR DESCRIPTION
## Summary
- parameterize the NATS server address via `NATS_URL`
- use the env var in setup script and test script
- document the new setting in the README

## Testing
- `flake8 src tests nats_deepthought_script.py setup_jetstream.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c87705b548326a8f747e1d12c4835