### PR TITLE
Add docs for self-hosted runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ the test suite whenever code changes are detected. Detection is handled by
 [`scripts/check_code_changes.py`](scripts/check_code_changes.py), which
 inspects diffs and skips CI when only documentation or comments change.
 The workflow installs its dependencies from `requirements-ci.txt`.
+If you would like to run the workflow on your own machine, see
+[docs/ci.md](docs/ci.md) for instructions on registering a self-hosted runner.
 
 You can run the same check locally:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,22 @@
+# Continuous Integration
+
+This project uses GitHub Actions for its CI workflow. By default, jobs run on GitHub-hosted runners. If you want to use your own machine, you can register a self-hosted runner and update the workflow accordingly.
+
+## Registering a Self-Hosted Runner
+
+1. Open your repository on GitHub and go to **Settings** > **Actions** > **Runners**.
+2. Click **New self-hosted runner** and choose the operating system and architecture of your machine.
+3. Download the runner package and extract it on the host you want to use.
+4. From the runner directory, run:
+   ```bash
+   ./config.sh --url https://github.com/<OWNER>/<REPO> --token <TOKEN>
+   ```
+   Replace `<OWNER>` and `<REPO>` with your repository information. The token is generated on the GitHub page and is time limited.
+5. Start the runner with `./run.sh` or install it as a service using `./svc.sh install` followed by `./svc.sh start`.
+
+Once the runner is online, you can change `.github/workflows/ci.yml` to target it by setting the job's `runs-on` value to:
+
+```yaml
+runs-on: ["self-hosted", "linux"]
+```
+


### PR DESCRIPTION
## Summary
- document how to register a self-hosted runner in `docs/ci.md`
- link to the new guide from the README

## Testing
- `pre-commit` *(skipped: documentation only)*
- `pytest` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_6852d1f6724c83268dc281c008246e37