### PR TITLE
Add unit tests for monitor_channels and prism calls

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,19 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+@pytest.fixture
+def prism_calls(monkeypatch):
+    calls = []
+
+    async def fake_send(data):
+        calls.append(data)
+
+    monkeypatch.setattr(sg, "send_to_prism", fake_send)
+    return calls

--- a/tests/test_monitor_channels.py
+++ b/tests/test_monitor_channels.py
@@ -1,0 +1,68 @@
+import asyncio
+import random
+
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent_messages = []
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield  # pragma: no cover
+
+        return _gen()
+
+    async def send(self, content):
+        self.sent_messages.append(content)
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyBot:
+    def __init__(self, channel):
+        self._closed = False
+        self._channel = channel
+
+    async def wait_until_ready(self):
+        return None
+
+    def get_channel(self, cid):
+        return self._channel
+
+    def is_closed(self):
+        if self._closed:
+            return True
+        self._closed = True
+        return False
+
+
+@pytest.mark.asyncio
+async def test_monitor_channels_idle_prompt(monkeypatch):
+    channel = DummyChannel()
+    bot = DummyBot(channel)
+
+    monkeypatch.setattr(sg, "idle_response_candidates", ["ping"])  # deterministic prompt
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    await sg.monitor_channels(bot, 1)
+
+    assert channel.sent_messages == ["ping"]


### PR DESCRIPTION
## Summary
- add fixture to capture prism calls and avoid network
- test idle prompt logic in `monitor_channels`
- assert `send_to_prism` is invoked in `on_message`

## Testing
- `pre-commit run --files tests/conftest.py tests/test_on_message_memory.py tests/test_monitor_channels.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850918a1b3883269e187790bed2a797