### PR TITLE
Add MemoryService with GraphDAL

### DIFF
--- a/src/deepthought/services/graph_dal.py
+++ b/src/deepthought/services/graph_dal.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import List
+
+import networkx as nx
+
+logger = logging.getLogger(__name__)
+
+
+class GraphDAL:
+    """Simple file-backed graph storage using NetworkX."""
+
+    def __init__(self, graph_file: str = "graph_memory.json") -> None:
+        self._graph_file = graph_file
+        dir_path = os.path.dirname(graph_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+
+        if os.path.exists(graph_file):
+            self._graph = self._read_graph()
+        else:
+            self._graph = nx.DiGraph()
+            self._write_graph()
+        logger.info("GraphDAL initialized with file %s", graph_file)
+
+    def _read_graph(self) -> nx.DiGraph:
+        try:
+            with open(self._graph_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return nx.readwrite.json_graph.node_link_graph(data)
+        except Exception as e:
+            logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
+            return nx.DiGraph()
+
+    def _write_graph(self) -> None:
+        data = nx.readwrite.json_graph.node_link_data(self._graph)
+        with open(self._graph_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def add_interaction(self, user_input: str) -> str:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        node_id = timestamp
+        self._graph.add_node(node_id, user_input=user_input, timestamp=timestamp)
+        nodes = list(self._graph.nodes())
+        if len(nodes) > 1:
+            self._graph.add_edge(nodes[-2], node_id, relation="next")
+        self._write_graph()
+        return node_id
+
+    def get_recent_facts(self, count: int = 3) -> List[str]:
+        nodes = sorted(self._graph.nodes(data=True), key=lambda n: n[1].get("timestamp", ""))
+        recent = nodes[-count:]
+        return [n[1].get("user_input", "") for n in recent]

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -1,0 +1,102 @@
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+from .graph_dal import GraphDAL
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryService:
+    """Service that stores user interactions in a graph using GraphDAL."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, dal: Optional[GraphDAL] = None) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._dal = dal or GraphDAL()
+
+    async def _handle_input(self, msg: Msg) -> None:
+        input_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("InputReceived payload must be a dict")
+            input_id = data.get("input_id")
+            user_input = data.get("user_input")
+            if not isinstance(input_id, str) or not isinstance(user_input, str):
+                raise ValueError("Invalid input payload fields")
+            logger.info("MemoryService received input event ID %s", input_id)
+
+            self._dal.add_interaction(user_input)
+            facts = self._dal.get_recent_facts()
+            memory_data = {"facts": facts, "source": "memory_service"}
+            payload = MemoryRetrievedPayload(
+                retrieved_knowledge={"retrieved_knowledge": memory_data},
+                input_id=input_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+
+            await self._publisher.publish(EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0)
+            logger.info("MemoryService published memory event ID %s", input_id)
+            await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+        except Exception as e:
+            logger.error("Error in MemoryService handler: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except nats.errors.Error:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except nats.errors.Error:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+    async def start(self, durable_name: str = "memory_service_listener") -> bool:
+        if self._subscriber is None:
+            logger.error("Subscriber not initialized for MemoryService.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("MemoryService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            return True
+        except nats.errors.Error as e:
+            logger.error("MemoryService failed to subscribe: %s", e, exc_info=True)
+            return False
+        except Exception as e:
+            logger.error("MemoryService failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("MemoryService stopped listening.")
+        else:
+            logger.warning("Cannot stop listening - no subscriber available.")

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -1,0 +1,78 @@
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.services.memory_service import MemoryService
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyDAL:
+    def __init__(self):
+        self.interactions = []
+
+    def add_interaction(self, text):
+        self.interactions.append(text)
+
+    def get_recent_facts(self, count=3):
+        return self.interactions[-count:]
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_handle_input_updates_graph_and_publishes(monkeypatch):
+    dal = DummyDAL()
+    monkeypatch.setattr(MemoryService, "_publisher", DummyPublisher(DummyNATS(), DummyJS()), raising=False)
+    monkeypatch.setattr(MemoryService, "_subscriber", DummySubscriber(), raising=False)
+    service = MemoryService(DummyNATS(), DummyJS(), dal)
+    # replace publisher and subscriber with dummies
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hello", input_id="x")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_input(msg)
+
+    assert msg.acked
+    assert dal.interactions == ["hello"]
+    subject, sent_payload = service._publisher.published[0]
+    assert subject == EventSubjects.MEMORY_RETRIEVED
+    assert sent_payload.input_id == "x"
+    assert "hello" in sent_payload.retrieved_knowledge["retrieved_knowledge"]["facts"]
+    ts = sent_payload.timestamp
+    assert datetime.fromisoformat(ts).tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- implement GraphDAL for storing a simple interaction graph
- add MemoryService using Publisher/Subscriber and GraphDAL
- test MemoryService `_handle_input`

## Testing
- `pre-commit run --files src/deepthought/services/graph_dal.py src/deepthought/services/memory_service.py tests/unit/services/test_memory_service.py`
- `PYTHONPATH=src pytest -q tests/unit/services/test_memory_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68580de6c2748326be3ecd4b048eab54