### PR TITLE
Add validation tests for sentiment trend

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -3,20 +3,21 @@ import json
 import logging
 import os
 import random
+import uuid
 from datetime import timezone
 from typing import List, Tuple
 
 import aiohttp
 import aiosqlite
 import discord
-from textblob import TextBlob
-from deepthought.eda.events import EventSubjects, InputReceivedPayload
-from deepthought.eda.publisher import Publisher
-from deepthought.config import get_settings
 import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
-import uuid
+from textblob import TextBlob
+
+from deepthought.config import get_settings
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.eda.publisher import Publisher
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -231,6 +232,10 @@ class DBManager:
         channel_id: int,
         sentiment_score: float,
     ) -> None:
+        if not isinstance(sentiment_score, (int, float)):
+            raise ValueError("sentiment_score must be numeric")
+        if not -1 <= float(sentiment_score) <= 1:
+            raise ValueError("sentiment_score out of range")
         await self.connect()
         assert self._db
         await self._db.execute(

--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-
 from .connector import GraphConnector
 
 
 class GraphDAL:
     """Data access layer providing high level graph operations."""
-
 
     def __init__(self, connector: GraphConnector) -> None:
         self._connector = connector
@@ -21,3 +19,25 @@ class GraphDAL:
             "MATCH (a:Entity {name: $src}), (b:Entity {name: $dst}) MERGE (a)-[:NEXT]->(b)",
             {"src": src, "dst": dst},
         )
+
+    # --- Methods used in tests ---
+    def add_entity(self, label: str, props: dict) -> None:
+        """Create or update a node with ``label`` and ``props``."""
+        query = f"MERGE (n:{label} $props)"
+        self._connector.execute(query, {"props": props})
+
+    def add_relationship(self, start_id: int, end_id: int, rel_type: str, props: dict | None = None) -> None:
+        """Create or update a relationship of type ``rel_type`` between nodes."""
+        props = props or {}
+        query = f"MATCH (a {{id: $start_id}}), (b {{id: $end_id}}) MERGE (a)-[r:{rel_type} $props]->(b)"
+        self._connector.execute(query, {"start_id": start_id, "end_id": end_id, "props": props})
+
+    def get_entity(self, label: str, key: str, value: str):
+        """Return a single node matching ``label`` and ``key``."""
+        query = f"MATCH (n:{label} {{{key}: $value}}) RETURN n"
+        rows = self._connector.execute(query, {"value": value})
+        return rows[0] if rows else None
+
+    def query_subgraph(self, query: str, params: dict | None = None):
+        """Run an arbitrary query and return the results."""
+        return self._connector.execute(query, params or {})

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -127,6 +127,21 @@ async def test_update_sentiment_trend(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_update_sentiment_trend_validation(tmp_path):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.init_db()
+
+    with pytest.raises(ValueError):
+        await sg.update_sentiment_trend("u1", "c1", "bad")
+
+    with pytest.raises(ValueError):
+        await sg.update_sentiment_trend("u1", "c1", 1.5)
+
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
 async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch, input_events):
 
     sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))


### PR DESCRIPTION
## Summary
- validate sentiment scores when updating sentiment trends
- support basic graph DAL operations used in tests
- cover invalid inputs for `update_sentiment_trend`

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py src/deepthought/graph/dal.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859680904f48326833a6e340c91a35b