### PR TITLE
Refine GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
       - '**/*.py'
       - '**/*.cs'
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'src/**'
       - 'tests/**'
@@ -18,21 +18,6 @@ on:
       - 'examples/**'
       - '**/*.py'
       - '**/*.cs'
-
-# limit to one concurrent run per branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-# limit to one concurrent run per branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
-# limit to one concurrent run per branch
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 # limit to one concurrent run per branch
 concurrency:
@@ -62,7 +47,7 @@ jobs:
   lint_and_test:
     needs: detect_changes
     if: needs.detect_changes.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "linux"]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted", "linux"]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -318,9 +318,11 @@ The project includes a GitHub Actions workflow that runs `flake8` and
 the test suite whenever code changes are detected. Detection is handled by
 [`scripts/check_code_changes.py`](scripts/check_code_changes.py), which
 inspects diffs and skips CI when only documentation or comments change.
-The workflow installs its dependencies from `requirements-ci.txt`.
-If you would like to run the workflow on your own machine, see
-[docs/ci.md](docs/ci.md) for instructions on registering a self-hosted runner.
+The workflow installs its dependencies from `requirements-ci.txt` and
+only triggers for changes on the `main` and `develop` branches. Each run
+is isolated with a concurrency group so outdated jobs are cancelled
+automatically. If you would like to run the workflow on your own machine,
+see [docs/ci.md](docs/ci.md) for instructions on registering a self-hosted runner.
 
 You can run the same check locally:
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,6 +1,10 @@
 # Continuous Integration
 
-This project uses GitHub Actions for its CI workflow. By default, jobs run on GitHub-hosted runners. If you want to use your own machine, you can register a self-hosted runner and update the workflow accordingly.
+This project uses GitHub Actions for its CI workflow. Jobs run on a self-hosted
+runner for heavy tasks like linting and tests. Lightweight checks still use
+GitHub-hosted runners. Workflows are limited to the `main` and `develop`
+branches and old runs are cancelled automatically via GitHub's concurrency
+feature.
 
 ## Registering a Self-Hosted Runner
 


### PR DESCRIPTION
## Summary
- run CI on `main` and `develop` branches only
- keep one concurrency block
- run heavy jobs on a self-hosted Linux runner
- document updated CI strategy

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/release.yml README.md docs/ci.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685321e0e2ac8326abbb7d875fa3c34d