### PR TITLE
Handle directory creation for persistence

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -51,6 +51,9 @@ class DBManager:
 
     async def connect(self) -> None:
         if self._db is None:
+            dir_path = os.path.dirname(self.db_path)
+            if dir_path:
+                os.makedirs(dir_path, exist_ok=True)
             self._db = await aiosqlite.connect(self.db_path)
 
     async def close(self) -> None:

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -29,6 +29,10 @@ class BasicMemory:
         self._subscriber = Subscriber(nats_client, js_context)
         self._memory_file = memory_file or get_settings().memory_file
 
+        dir_path = os.path.dirname(self._memory_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+
         if not os.path.exists(self._memory_file):
             with open(self._memory_file, "w", encoding="utf-8") as f:
                 json.dump([], f)

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -23,6 +23,11 @@ class GraphMemory:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._graph_file = graph_file
+
+        dir_path = os.path.dirname(self._graph_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+
         if os.path.exists(self._graph_file):
             self._graph = self._read_graph()
         else:

--- a/tests/unit/modules/test_dbmanager.py
+++ b/tests/unit/modules/test_dbmanager.py
@@ -1,0 +1,17 @@
+import asyncio
+import os
+
+import aiosqlite
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_directory(tmp_path):
+    db_file = tmp_path / "subdir" / "db.sqlite"
+    manager = sg.DBManager(str(db_file))
+    await manager.connect()
+    assert db_file.parent.is_dir()
+    assert os.path.exists(db_file)
+    await manager.close()

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -104,3 +104,12 @@ def test_read_memory_invalid_json_logs_error(tmp_path, monkeypatch, caplog):
 
     assert data == []
     assert any("Failed to read memory file" in record.getMessage() for record in caplog.records)
+
+
+def test_init_creates_directory(tmp_path, monkeypatch):
+    mem_file = tmp_path / "newdir" / "mem.json"
+    create_memory(monkeypatch, mem_file)
+    assert mem_file.parent.is_dir()
+    assert mem_file.exists()
+    with open(mem_file, "r", encoding="utf-8") as f:
+        assert json.load(f) == []

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -54,3 +54,13 @@ def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
     assert len(mem._graph.nodes) == 0
     error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert any("Failed to read graph file" in r.getMessage() for r in error_logs)
+
+
+def test_init_creates_directory(tmp_path, monkeypatch):
+    graph_file = tmp_path / "newdir" / "graph.json"
+    mem = create_memory(monkeypatch, graph_file)
+    assert graph_file.parent.is_dir()
+    assert graph_file.exists()
+    assert isinstance(mem._graph, nx.DiGraph)
+    with open(graph_file, "r", encoding="utf-8") as f:
+        assert isinstance(json.load(f), dict)


### PR DESCRIPTION
## Summary
- ensure BasicMemory and GraphMemory create parent directories
- create DB directory in DBManager.connect
- test that BasicMemory, GraphMemory, and DBManager make directories when given paths

## Testing
- `pre-commit run --files examples/social_graph_bot.py src/deepthought/modules/memory_basic.py src/deepthought/modules/memory_graph.py tests/unit/modules/test_memory_basic.py tests/unit/modules/test_memory_graph.py tests/unit/modules/test_dbmanager.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b87c1a288326b77d2d22a9c22937