### PR TITLE
Add user_flags table and tests

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -90,6 +90,14 @@ async def init_db():
             )
             """
         )
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_flags (
+                user_id TEXT PRIMARY KEY,
+                do_not_mock INTEGER
+            )
+            """
+        )
         await db.commit()
 
 

--- a/tests/test_user_flags.py
+++ b/tests/test_user_flags.py
@@ -1,0 +1,22 @@
+import aiosqlite
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+@pytest.mark.asyncio
+async def test_user_flags_table_and_functions(tmp_path):
+    sg.DB_PATH = str(tmp_path / "sg.db")
+    await sg.init_db()
+
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='user_flags'") as cur:
+            row = await cur.fetchone()
+    assert row is not None, "user_flags table should exist"
+
+    await sg.set_do_not_mock("u1", True)
+    assert await sg.is_do_not_mock("u1") is True
+
+    await sg.set_do_not_mock("u1", False)
+    assert await sg.is_do_not_mock("u1") is False
+    assert await sg.is_do_not_mock("u2") is False


### PR DESCRIPTION
## Summary
- extend `init_db` to create a `user_flags` table
- test table creation and related functions

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_user_flags.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851947cfa38832686e169339ca643cd