### PR TITLE
Improve NATS helper parsing

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,18 +1,29 @@
 import os
 import socket
+from typing import Optional
+from urllib.parse import urlparse
+
+DEFAULT_NATS_PORT = 4222
 
 
-def nats_server_available(url=None):
-    """Check if a NATS server is reachable."""
+def nats_server_available(url: Optional[str] = None) -> bool:
+    """Return ``True`` if a NATS server can be reached at ``url``.
+
+    ``url`` may be a bare ``host:port`` pair or a full URL with scheme. If not
+    provided, the ``NATS_URL`` environment variable or ``nats://localhost:4222``
+    is used.
+    """
     if url is None:
-        url = os.getenv("NATS_URL", "nats://localhost:4222")
+        url = os.getenv("NATS_URL", f"nats://localhost:{DEFAULT_NATS_PORT}")
+
+    parsed = urlparse(url if "://" in url else f"//{url}")
+    host = parsed.hostname
+    port = parsed.port or DEFAULT_NATS_PORT
+    if not host:
+        return False
+
     try:
-        # Extract host and port
-        if "://" in url:
-            url = url.split("://", 1)[1]
-        host, port = url.split(":")
         with socket.create_connection((host, int(port)), timeout=1):
             return True
     except Exception:
         return False
-    return True

--- a/tests/test_helpers_nats.py
+++ b/tests/test_helpers_nats.py
@@ -1,0 +1,38 @@
+import socket
+
+from tests.helpers import nats_server_available
+
+
+class DummySocket:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+def test_nats_server_available_with_port(monkeypatch):
+    captured = {}
+
+    def fake_create_connection(addr, timeout=1):
+        captured["addr"] = addr
+        return DummySocket()
+
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+
+    assert nats_server_available("nats://example.com:4222") is True
+    assert captured["addr"] == ("example.com", 4222)
+
+
+def test_nats_server_available_without_port(monkeypatch):
+    captured = {}
+
+    def fake_create_connection(addr, timeout=1):
+        captured["addr"] = addr
+        return DummySocket()
+
+    monkeypatch.setattr(socket, "create_connection", fake_create_connection)
+
+    assert nats_server_available("nats://example.com") is True
+    # Default NATS port 4222 should be used
+    assert captured["addr"] == ("example.com", 4222)


### PR DESCRIPTION
## Summary
- improve NATS URL parsing with a constant default port and better docstring
- add unit tests checking host and port extraction

## Testing
- `pre-commit run --files tests/helpers.py tests/test_helpers_nats.py`
- `pytest -q tests/test_helpers_nats.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854b88ba99c832699e35341d5c52468