### PR TITLE
Add log for memory read failure

### DIFF
--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -38,7 +38,8 @@ class BasicMemory:
         try:
             with open(self._memory_file, "r", encoding="utf-8") as f:
                 return json.load(f)
-        except Exception:
+        except Exception as e:
+            logger.error("Failed to read memory file: %s", e)
             return []
 
     def _write_memory(self, data: List[Dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
- log read errors in `BasicMemory._read_memory`
- add regression test for invalid JSON logging

## Testing
- `pre-commit run --files src/deepthought/modules/memory_basic.py tests/unit/modules/test_memory_basic.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c877104588326a7312efd2f174937