### PR TITLE
Handle missing channel in monitor

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -424,6 +424,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
     """Monitor a channel and occasionally speak during idle periods."""
     await bot.wait_until_ready()
     channel = bot.get_channel(channel_id)
+    if channel is None:
+        logger.error("Channel %s does not exist", channel_id)
+        return
     while not bot.is_closed():
         last_message = None
         async for msg in channel.history(limit=1):

--- a/tests/test_monitor_channels.py
+++ b/tests/test_monitor_channels.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import random
 
 import pytest
@@ -148,3 +149,24 @@ async def test_monitor_channels_idle_prompt_old_message(monkeypatch):
     await sg.monitor_channels(bot, 1)
 
     assert channel.sent_messages == ["ping"]
+
+
+class DummyNoChannelBot:
+    async def wait_until_ready(self):
+        return None
+
+    def get_channel(self, cid):
+        return None
+
+    def is_closed(self):
+        return True
+
+
+@pytest.mark.asyncio
+async def test_monitor_channels_no_channel(monkeypatch, caplog):
+    bot = DummyNoChannelBot()
+
+    with caplog.at_level(logging.ERROR):
+        await sg.monitor_channels(bot, 123)
+
+    assert any("does not exist" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- guard against missing monitor channels in social_graph_bot
- add regression test for missing monitor channels

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_monitor_channels.py`
- `pytest tests/test_monitor_channels.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685370c642b88326bcc32cd67a44c5c0