### PR TITLE
Fix DB manager setup in theories queue tests

### DIFF
--- a/tests/test_theories_queue.py
+++ b/tests/test_theories_queue.py
@@ -126,6 +126,7 @@ class DummyBot:
 @pytest.mark.asyncio
 async def test_process_deep_reflections_posts(tmp_path, monkeypatch):
     sg.DB_PATH = str(tmp_path / "db.sqlite")
+    sg.db_manager = sg.DBManager(str(tmp_path / "db.sqlite"))
     await sg.init_db()
 
     bot = DummyBot()
@@ -150,6 +151,7 @@ async def test_process_deep_reflections_posts(tmp_path, monkeypatch):
 @pytest.mark.asyncio
 async def test_process_deep_reflections_negative(tmp_path, monkeypatch):
     sg.DB_PATH = str(tmp_path / "db.sqlite")
+    sg.db_manager = sg.DBManager(str(tmp_path / "db.sqlite"))
     await sg.init_db()
 
     bot = DummyBot()


### PR DESCRIPTION
## Summary
- use `sg.DBManager` for deep reflection tests to keep the DB isolated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1f3b25c832696179d0258826afc