### PR TITLE
Add sentiment score option to store_memory

### DIFF
--- a/tests/test_theories_queue.py
+++ b/tests/test_theories_queue.py
@@ -37,7 +37,7 @@ async def test_store_memory(tmp_path):
     db_file = tmp_path / "db.sqlite"
     sg.DB_PATH = str(db_file)
     await sg.init_db()
-    await sg.store_memory("u1", "hello", 0.3)
+    await sg.store_memory("u1", "hello", sentiment_score=0.3)
     async with aiosqlite.connect(sg.DB_PATH) as db:
         async with db.execute(
             "SELECT memory, sentiment_score FROM memories WHERE user_id=?",


### PR DESCRIPTION
## Summary
- allow optional sentiment score in `store_memory`
- update bot logic to pass explicit scores
- adjust unit test for new argument

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_theories_queue.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685013c17cc08326b19a6f42a22fce78