### PR TITLE
Improve reflection tests

### DIFF
--- a/tests/test_theories_queue.py
+++ b/tests/test_theories_queue.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import aiosqlite
 import pytest
 
@@ -71,3 +73,91 @@ def test_evaluate_triggers():
     assert ("social chameleon", 0.6) in sg.evaluate_triggers(m1)
     m2 = Dummy("hello", 2)
     assert ("insomniac", 0.7) in sg.evaluate_triggers(m2)
+
+
+def test_generate_reflection_positive_negative():
+    pos = sg.generate_reflection("I love this!")
+    neg = sg.generate_reflection("I hate this!")
+    assert pos == "Your message felt positive."
+    assert neg == "Your message felt negative."
+
+
+def test_generate_reflection_neutral():
+    neutral = sg.generate_reflection("Meh")
+    assert neutral == "Your message felt neutral."
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    async def fetch_message(self, message_id):
+        return None
+
+
+class DummyBot:
+    def __init__(self):
+        self.channel = DummyChannel()
+        self.closed = False
+
+    async def wait_until_ready(self):
+        return None
+
+    def is_closed(self):
+        was_closed = self.closed
+        self.closed = True
+        return was_closed
+
+    def get_channel(self, channel_id):
+        return self.channel if channel_id == 1 else None
+
+
+@pytest.mark.asyncio
+async def test_process_deep_reflections_posts(tmp_path, monkeypatch):
+    sg.DB_PATH = str(tmp_path / "db.sqlite")
+    await sg.init_db()
+
+    bot = DummyBot()
+
+    await sg.queue_deep_reflection("u1", {"channel_id": 1, "message_id": 1}, "I love bots")
+
+    async def noop(*_, **__):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(sg, "REFLECTION_CHECK_SECONDS", 0)
+
+    await sg.process_deep_reflections(bot)
+
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute("SELECT status FROM queued_tasks WHERE task_id=1") as cur:
+            row = await cur.fetchone()
+    assert row[0] == "done"
+    assert bot.channel.sent_messages == ["After some thought... Your message felt positive."]
+
+
+@pytest.mark.asyncio
+async def test_process_deep_reflections_negative(tmp_path, monkeypatch):
+    sg.DB_PATH = str(tmp_path / "db.sqlite")
+    await sg.init_db()
+
+    bot = DummyBot()
+
+    await sg.queue_deep_reflection("u1", {"channel_id": 1, "message_id": 1}, "I hate bots")
+
+    async def noop(*_, **__):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(sg, "REFLECTION_CHECK_SECONDS", 0)
+
+    await sg.process_deep_reflections(bot)
+
+    async with aiosqlite.connect(sg.DB_PATH) as db:
+        async with db.execute("SELECT status FROM queued_tasks WHERE task_id=1") as cur:
+            row = await cur.fetchone()
+    assert row[0] == "done"
+    assert bot.channel.sent_messages == ["After some thought... Your message felt negative."]


### PR DESCRIPTION
## Summary
- add neutral case test for `generate_reflection`
- add negative case for processing queued reflections

## Testing
- `pre-commit run --files tests/test_theories_queue.py`
- `pytest -q tests/test_theories_queue.py`


------
https://chatgpt.com/codex/tasks/task_e_6852b9b3aaf48326a12661f38b232279