### PR TITLE
Handle prompt prefix in response

### DIFF
--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -87,7 +87,10 @@ class BasicLLM:
             with torch.no_grad():
                 outputs = self._model.generate(**inputs, max_length=inputs["input_ids"].shape[1] + 20)
             generated = self._tokenizer.decode(outputs[0], skip_special_tokens=True)
-            response_text = generated[len(prompt) :].strip()  # noqa: E203
+            if generated.startswith(prompt):
+                response_text = generated[len(prompt) :].strip()  # noqa: E203
+            else:
+                response_text = generated.strip()
 
             payload = ResponseGeneratedPayload(
                 final_response=response_text,

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -96,7 +96,10 @@ class ProductionLLM:
             with torch.no_grad():
                 outputs = self._model.generate(**inputs, max_length=inputs["input_ids"].shape[1] + 20)
             generated = self._tokenizer.decode(outputs[0], skip_special_tokens=True)
-            response_text = generated[len(prompt) :].strip()  # noqa: E203
+            if generated.startswith(prompt):
+                response_text = generated[len(prompt) :].strip()  # noqa: E203
+            else:
+                response_text = generated.strip()
 
             payload = ResponseGeneratedPayload(
                 final_response=response_text,

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -165,3 +165,36 @@ async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
     pub = llm._publisher
     assert not pub.published
     assert any("missing facts" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_success(monkeypatch):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="prod_ok")
+    msg = DummyMsg(payload.to_json())
+    await llm._handle_memory_event(msg)
+
+    assert msg.acked
+    pub = llm._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert sent_payload.final_response == "generated"
+    ts = sent_payload.timestamp
+    assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_no_prompt_prefix(monkeypatch):
+    llm = create_llm(monkeypatch)
+    monkeypatch.setattr(llm._tokenizer, "decode", lambda *_args, **_kwargs: "untrimmed")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="prod_pref")
+    msg = DummyMsg(payload.to_json())
+    await llm._handle_memory_event(msg)
+
+    assert msg.acked
+    pub = llm._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert sent_payload.final_response == "untrimmed"


### PR DESCRIPTION
## Summary
- improve text parsing in BasicLLM and ProductionLLM
- if generated text starts with the prompt, remove that prefix
- add regression tests covering prefix trimming logic

## Testing
- `pre-commit run --files src/deepthought/modules/llm_basic.py src/deepthought/modules/llm_prod.py tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py`
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557969df7083269a1a03f79cf77f6a