### PR TITLE
Update OutputHandler logging behavior

### DIFF
--- a/src/deepthought/modules/output_handler.py
+++ b/src/deepthought/modules/output_handler.py
@@ -46,11 +46,11 @@ class OutputHandler:
             if len(self._responses) > self._max_responses:
                 self._responses.popitem(last=False)
 
-            # Use callback or print
+            # Use callback or log when no callback provided
             if self._output_callback:
                 self._output_callback(input_id, final_response)
             else:
-                print(f"Output ({input_id}): {final_response}")
+                logger.info(f"Output ({input_id}): {final_response}")
 
             # Acknowledge the received message
             await msg.ack()

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 import deepthought.modules.output_handler as output_handler
@@ -85,3 +87,27 @@ async def test_cache_limit(monkeypatch):
     assert len(responses) == 2
     assert "0" not in responses
     assert set(responses.keys()) == {"1", "2"}
+
+
+@pytest.mark.asyncio
+async def test_handle_response_logs_when_no_callback(monkeypatch, caplog):
+    handler = create_handler(monkeypatch)
+
+    called = False
+
+    def fake_print(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("builtins.print", fake_print)
+    payload = ResponseGeneratedPayload(final_response="hello", input_id="99")
+    msg = DummyMsg(payload.to_json())
+    with caplog.at_level(logging.INFO):
+        await handler._handle_response_event(msg)
+
+    assert (
+        "deepthought.modules.output_handler",
+        logging.INFO,
+        "Output (99): hello",
+    ) in caplog.record_tuples
+    assert not called


### PR DESCRIPTION
## Summary
- log responses via `logger.info` when no output callback is provided
- test that OutputHandler does not print when callback is missing
- refine log assertion in unit test

## Testing
- `pre-commit run --files src/deepthought/modules/output_handler.py tests/unit/modules/test_output_handler.py`
- `pytest tests/unit/modules/test_output_handler.py`


------
https://chatgpt.com/codex/tasks/task_e_68557973118c8326b62c12cc087d58e1