### PR TITLE
Wrap check_code_changes logic in main

### DIFF
--- a/scripts/check_code_changes.py
+++ b/scripts/check_code_changes.py
@@ -11,72 +11,77 @@ import subprocess
 import sys
 from pathlib import Path
 
-# Determine the files changed compared to the base commit.
-BASE_REF = os.environ.get("GITHUB_BASE_REF")
-GITHUB_SHA = os.environ.get("GITHUB_SHA")
-BASE_SHA = None
 
-if BASE_REF and GITHUB_SHA:
-    try:
-        base_sha_result = subprocess.run(
-            ["git", "merge-base", f"origin/{BASE_REF}", GITHUB_SHA],
-            stdout=subprocess.PIPE,
-            check=True,
-        )
-        BASE_SHA = base_sha_result.stdout.decode().strip()
-    except subprocess.CalledProcessError:
-        BASE_SHA = None
+def main() -> None:
+    """Entry point for the code change checker."""
 
-if BASE_SHA:
-    diff_args = ["git", "diff", "--name-only", BASE_SHA, GITHUB_SHA]
-else:
-    diff_args = ["git", "diff", "--name-only", "HEAD^"]
+    # Determine the files changed compared to the base commit.
+    BASE_REF = os.environ.get("GITHUB_BASE_REF")
+    GITHUB_SHA = os.environ.get("GITHUB_SHA")
+    BASE_SHA = None
 
-result = subprocess.run(diff_args, stdout=subprocess.PIPE, check=True)
+    if BASE_REF and GITHUB_SHA:
+        try:
+            base_sha_result = subprocess.run(
+                ["git", "merge-base", f"origin/{BASE_REF}", GITHUB_SHA],
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            BASE_SHA = base_sha_result.stdout.decode().strip()
+        except subprocess.CalledProcessError:
+            BASE_SHA = None
 
-changed_files = [f for f in result.stdout.decode().splitlines() if f]
+    if BASE_SHA:
+        diff_args = ["git", "diff", "--name-only", BASE_SHA, GITHUB_SHA]
+    else:
+        diff_args = ["git", "diff", "--name-only", "HEAD^"]
 
-# Common documentation file extensions to ignore
-doc_extensions = {".md", ".markdown", ".mdown", ".rst", ".txt"}
+    result = subprocess.run(diff_args, stdout=subprocess.PIPE, check=True)
 
-# Helper to determine if a file is documentation
+    changed_files = [f for f in result.stdout.decode().splitlines() if f]
+
+    # Common documentation file extensions to ignore
+    doc_extensions = {".md", ".markdown", ".mdown", ".rst", ".txt"}
+
+    # Helper to determine if a file is documentation
+    def is_doc_file(path: str) -> bool:
+        """Return True if the path looks like documentation."""
+        p = Path(path)
+        suffix = p.suffix.lower()
+        return suffix in doc_extensions or path.startswith("docs/")
+
+    # If all changed files are docs, tests are unnecessary
+    if changed_files and all(is_doc_file(f) for f in changed_files):
+        print("false")
+        sys.exit(0)
+
+    # Inspect the diff to see if code lines changed (ignoring comments and blank lines)
+    if BASE_SHA:
+        diff_code_args = ["git", "diff", "--unified=0", BASE_SHA, GITHUB_SHA]
+    else:
+        diff_code_args = ["git", "diff", "--unified=0", "HEAD^"]
+
+    result = subprocess.run(diff_code_args, stdout=subprocess.PIPE, check=True)
+
+    diff_lines = result.stdout.decode().splitlines()
+    comment_prefixes = ("#", "//", "/*", "*", '"""', "'''")
+    code_changed = False
+    for line in diff_lines:
+        if not line.startswith(("+", "-")):
+            continue
+        # Ignore diff metadata markers
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        content = line[1:].strip()
+        if not content:
+            continue
+        if any(content.startswith(prefix) for prefix in comment_prefixes):
+            continue
+        code_changed = True
+        break
+
+    print("true" if code_changed else "false")
 
 
-def is_doc_file(path: str) -> bool:
-    """Return True if the path looks like documentation."""
-    p = Path(path)
-    suffix = p.suffix.lower()
-    return suffix in doc_extensions or path.startswith("docs/")
-
-
-# If all changed files are docs, tests are unnecessary
-if changed_files and all(is_doc_file(f) for f in changed_files):
-    print("false")
-    sys.exit(0)
-
-# Inspect the diff to see if code lines changed (ignoring comments and blank lines)
-if BASE_SHA:
-    diff_code_args = ["git", "diff", "--unified=0", BASE_SHA, GITHUB_SHA]
-else:
-    diff_code_args = ["git", "diff", "--unified=0", "HEAD^"]
-
-result = subprocess.run(diff_code_args, stdout=subprocess.PIPE, check=True)
-
-diff_lines = result.stdout.decode().splitlines()
-comment_prefixes = ("#", "//", "/*", "*", '"""', "'''")
-code_changed = False
-for line in diff_lines:
-    if not line.startswith(("+", "-")):
-        continue
-    # Ignore diff metadata markers
-    if line.startswith("+++") or line.startswith("---"):
-        continue
-    content = line[1:].strip()
-    if not content:
-        continue
-    if any(content.startswith(prefix) for prefix in comment_prefixes):
-        continue
-    code_changed = True
-    break
-
-print("true" if code_changed else "false")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restructure scripts/check_code_changes.py into a `main()` function
- keep shebang and execute `main()` when run as a script

## Testing
- `flake8 src tests scripts/check_code_changes.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68533438cf1883268098e5d9461b6bd0