### PR TITLE
Fix duplicate memory logging

### DIFF
--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -72,6 +72,7 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch):
             rows = await cur.fetchall()
 
     assert rows, "Memory row should be inserted"
+    assert len(rows) == 1, "Only one memory row should be created"
     stored_memory, score = rows[0]
     assert stored_memory == message.content
     assert isinstance(score, float)


### PR DESCRIPTION
## Summary
- compute message sentiment once in `SocialGraphBot.on_message`
- log a single memory entry per message
- update tests for single-row expectation

## Testing
- `flake8 examples/social_graph_bot.py tests/test_on_message_memory.py`
- `black examples/social_graph_bot.py tests/test_on_message_memory.py --line-length=120`
- `isort examples/social_graph_bot.py tests/test_on_message_memory.py --profile=black --line-length=120`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850918728848326ac525605d3bd6989