### PR TITLE
Add concurrency to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [main]
 
+# limit to one concurrent run per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   detect_changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+# limit to one concurrent run per branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -14,7 +14,9 @@ from textblob import TextBlob
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
-DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+DEFAULT_DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+# Current database path used by ``db_manager``. Tests may override this.
+DB_PATH = DEFAULT_DB_PATH
 
 # Endpoint for forwarding collected data
 PRISM_ENDPOINT = os.getenv("PRISM_ENDPOINT", "http://localhost:5000/receive_data")
@@ -264,9 +266,19 @@ class DBManager:
 
 
 db_manager = DBManager()
+_manager_id = id(db_manager)
 
 
 async def init_db() -> None:
+    global db_manager, DB_PATH, _manager_id
+    if id(db_manager) != _manager_id:
+        _manager_id = id(db_manager)
+        DB_PATH = db_manager.db_path
+    elif db_manager.db_path != DB_PATH:
+        await db_manager.close()
+        db_manager = DBManager(DB_PATH)
+        _manager_id = id(db_manager)
+    DB_PATH = db_manager.db_path
     await db_manager.init_db()
 
 


### PR DESCRIPTION
## Summary
- keep only one workflow run per branch by adding concurrency groups
- restore expected DB path switching in `examples/social_graph_bot.py`

## Testing
- `pre-commit run --files examples/social_graph_bot.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d1d9f2d083268248213edc00b7b5