### PR TITLE
Remove unused var from social_graph_bot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -267,7 +267,6 @@ class DBManager:
 
 DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
-_manager_id = id(db_manager)
 
 
 async def init_db(db_path: str | None = None) -> None:


### PR DESCRIPTION
## Summary
- delete unused `_manager_id` variable from social_graph_bot example

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546be6a080832685248a924c93bba9