### PR TITLE
Send Discord inputs to NATS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,14 @@ def prism_calls(monkeypatch):
 
     monkeypatch.setattr(sg, "send_to_prism", fake_send)
     return calls
+
+
+@pytest.fixture
+def input_events(monkeypatch):
+    calls = []
+
+    async def fake_publish(text):
+        calls.append(text)
+
+    monkeypatch.setattr(sg, "publish_input_received", fake_publish)
+    return calls

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -44,7 +44,7 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch):
+async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch, input_events):
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.init_db()
@@ -80,7 +80,7 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch):
+async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch, input_events):
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.init_db()

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -45,7 +45,7 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_on_message_stores_memory(tmp_path, monkeypatch):
+async def test_on_message_stores_memory(tmp_path, monkeypatch, input_events):
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.init_db()
@@ -84,7 +84,7 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls):
+async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls, input_events):
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.init_db()
@@ -108,6 +108,7 @@ async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls
 
     assert len(prism_calls) == 1
     assert prism_calls[0]["content"] == "send prism"
+    assert input_events == ["send prism"]
     await sg.db_manager.close()
 
 
@@ -126,7 +127,7 @@ async def test_update_sentiment_trend(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch):
+async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch, input_events):
 
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()


### PR DESCRIPTION
## Summary
- forward user inputs to Prism and publish INPUT_RECEIVED events via NATS
- capture INPUT_RECEIVED events in tests

## Testing
- `flake8 src examples tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580de76c048326bbf4f99502d4b24e