### PR TITLE
Add concurrency to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [main]
 
+# limit to one concurrent run per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect_changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+# limit to one concurrent run per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- keep only one workflow run per branch by adding concurrency groups
- remove unintended DB path changes from `examples/social_graph_bot.py`

## Testing
- `pre-commit run --files examples/social_graph_bot.py .github/workflows/ci.yml .github/workflows/release.yml`
- `pytest tests/test_theories_queue.py::test_process_deep_reflections_posts -q` *(fails: no such table `queued_tasks`)*

------
https://chatgpt.com/codex/tasks/task_e_6852d1d9f2d083268248213edc00b7b5