### PR TITLE
Enable member intents in SocialGraphBot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -333,6 +333,8 @@ class SocialGraphBot(discord.Client):
     def __init__(self, *args, monitor_channel_id: int, **kwargs):
         intents = discord.Intents.default()
         intents.message_content = True
+        intents.members = True
+        intents.presences = True
         super().__init__(*args, intents=intents, **kwargs)
         self.monitor_channel_id = monitor_channel_id
 

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -68,6 +68,8 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch):
     monkeypatch.setattr(sg, "is_do_not_mock", allow_mock)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
+    assert bot.intents.members
+    assert bot.intents.presences
 
     message = DummyMessage("You are an idiot")
     await bot.on_message(message)
@@ -100,6 +102,8 @@ async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch):
     monkeypatch.setattr(sg, "is_do_not_mock", prevent_mock)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
+    assert bot.intents.members
+    assert bot.intents.presences
 
     message = DummyMessage("You are an idiot")
     await bot.on_message(message)

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -61,6 +61,8 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", noop)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
+    assert bot.intents.members
+    assert bot.intents.presences
 
     message = DummyMessage("hello world")
     await bot.on_message(message)
@@ -95,6 +97,8 @@ async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls
     monkeypatch.setattr(asyncio, "sleep", noop)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
+    assert bot.intents.members
+    assert bot.intents.presences
 
     message = DummyMessage("send prism")
     await bot.on_message(message)
@@ -134,6 +138,8 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
     monkeypatch.setattr(asyncio, "sleep", noop)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
+    assert bot.intents.members
+    assert bot.intents.presences
 
     message = DummyMessage("hello again")
     await bot.on_message(message)
@@ -141,4 +147,3 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
     trend = await sg.get_sentiment_trend(message.author.id, message.channel.id)
     expected = sg.TextBlob(message.content).sentiment.polarity
     assert trend == (expected, 1)
-


### PR DESCRIPTION
## Summary
- ensure SocialGraphBot enables `members` and `presences` intents
- verify these intents in unit tests

## Testing
- `pytest -q`
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py tests/test_bullying_mock.py`


------
https://chatgpt.com/codex/tasks/task_e_68519480aa148326b804a0c6a623feac