### PR TITLE
Add optional VADER sentiment backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ implemented in `examples/prism_server.py`.
 Install the optional dependencies:
 
 ```bash
-pip install discord.py aiohttp aiosqlite textblob
+pip install discord.py aiohttp aiosqlite textblob vaderSentiment
 ```
 
-After installing TextBlob, download its corpora:
+If you choose the TextBlob backend, download its corpora:
 
 ```bash
 python -m textblob.download_corpora
@@ -183,6 +183,7 @@ export DISCORD_TOKEN=your_token
 export MONITOR_CHANNEL=1234567890
 export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
+export SENTIMENT_BACKEND=vader  # optional, defaults to textblob
 ```
 
 Run the bot:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -10,3 +10,4 @@ aiohttp==3.12.3
 discord.py==2.5.2
 textblob==0.17.1
 pre-commit==4.2.0
+vaderSentiment==3.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ discord.py
 textblob
 networkx
 pydantic-settings
+vaderSentiment

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -168,6 +168,6 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch, input_e
     await bot.on_message(message)
 
     trend = await sg.get_sentiment_trend(message.author.id, message.channel.id)
-    expected = sg.TextBlob(message.content).sentiment.polarity
+    expected = sg.analyze_sentiment(message.content)
     assert trend == (expected, 1)
     await sg.db_manager.close()

--- a/tests/test_sentiment_backend.py
+++ b/tests/test_sentiment_backend.py
@@ -1,0 +1,22 @@
+import importlib
+
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+@pytest.mark.parametrize("backend", [None, "vader"])
+def test_sentiment_backend(monkeypatch, backend):
+    if backend is None:
+        monkeypatch.delenv("SENTIMENT_BACKEND", raising=False)
+    else:
+        monkeypatch.setenv("SENTIMENT_BACKEND", backend)
+    module = importlib.reload(sg)
+
+    score_pos = module.analyze_sentiment("I love this")
+    score_neg = module.analyze_sentiment("I hate this")
+    assert score_pos > score_neg
+
+    # restore default for other tests
+    monkeypatch.delenv("SENTIMENT_BACKEND", raising=False)
+    importlib.reload(sg)


### PR DESCRIPTION
## Summary
- add `SENTIMENT_BACKEND` environment variable
- support VADER or TextBlob in Social Graph Bot
- document new option in README
- add VADER dependency
- test both backends

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py tests/test_sentiment_backend.py requirements.txt requirements-ci.txt README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ad8eeb8c483268411f03d97808038