### PR TITLE
Add default config class and adjust tests

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -1,1 +1,34 @@
-# Configuration module for DeepThought reThought
+"""Default configuration for the DeepThought reThought project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+import os
+
+
+@dataclass
+class DeepThoughtConfig:
+    """Configuration values for connecting to NATS and JetStream."""
+
+    #: URL of the NATS server used for tests and local development
+    nats_url: str = "nats://localhost:4222"
+
+    #: Default JetStream stream name for DeepThought events
+    stream_name: str = "deepthought_events"
+
+    def as_dict(self) -> dict[str, str]:
+        """Return the configuration as a dictionary."""
+        return asdict(self)
+
+
+def load_config_from_env() -> DeepThoughtConfig:
+    """Load configuration values, falling back to defaults."""
+
+    return DeepThoughtConfig(
+        nats_url=os.getenv("NATS_URL", DeepThoughtConfig.nats_url),
+        stream_name=os.getenv("STREAM_NAME", DeepThoughtConfig.stream_name),
+    )
+
+
+#: The configuration instance used by the library and tests
+DEFAULT_CONFIG: DeepThoughtConfig = load_config_from_env()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,19 +1,32 @@
 # tests/test_basic.py
 import pytest
 
+
 def test_example_basic_assertion():
     """A basic test that always passes, confirming test setup works."""
     assert True, "This basic assertion should always pass."
 
+
 # Example of importing a module
 try:
-    from src.deepthought import config # Assuming a config.py exists in src/deepthought
+    from src.deepthought import config  # Assuming a config.py exists in src/deepthought
 except ImportError:
-    config = None # Handle if module cannot be imported
+    config = None  # Handle if module cannot be imported
+
 
 def test_import_config():
     """Tests if a core configuration module can be imported."""
     # This test would fail if 'from src.deepthought import config' fails
     # Pytest typically handles PYTHONPATH for 'src' if 'src' is at the project root,
     # but try-except makes it robust.
-    assert config is not None, "Failed to import config module from src.deepthought. Check PYTHONPATH and src/deepthought/config.py."
+    assert (
+        config is not None
+    ), "Failed to import config module from src.deepthought. Check PYTHONPATH and src/deepthought/config.py."
+    assert hasattr(
+        config, "DEFAULT_CONFIG"
+    ), "config module should expose DEFAULT_CONFIG"
+    cfg = config.DEFAULT_CONFIG
+    assert cfg.nats_url.startswith(
+        "nats://"
+    ), "DEFAULT_CONFIG should provide a NATS URL"
+    assert cfg.stream_name, "DEFAULT_CONFIG should define a stream name"

--- a/tests/test_basic_nats.py
+++ b/tests/test_basic_nats.py
@@ -3,13 +3,17 @@ import nats
 import pytest
 import logging
 import uuid
+from src.deepthought.config import DEFAULT_CONFIG
 
 # Basic logging for the test
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 TEST_SUBJECT = f"test.basic_communication.{uuid.uuid4()}"
 TEST_PAYLOAD = b"ping"
+
 
 @pytest.mark.asyncio
 async def test_nats_basic_pub_sub():
@@ -29,20 +33,20 @@ async def test_nats_basic_pub_sub():
     try:
         # Connect Publisher Client
         logger.info("Connecting publisher client...")
-        nc_pub = await nats.connect("nats://localhost:4222", name="pytest_basic_pub")
+        nc_pub = await nats.connect(DEFAULT_CONFIG.nats_url, name="pytest_basic_pub")
         assert nc_pub.is_connected
         logger.info("Publisher client connected.")
 
         # Connect Subscriber Client
         logger.info("Connecting subscriber client...")
-        nc_sub = await nats.connect("nats://localhost:4222", name="pytest_basic_sub")
+        nc_sub = await nats.connect(DEFAULT_CONFIG.nats_url, name="pytest_basic_sub")
         assert nc_sub.is_connected
         logger.info("Subscriber client connected.")
 
         # Subscribe
         logger.info(f"Subscribing to subject: {TEST_SUBJECT}")
         sub = await nc_sub.subscribe(TEST_SUBJECT, cb=message_handler)
-        await asyncio.sleep(0.1) # Allow subscription to register
+        await asyncio.sleep(0.1)  # Allow subscription to register
 
         # Publish
         logger.info(f"Publishing message to subject: {TEST_SUBJECT}")
@@ -55,7 +59,9 @@ async def test_nats_basic_pub_sub():
 
         # Assertions
         assert received_message is not None, "Did not receive any message"
-        assert received_message == TEST_PAYLOAD, f"Received payload '{received_message.decode()}' does not match expected '{TEST_PAYLOAD.decode()}'"
+        assert (
+            received_message == TEST_PAYLOAD
+        ), f"Received payload '{received_message.decode()}' does not match expected '{TEST_PAYLOAD.decode()}'"
         logger.info("Message received and verified successfully.")
 
     except asyncio.TimeoutError:
@@ -78,4 +84,4 @@ async def test_nats_basic_pub_sub():
             logger.info("Publisher client closed.")
         if nc_sub and nc_sub.is_connected:
             await nc_sub.close()
-            logger.info("Subscriber client closed.") 
+            logger.info("Subscriber client closed.")

--- a/tests/test_eda_flow.py
+++ b/tests/test_eda_flow.py
@@ -8,26 +8,39 @@ import logging
 import os
 import pytest
 import pytest_asyncio
+from src.deepthought.config import DEFAULT_CONFIG
 from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrTimeout
 from nats.js import JetStreamContext
-from nats.js.api import StreamConfig, ConsumerConfig, AckPolicy, DeliverPolicy, RetentionPolicy, StorageType, DiscardPolicy
+from nats.js.api import (
+    StreamConfig,
+    ConsumerConfig,
+    AckPolicy,
+    DeliverPolicy,
+    RetentionPolicy,
+    StorageType,
+    DiscardPolicy,
+)
 from nats.js.errors import Error
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 # Define subjects and stream name
-SUBJECT_PREFIX = "dtr.tasks" # Changed to align with 'dtr.>' stream
+SUBJECT_PREFIX = "dtr.tasks"  # Changed to align with 'dtr.>' stream
 SUBJECT_REQUEST_NEW_TASK = f"{SUBJECT_PREFIX}.request.new"
 SUBJECT_TASK_STATUS_UPDATE = f"{SUBJECT_PREFIX}.status.update"
 SUBJECT_GET_FINAL_RESULT = f"{SUBJECT_PREFIX}.result.get"
-STREAM_NAME = "deepthought_events"
+STREAM_NAME = DEFAULT_CONFIG.stream_name
+
 
 # Helper function to get NATS URL from environment variable
 def get_nats_url() -> str:
-    return os.getenv("NATS_URL", "nats://localhost:4222")
+    return os.getenv("NATS_URL", DEFAULT_CONFIG.nats_url)
+
 
 # NATS connection fixture
 @pytest_asyncio.fixture
@@ -37,17 +50,19 @@ async def nats_connection():
     This fixture only yields the NATS client, not the JetStream context.
     """
     nc = None
-    
+
     try:
         # Connect to NATS
         logger.info(f"Fixture: Connecting to NATS at {get_nats_url()}")
         nc = NATS()
-        await nc.connect(servers=[get_nats_url()], connect_timeout=30)  # Increased timeout
+        await nc.connect(
+            servers=[get_nats_url()], connect_timeout=30
+        )  # Increased timeout
         logger.info("Fixture: NATS connection successful")
-        
+
         # Yield only the NATS client
         yield nc
-        
+
     finally:
         # Close NATS connection
         if nc and nc.is_connected:
@@ -55,12 +70,14 @@ async def nats_connection():
             await nc.close()
             logger.info("Fixture: NATS connection closed")
 
+
 # Simple test to check that the fixture works
 @pytest.mark.asyncio
 async def test_nats_connection_fixture(nats_connection):
     """Test that the NATS connection fixture is working properly."""
     assert nats_connection.is_connected, "NATS connection should be connected"
     logger.info("NATS connection fixture test passed")
+
 
 # The test function using an ephemeral consumer
 @pytest.mark.asyncio
@@ -78,14 +95,17 @@ async def test_full_flow_direct_subscribe(nats_connection):
         if not nc.is_connected:
             pytest.fail("NATS connection is not connected")
         logger.info("NATS connection from fixture is connected.")
-        
+
         # --- Existing Test Logic START ---
         logger.info("Starting test_full_flow_direct_subscribe...")
 
         # Define payloads
         task_request_payload = {"task_id": "task123", "data": "Sample data"}
         status_update_payload = {"task_id": "task123", "status": "Processing"}
-        final_result_payload = {"task_id": "task123", "result": "Completed successfully"}
+        final_result_payload = {
+            "task_id": "task123",
+            "result": "Completed successfully",
+        }
 
         received_messages = []
         subscription_ready = asyncio.Event()
@@ -95,7 +115,9 @@ async def test_full_flow_direct_subscribe(nats_connection):
             nonlocal received_messages
             subject = msg.subject
             data = msg.data.decode()
-            logger.info(f"Ephemeral consumer received message on subject '{subject}': {data}")
+            logger.info(
+                f"Ephemeral consumer received message on subject '{subject}': {data}"
+            )
             received_messages.append((subject, data))
             await msg.ack()
             logger.info(f"Acknowledged message on subject '{subject}'.")
@@ -110,17 +132,21 @@ async def test_full_flow_direct_subscribe(nats_connection):
             if not js:
                 pytest.fail("Failed to get JetStream context inside test function.")
             logger.info("JetStream context obtained successfully inside test function.")
-            
+
             # Ensure stream exists
             try:
                 logger.info(f"Checking if stream '{STREAM_NAME}' exists...")
-                await asyncio.wait_for(js.stream_info(STREAM_NAME), timeout=60.0)  # Added explicit timeout
+                await asyncio.wait_for(
+                    js.stream_info(STREAM_NAME), timeout=60.0
+                )  # Added explicit timeout
                 logger.info(f"Stream '{STREAM_NAME}' already exists.")
             except asyncio.TimeoutError:
                 logger.error("Timeout while checking stream info")
                 pytest.fail("Timeout while checking stream info")
             except Exception as e:
-                logger.info(f"Stream '{STREAM_NAME}' does not exist, creating it... ({e})")
+                logger.info(
+                    f"Stream '{STREAM_NAME}' does not exist, creating it... ({e})"
+                )
                 stream_config = StreamConfig(
                     name=STREAM_NAME,
                     subjects=[f"{SUBJECT_PREFIX}.>"],
@@ -130,7 +156,9 @@ async def test_full_flow_direct_subscribe(nats_connection):
                     discard=DiscardPolicy.OLD,
                 )
                 try:
-                    await asyncio.wait_for(js.add_stream(stream_config), timeout=60.0)  # Added explicit timeout
+                    await asyncio.wait_for(
+                        js.add_stream(stream_config), timeout=60.0
+                    )  # Added explicit timeout
                     logger.info(f"Stream '{STREAM_NAME}' created successfully.")
                 except asyncio.TimeoutError:
                     logger.error("Timeout while creating stream")
@@ -138,8 +166,10 @@ async def test_full_flow_direct_subscribe(nats_connection):
                 except Exception as e:
                     logger.error(f"Failed to create stream: {e}")
                     pytest.fail(f"Failed to create stream: {e}")
-            
-            logger.info(f"Creating ephemeral push consumer by subscribing directly to '{SUBJECT_PREFIX}.>'...")
+
+            logger.info(
+                f"Creating ephemeral push consumer by subscribing directly to '{SUBJECT_PREFIX}.>'..."
+            )
             ephemeral_sub = await js.subscribe(
                 subject=f"{SUBJECT_PREFIX}.>",
                 durable=None,  # Ephemeral
@@ -147,76 +177,112 @@ async def test_full_flow_direct_subscribe(nats_connection):
                 stream=STREAM_NAME,  # Explicitly specify stream name
             )
             logger.info("Ephemeral consumer subscription successful.")
-            subscription_ready.set() # Signal that subscription is ready
-            
+            subscription_ready.set()  # Signal that subscription is ready
+
             # Wait briefly for subscription to be fully established
             await asyncio.sleep(1.0)  # Increased wait time
-            
+
             # Publish messages
             logger.info(f"Publishing task request to '{SUBJECT_REQUEST_NEW_TASK}'...")
-            await asyncio.wait_for(js.publish(SUBJECT_REQUEST_NEW_TASK, str(task_request_payload).encode()), timeout=30.0)  # Added explicit timeout
+            await asyncio.wait_for(
+                js.publish(
+                    SUBJECT_REQUEST_NEW_TASK, str(task_request_payload).encode()
+                ),
+                timeout=30.0,
+            )  # Added explicit timeout
             logger.info("Task request published.")
-            
+
             # Wait briefly between publishes
             await asyncio.sleep(0.5)
-            
-            logger.info(f"Publishing status update to '{SUBJECT_TASK_STATUS_UPDATE}'...")
-            await asyncio.wait_for(js.publish(SUBJECT_TASK_STATUS_UPDATE, str(status_update_payload).encode()), timeout=30.0)  # Added explicit timeout
+
+            logger.info(
+                f"Publishing status update to '{SUBJECT_TASK_STATUS_UPDATE}'..."
+            )
+            await asyncio.wait_for(
+                js.publish(
+                    SUBJECT_TASK_STATUS_UPDATE, str(status_update_payload).encode()
+                ),
+                timeout=30.0,
+            )  # Added explicit timeout
             logger.info("Status update published.")
-            
+
             # Wait briefly between publishes
             await asyncio.sleep(0.5)
-            
+
             logger.info(f"Publishing final result to '{SUBJECT_GET_FINAL_RESULT}'...")
-            await asyncio.wait_for(js.publish(SUBJECT_GET_FINAL_RESULT, str(final_result_payload).encode()), timeout=30.0)  # Added explicit timeout
+            await asyncio.wait_for(
+                js.publish(
+                    SUBJECT_GET_FINAL_RESULT, str(final_result_payload).encode()
+                ),
+                timeout=30.0,
+            )  # Added explicit timeout
             logger.info("Final result published.")
-            
+
             # Wait for all messages to be received by the handler
             try:
-                logger.info("Waiting for all messages to be received by ephemeral consumer...")
-                await asyncio.wait_for(all_messages_received.wait(), timeout=30.0)  # Increased timeout
+                logger.info(
+                    "Waiting for all messages to be received by ephemeral consumer..."
+                )
+                await asyncio.wait_for(
+                    all_messages_received.wait(), timeout=30.0
+                )  # Increased timeout
                 logger.info("All messages received.")
             except asyncio.TimeoutError:
-                logger.error(f"Timeout waiting for messages. Received {len(received_messages)} messages.")
-                pytest.fail(f"Timeout: Did not receive all 3 messages. Received: {received_messages}")
-            
+                logger.error(
+                    f"Timeout waiting for messages. Received {len(received_messages)} messages."
+                )
+                pytest.fail(
+                    f"Timeout: Did not receive all 3 messages. Received: {received_messages}"
+                )
+
             # Verification
-            assert len(received_messages) == 3, f"Expected 3 messages, got {len(received_messages)}"
+            assert (
+                len(received_messages) == 3
+            ), f"Expected 3 messages, got {len(received_messages)}"
             logger.info("Verifying received messages...")
-            
+
             # We convert payloads to strings for comparison as they were published
             expected_payloads = {
                 SUBJECT_REQUEST_NEW_TASK: str(task_request_payload),
                 SUBJECT_TASK_STATUS_UPDATE: str(status_update_payload),
-                SUBJECT_GET_FINAL_RESULT: str(final_result_payload)
+                SUBJECT_GET_FINAL_RESULT: str(final_result_payload),
             }
             received_payloads = {subj: data for subj, data in received_messages}
-            
-            assert received_payloads == expected_payloads, f"Received payloads do not match expected. Got: {received_payloads}"
+
+            assert (
+                received_payloads == expected_payloads
+            ), f"Received payloads do not match expected. Got: {received_payloads}"
             logger.info("Received messages verified successfully.")
-            
+
         except ErrTimeout:
             logger.error("NATS operation timed out.")
             pytest.fail("NATS operation timed out.")
         except Exception as e:
-            logger.error(f"An unexpected error occurred during the test: {e}", exc_info=True)
+            logger.error(
+                f"An unexpected error occurred during the test: {e}", exc_info=True
+            )
             pytest.fail(f"Test failed due to unexpected error: {e}")
         finally:
             logger.info("Cleaning up test resources (subscription)...")
             if ephemeral_sub:
                 try:
                     logger.info("Unsubscribing ephemeral consumer...")
-                    await asyncio.wait_for(ephemeral_sub.unsubscribe(), timeout=10.0)  # Added explicit timeout
+                    await asyncio.wait_for(
+                        ephemeral_sub.unsubscribe(), timeout=10.0
+                    )  # Added explicit timeout
                     logger.info("Ephemeral consumer unsubscribed.")
                 except asyncio.TimeoutError:
                     logger.error("Timeout during unsubscribe")
                 except Exception as e:
-                    logger.error(f"Error during ephemeral subscription cleanup: {e}", exc_info=True)
+                    logger.error(
+                        f"Error during ephemeral subscription cleanup: {e}",
+                        exc_info=True,
+                    )
             logger.info("Test cleanup (subscription) finished.")
-        
+
         logger.info("test_full_flow_direct_subscribe completed successfully.")
         # --- Existing Test Logic END ---
-        
+
     except Exception as e:
         logger.error(f"Unexpected error in top-level test: {e}", exc_info=True)
         pytest.fail(f"Test failed due to unexpected error: {e}")

--- a/tests/test_jetstream_publish.py
+++ b/tests/test_jetstream_publish.py
@@ -4,14 +4,22 @@ import pytest
 import logging
 import uuid
 from nats.js.client import JetStreamContext
+from src.deepthought.config import DEFAULT_CONFIG
 
 # Basic logging for the test
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
-TEST_SUBJECT = f"dtr.test.publish.{uuid.uuid4()}" # Publish to a subject within the stream
+TEST_SUBJECT = (
+    f"dtr.test.publish.{uuid.uuid4()}"  # Publish to a subject within the stream
+)
 TEST_PAYLOAD = b"JetStream test publish"
-STREAM_NAME = "deepthought_events" # Ensure this matches the stream created by setup_jetstream.py
+STREAM_NAME = (
+    DEFAULT_CONFIG.stream_name
+)  # Ensure this matches the stream created by setup_jetstream.py
+
 
 @pytest.mark.asyncio
 async def test_nats_jetstream_publish_only():
@@ -21,34 +29,40 @@ async def test_nats_jetstream_publish_only():
     try:
         # Connect Client and get JetStream context
         logger.info("Connecting NATS client...")
-        nc = await nats.connect("nats://localhost:4222", name="pytest_js_pub_only")
+        nc = await nats.connect(DEFAULT_CONFIG.nats_url, name="pytest_js_pub_only")
         assert nc.is_connected
         logger.info("NATS client connected.")
 
         logger.info("Getting JetStream context...")
-        js = nc.jetstream(timeout=5.0) # Add timeout for context acquisition
+        js = nc.jetstream(timeout=5.0)  # Add timeout for context acquisition
         assert js is not None
         logger.info("JetStream context obtained.")
 
         # Check if stream exists (optional but good practice)
         try:
-             stream_info = await js.stream_info(STREAM_NAME)
-             logger.info(f"Confirmed stream '{STREAM_NAME}' exists.")
-             assert stream_info.config.name == STREAM_NAME
+            stream_info = await js.stream_info(STREAM_NAME)
+            logger.info(f"Confirmed stream '{STREAM_NAME}' exists.")
+            assert stream_info.config.name == STREAM_NAME
         except Exception as e:
-             logger.error(f"Failed to confirm stream '{STREAM_NAME}' exists: {e}. Ensure setup_jetstream.py ran.")
-             pytest.fail(f"JetStream stream '{STREAM_NAME}' not found or accessible.")
+            logger.error(
+                f"Failed to confirm stream '{STREAM_NAME}' exists: {e}. Ensure setup_jetstream.py ran."
+            )
+            pytest.fail(f"JetStream stream '{STREAM_NAME}' not found or accessible.")
 
         # Publish to JetStream
         logger.info(f"Attempting JetStream publish to subject: {TEST_SUBJECT}")
         # Add a timeout to the publish call itself
-        ack = await js.publish(TEST_SUBJECT, TEST_PAYLOAD, timeout=5.0) 
+        ack = await js.publish(TEST_SUBJECT, TEST_PAYLOAD, timeout=5.0)
         assert ack is not None
-        assert ack.seq > 0 # Check if we got a valid sequence number
-        logger.info(f"JetStream publish successful. Ack: stream={ack.stream}, seq={ack.seq}")
+        assert ack.seq > 0  # Check if we got a valid sequence number
+        logger.info(
+            f"JetStream publish successful. Ack: stream={ack.stream}, seq={ack.seq}"
+        )
 
     except asyncio.TimeoutError:
-        logger.error("Timeout during JetStream operation (connect, context, or publish).")
+        logger.error(
+            "Timeout during JetStream operation (connect, context, or publish)."
+        )
         pytest.fail("Timeout during JetStream operation.")
     except Exception as e:
         logger.error(f"An error occurred during the JetStream publish test: {e}")
@@ -58,4 +72,4 @@ async def test_nats_jetstream_publish_only():
         logger.info("Cleaning up connection...")
         if nc and nc.is_connected:
             await nc.close()
-            logger.info("NATS client closed.") 
+            logger.info("NATS client closed.")

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -17,22 +17,28 @@ from nats.js.api import StreamConfig, RetentionPolicy, StorageType, DiscardPolic
 from nats.errors import TimeoutError
 
 # Add the src directory to the path for imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import the modules to test
 from src.deepthought.modules import InputHandler, MemoryStub, LLMStub, OutputHandler
 from src.deepthought.eda.events import EventSubjects
+from src.deepthought.config import DEFAULT_CONFIG
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
+
 
 # Helper function to get NATS URL from environment variable
 def get_nats_url() -> str:
-    return os.getenv("NATS_URL", "nats://localhost:4222")
+    return os.getenv("NATS_URL", DEFAULT_CONFIG.nats_url)
+
 
 # Stream name - using the same as in setup_jetstream.py
-STREAM_NAME = "deepthought_events"
+STREAM_NAME = DEFAULT_CONFIG.stream_name
+
 
 # Helper function to ensure the JetStream stream exists
 async def ensure_stream_exists(js: JetStreamContext, stream_name: str) -> bool:
@@ -45,7 +51,7 @@ async def ensure_stream_exists(js: JetStreamContext, stream_name: str) -> bool:
         return True
     except Exception as e:
         logger.info(f"Stream '{stream_name}' does not exist, creating it... ({e})")
-        
+
         # Create the stream with appropriate settings
         stream_config = StreamConfig(
             name=stream_name,
@@ -55,7 +61,7 @@ async def ensure_stream_exists(js: JetStreamContext, stream_name: str) -> bool:
             max_msgs_per_subject=100,
             discard=DiscardPolicy.OLD,
         )
-        
+
         try:
             await js.add_stream(stream_config)
             logger.info(f"Stream '{stream_name}' created successfully.")
@@ -63,6 +69,7 @@ async def ensure_stream_exists(js: JetStreamContext, stream_name: str) -> bool:
         except Exception as create_err:
             logger.error(f"Failed to create stream '{stream_name}': {create_err}")
             return False
+
 
 # The integration test function
 @pytest.mark.asyncio
@@ -78,7 +85,7 @@ async def test_full_module_flow():
     memory_stub = None
     llm_stub = None
     output_handler = None
-    
+
     try:
         # --- Connect NATS ---
         logger.info(f"Attempting to connect to NATS at {get_nats_url()}")
@@ -87,35 +94,41 @@ async def test_full_module_flow():
         if not nc.is_connected:
             pytest.fail("NATS connection failed")
         logger.info("NATS connection successful.")
-        
+
         # --- Get JetStream context ---
         logger.info("Getting JetStream context...")
         js = nc.jetstream(timeout=30.0)
         if not js:
             pytest.fail("Failed to get JetStream context.")
         logger.info("JetStream context obtained.")
-        
+
         # --- Ensure stream exists ---
         if not await ensure_stream_exists(js, STREAM_NAME):
             pytest.fail(f"Failed to ensure stream '{STREAM_NAME}' exists.")
-        
+
         # --- Create event for completion signaling ---
         final_response_received_event = asyncio.Event()
         responses = {}
         test_input_id = None
-        
+
         # --- Define output callback ---
         def output_callback(input_id, response):
             nonlocal test_input_id
-            logger.info(f"Output callback received response for input_id={input_id}: {response}")
+            logger.info(
+                f"Output callback received response for input_id={input_id}: {response}"
+            )
             responses[input_id] = response
             # Only set event if it matches the ID we sent for this test run
             if input_id == test_input_id:
-                logger.info(f"Correct final response received via callback for ID {input_id}. Setting event.")
+                logger.info(
+                    f"Correct final response received via callback for ID {input_id}. Setting event."
+                )
                 final_response_received_event.set()
             else:
-                logger.warning(f"Callback received response for unexpected ID {input_id}, expected {test_input_id}")
-        
+                logger.warning(
+                    f"Callback received response for unexpected ID {input_id}, expected {test_input_id}"
+                )
+
         # --- Instantiate module stubs ---
         logger.info("Initializing module stubs...")
         input_handler = InputHandler(nc, js)
@@ -123,14 +136,14 @@ async def test_full_module_flow():
         llm_stub = LLMStub(nc, js)
         output_handler = OutputHandler(nc, js, output_callback=output_callback)
         logger.info("Module stubs initialized.")
-        
+
         # --- Set up subscriptions for the stubs ---
         logger.info("Starting stub listeners...")
         results = await asyncio.gather(
             memory_stub.start_listening(durable_name="test_mem_listener"),
             llm_stub.start_listening(durable_name="test_llm_listener"),
             output_handler.start_listening(durable_name="test_out_listener"),
-            return_exceptions=True  # Capture exceptions instead of raising immediately
+            return_exceptions=True,  # Capture exceptions instead of raising immediately
         )
 
         # Check if any listeners failed to start
@@ -143,18 +156,18 @@ async def test_full_module_flow():
                 pytest.fail(f"Listener {i} reported failure to start.")
 
         logger.info("Stub listeners started successfully.")
-        
+
         # Wait briefly for all subscriptions to be established
         await asyncio.sleep(1.0)
-        
+
         # --- Trigger the flow ---
         sample_input = "Test the full module integration flow"
         logger.info(f"Processing input: '{sample_input}'")
-        
+
         # Process the input via InputHandler
         test_input_id = await input_handler.process_input(sample_input)
         logger.info(f"Input processed, ID: {test_input_id}")
-        
+
         # --- Wait for the complete flow to finish ---
         logger.info("Waiting for complete flow to finish (final response)...")
         try:
@@ -163,21 +176,27 @@ async def test_full_module_flow():
         except asyncio.TimeoutError:
             logger.error("Timeout waiting for final response.")
             pytest.fail("Timeout: Final response was not received within 20 seconds.")
-        
+
         # --- Assertions ---
-        assert final_response_received_event.is_set(), "Final response signal was not received via callback"
-        assert test_input_id in responses, f"OutputHandler did not record response for input_id {test_input_id}"
+        assert (
+            final_response_received_event.is_set()
+        ), "Final response signal was not received via callback"
+        assert (
+            test_input_id in responses
+        ), f"OutputHandler did not record response for input_id {test_input_id}"
         assert responses[test_input_id] is not None, "Response content is None"
-        
+
         logger.info("Full module flow test completed successfully.")
-        
+
     except Exception as e:
-        logger.error(f"An unexpected error occurred during the test: {e}", exc_info=True)
+        logger.error(
+            f"An unexpected error occurred during the test: {e}", exc_info=True
+        )
         pytest.fail(f"Test failed due to unexpected error: {e}")
     finally:
         # --- Cleanup ---
         logger.info("Cleaning up test resources...")
-        
+
         # --- Stop stub listeners ---
         logger.info("Stopping stub listeners...")
         stubs_to_stop = []
@@ -187,14 +206,17 @@ async def test_full_module_flow():
             stubs_to_stop.append(llm_stub.stop_listening())
         if output_handler:
             stubs_to_stop.append(output_handler.stop_listening())
-            
+
         if stubs_to_stop:
             results = await asyncio.gather(*stubs_to_stop, return_exceptions=True)
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
-                    logger.error(f"Error during stub listener cleanup {i}: {result}", exc_info=False)  # Avoid deep traceback in cleanup
+                    logger.error(
+                        f"Error during stub listener cleanup {i}: {result}",
+                        exc_info=False,
+                    )  # Avoid deep traceback in cleanup
         logger.info("Stub listeners stopped.")
-        
+
         # Close NATS connection
         if nc and nc.is_connected:
             logger.info("Closing NATS connection...")
@@ -204,5 +226,5 @@ async def test_full_module_flow():
             logger.warning("NATS client existed but was not connected during teardown.")
         else:
             logger.warning("NATS client was not created during setup.")
-        
-        logger.info("Test cleanup finished.") 
+
+        logger.info("Test cleanup finished.")


### PR DESCRIPTION
## Summary
- implement `DeepThoughtConfig` with default NATS settings
- expose `DEFAULT_CONFIG` and update tests to use it
- format config and tests with `black`

## Testing
- `black --check src/deepthought/config.py tests/test_basic.py tests/test_basic_nats.py tests/test_eda_flow.py tests/test_jetstream_publish.py tests/test_module_integration.py`
- `pytest tests/test_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68535c729a308326b47812992eea1719