### PR TITLE
Improve error handling for file writes

### DIFF
--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -34,8 +34,12 @@ class BasicMemory:
             os.makedirs(dir_path, exist_ok=True)
 
         if not os.path.exists(self._memory_file):
-            with open(self._memory_file, "w", encoding="utf-8") as f:
-                json.dump([], f)
+            try:
+                with open(self._memory_file, "w", encoding="utf-8") as f:
+                    json.dump([], f)
+            except Exception as e:
+                logger.error("Failed to initialize memory file %s: %s", self._memory_file, e, exc_info=True)
+                raise
         logger.info("BasicMemory initialized with file %s", self._memory_file)
 
     def _read_memory(self) -> List[Dict[str, Any]]:
@@ -47,8 +51,12 @@ class BasicMemory:
             return []
 
     def _write_memory(self, data: List[Dict[str, Any]]) -> None:
-        with open(self._memory_file, "w", encoding="utf-8") as f:
-            json.dump(data, f)
+        try:
+            with open(self._memory_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+        except Exception as e:
+            logger.error("Failed to write memory file %s: %s", self._memory_file, e, exc_info=True)
+            raise
 
     async def _handle_input_event(self, msg: Msg) -> None:
         input_id = "unknown"

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -32,7 +32,11 @@ class GraphMemory:
             self._graph = self._read_graph()
         else:
             self._graph = nx.DiGraph()
-            self._write_graph()
+            try:
+                self._write_graph()
+            except Exception:
+                # _write_graph already logs the error
+                raise
         logger.info("GraphMemory initialized with file %s", self._graph_file)
 
     def _read_graph(self) -> nx.DiGraph:
@@ -46,8 +50,12 @@ class GraphMemory:
 
     def _write_graph(self) -> None:
         data = nx.readwrite.json_graph.node_link_data(self._graph)
-        with open(self._graph_file, "w", encoding="utf-8") as f:
-            json.dump(data, f)
+        try:
+            with open(self._graph_file, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+        except Exception as e:
+            logger.error("Failed to write graph file %s: %s", self._graph_file, e, exc_info=True)
+            raise
 
     def _add_interaction(self, user_input: str) -> str:
         timestamp = datetime.now(timezone.utc).isoformat()

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -1,3 +1,4 @@
+import builtins
 import json
 import logging
 from types import SimpleNamespace
@@ -64,3 +65,30 @@ def test_init_creates_directory(tmp_path, monkeypatch):
     assert isinstance(mem._graph, nx.DiGraph)
     with open(graph_file, "r", encoding="utf-8") as f:
         assert isinstance(json.load(f), dict)
+
+
+def test_write_graph_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
+    graph_file = tmp_path / "graph.json"
+    mem = create_memory(monkeypatch, graph_file)
+
+    def fail_open(*args, **kwargs):
+        raise IOError("fail")
+
+    monkeypatch.setattr(builtins, "open", fail_open)
+    with caplog.at_level(logging.ERROR), pytest.raises(IOError):
+        mem._write_graph()
+
+    assert any("Failed to write graph file" in r.getMessage() for r in caplog.records)
+
+
+def test_init_write_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
+    graph_file = tmp_path / "graph.json"
+
+    def fail_open(*args, **kwargs):
+        raise IOError("fail")
+
+    monkeypatch.setattr(builtins, "open", fail_open)
+    with caplog.at_level(logging.ERROR), pytest.raises(IOError):
+        memory_graph.GraphMemory(DummyNATS(), DummyJS(), graph_file=graph_file)
+
+    assert any("Failed to write graph file" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- handle initialization write errors in memory modules
- catch and re-raise write errors for basic and graph memories
- test write failure behavior for memory modules
- cover initialization write failures

## Testing
- `pre-commit run --files tests/unit/modules/test_memory_basic.py tests/unit/modules/test_memory_graph.py`
- `pytest tests/unit/modules/test_memory_basic.py tests/unit/modules/test_memory_graph.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6855797fbb648326a60e90588df55f20