### PR TITLE
Implement GraphDAL and unit tests

### DIFF
--- a/src/deepthought/graph/__init__.py
+++ b/src/deepthought/graph/__init__.py
@@ -1,5 +1,6 @@
 """Graph utilities for DeepThought."""
 
 from .connector import GraphConnector
+from .dal import GraphDAL
 
-__all__ = ["GraphConnector"]
+__all__ = ["GraphConnector", "GraphDAL"]

--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .connector import GraphConnector
+
+
+class GraphDAL:
+    """Simple data access layer using :class:`GraphConnector`."""
+
+    def __init__(self, connector: GraphConnector) -> None:
+        self._connector = connector
+
+    def add_entity(self, label: str, properties: Dict[str, Any]) -> None:
+        """Create or merge a node with the given ``label`` and ``properties``."""
+        query = f"MERGE (n:{label} $props)"
+        self._connector.execute(query, {"props": properties})
+
+    def add_relationship(
+        self,
+        start_id: Any,
+        end_id: Any,
+        rel_type: str,
+        properties: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Create or merge a relationship between two nodes by ``id``."""
+        query = (
+            "MATCH (a {id: $start_id}), (b {id: $end_id}) "
+            f"MERGE (a)-[r:{rel_type} $props]->(b)"
+        )
+        self._connector.execute(
+            query,
+            {"start_id": start_id, "end_id": end_id, "props": properties or {}},
+        )
+
+    def get_entity(self, label: str, key: str, value: Any) -> Optional[Dict[str, Any]]:
+        """Return the first node matching ``label`` and property ``key``."""
+        query = f"MATCH (n:{label} {{{key}: $value}}) RETURN n"
+        result = self._connector.execute(query, {"value": value})
+        return result[0] if result else None
+
+    def query_subgraph(self, query: str, params: Optional[Dict[str, Any]] = None) -> List:
+        """Execute an arbitrary Cypher ``query`` and return the results."""
+        return self._connector.execute(query, params)

--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -1,0 +1,55 @@
+from deepthought.graph.dal import GraphDAL
+
+
+class DummyConnector:
+    def __init__(self, result=None):
+        self.executed = []
+        self.result = result if result is not None else []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+        return self.result
+
+
+def test_add_entity():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    dal.add_entity("Person", {"name": "Alice"})
+
+    assert connector.executed == [
+        ("MERGE (n:Person $props)", {"props": {"name": "Alice"}})
+    ]
+
+
+def test_add_relationship():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    dal.add_relationship(1, 2, "KNOWS", {"since": 2020})
+
+    assert connector.executed == [
+        (
+            "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:KNOWS $props]->(b)",
+            {"start_id": 1, "end_id": 2, "props": {"since": 2020}},
+        )
+    ]
+
+
+def test_get_entity():
+    connector = DummyConnector(result=[{"name": "Alice"}])
+    dal = GraphDAL(connector)
+    result = dal.get_entity("Person", "name", "Alice")
+
+    assert result == {"name": "Alice"}
+    assert connector.executed == [
+        ("MATCH (n:Person {name: $value}) RETURN n", {"value": "Alice"})
+    ]
+
+
+def test_query_subgraph():
+    connector = DummyConnector(result=[{"id": 1}])
+    dal = GraphDAL(connector)
+    q = "MATCH (n) RETURN n LIMIT 1"
+    result = dal.query_subgraph(q, {"limit": 1})
+
+    assert result == [{"id": 1}]
+    assert connector.executed == [(q, {"limit": 1})]


### PR DESCRIPTION
## Summary
- add GraphDAL class with common graph operations
- export GraphDAL from graph package
- test GraphDAL behavior with a dummy connector

## Testing
- `pip install -q -r requirements-ci.txt`
- `PYTHONPATH=src pytest -q`
- `flake8 src tests`

------
https://chatgpt.com/codex/tasks/task_e_68580de5796083268f781d8c8f7a7692