### PR TITLE
Add GraphDAL example instructions

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -29,7 +29,7 @@ The snippet below starts `KnowledgeGraphMemory` which listens for `INPUT_RECEIVE
 python - <<'PY'
 import asyncio, os
 from nats.aio.client import Client as NATS
-from deepthought.graph import GraphConnector
+from deepthought.graph import GraphConnector, GraphDAL
 from deepthought.modules import KnowledgeGraphMemory
 
 async def main():
@@ -42,7 +42,8 @@ async def main():
         username=os.getenv("MG_USER", ""),
         password=os.getenv("MG_PASSWORD", ""),
     )
-    memory = KnowledgeGraphMemory(nc, js, connector)
+    dal = GraphDAL(connector)
+    memory = KnowledgeGraphMemory(nc, js, dal)
     await memory.start_listening()
     await asyncio.Event().wait()
 


### PR DESCRIPTION
## Summary
- document how to run the `memgraph_memory_service` example using GraphDAL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685af93f88488326a8a5befdbc329fa6