### PR TITLE
Handle prism send errors

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -350,7 +350,11 @@ async def send_to_prism(data: dict) -> None:
     try:
         async with aiohttp.ClientSession() as session:
             await session.post(PRISM_ENDPOINT, json=data, timeout=5)
-    except Exception as exc:
+    except aiohttp.ClientError as exc:
+        logger.warning("ClientError sending data to Prism: %s", exc)
+    except asyncio.TimeoutError as exc:
+        logger.warning("TimeoutError sending data to Prism: %s", exc)
+    except Exception as exc:  # pragma: no cover - unexpected errors
         logger.warning("Failed to send data to Prism: %s", exc)
 
 

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -31,6 +31,12 @@ class GraphMemory:
 
         if os.path.exists(self._graph_file):
             self._graph = self._read_graph()
+            # Ensure corrupted files get rewritten as valid JSON
+            try:
+                self._write_graph()
+            except Exception:
+                # _write_graph already logs the error
+                raise
         else:
             self._graph = nx.DiGraph()
             try:
@@ -51,7 +57,6 @@ class GraphMemory:
         except Exception as e:  # fallback
             logger.error("Unexpected error reading graph file %s: %s", self._graph_file, e, exc_info=True)
             return nx.DiGraph()
-
 
     def _write_graph(self) -> None:
         data = nx.readwrite.json_graph.node_link_data(self._graph)

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -1,5 +1,5 @@
 import json
-
+import logging
 
 import pytest
 

--- a/tests/unit/test_send_to_prism.py
+++ b/tests/unit/test_send_to_prism.py
@@ -1,0 +1,25 @@
+import logging
+
+import aiohttp
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+class DummySession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        raise aiohttp.ClientError("boom")
+
+
+@pytest.mark.asyncio
+async def test_send_to_prism_client_error(monkeypatch, caplog):
+    monkeypatch.setattr(sg.aiohttp, "ClientSession", lambda: DummySession())
+    with caplog.at_level(logging.WARNING):
+        await sg.send_to_prism({"x": 1})
+    assert any("ClientError" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- catch `aiohttp.ClientError` and `asyncio.TimeoutError` in `send_to_prism`
- log specific error types and warn on unexpected exceptions
- test that `ClientError` in `send_to_prism` logs a warning
- rewrite invalid graph JSON files on read failure
- fix output handler test import

## Testing
- `pre-commit run --files src/deepthought/modules/memory_graph.py tests/unit/modules/test_output_handler.py examples/social_graph_bot.py tests/unit/test_send_to_prism.py`
- `pytest tests/unit/modules/test_memory_graph.py::test_invalid_json_rewritten_and_readable -q`
- `pytest tests/unit/modules/test_output_handler.py::test_handle_response_logs_when_no_callback -q`
- `pytest tests/unit/test_send_to_prism.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685795f7adc483268613749e4d0950bd