### PR TITLE
Remove write permission from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 # limit to one concurrent run per branch
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 # limit to one concurrent run per branch
 concurrency:


### PR DESCRIPTION
## Summary
- remove `actions: write` from workflow permissions

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/release.yml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68533f58b4608326823ff540b8712041