### PR TITLE
Fix server info retrieval

### DIFF
--- a/nats_deepthought_script.py
+++ b/nats_deepthought_script.py
@@ -83,10 +83,14 @@ async def run_test():
     print(f"Connected to NATS server at {nc.connected_url.netloc}")
 
     try:
-        # Print NATS server info
-        server_info = nc._server_info
+        # Print NATS server info using documented attributes
+        server_info = {
+            "server_version": str(nc.connected_server_version),
+            "client_id": nc.client_id,
+            "max_payload": nc.max_payload,
+        }
         print(f"Server info: {server_info}")
-        print(f"Server ID: {server_info['server_id']}")
+        print(f"Server version: {server_info['server_version']}")
 
         # Create a unique input ID for this test
         input_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary
- use documented properties in `nats_deepthought_script`

## Testing
- `pre-commit run --files nats_deepthought_script.py`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b87d98588326947ccb90ef98c6d5