### PR TITLE
Improve config loading validation

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -43,12 +43,23 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
     if file_path:
         path = Path(file_path)
         with path.open("r", encoding="utf-8") as f:
+            content = f.read()
+        if not content.strip():
+            raise ValueError("Config file is empty")
+
+        try:
             if path.suffix in {".yaml", ".yml"}:
                 if not yaml:
                     raise RuntimeError("PyYAML required to load YAML config")
-                data = yaml.safe_load(f)
+                data = yaml.safe_load(content)
             else:
-                data = json.load(f)
+                data = json.loads(content)
+        except Exception as e:
+            raise ValueError(f"Invalid config structure: {e}") from e
+
+        if not isinstance(data, dict):
+            raise ValueError("Config data must be a mapping")
+
         return Settings.model_validate(data)
     return Settings()
 

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -47,7 +47,14 @@ class GraphMemory:
             return nx.readwrite.json_graph.node_link_graph(data)
         except (FileNotFoundError, PermissionError, OSError, json.JSONDecodeError) as e:
             logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
-            return nx.DiGraph()
+            graph = nx.DiGraph()
+            self._graph = graph
+            try:
+                self._write_graph()
+            except Exception:
+                # _write_graph already logs the error
+                pass
+            return graph
         except Exception as e:  # fallback
             logger.error("Unexpected error reading graph file %s: %s", self._graph_file, e, exc_info=True)
             return nx.DiGraph()

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,5 +1,5 @@
 import json
-
+import logging
 
 import pytest
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,7 @@
 import json
 
 import yaml
+import pytest
 
 from deepthought.config import get_settings, load_settings
 
@@ -65,3 +66,17 @@ def test_get_settings_reload(monkeypatch, tmp_path):
     monkeypatch.setenv("DT_CONFIG_FILE", str(cfg2))
     second = get_settings()
     assert second.nats_url == "nats://second"
+
+
+def test_load_settings_empty_file(tmp_path):
+    cfg = tmp_path / "empty.json"
+    cfg.write_text("")
+    with pytest.raises(ValueError):
+        load_settings(str(cfg))
+
+
+def test_load_settings_invalid_structure(tmp_path):
+    cfg = tmp_path / "bad.yaml"
+    cfg.write_text(yaml.safe_dump([1, 2, 3]))
+    with pytest.raises(ValueError):
+        load_settings(str(cfg))


### PR DESCRIPTION
## Summary
- validate that loaded config is a mapping in `load_settings`
- handle empty/invalid config files
- fix `OutputHandler` tests by importing `logging`
- rewrite bad graph files in `GraphMemory`
- add unit tests for invalid config files

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685795f979e48326980c0b32b8cb0a23