### PR TITLE
Configure Prism endpoint via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Set the environment variables used by the bot:
 export DISCORD_TOKEN=your_token
 export MONITOR_CHANNEL=1234567890
 export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
+export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
 ```
 
 Run the bot:
@@ -182,8 +183,9 @@ To test Prism integration, start the simple Flask server:
 python examples/prism_server.py
 ```
 
-The bot's `send_to_prism` function posts JSON data to
-`http://localhost:5000/receive_data`.
+The bot's `send_to_prism` function posts JSON data to the endpoint
+defined by the `PRISM_ENDPOINT` environment variable (default:
+`http://localhost:5000/receive_data`).
 
 ### Idle Channel Monitoring
 

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -16,6 +16,9 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 
 DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
 
+# Endpoint for forwarding collected data
+PRISM_ENDPOINT = os.getenv("PRISM_ENDPOINT", "http://localhost:5000/receive_data")
+
 # Configuration values
 MAX_BOT_SPEAKERS = int(os.getenv("MAX_BOT_SPEAKERS", "2"))
 IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
@@ -139,7 +142,7 @@ async def send_to_prism(data: dict) -> None:
     """Send collected data to a Prism endpoint."""
     try:
         async with aiohttp.ClientSession() as session:
-            await session.post("http://localhost:5000/receive_data", json=data, timeout=5)
+            await session.post(PRISM_ENDPOINT, json=data, timeout=5)
     except Exception as exc:
         logger.warning("Failed to send data to Prism: %s", exc)
 

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -147,3 +147,14 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
     trend = await sg.get_sentiment_trend(message.author.id, message.channel.id)
     expected = sg.TextBlob(message.content).sentiment.polarity
     assert trend == (expected, 1)
+
+
+def test_prism_endpoint_env(monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("PRISM_ENDPOINT", "http://example.com/prism")
+    importlib.reload(sg)
+    assert sg.PRISM_ENDPOINT == "http://example.com/prism"
+
+    monkeypatch.delenv("PRISM_ENDPOINT")
+    importlib.reload(sg)


### PR DESCRIPTION
## Summary
- add `PRISM_ENDPOINT` configuration in `social_graph_bot`
- use the constant in `send_to_prism`
- document the endpoint variable in the README
- test environment variable loading

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py README.md`
- `pytest tests/test_on_message_memory.py::test_prism_endpoint_env tests/test_on_message_memory.py::test_on_message_calls_send_to_prism tests/test_on_message_memory.py::test_on_message_stores_memory tests/test_on_message_memory.py::test_update_sentiment_trend tests/test_on_message_memory.py::test_on_message_updates_sentiment_trend -q`

------
https://chatgpt.com/codex/tasks/task_e_68522644b334832681392af62bba2eac