### PR TITLE
Fix Python matrix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             -p 4222:4222 -p 8222:8222 nats:latest -js
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - id: requirements-hash
         run: |
           echo "hash=$(pip hash requirements-ci.txt | \


### PR DESCRIPTION
## Summary
- update CI workflow to use Python matrix

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -k "" -q`

------
https://chatgpt.com/codex/tasks/task_e_68535fb08f7c8326bf531374b7af4449