### PR TITLE
Add logging for graph load errors and tests

### DIFF
--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -35,7 +35,8 @@ class GraphMemory:
             with open(self._graph_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
             return nx.readwrite.json_graph.node_link_graph(data)
-        except Exception:
+        except Exception as e:
+            logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
             return nx.DiGraph()
 
     def _write_graph(self) -> None:

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -1,0 +1,56 @@
+import json
+import logging
+from types import SimpleNamespace
+
+import networkx as nx
+import pytest
+
+import deepthought.modules.memory_graph as memory_graph
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+def create_memory(monkeypatch, graph_file):
+    monkeypatch.setattr(memory_graph, "Publisher", DummyPublisher)
+    monkeypatch.setattr(memory_graph, "Subscriber", DummySubscriber)
+    return memory_graph.GraphMemory(DummyNATS(), DummyJS(), graph_file=graph_file)
+
+
+def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text("{ invalid json")
+
+    caplog.set_level(logging.ERROR)
+    mem = create_memory(monkeypatch, graph_file)
+
+    assert isinstance(mem._graph, nx.DiGraph)
+    assert len(mem._graph.nodes) == 0
+    error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
+    assert any("Failed to read graph file" in r.getMessage() for r in error_logs)


### PR DESCRIPTION
## Summary
- log exceptions when failing to load a graph in `GraphMemory`
- test that invalid JSON is logged and results in an empty graph

## Testing
- `pre-commit run --files src/deepthought/modules/memory_graph.py tests/unit/modules/test_memory_graph.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8760c47c8326b3f9cc414fe6acff