### PR TITLE
Improve GraphMemory error recovery

### DIFF
--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -66,6 +66,7 @@ def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
 
     assert isinstance(mem._graph, nx.DiGraph)
     assert len(mem._graph.nodes) == 0
+    assert mem.repaired
     error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert any("Failed to read graph file" in r.getMessage() for r in error_logs)
 
@@ -75,15 +76,20 @@ def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
     graph_file.write_text("{ invalid json")
 
     caplog.set_level(logging.ERROR)
-    create_memory(monkeypatch, graph_file)
+    mem = create_memory(monkeypatch, graph_file)
+    first_mtime = graph_file.stat().st_mtime
+    assert mem.repaired
 
     with open(graph_file, "r", encoding="utf-8") as f:
         data = json.load(f)
     assert data == nx.readwrite.json_graph.node_link_data(nx.DiGraph())
 
     caplog.clear()
-    create_memory(monkeypatch, graph_file)
+    mem2 = create_memory(monkeypatch, graph_file)
+    second_mtime = graph_file.stat().st_mtime
 
+    assert not mem2.repaired
+    assert first_mtime == second_mtime
     assert not any(
         "Failed to read graph file" in r.getMessage() for r in caplog.records
     )

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,5 +1,5 @@
 import json
-
+import logging
 
 import pytest
 


### PR DESCRIPTION
## Summary
- add `repaired` flag to `GraphMemory` to track file fixes
- re-write graph file only when needed
- ensure output handler tests import `logging`
- extend graph memory tests to verify repaired state and avoid redundant writes

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_685795f6f2b88326bcf720a98e1be40d