### PR TITLE
Validate memory retrievals

### DIFF
--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -52,9 +52,34 @@ class BasicLLM:
             elif isinstance(retrieved, dict):
                 knowledge = retrieved
             else:
-                logger.warning("Unexpected retrieved_knowledge format: %s", type(retrieved))
-                knowledge = {}
-            facts = knowledge.get("facts", [])
+                logger.error("retrieved_knowledge is not a dict for input_id %s", input_id)
+                if hasattr(msg, "nak") and callable(msg.nak):
+                    try:
+                        await msg.nak()
+                    except Exception:
+                        logger.error("Failed to NAK message", exc_info=True)
+                elif hasattr(msg, "ack") and callable(msg.ack):
+                    try:
+                        await msg.ack()
+                    except Exception:
+                        logger.error("Failed to ack message after error", exc_info=True)
+                return
+
+            facts = knowledge.get("facts")
+            if not isinstance(facts, list):
+                logger.error("retrieved_knowledge missing facts list for input_id %s", input_id)
+                if hasattr(msg, "nak") and callable(msg.nak):
+                    try:
+                        await msg.nak()
+                    except Exception:
+                        logger.error("Failed to NAK message", exc_info=True)
+                elif hasattr(msg, "ack") and callable(msg.ack):
+                    try:
+                        await msg.ack()
+                    except Exception:
+                        logger.error("Failed to ack message after error", exc_info=True)
+                return
+
             logger.info("BasicLLM received memory event ID %s", input_id)
 
             prompt = self._build_prompt([str(f) for f in facts])

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -43,9 +43,34 @@ class LLMStub:
             elif isinstance(retrieved, dict):
                 knowledge = retrieved
             else:
-                logger.warning("Unexpected retrieved_knowledge format: %s", type(retrieved))
-                knowledge = {}
-            facts = knowledge.get("facts", [])
+                logger.error("retrieved_knowledge is not a dict for input_id %s", input_id)
+                if hasattr(msg, "nak") and callable(msg.nak):
+                    try:
+                        await msg.nak()
+                    except Exception:
+                        logger.error("Failed to NAK message", exc_info=True)
+                elif hasattr(msg, "ack") and callable(msg.ack):
+                    try:
+                        await msg.ack()
+                    except Exception:
+                        logger.error("Failed to ack message after error", exc_info=True)
+                return
+
+            facts = knowledge.get("facts")
+            if not isinstance(facts, list):
+                logger.error("retrieved_knowledge missing facts list for input_id %s", input_id)
+                if hasattr(msg, "nak") and callable(msg.nak):
+                    try:
+                        await msg.nak()
+                    except Exception:
+                        logger.error("Failed to NAK message", exc_info=True)
+                elif hasattr(msg, "ack") and callable(msg.ack):
+                    try:
+                        await msg.ack()
+                    except Exception:
+                        logger.error("Failed to ack message after error", exc_info=True)
+                return
+
             logger.info(f"LLMStub received memory event ID {input_id}")
 
             await asyncio.sleep(0.5)  # Simulate work

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -1,9 +1,9 @@
 import importlib
+import logging
 import sys
 import types
 from datetime import datetime, timezone
 from types import SimpleNamespace
-import logging
 
 import pytest
 
@@ -138,8 +138,33 @@ async def test_handle_memory_event_non_dict(monkeypatch, caplog):
 
     assert msg.acked
     pub = llm._publisher
-    assert pub.published
-    assert any(
-        "Unexpected retrieved_knowledge format" in r.getMessage()
-        for r in caplog.records
-    )
+    assert not pub.published
+    assert any("not a dict" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_missing_facts(monkeypatch, caplog):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={}, input_id="b1")
+    msg = DummyMsg(payload.to_json())
+    with caplog.at_level(logging.ERROR):
+        await llm._handle_memory_event(msg)
+
+    assert msg.acked
+    pub = llm._publisher
+    assert not pub.published
+    assert any("missing facts" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": "nope"}, input_id="b2")
+    msg = DummyMsg(payload.to_json())
+    with caplog.at_level(logging.ERROR):
+        await llm._handle_memory_event(msg)
+
+    assert msg.acked
+    pub = llm._publisher
+    assert not pub.published
+    assert any("missing facts" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- validate retrieved_knowledge contents in LLM handlers
- add tests for invalid memory structures

## Testing
- `pre-commit run --files src/deepthought/modules/llm_stub.py src/deepthought/modules/llm_basic.py src/deepthought/modules/llm_prod.py tests/unit/modules/test_llm_stub.py tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py`
- `PYTHONPATH=src pytest tests/unit/modules/test_llm_stub.py tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b88755b083268e39f7698c6ef544