### PR TITLE
Adjust CI triggers for code only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,22 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'examples/**'
+      - '**/*.py'
+      - '**/*.cs'
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - 'examples/**'
+      - '**/*.py'
+      - '**/*.cs'
 
 jobs:
   detect_changes:

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -263,10 +263,24 @@ class DBManager:
             return bool(row[0]) if row else False
 
 
+DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
+LAST_INIT_PATH = DB_PATH
 
 
 async def init_db() -> None:
+    """Initialize the database, respecting any updated ``DB_PATH`` value."""
+    global db_manager, DB_PATH, LAST_INIT_PATH
+    if DB_PATH != LAST_INIT_PATH:
+        # ``DB_PATH`` was updated since the last init call
+        if db_manager.db_path != DB_PATH:
+            await db_manager.close()
+            db_manager = DBManager(DB_PATH)
+        LAST_INIT_PATH = DB_PATH
+    elif db_manager.db_path != DB_PATH:
+        # ``db_manager`` was replaced without updating ``DB_PATH``
+        DB_PATH = db_manager.db_path
+        LAST_INIT_PATH = DB_PATH
     await db_manager.init_db()
 
 


### PR DESCRIPTION
## Summary
- run CI only on code changes via path filters
- maintain DB path during test setup

## Testing
- `pre-commit run --files .github/workflows/ci.yml examples/social_graph_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1e378bc8326ac081f60206fb648