### PR TITLE
Make DB path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Set the environment variables used by the bot:
 ```bash
 export DISCORD_TOKEN=your_token
 export MONITOR_CHANNEL=1234567890
+export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 ```
 
 Run the bot:

--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -44,6 +44,7 @@ pip install discord.py aiohttp aiosqlite textblob
 
 export DISCORD_TOKEN=your_token
 export MONITOR_CHANNEL=1234567890
+export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 
 python examples/social_graph_bot.py
 ```

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -13,7 +13,7 @@ from textblob import TextBlob
 
 logger = logging.getLogger(__name__)
 
-DB_PATH = "social_graph.db"
+DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
 
 # Configuration values
 MAX_BOT_SPEAKERS = int(os.getenv("MAX_BOT_SPEAKERS", "2"))


### PR DESCRIPTION
## Summary
- allow overriding DB_PATH via `SOCIAL_GRAPH_DB`
- document the new `SOCIAL_GRAPH_DB` variable in README and phase report

## Testing
- `pre-commit run --files examples/social_graph_bot.py README.md docs/discord_bot_phase_report.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851948ca7c48326bcc6c1e9edbff683