### PR TITLE
Update config to use SettingsConfigDict

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 try:  # YAML support is optional
     import yaml  # type: ignore
@@ -34,9 +34,9 @@ class Settings(BaseSettings):
     model_path: str = "distilgpt2"
     memory_file: str = "memory.json"
 
-    class Config:
-        env_prefix = "DT_"
-        env_nested_delimiter = "__"
+    model_config = SettingsConfigDict(
+        env_prefix="DT_", env_nested_delimiter="__"
+    )
 
 
 def load_settings(config_file: Optional[str] = None) -> Settings:


### PR DESCRIPTION
## Summary
- configure pydantic settings with `SettingsConfigDict`
- adjust imports accordingly

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68518c585a88832684c14a40c9cdc838