### PR TITLE
Add idle text generation

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -51,6 +51,44 @@ idle_response_candidates = [
     "Silence can be golden, but conversation is better.",
 ]
 
+# -----------------------------
+# Idle text generation helpers
+# -----------------------------
+_idle_text_generator = None
+
+
+def _get_idle_generator():
+    """Return a cached HuggingFace text-generation pipeline."""
+    global _idle_text_generator
+    if _idle_text_generator is None:
+        from transformers import pipeline
+
+        model_name = os.getenv("IDLE_MODEL_NAME", "distilgpt2")
+        _idle_text_generator = pipeline("text-generation", model=model_name)
+    return _idle_text_generator
+
+
+async def generate_idle_response(prompt: str | None = None) -> str | None:
+    """Generate a prompt to send when the channel has been idle.
+
+    The seed text can be provided via ``prompt`` or the ``IDLE_GENERATOR_PROMPT``
+    environment variable. ``None`` is returned if generation fails for any
+    reason.
+    """
+    try:
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
+        generator = _get_idle_generator()
+        outputs = await asyncio.to_thread(
+            generator, gen_prompt, max_new_tokens=20, num_return_sequences=1
+        )
+        text = outputs[0]["generated_text"].strip()
+        return text
+    except Exception:  # pragma: no cover - optional dependency or runtime error
+        logger.exception("Idle text generation failed")
+        return None
+
 # Simple list of phrases considered bullying
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
 
@@ -545,7 +583,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                             respond_to = last_message
 
         if send_prompt:
-            prompt = random.choice(idle_response_candidates)
+            prompt = await generate_idle_response()
+            if not prompt:
+                prompt = random.choice(idle_response_candidates)
             async with channel.typing():
                 await asyncio.sleep(random.uniform(3, 10))
                 if respond_to is not None:

--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -21,3 +21,30 @@ class GraphDAL:
             "MATCH (a:Entity {name: $src}), (b:Entity {name: $dst}) MERGE (a)-[:NEXT]->(b)",
             {"src": src, "dst": dst},
         )
+
+    # ------------------------------------------------------------------
+    # Additional helper methods used by tests
+    # ------------------------------------------------------------------
+
+    def add_entity(self, label: str, props: dict) -> None:
+        """Create or merge an entity node with arbitrary properties."""
+        self._connector.execute(f"MERGE (n:{label} $props)", {"props": props})
+
+    def add_relationship(self, start_id: int, end_id: int, rel_type: str, props: dict) -> None:
+        """Create or merge a relationship between two nodes."""
+        self._connector.execute(
+            f"MATCH (a {{id: $start_id}}), (b {{id: $end_id}}) MERGE (a)-[r:{rel_type} $props]->(b)",
+            {"start_id": start_id, "end_id": end_id, "props": props},
+        )
+
+    def get_entity(self, label: str, prop: str, value: str) -> dict | None:
+        """Retrieve the first entity matching ``prop``."""
+        result = self._connector.execute(
+            f"MATCH (n:{label} {{{prop}: $value}}) RETURN n",
+            {"value": value},
+        )
+        return result[0] if result else None
+
+    def query_subgraph(self, query: str, params: dict) -> list:
+        """Run an arbitrary Cypher query and return the results."""
+        return self._connector.execute(query, params)


### PR DESCRIPTION
## Summary
- replace static idle prompts with generated text
- fall back to existing prompts if generation fails
- extend GraphDAL with helper methods used in tests
- test generator path and fallback
- allow custom seed text for idle generator via environment variable

## Testing
- `flake8 src tests examples/social_graph_bot.py`
- `PYTHONPATH=src pytest tests/test_monitor_channels.py::test_monitor_channels_idle_prompt tests/test_monitor_channels.py::test_monitor_channels_generator_failure tests/test_monitor_channels.py::test_generate_idle_response_env -q`


------
https://chatgpt.com/codex/tasks/task_e_685967f8140483268c5cf4cbae2cc874