### PR TITLE
Fix duplicate memory logging

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -101,10 +101,7 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    """Persist a memory snippet with optional sentiment analysis."""
-    if sentiment_score is None:
-        blob = TextBlob(memory)
-        sentiment_score = blob.sentiment.polarity
+    """Persist a memory snippet."""
 
     async with aiosqlite.connect(DB_PATH) as db:
         await db.execute(


### PR DESCRIPTION
## Summary
- store memory without extra sentiment analysis
- ensure SocialGraphBot stores exactly one memory row per message
- test multiple messages only create a single row each

## Testing
- `flake8 src tests examples/social_graph_bot.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685167f2db80832687d9c50bbcedcc1c