### PR TITLE
Fix corrupted graph file handling

### DIFF
--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -41,8 +41,23 @@ class GraphMemory:
                 data = json.load(f)
             return nx.readwrite.json_graph.node_link_graph(data)
         except Exception as e:
-            logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
-            return nx.DiGraph()
+            logger.error(
+                "Failed to read graph file %s: %s", self._graph_file, e, exc_info=True
+            )
+            empty_graph = nx.DiGraph()
+            try:
+                with open(self._graph_file, "w", encoding="utf-8") as f:
+                    json.dump(
+                        nx.readwrite.json_graph.node_link_data(empty_graph), f
+                    )
+            except Exception as write_err:
+                logger.error(
+                    "Failed to write empty graph file %s: %s",
+                    self._graph_file,
+                    write_err,
+                    exc_info=True,
+                )
+            return empty_graph
 
     def _write_graph(self) -> None:
         data = nx.readwrite.json_graph.node_link_data(self._graph)

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -56,6 +56,24 @@ def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
     assert any("Failed to read graph file" in r.getMessage() for r in error_logs)
 
 
+def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
+    graph_file = tmp_path / "graph.json"
+    graph_file.write_text("{ invalid json")
+
+    caplog.set_level(logging.ERROR)
+    create_memory(monkeypatch, graph_file)
+
+    with open(graph_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data == nx.readwrite.json_graph.node_link_data(nx.DiGraph())
+
+    caplog.clear()
+    create_memory(monkeypatch, graph_file)
+
+    assert not any(
+        "Failed to read graph file" in r.getMessage() for r in caplog.records
+    )
+
 def test_init_creates_directory(tmp_path, monkeypatch):
     graph_file = tmp_path / "newdir" / "graph.json"
     mem = create_memory(monkeypatch, graph_file)


### PR DESCRIPTION
## Summary
- repair `_read_graph` in `GraphMemory` so corrupted files are replaced
- test that an invalid file is rewritten and can be read again

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855795bd79c83268f32e5296a2a2f28