### PR TITLE
Validate payloads and add tests

### DIFF
--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -23,6 +23,9 @@ class InputHandler:
 
     async def process_input(self, user_input: str) -> str:
         """Process input and publish via JetStream."""
+        if not isinstance(user_input, str):
+            raise ValueError("user_input must be a string")
+
         input_id = str(uuid.uuid4())
         # Use timezone-aware UTC timestamp
         timestamp = datetime.now(timezone.utc).isoformat()

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -45,8 +45,12 @@ class BasicLLM:
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
-            input_id = data.get("input_id", "unknown")
-            retrieved = data.get("retrieved_knowledge", {})
+            if not isinstance(data, dict):
+                raise ValueError("MemoryRetrieved payload must be a dict")
+            input_id = data.get("input_id")
+            retrieved = data.get("retrieved_knowledge")
+            if not isinstance(input_id, str) or retrieved is None:
+                raise ValueError("Invalid memory payload fields")
             if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
                 knowledge = retrieved.get("retrieved_knowledge", {})
             elif isinstance(retrieved, dict):
@@ -109,6 +113,18 @@ class BasicLLM:
                     input_id,
                 )
             await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Invalid MemoryRetrieved payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
         except Exception as e:
             logger.error("Error in BasicLLM handler: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -54,8 +54,12 @@ class ProductionLLM:
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
-            input_id = data.get("input_id", "unknown")
-            retrieved = data.get("retrieved_knowledge", {})
+            if not isinstance(data, dict):
+                raise ValueError("MemoryRetrieved payload must be a dict")
+            input_id = data.get("input_id")
+            retrieved = data.get("retrieved_knowledge")
+            if not isinstance(input_id, str) or retrieved is None:
+                raise ValueError("Invalid memory payload fields")
             if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
                 knowledge = retrieved.get("retrieved_knowledge", {})
             elif isinstance(retrieved, dict):
@@ -107,6 +111,18 @@ class ProductionLLM:
             await self._publisher.publish(EventSubjects.RESPONSE_GENERATED, payload, use_jetstream=True, timeout=10.0)
             logger.info("ProductionLLM published RESPONSE_GENERATED for %s", input_id)
             await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:  # pragma: no cover - validation errors
+            logger.error("Invalid MemoryRetrieved payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
         except Exception as e:  # pragma: no cover - runtime errors are logged
             logger.error("Error in ProductionLLM handler: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -54,8 +54,12 @@ class BasicMemory:
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
-            input_id = data.get("input_id", "unknown")
-            user_input = data.get("user_input", "")
+            if not isinstance(data, dict):
+                raise ValueError("InputReceived payload must be a dict")
+            input_id = data.get("input_id")
+            user_input = data.get("user_input")
+            if not isinstance(input_id, str) or not isinstance(user_input, str):
+                raise ValueError("Invalid input payload fields")
             logger.info("BasicMemory received input event ID %s", input_id)
 
             history = self._read_memory()
@@ -74,6 +78,18 @@ class BasicMemory:
             await self._publisher.publish(EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0)
             logger.info("BasicMemory published memory event ID %s", input_id)
             await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
         except Exception as e:
             logger.error("Error in BasicMemory handler: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -46,8 +46,12 @@ class KnowledgeGraphMemory:
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
-            input_id = data.get("input_id", "unknown")
-            user_input = data.get("user_input", "")
+            if not isinstance(data, dict):
+                raise ValueError("InputReceived payload must be a dict")
+            input_id = data.get("input_id")
+            user_input = data.get("user_input")
+            if not isinstance(input_id, str) or not isinstance(user_input, str):
+                raise ValueError("Invalid input payload fields")
             logger.info("KnowledgeGraphMemory received input %s", input_id)
 
             nodes, edges = self._parse_input(user_input)
@@ -65,6 +69,18 @@ class KnowledgeGraphMemory:
                 timeout=10.0,
             )
             await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:  # pragma: no cover - validation errors
+            logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
         except Exception as e:  # pragma: no cover - error path
             logger.error("Error in KnowledgeGraphMemory: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -57,3 +57,12 @@ async def test_process_input_error():
     handler = InputHandler(nc, js)
     with pytest.raises(RuntimeError):
         await handler.process_input("boom")
+
+
+@pytest.mark.asyncio
+async def test_process_input_invalid_type():
+    js = DummyJS()
+    nc = DummyNATS()
+    handler = InputHandler(nc, js)
+    with pytest.raises(ValueError):
+        await handler.process_input(123)

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -43,9 +43,13 @@ class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
         self.acked = False
+        self.nacked = False
 
     async def ack(self):
         self.acked = True
+
+    async def nak(self):
+        self.nacked = True
 
 
 class DummyTensor:
@@ -136,7 +140,7 @@ async def test_handle_memory_event_non_dict(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("not a dict" in r.getMessage() for r in caplog.records)
@@ -150,7 +154,7 @@ async def test_handle_memory_event_missing_facts(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("missing facts" in r.getMessage() for r in caplog.records)
@@ -164,7 +168,19 @@ async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("missing facts" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_missing_input_id(monkeypatch):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]})
+    msg = DummyMsg(payload.to_json())
+    await llm._handle_memory_event(msg)
+
+    assert msg.nacked
+    pub = llm._publisher
+    assert not pub.published

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -43,9 +43,13 @@ class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
         self.acked = False
+        self.nacked = False
 
     async def ack(self):
         self.acked = True
+
+    async def nak(self):
+        self.nacked = True
 
 
 class DummyTensor:
@@ -133,7 +137,7 @@ async def test_handle_memory_event_non_dict(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("not a dict" in r.getMessage() for r in caplog.records)
@@ -147,7 +151,7 @@ async def test_handle_memory_event_missing_facts(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("missing facts" in r.getMessage() for r in caplog.records)
@@ -161,7 +165,19 @@ async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
     with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
-    assert msg.acked
+    assert msg.nacked
     pub = llm._publisher
     assert not pub.published
     assert any("missing facts" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_missing_input_id(monkeypatch):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["x"]})
+    msg = DummyMsg(payload.to_json())
+    await llm._handle_memory_event(msg)
+
+    assert msg.nacked
+    pub = llm._publisher
+    assert not pub.published

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -47,9 +47,13 @@ class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
         self.acked = False
+        self.nacked = False
 
     async def ack(self):
         self.acked = True
+
+    async def nak(self):
+        self.nacked = True
 
 
 def create_memory(monkeypatch, memory_file, publisher_cls=DummyPublisher):
@@ -87,11 +91,34 @@ async def test_handle_input_error(tmp_path, monkeypatch):
     msg = DummyMsg(payload.to_json())
     await mem._handle_input_event(msg)
 
-    assert msg.acked  # Even on error, ack() should be called
+    assert msg.nacked
+    assert not msg.acked
     assert mem._publisher.published == []
     with open(mem_file, "r", encoding="utf-8") as f:
         history = json.load(f)
     assert history[-1]["user_input"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_handle_input_invalid_payload(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.json"
+    mem = create_memory(monkeypatch, mem_file)
+    msg = DummyMsg("not json")
+    await mem._handle_input_event(msg)
+
+    assert msg.nacked
+    assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_input_missing_fields(tmp_path, monkeypatch):
+    mem_file = tmp_path / "mem.json"
+    mem = create_memory(monkeypatch, mem_file)
+    msg = DummyMsg(json.dumps({"input_id": "1"}))
+    await mem._handle_input_event(msg)
+
+    assert msg.nacked
+    assert not msg.acked
 
 
 def test_read_memory_invalid_json_logs_error(tmp_path, monkeypatch, caplog):

--- a/tests/unit/modules/test_memory_stub.py
+++ b/tests/unit/modules/test_memory_stub.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -92,3 +93,25 @@ async def test_handle_input_error(monkeypatch):
 
     assert msg.nacked
     assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_input_invalid_payload(monkeypatch):
+    stub = create_stub(monkeypatch)
+    msg = DummyMsg("not json")
+    await stub._handle_input_event(msg)
+
+    assert msg.nacked
+    pub = stub._publisher
+    assert not pub.published
+
+
+@pytest.mark.asyncio
+async def test_handle_input_missing_fields(monkeypatch):
+    stub = create_stub(monkeypatch)
+    msg = DummyMsg(json.dumps({"input_id": "x"}))
+    await stub._handle_input_event(msg)
+
+    assert msg.nacked
+    pub = stub._publisher
+    assert not pub.published

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 import deepthought.modules.output_handler as output_handler
@@ -70,6 +72,26 @@ async def test_handle_response_error(monkeypatch):
     assert handler.get_all_responses() == {}
     assert msg.nacked
     assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_response_missing_fields(monkeypatch):
+    handler = create_handler(monkeypatch)
+    msg = DummyMsg(json.dumps({"input_id": "1"}))
+    await handler._handle_response_event(msg)
+
+    assert handler.get_all_responses() == {}
+    assert msg.nacked
+
+
+@pytest.mark.asyncio
+async def test_handle_response_invalid_types(monkeypatch):
+    handler = create_handler(monkeypatch)
+    msg = DummyMsg(json.dumps({"input_id": 123, "final_response": ["bad"]}))
+    await handler._handle_response_event(msg)
+
+    assert handler.get_all_responses() == {}
+    assert msg.nacked
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -1,4 +1,5 @@
 import pytest
+
 from deepthought.graph.connector import GraphConnector
 
 


### PR DESCRIPTION
## Summary
- add payload validation for message handlers
- ensure OutputHandler rejects invalid responses
- test missing field scenarios across modules

## Testing
- `pre-commit run --files tests/unit/modules/test_output_handler.py tests/unit/modules/test_memory_basic.py tests/unit/modules/test_memory_stub.py tests/unit/modules/test_memory_graph.py tests/unit/modules/test_memory_kg.py src/deepthought/modules/output_handler.py src/deepthought/modules/memory_basic.py src/deepthought/modules/memory_stub.py src/deepthought/modules/memory_graph.py src/deepthought/modules/memory_kg.py`
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557984f6c0832687d8008ec4381314