### PR TITLE
Refactor GraphConnector execute logic

### DIFF
--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -1,4 +1,5 @@
 import pytest
+
 from deepthought.graph.connector import GraphConnector
 
 
@@ -29,6 +30,22 @@ class DummyConnection:
         self.commit_called = True
 
 
+class DummyExecuteConnection:
+    def __init__(self):
+        self.commit_called = False
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+        return self
+
+    def fetchall(self):
+        return [1]
+
+    def commit(self):
+        self.commit_called = True
+
+
 def test_execute_commits(monkeypatch):
     conn = DummyConnection()
     connector = GraphConnector()
@@ -39,3 +56,15 @@ def test_execute_commits(monkeypatch):
     assert result == [1]
     assert conn.commit_called
     assert conn.cursor_obj.closed
+
+
+def test_execute_direct_execute_commits(monkeypatch):
+    conn = DummyExecuteConnection()
+    connector = GraphConnector()
+    monkeypatch.setattr(connector, "connect", lambda: conn)
+
+    result = connector.execute("SELECT 1")
+
+    assert result == [1]
+    assert conn.commit_called
+    assert conn.executed == [("SELECT 1", {})]


### PR DESCRIPTION
## Summary
- enhance GraphConnector.execute for connectors exposing an `execute` method
- clarify return type in execute docstring
- add tests for direct execute connections
- fix direct execute test expectations

## Testing
- `pre-commit run --files src/deepthought/graph/connector.py tests/unit/test_graph_connector.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68557955300c83268bde0923244f9f97