### PR TITLE
Fix GraphConnector cursor closing and commit

### DIFF
--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -46,8 +46,11 @@ class GraphConnector:
         if hasattr(conn, "execute"):
             return conn.execute(query, params or {})
         cur = conn.cursor()
-        cur.execute(query, params or {})
-        rows = cur.fetchall()
-        if hasattr(cur, "close"):
+        try:
+            cur.execute(query, params or {})
+            rows = cur.fetchall()
+            if hasattr(conn, "commit"):
+                conn.commit()
+            return rows
+        finally:
             cur.close()
-        return rows

--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -1,0 +1,41 @@
+import pytest
+from deepthought.graph.connector import GraphConnector
+
+
+class DummyCursor:
+    def __init__(self):
+        self.executed = []
+        self.closed = False
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return [1]
+
+    def close(self):
+        self.closed = True
+
+
+class DummyConnection:
+    def __init__(self):
+        self.commit_called = False
+        self.cursor_obj = DummyCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.commit_called = True
+
+
+def test_execute_commits(monkeypatch):
+    conn = DummyConnection()
+    connector = GraphConnector()
+    monkeypatch.setattr(connector, "connect", lambda: conn)
+
+    result = connector.execute("SELECT 1")
+
+    assert result == [1]
+    assert conn.commit_called
+    assert conn.cursor_obj.closed


### PR DESCRIPTION
## Summary
- ensure `GraphConnector.execute` always closes the cursor and commits
- add unit test covering commit behavior

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68546be8e7548326819c8200f95e05dc