### PR TITLE
Implement reloadable settings

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -53,5 +53,15 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
     return Settings()
 
 
-# Module level singleton for convenience
-settings = load_settings()
+_settings_cache: Optional[Settings] = None
+_settings_path: Optional[str] = None
+
+
+def get_settings(config_file: Optional[str] = None) -> Settings:
+    """Return cached :class:`Settings`, reloading if the config source changed."""
+    global _settings_cache, _settings_path
+    path = config_file or os.getenv("DT_CONFIG_FILE")
+    if _settings_cache is None or path != _settings_path or config_file:
+        _settings_cache = load_settings(config_file)
+        _settings_path = path
+    return _settings_cache

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -9,7 +9,7 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from ..config import settings
+from ..config import get_settings
 from ..eda.events import EventSubjects, ResponseGeneratedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -26,7 +26,7 @@ class BasicLLM:
         js_context: Optional[JetStreamContext] = None,
         model_name: Optional[str] = None,
     ) -> None:
-        model_name = model_name or settings.model_path
+        model_name = model_name or get_settings().model_path
         if nats_client is not None and js_context is not None:
             self._publisher: Optional[Publisher] = Publisher(nats_client, js_context)
             self._subscriber: Optional[Subscriber] = Subscriber(nats_client, js_context)
@@ -52,9 +52,7 @@ class BasicLLM:
             elif isinstance(retrieved, dict):
                 knowledge = retrieved
             else:
-                logger.warning(
-                    "Unexpected retrieved_knowledge format: %s", type(retrieved)
-                )
+                logger.warning("Unexpected retrieved_knowledge format: %s", type(retrieved))
                 knowledge = {}
             facts = knowledge.get("facts", [])
             logger.info("BasicLLM received memory event ID %s", input_id)

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -11,7 +11,7 @@ from nats.js.client import JetStreamContext
 from peft import PeftModel
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-from ..config import settings
+from ..config import get_settings
 from ..eda.events import EventSubjects, ResponseGeneratedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -29,7 +29,7 @@ class ProductionLLM:
         model_name: Optional[str] = None,
         adapter_dir: str = "./results/lora-adapter",
     ) -> None:
-        model_name = model_name or settings.model_path
+        model_name = model_name or get_settings().model_path
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -61,9 +61,7 @@ class ProductionLLM:
             elif isinstance(retrieved, dict):
                 knowledge = retrieved
             else:
-                logger.warning(
-                    "Unexpected retrieved_knowledge format: %s", type(retrieved)
-                )
+                logger.warning("Unexpected retrieved_knowledge format: %s", type(retrieved))
                 knowledge = {}
             facts = knowledge.get("facts", [])
             logger.info("ProductionLLM received memory event ID %s", input_id)

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -8,7 +8,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..config import settings
+from ..config import get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -27,7 +27,7 @@ class BasicMemory:
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._memory_file = memory_file or settings.memory_file
+        self._memory_file = memory_file or get_settings().memory_file
 
         if not os.path.exists(self._memory_file):
             with open(self._memory_file, "w", encoding="utf-8") as f:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -2,7 +2,7 @@ import json
 
 import yaml
 
-from deepthought.config import load_settings
+from deepthought.config import get_settings, load_settings
 
 
 def test_env_overrides(monkeypatch):
@@ -50,3 +50,18 @@ def test_yaml_file_load(tmp_path):
     assert settings.db.port == 456
     assert settings.model_path == "yaml/model"
     assert settings.memory_file == "yaml.json"
+
+
+def test_get_settings_reload(monkeypatch, tmp_path):
+    cfg1 = tmp_path / "cfg1.json"
+    cfg1.write_text(json.dumps({"nats_url": "nats://first"}))
+    cfg2 = tmp_path / "cfg2.json"
+    cfg2.write_text(json.dumps({"nats_url": "nats://second"}))
+
+    monkeypatch.setenv("DT_CONFIG_FILE", str(cfg1))
+    first = get_settings(str(cfg1))
+    assert first.nats_url == "nats://first"
+
+    monkeypatch.setenv("DT_CONFIG_FILE", str(cfg2))
+    second = get_settings()
+    assert second.nats_url == "nats://second"


### PR DESCRIPTION
## Summary
- remove static `settings` object
- cache config in new `get_settings` helper
- update modules to use `get_settings`
- test reloading when `DT_CONFIG_FILE` changes

## Testing
- `pre-commit run --files src/deepthought/config.py src/deepthought/modules/llm_basic.py src/deepthought/modules/llm_prod.py src/deepthought/modules/memory_basic.py tests/unit/test_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546be7f91083269dd721cb6effdeff