### PR TITLE
Introduce async DBManager for SocialGraphBot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -33,10 +33,26 @@ idle_response_candidates = [
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
 
 
-async def init_db():
-    """Initialize the SQLite database for tracking interactions and memories."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+class DBManager:
+    """Lightweight wrapper managing a single aiosqlite connection."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._db: aiosqlite.Connection | None = None
+
+    async def connect(self) -> None:
+        if self._db is None:
+            self._db = await aiosqlite.connect(self.db_path)
+
+    async def close(self) -> None:
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+
+    async def init_db(self) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS interactions (
                 user_id TEXT,
@@ -45,7 +61,7 @@ async def init_db():
             )
             """
         )
-        await db.execute(
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS memories (
                 user_id TEXT,
@@ -56,7 +72,7 @@ async def init_db():
             )
             """
         )
-        await db.execute(
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS theories (
                 subject_id TEXT,
@@ -67,7 +83,7 @@ async def init_db():
             )
             """
         )
-        await db.execute(
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS queued_tasks (
                 task_id INTEGER PRIMARY KEY,
@@ -79,7 +95,7 @@ async def init_db():
             )
             """
         )
-        await db.execute(
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS sentiment_trends (
                 user_id TEXT,
@@ -91,7 +107,7 @@ async def init_db():
             )
             """
         )
-        await db.execute(
+        await self._db.execute(
             """
             CREATE TABLE IF NOT EXISTS user_flags (
                 user_id TEXT PRIMARY KEY,
@@ -99,24 +115,160 @@ async def init_db():
             )
             """
         )
-        await db.commit()
+        await self._db.commit()
 
-
-async def log_interaction(user_id: int, target_id: int) -> None:
-    """Insert a user interaction record into the database."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
+    async def log_interaction(self, user_id: int, target_id: int) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
             "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
             (str(user_id), str(target_id)),
         )
-        await db.commit()
+        await self._db.commit()
+
+    async def recall_user(self, user_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT topic, memory FROM memories WHERE user_id= ?",
+            (str(user_id),),
+        ) as cur:
+            return await cur.fetchall()
+
+    async def store_memory(
+        self,
+        user_id: int,
+        memory: str,
+        topic: str = "",
+        sentiment_score: float | None = None,
+    ) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO memories (user_id, topic, memory, sentiment_score) VALUES (?, ?, ?, ?)",
+            (str(user_id), topic, memory, sentiment_score),
+        )
+        await self._db.commit()
+
+    async def store_theory(self, subject_id: int, theory: str, confidence: float) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO theories (subject_id, theory, confidence)
+            VALUES (?, ?, ?)
+            ON CONFLICT(subject_id, theory) DO UPDATE SET
+                confidence=excluded.confidence,
+                updated=CURRENT_TIMESTAMP
+            """,
+            (str(subject_id), theory, confidence),
+        )
+        await self._db.commit()
+
+    async def get_theories(self, subject_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT theory, confidence FROM theories WHERE subject_id=?",
+            (str(subject_id),),
+        ) as cur:
+            return await cur.fetchall()
+
+    async def update_sentiment_trend(
+        self,
+        user_id: int,
+        channel_id: int,
+        sentiment_score: float,
+    ) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO sentiment_trends (user_id, channel_id, sentiment_sum, message_count)
+            VALUES (?, ?, ?, 1)
+            ON CONFLICT(user_id, channel_id) DO UPDATE SET
+                sentiment_sum=sentiment_trends.sentiment_sum + excluded.sentiment_sum,
+                message_count=sentiment_trends.message_count + 1
+            """,
+            (str(user_id), str(channel_id), sentiment_score),
+        )
+        await self._db.commit()
+
+    async def get_sentiment_trend(self, user_id: int, channel_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT sentiment_sum, message_count FROM sentiment_trends WHERE user_id=? AND channel_id=?",
+            (str(user_id), str(channel_id)),
+        ) as cur:
+            return await cur.fetchone()
+
+    async def queue_deep_reflection(self, user_id: int, context: dict, prompt: str) -> int:
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute(
+            "INSERT INTO queued_tasks (user_id, context, prompt) VALUES (?, ?, ?)",
+            (str(user_id), json.dumps(context), prompt),
+        )
+        await self._db.commit()
+        return cur.lastrowid
+
+    async def list_pending_tasks(self):
+        """Return pending reflection tasks."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT task_id, user_id, context, prompt FROM queued_tasks WHERE status='pending'"
+        ) as cur:
+            return await cur.fetchall()
+
+    async def mark_task_done(self, task_id: int) -> None:
+        """Mark a queued task as completed."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "UPDATE queued_tasks SET status='done' WHERE task_id=?",
+            (task_id,),
+        )
+        await self._db.commit()
+
+    async def set_do_not_mock(self, user_id: int, flag: bool = True) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO user_flags (user_id, do_not_mock)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET do_not_mock=excluded.do_not_mock
+            """,
+            (str(user_id), int(flag)),
+        )
+        await self._db.commit()
+
+    async def is_do_not_mock(self, user_id: int) -> bool:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT do_not_mock FROM user_flags WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+            return bool(row[0]) if row else False
+
+
+db_manager = DBManager()
+
+
+async def init_db() -> None:
+    await db_manager.init_db()
+
+
+async def log_interaction(user_id: int, target_id: int) -> None:
+    await db_manager.log_interaction(user_id, target_id)
 
 
 async def recall_user(user_id: int):
-    """Retrieve memories for a given user."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        async with db.execute("SELECT topic, memory FROM memories WHERE user_id = ?", (str(user_id),)) as cur:
-            return await cur.fetchall()
+    return await db_manager.recall_user(user_id)
 
 
 async def store_memory(
@@ -125,14 +277,7 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    """Persist a memory snippet."""
-
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            "INSERT INTO memories (user_id, topic, memory, sentiment_score) VALUES (?, ?, ?, ?)",
-            (str(user_id), topic, memory, sentiment_score),
-        )
-        await db.commit()
+    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
 
 
 async def send_to_prism(data: dict) -> None:
@@ -145,29 +290,11 @@ async def send_to_prism(data: dict) -> None:
 
 
 async def store_theory(subject_id: int, theory: str, confidence: float) -> None:
-    """Persist an inferred theory about a user."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            """
-            INSERT INTO theories (subject_id, theory, confidence)
-            VALUES (?, ?, ?)
-            ON CONFLICT(subject_id, theory) DO UPDATE SET
-                confidence=excluded.confidence,
-                updated=CURRENT_TIMESTAMP
-            """,
-            (str(subject_id), theory, confidence),
-        )
-        await db.commit()
+    return await db_manager.store_theory(subject_id, theory, confidence)
 
 
 async def get_theories(subject_id: int):
-    """Retrieve stored theories about a subject."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        async with db.execute(
-            "SELECT theory, confidence FROM theories WHERE subject_id=?",
-            (str(subject_id),),
-        ) as cur:
-            return await cur.fetchall()
+    return await db_manager.get_theories(subject_id)
 
 
 async def update_sentiment_trend(
@@ -175,65 +302,23 @@ async def update_sentiment_trend(
     channel_id: int,
     sentiment_score: float,
 ) -> None:
-    """Update cumulative sentiment metrics for a user and channel."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            """
-            INSERT INTO sentiment_trends (user_id, channel_id, sentiment_sum, message_count)
-            VALUES (?, ?, ?, 1)
-            ON CONFLICT(user_id, channel_id) DO UPDATE SET
-                sentiment_sum=sentiment_trends.sentiment_sum + excluded.sentiment_sum,
-                message_count=sentiment_trends.message_count + 1
-            """,
-            (str(user_id), str(channel_id), sentiment_score),
-        )
-        await db.commit()
+    await db_manager.update_sentiment_trend(user_id, channel_id, sentiment_score)
 
 
 async def get_sentiment_trend(user_id: int, channel_id: int):
-    """Retrieve cumulative sentiment statistics."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        async with db.execute(
-            "SELECT sentiment_sum, message_count FROM sentiment_trends WHERE user_id=? AND channel_id=?",
-            (str(user_id), str(channel_id)),
-        ) as cur:
-            return await cur.fetchone()
+    return await db_manager.get_sentiment_trend(user_id, channel_id)
 
 
 async def queue_deep_reflection(user_id: int, context: dict, prompt: str) -> int:
-    """Add a deep reflection task to the queue."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        cur = await db.execute(
-            "INSERT INTO queued_tasks (user_id, context, prompt) VALUES (?, ?, ?)",
-            (str(user_id), json.dumps(context), prompt),
-        )
-        await db.commit()
-        return cur.lastrowid
+    return await db_manager.queue_deep_reflection(user_id, context, prompt)
 
 
 async def set_do_not_mock(user_id: int, flag: bool = True) -> None:
-    """Set or unset the do_not_mock flag for a user."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        await db.execute(
-            """
-            INSERT INTO user_flags (user_id, do_not_mock)
-            VALUES (?, ?)
-            ON CONFLICT(user_id) DO UPDATE SET do_not_mock=excluded.do_not_mock
-            """,
-            (str(user_id), int(flag)),
-        )
-        await db.commit()
+    await db_manager.set_do_not_mock(user_id, flag)
 
 
 async def is_do_not_mock(user_id: int) -> bool:
-    """Return True if the user is protected from mock replies."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        async with db.execute(
-            "SELECT do_not_mock FROM user_flags WHERE user_id=?",
-            (str(user_id),),
-        ) as cur:
-            row = await cur.fetchone()
-            return bool(row[0]) if row else False
+    return await db_manager.is_do_not_mock(user_id)
 
 
 def generate_reflection(prompt: str) -> str:
@@ -253,36 +338,28 @@ async def process_deep_reflections(bot: discord.Client) -> None:
     """Background task to process queued reflections."""
     await bot.wait_until_ready()
     while not bot.is_closed():
-        async with aiosqlite.connect(DB_PATH) as db:
-            async with db.execute(
-                "SELECT task_id, user_id, context, prompt FROM queued_tasks WHERE status='pending'"
-            ) as cur:
-                rows = await cur.fetchall()
-            if not rows:
-                logger.debug("No queued reflections to process")
-            for task_id, user_id, ctx_json, prompt in rows:
-                context = json.loads(ctx_json)
-                channel = bot.get_channel(int(context.get("channel_id")))
-                msg_id = context.get("message_id")
-                ref = None
-                if channel and msg_id:
-                    try:
-                        ref = await channel.fetch_message(int(msg_id))
-                    except Exception:
-                        ref = None
-                if channel:
-                    await asyncio.sleep(2)
-                    reflection = generate_reflection(prompt)
-                    logger.info(f"Posting deep reflection for task {task_id}")
-                    await channel.send(
-                        f"After some thought... {reflection}",
-                        reference=ref,
-                    )
-                await db.execute(
-                    "UPDATE queued_tasks SET status='done' WHERE task_id=?",
-                    (task_id,),
+        rows = await db_manager.list_pending_tasks()
+        if not rows:
+            logger.debug("No queued reflections to process")
+        for task_id, user_id, ctx_json, prompt in rows:
+            context = json.loads(ctx_json)
+            channel = bot.get_channel(int(context.get("channel_id")))
+            msg_id = context.get("message_id")
+            ref = None
+            if channel and msg_id:
+                try:
+                    ref = await channel.fetch_message(int(msg_id))
+                except Exception:
+                    ref = None
+            if channel:
+                await asyncio.sleep(2)
+                reflection = generate_reflection(prompt)
+                logger.info(f"Posting deep reflection for task {task_id}")
+                await channel.send(
+                    f"After some thought... {reflection}",
+                    reference=ref,
                 )
-            await db.commit()
+            await db_manager.mark_task_done(task_id)
         await asyncio.sleep(REFLECTION_CHECK_SECONDS)
 
 
@@ -348,6 +425,7 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
 
     async def setup_hook(self) -> None:
+        await db_manager.connect()
         await init_db()
         self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
         self.loop.create_task(process_deep_reflections(self))

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -45,7 +45,8 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     async def noop(*args, **kwargs):
@@ -75,11 +76,13 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch):
     await bot.on_message(message)
 
     assert "Oh, how original." in message.channel.sent_messages
+    await sg.db_manager.close()
 
 
 @pytest.mark.asyncio
 async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     async def noop(*args, **kwargs):
@@ -109,3 +112,4 @@ async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch):
     await bot.on_message(message)
 
     assert "Oh, how original." not in message.channel.sent_messages
+    await sg.db_manager.close()

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -46,7 +46,8 @@ class DummyMessage:
 
 @pytest.mark.asyncio
 async def test_on_message_stores_memory(tmp_path, monkeypatch):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     async def noop(*args, **kwargs):
@@ -67,7 +68,7 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch):
     message = DummyMessage("hello world")
     await bot.on_message(message)
 
-    async with aiosqlite.connect(sg.DB_PATH) as db:
+    async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
         async with db.execute(
             "SELECT memory, sentiment_score FROM memories WHERE user_id=?",
             (str(message.author.id),),
@@ -79,11 +80,13 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch):
     stored_memory, score = rows[0]
     assert stored_memory == message.content
     assert isinstance(score, float)
+    await sg.db_manager.close()
 
 
 @pytest.mark.asyncio
 async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     async def noop(*args, **kwargs):
@@ -105,11 +108,13 @@ async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls
 
     assert len(prism_calls) == 1
     assert prism_calls[0]["content"] == "send prism"
+    await sg.db_manager.close()
 
 
 @pytest.mark.asyncio
 async def test_update_sentiment_trend(tmp_path):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     await sg.update_sentiment_trend("u1", "c1", 0.2)
@@ -117,12 +122,14 @@ async def test_update_sentiment_trend(tmp_path):
 
     row = await sg.get_sentiment_trend("u1", "c1")
     assert row == (0.1, 2)
+    await sg.db_manager.close()
 
 
 @pytest.mark.asyncio
 async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
 
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
     async def noop(*args, **kwargs):
@@ -147,3 +154,4 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
     trend = await sg.get_sentiment_trend(message.author.id, message.channel.id)
     expected = sg.TextBlob(message.content).sentiment.polarity
     assert trend == (expected, 1)
+    await sg.db_manager.close()

--- a/tests/test_user_flags.py
+++ b/tests/test_user_flags.py
@@ -6,10 +6,11 @@ import examples.social_graph_bot as sg
 
 @pytest.mark.asyncio
 async def test_user_flags_table_and_functions(tmp_path):
-    sg.DB_PATH = str(tmp_path / "sg.db")
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
     await sg.init_db()
 
-    async with aiosqlite.connect(sg.DB_PATH) as db:
+    async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
         async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='user_flags'") as cur:
             row = await cur.fetchone()
     assert row is not None, "user_flags table should exist"
@@ -20,3 +21,4 @@ async def test_user_flags_table_and_functions(tmp_path):
     await sg.set_do_not_mock("u1", False)
     assert await sg.is_do_not_mock("u1") is False
     assert await sg.is_do_not_mock("u2") is False
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- centralize DB access in `DBManager` with a single `aiosqlite` connection
- adapt `process_deep_reflections` and other helpers to use `DBManager`
- update SocialGraphBot setup to initialize the manager
- adjust tests to create and close `DBManager` instances
- add helpers for listing and marking pending reflection tasks

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685226468170832690c9ac3c8043abc6