### PR TITLE
Add bot chat monitoring

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -22,6 +22,10 @@ IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
 REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
 SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
 
+# Optional bot-to-bot chatter configuration
+# Accepts values like "true", "1", or "yes" (case-insensitive)
+BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {"true", "1", "yes"}
+
 # Candidate prompts used when the bot speaks after a period of silence
 idle_response_candidates = [
     "Ever feel like everyone vanished?",
@@ -309,6 +313,14 @@ async def who_is_active(channel: discord.TextChannel, limit: int = 20):
     return bots, humans
 
 
+async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
+    """Return minutes since the most recent human message or ``None`` if none."""
+    async for msg in channel.history(limit=limit):
+        if not msg.author.bot:
+            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+    return None
+
+
 async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
     """Monitor a channel and occasionally speak during idle periods."""
     await bot.wait_until_ready()
@@ -319,19 +331,32 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
             last_message = msg
             break
 
+        respond_to = None
+        send_prompt = False
         if not last_message:
-            prompt = random.choice(idle_response_candidates)
-            async with channel.typing():
-                await asyncio.sleep(random.uniform(3, 10))
-                await channel.send(prompt)
+            send_prompt = True
         else:
             idle_minutes = (
                 discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
             ).total_seconds() / 60
             if idle_minutes >= IDLE_TIMEOUT_MINUTES:
-                prompt = random.choice(idle_response_candidates)
-                async with channel.typing():
-                    await asyncio.sleep(random.uniform(3, 10))
+                send_prompt = True
+            elif BOT_CHAT_ENABLED:
+                bots, humans = await who_is_active(channel)
+                if bots and not humans:
+                    age = await last_human_message_age(channel)
+                    if age is None or age >= IDLE_TIMEOUT_MINUTES:
+                        send_prompt = True
+                        if last_message.author.bot:
+                            respond_to = last_message
+
+        if send_prompt:
+            prompt = random.choice(idle_response_candidates)
+            async with channel.typing():
+                await asyncio.sleep(random.uniform(3, 10))
+                if respond_to is not None:
+                    await channel.send(prompt, reference=respond_to)
+                else:
                     await channel.send(prompt)
         await asyncio.sleep(60)
 

--- a/tests/test_monitor_channels.py
+++ b/tests/test_monitor_channels.py
@@ -17,7 +17,7 @@ class DummyChannel:
 
         return _gen()
 
-    async def send(self, content):
+    async def send(self, content, *, reference=None, **kwargs):
         self.sent_messages.append(content)
 
     def typing(self):
@@ -55,6 +55,55 @@ async def test_monitor_channels_idle_prompt(monkeypatch):
     bot = DummyBot(channel)
 
     monkeypatch.setattr(sg, "idle_response_candidates", ["ping"])  # deterministic prompt
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    await sg.monitor_channels(bot, 1)
+
+    assert channel.sent_messages == ["ping"]
+
+
+@pytest.mark.asyncio
+async def test_monitor_channels_only_bots(monkeypatch):
+    """Prompt when only bots have chatted for a while."""
+    channel = DummyChannel()
+    bot = DummyBot(channel)
+
+    from datetime import timedelta
+    from types import SimpleNamespace
+
+    from discord.utils import utcnow
+
+    class DummyMessage:
+        def __init__(self, created_at, is_bot=True):
+            self.created_at = created_at
+            self.author = SimpleNamespace(bot=is_bot)
+
+    messages = [
+        DummyMessage(utcnow() - timedelta(minutes=1), True),
+        DummyMessage(utcnow() - timedelta(minutes=sg.IDLE_TIMEOUT_MINUTES + 1), False),
+    ]
+
+    def history_gen(limit=1):
+        async def _gen():
+            for msg in messages[:limit]:
+                yield msg
+
+        return _gen()
+
+    channel.history = history_gen
+
+    f = asyncio.Future()
+    f.set_result(({1}, set()))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel, limit=20: f)
+
+    monkeypatch.setattr(sg, "BOT_CHAT_ENABLED", True)
+    monkeypatch.setattr(sg, "idle_response_candidates", ["ping"])  # deterministic
 
     async def fake_sleep(*args, **kwargs):
         return None


### PR DESCRIPTION
## Summary
- detect when only bots are active and respond if enabled
- add `BOT_CHAT_ENABLED` option
- update README with new channel monitoring logic
- cover idle bot chat scenario in unit tests
- refine bot chat configuration and tests

## Testing
- `pre-commit run --files README.md examples/social_graph_bot.py tests/test_monitor_channels.py`
- `pytest tests/test_monitor_channels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6852264e138883268d2abe77e6d92609