### PR TITLE
Adjust CI to run pre-commit once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
       - run: pip install -e . --no-deps
-      - run: pre-commit run --all-files
+      - name: Run pre-commit
+        if: matrix.python-version == '3.11'
+        run: pre-commit run --all-files
       - name: Setup JetStream
         run: python setup_jetstream.py
       - env:


### PR DESCRIPTION
## Summary
- update `lint_and_test` workflow so `pre-commit` runs only for Python 3.11

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548c4a6ccc83269371bba4c351f434