### PR TITLE
Fix rewriting corrupt graph file

### DIFF
--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -77,6 +77,9 @@ def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
     caplog.set_level(logging.ERROR)
     create_memory(monkeypatch, graph_file)
 
+    error_logs = [r for r in caplog.records if "Failed to read graph file" in r.getMessage()]
+    assert len(error_logs) == 1
+
     with open(graph_file, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data == nx.readwrite.json_graph.node_link_data(nx.DiGraph())

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,5 +1,5 @@
 import json
-
+import logging
 
 import pytest
 


### PR DESCRIPTION
## Summary
- detect JSON decode errors on graph load
- rewrite corrupt graph file with valid empty graph
- record last read error for detection
- test rewritten file loads without errors
- fix flake8 undefined name in tests

## Testing
- `flake8`
- `pytest -q tests/unit/modules/test_memory_graph.py::test_invalid_json_rewritten_and_readable -q`
- `pytest -q tests/unit/modules/test_memory_graph.py::test_read_graph_invalid_json -q`
- `pytest -q tests/unit/modules/test_output_handler.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685795f41f408326a435a2689a338d71