### PR TITLE
Add Discord bot roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Ensure the dependency is installed (included in `requirements.txt`).
 
 An example Discord bot demonstrating social graph logging is available at `examples/social_graph_bot.py`. It records user interactions in a SQLite database, monitors channel activity, and forwards data to a Prism endpoint implemented in `examples/prism_server.py`.
 
+## Discord Bot Roadmap
+
+For a detailed overview of the Discord bot progress, see [docs/discord_bot_roadmap.md](docs/discord_bot_roadmap.md).
+
+
 
 ## Basic Modules
 

--- a/docs/discord_bot_roadmap.md
+++ b/docs/discord_bot_roadmap.md
@@ -1,0 +1,17 @@
+# Discord Bot Roadmap
+
+This document summarizes the progress reports for the planned Discord bot integration.
+
+## Phase 1: Foundation
+
+- Establish event-driven architecture using NATS and JetStream.
+- Implement a minimal Discord bot that logs user interactions.
+- Create initial tests for message flow and JetStream integration.
+- Document environment setup and hardware considerations.
+
+## Phase 2: Social Graph Logging
+
+- Extend the bot with a social graph that records interactions.
+- Add SQLite storage and basic sentiment analysis.
+- Provide a Prism server example for forwarding data for analysis.
+- Plan for knowledge graph integration and advanced response generation.


### PR DESCRIPTION
## Summary
- add placeholder doc for Discord bot roadmap
- reference the roadmap in README

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_684f49621c908326aeb92ec529066067