### PR TITLE
Rename GraphDAL to FileGraphDAL

### DIFF
--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-
 from .connector import GraphConnector
 
 
 class GraphDAL:
     """Data access layer providing high level graph operations."""
-
 
     def __init__(self, connector: GraphConnector) -> None:
         self._connector = connector
@@ -21,3 +19,28 @@ class GraphDAL:
             "MATCH (a:Entity {name: $src}), (b:Entity {name: $dst}) MERGE (a)-[:NEXT]->(b)",
             {"src": src, "dst": dst},
         )
+
+    # New methods expected by unit tests
+
+    def add_entity(self, label: str, props: dict) -> None:
+        """Create or merge a node with ``label`` and ``props``."""
+        query = f"MERGE (n:{label} $props)"
+        self._connector.execute(query, {"props": props})
+
+    def add_relationship(self, start_id: int, end_id: int, rel_type: str, props: dict) -> None:
+        """Create or merge a relationship of ``rel_type`` between two nodes."""
+        query = "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:" f"{rel_type} $props]->(b)"
+        self._connector.execute(
+            query,
+            {"start_id": start_id, "end_id": end_id, "props": props},
+        )
+
+    def get_entity(self, label: str, field: str, value):
+        """Return the first node of ``label`` where ``field`` equals ``value``."""
+        query = f"MATCH (n:{label} {{{field}: $value}}) RETURN n"
+        rows = self._connector.execute(query, {"value": value})
+        return rows[0] if rows else None
+
+    def query_subgraph(self, query: str, params: dict):
+        """Execute an arbitrary query and return the resulting rows."""
+        return self._connector.execute(query, params)

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -1,0 +1,6 @@
+"""Service utilities for DeepThought."""
+
+from .file_graph_dal import FileGraphDAL
+from .memory_service import MemoryService
+
+__all__ = ["FileGraphDAL", "MemoryService"]

--- a/src/deepthought/services/file_graph_dal.py
+++ b/src/deepthought/services/file_graph_dal.py
@@ -9,7 +9,7 @@ import networkx as nx
 logger = logging.getLogger(__name__)
 
 
-class GraphDAL:
+class FileGraphDAL:
     """Simple file-backed graph storage using NetworkX."""
 
     def __init__(self, graph_file: str = "graph_memory.json") -> None:
@@ -23,7 +23,7 @@ class GraphDAL:
         else:
             self._graph = nx.DiGraph()
             self._write_graph()
-        logger.info("GraphDAL initialized with file %s", graph_file)
+        logger.info("FileGraphDAL initialized with file %s", graph_file)
 
     def _read_graph(self) -> nx.DiGraph:
         try:

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -11,18 +11,18 @@ from nats.js.client import JetStreamContext
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
-from .graph_dal import GraphDAL
+from .file_graph_dal import FileGraphDAL
 
 logger = logging.getLogger(__name__)
 
 
 class MemoryService:
-    """Service that stores user interactions in a graph using GraphDAL."""
+    """Service that stores user interactions in a graph using FileGraphDAL."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, dal: Optional[GraphDAL] = None) -> None:
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, dal: Optional[FileGraphDAL] = None) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._dal = dal or GraphDAL()
+        self._dal = dal or FileGraphDAL()
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"


### PR DESCRIPTION
## Summary
- rename `graph_dal.py` to `file_graph_dal.py`
- update `MemoryService` to import `FileGraphDAL`
- export `FileGraphDAL` via services package
- add missing methods to `GraphDAL`

## Testing
- `pre-commit run --files src/deepthought/graph/dal.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685967e857508326a9a1b46a2cb06a51