### PR TITLE
Ensure NAK on OutputHandler and MemoryStub errors

### DIFF
--- a/src/deepthought/modules/memory_stub.py
+++ b/src/deepthought/modules/memory_stub.py
@@ -65,7 +65,16 @@ class MemoryStub:
 
         except Exception as e:
             logger.error(f"Error in MemoryStub handler: {e}", exc_info=True)
-            # Do not ack/nak on failure; leave message for retry
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
 
     async def start_listening(self, durable_name: str = "memory_stub_listener") -> bool:
         """

--- a/tests/unit/modules/test_memory_stub.py
+++ b/tests/unit/modules/test_memory_stub.py
@@ -45,9 +45,13 @@ class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
         self.acked = False
+        self.nacked = False
 
     async def ack(self):
         self.acked = True
+
+    async def nak(self):
+        self.nacked = True
 
 
 def create_stub(monkeypatch, publisher_cls=DummyPublisher):
@@ -86,4 +90,5 @@ async def test_handle_input_error(monkeypatch):
     msg = DummyMsg(payload.to_json())
     await stub._handle_input_event(msg)
 
+    assert msg.nacked
     assert not msg.acked

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -28,9 +28,13 @@ class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
         self.acked = False
+        self.nacked = False
 
     async def ack(self):
         self.acked = True
+
+    async def nak(self):
+        self.nacked = True
 
 
 def create_handler(monkeypatch, callback=None, max_responses=100):
@@ -64,6 +68,7 @@ async def test_handle_response_error(monkeypatch):
     await handler._handle_response_event(msg)
 
     assert handler.get_all_responses() == {}
+    assert msg.nacked
     assert not msg.acked
 
 


### PR DESCRIPTION
## Summary
- send `nak()` on OutputHandler and MemoryStub exceptions
- update unit tests for new ack/nak logic

## Testing
- `pre-commit run --files src/deepthought/modules/output_handler.py src/deepthought/modules/memory_stub.py tests/unit/modules/test_output_handler.py tests/unit/modules/test_memory_stub.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b88185388326a0021a02f6e96758