### PR TITLE
Fix LLMStub payload handling

### DIFF
--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -30,13 +30,21 @@ class LLMStub:
         input_id = "unknown"
         data = None
         try:
-            data = json.loads(msg.data.decode())
+            raw = json.loads(msg.data.decode())
+            if not isinstance(raw, dict):
+                logger.warning("Unexpected MemoryRetrieved payload format: %s", type(raw))
+                data = {}
+            else:
+                data = raw
             input_id = data.get("input_id", "unknown")
             retrieved = data.get("retrieved_knowledge", {})
             if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
                 knowledge = retrieved.get("retrieved_knowledge", {})
-            else:
+            elif isinstance(retrieved, dict):
                 knowledge = retrieved
+            else:
+                logger.warning("Unexpected retrieved_knowledge format: %s", type(retrieved))
+                knowledge = {}
             facts = knowledge.get("facts", [])
             logger.info(f"LLMStub received memory event ID {input_id}")
 


### PR DESCRIPTION
## Summary
- guard against non-dictionary payloads in LLMStub
- expand LLMStub tests for invalid payloads

## Testing
- `pre-commit run --files src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_stub.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68549cfc0b248326b96063e624b65623