### PR TITLE
Fix subscriber checks and document GraphMemory behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ This step is necessary before running the tests below.
 The `GraphMemory` module uses the lightweight `networkx` library as an
 embedded graph store. No external database service needs to be started.
 Ensure the dependency is installed (included in `requirements.txt`).
+If the graph file contains invalid JSON, `GraphMemory` will automatically
+rewrite it with an empty graph so subsequent loads succeed.
 
 ## Social Graph Bot Example
 

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -144,7 +144,7 @@ class BasicLLM:
                     logger.error("Failed to ack message after error", exc_info=True)
 
     async def start_listening(self, durable_name: str = "llm_basic_listener") -> bool:
-        if not self._subscriber:
+        if self._subscriber is None:
             logger.error("Subscriber not initialized for BasicLLM.")
             return False
         try:

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -142,7 +142,7 @@ class ProductionLLM:
                     logger.error("Failed to ack message after error", exc_info=True)
 
     async def start_listening(self, durable_name: str = "llm_prod_listener") -> bool:
-        if not self._subscriber:
+        if self._subscriber is None:
             logger.error("Subscriber not initialized for ProductionLLM.")
             return False
         try:

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -117,7 +117,7 @@ class BasicMemory:
                     logger.error("Failed to ack message after error", exc_info=True)
 
     async def start_listening(self, durable_name: str = "memory_basic_listener") -> bool:
-        if not self._subscriber:
+        if self._subscriber is None:
             logger.error("Subscriber not initialized for BasicMemory.")
             return False
         try:

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -31,6 +31,12 @@ class GraphMemory:
 
         if os.path.exists(self._graph_file):
             self._graph = self._read_graph()
+            if self._graph.number_of_nodes() == 0 and self._graph.number_of_edges() == 0:
+                try:
+                    self._write_graph()
+                except Exception:
+                    # _write_graph already logs the error
+                    raise
         else:
             self._graph = nx.DiGraph()
             try:
@@ -130,7 +136,7 @@ class GraphMemory:
                     logger.error("Failed to ack message after error", exc_info=True)
 
     async def start_listening(self, durable_name: str = "memory_graph_listener") -> bool:
-        if not self._subscriber:
+        if self._subscriber is None:
             logger.error("Subscriber not initialized for GraphMemory.")
             return False
         try:

--- a/src/deepthought/modules/memory_stub.py
+++ b/src/deepthought/modules/memory_stub.py
@@ -104,7 +104,7 @@ class MemoryStub:
         Returns:
             bool: True if subscription was successful, False otherwise.
         """
-        if not self._subscriber:
+        if self._subscriber is None:
             logger.error("Subscriber not initialized for MemoryStub.")
             return False
 

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -185,3 +185,16 @@ async def test_handle_memory_event_missing_input_id(monkeypatch):
     pub = llm._publisher
     assert not pub.published
 
+
+@pytest.mark.asyncio
+async def test_start_listening_no_subscriber(monkeypatch, caplog):
+    llm = create_llm(monkeypatch)
+    llm._subscriber = None
+    with caplog.at_level(logging.ERROR):
+        result = await llm.start_listening()
+
+    assert result is False
+    assert any(
+        "Subscriber not initialized for BasicLLM." in r.getMessage() for r in caplog.records
+    )
+

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -182,3 +182,16 @@ async def test_handle_memory_event_missing_input_id(monkeypatch):
     pub = llm._publisher
     assert not pub.published
 
+
+@pytest.mark.asyncio
+async def test_start_listening_no_subscriber(monkeypatch, caplog):
+    llm = create_llm(monkeypatch)
+    llm._subscriber = None
+    with caplog.at_level(logging.ERROR):
+        result = await llm.start_listening()
+
+    assert result is False
+    assert any(
+        "Subscriber not initialized for ProductionLLM." in r.getMessage() for r in caplog.records
+    )
+

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -168,3 +168,17 @@ def test_init_write_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
         memory_basic.BasicMemory(DummyNATS(), DummyJS(), memory_file=mem_file)
 
     assert any("Failed to initialize memory file" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_start_listening_no_subscriber(tmp_path, monkeypatch, caplog):
+    mem_file = tmp_path / "mem.json"
+    mem = create_memory(monkeypatch, mem_file)
+    mem._subscriber = None
+    with caplog.at_level(logging.ERROR):
+        result = await mem.start_listening()
+
+    assert result is False
+    assert any(
+        "Subscriber not initialized for BasicMemory." in r.getMessage() for r in caplog.records
+    )

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -118,3 +118,17 @@ async def test_handle_input_missing_fields(tmp_path, monkeypatch):
     assert msg.nacked
     assert not msg.acked
 
+
+@pytest.mark.asyncio
+async def test_start_listening_no_subscriber(tmp_path, monkeypatch, caplog):
+    graph_file = tmp_path / "graph.json"
+    mem = create_memory(monkeypatch, graph_file)
+    mem._subscriber = None
+    with caplog.at_level(logging.ERROR):
+        result = await mem.start_listening()
+
+    assert result is False
+    assert any(
+        "Subscriber not initialized for GraphMemory." in r.getMessage() for r in caplog.records
+    )
+

--- a/tests/unit/modules/test_memory_stub.py
+++ b/tests/unit/modules/test_memory_stub.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -115,3 +116,16 @@ async def test_handle_input_missing_fields(monkeypatch):
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
+
+
+@pytest.mark.asyncio
+async def test_start_listening_no_subscriber(monkeypatch, caplog):
+    stub = create_stub(monkeypatch)
+    stub._subscriber = None
+    with caplog.at_level(logging.ERROR):
+        result = await stub.start_listening()
+
+    assert result is False
+    assert any(
+        "Subscriber not initialized for MemoryStub." in r.getMessage() for r in caplog.records
+    )

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,5 +1,5 @@
 import json
-
+import logging
 
 import pytest
 


### PR DESCRIPTION
## Summary
- ensure `start_listening` methods check explicitly for `None`
- rewrite graph file on invalid JSON
- document GraphMemory's invalid JSON handling
- test subscriber-not-initialized cases

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685795f4ee10832692003e0c4439da43