### PR TITLE
Add Memgraph Memory service example

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -51,3 +51,9 @@ PY
 ```
 
 This service can be used alongside other modules to persist conversations in a graph database.
+
+Alternatively, run the example script directly:
+
+```bash
+python examples/memgraph_memory_service.py
+```

--- a/examples/memgraph_memory_service.py
+++ b/examples/memgraph_memory_service.py
@@ -1,0 +1,33 @@
+import asyncio
+import logging
+import os
+
+from nats.aio.client import Client as NATS
+
+from deepthought.graph import GraphConnector, GraphDAL
+from deepthought.modules import KnowledgeGraphMemory
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    nc = NATS()
+    await nc.connect(servers=[os.getenv("NATS_URL", "nats://localhost:4222")])
+    js = nc.jetstream()
+
+    connector = GraphConnector(
+        host=os.getenv("MG_HOST", "localhost"),
+        port=int(os.getenv("MG_PORT", "7687")),
+        username=os.getenv("MG_USER", ""),
+        password=os.getenv("MG_PASSWORD", ""),
+    )
+    dal = GraphDAL(connector)
+    memory = KnowledgeGraphMemory(nc, js, dal)
+    await memory.start_listening()
+    logger.info("KnowledgeGraphMemory listening for INPUT_RECEIVED events")
+    await asyncio.Event().wait()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `examples/memgraph_memory_service.py` using `GraphConnector` and `KnowledgeGraphMemory`
- document how to run the example in `docs/graphdal.md`

## Testing
- `pre-commit run --files examples/memgraph_memory_service.py docs/graphdal.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad8ef932883269094ba06c4d541cb