### PR TITLE
Fix dict serialization check

### DIFF
--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -36,7 +36,7 @@ class Publisher:
             data = payload.encode()
         elif hasattr(payload, "to_json"):
             data = payload.to_json().encode()
-        elif isinstance(payload, (Dict, list)):
+        elif isinstance(payload, (dict, list)):
             import json
 
             data = json.dumps(payload).encode()


### PR DESCRIPTION
## Summary
- fix isinstance check when publishing dictionaries

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549cf6f9908326a373993b9193de49