### PR TITLE
Handle corrupted JSON in memory files

### DIFF
--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -38,6 +38,25 @@ class BasicMemory:
         try:
             with open(self._memory_file, "r", encoding="utf-8") as f:
                 return json.load(f)
+        except json.JSONDecodeError as e:  # corrupted file
+            logger.error(
+                "Corrupted memory file %s: %s",
+                self._memory_file,
+                e,
+                exc_info=True,
+            )
+            backup_file = f"{self._memory_file}.bak"
+            try:
+                os.rename(self._memory_file, backup_file)
+            except OSError as rename_error:  # pragma: no cover - unlikely
+                logger.error(
+                    "Failed to rename corrupted memory file %s: %s",
+                    self._memory_file,
+                    rename_error,
+                    exc_info=True,
+                )
+            self._write_memory([])
+            return []
         except Exception as e:
             logger.error("Failed to read memory file: %s", e)
             return []

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -103,4 +103,19 @@ def test_read_memory_invalid_json_logs_error(tmp_path, monkeypatch, caplog):
         data = mem._read_memory()
 
     assert data == []
-    assert any("Failed to read memory file" in record.getMessage() for record in caplog.records)
+    assert any("Corrupted memory file" in record.getMessage() for record in caplog.records)
+
+
+def test_read_memory_invalid_json_backup(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.json"
+    mem_file.write_text("{ invalid json")
+    mem = create_memory(monkeypatch, mem_file)
+
+    data = mem._read_memory()
+
+    assert data == []
+    backup_path = tmp_path / "mem.json.bak"
+    assert backup_path.exists()
+    assert mem_file.exists()
+    assert json.load(open(mem_file, "r", encoding="utf-8")) == []
+    assert "{ invalid json" in backup_path.read_text()


### PR DESCRIPTION
## Summary
- catch `JSONDecodeError` when reading memory/graph files
- create `.bak` backup and initialize fresh storage when corruption occurs
- test backup and recovery for corrupted BasicMemory
- test backup and recovery for corrupted GraphMemory
- log full trace and use helper when resetting BasicMemory

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68546be728688326a52ba17f5911ff04