### PR TITLE
Add fallback sentiment backend test

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
 export SENTIMENT_BACKEND=vader  # optional, defaults to textblob
 ```
 
+Set `SENTIMENT_BACKEND` to either `textblob` or `vader` to choose the library
+used for sentiment analysis. Any other value falls back to `textblob`.
+
 Run the bot:
 
 ```bash

--- a/tests/test_sentiment_backend.py
+++ b/tests/test_sentiment_backend.py
@@ -1,4 +1,6 @@
 import importlib
+import sys
+import types
 
 import pytest
 
@@ -19,4 +21,28 @@ def test_sentiment_backend(monkeypatch, backend):
 
     # restore default for other tests
     monkeypatch.delenv("SENTIMENT_BACKEND", raising=False)
+    importlib.reload(sg)
+
+
+def test_invalid_backend_defaults_to_textblob(monkeypatch):
+    monkeypatch.setenv("SENTIMENT_BACKEND", "unknown")
+
+    class Dummy:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        @property
+        def sentiment(self):
+            return types.SimpleNamespace(polarity=0.42)
+
+    original_tb = sys.modules.get("textblob")
+    monkeypatch.setitem(sys.modules, "textblob", types.SimpleNamespace(TextBlob=Dummy))
+    module = importlib.reload(sg)
+    assert module.analyze_sentiment("hello") == 0.42
+
+    monkeypatch.delenv("SENTIMENT_BACKEND", raising=False)
+    if original_tb is not None:
+        monkeypatch.setitem(sys.modules, "textblob", original_tb)
+    else:
+        monkeypatch.delitem(sys.modules, "textblob", raising=False)
     importlib.reload(sg)


### PR DESCRIPTION
## Summary
- clarify sentiment backend selection in the README
- test that unknown backends fall back to TextBlob

## Testing
- `pre-commit run --files tests/test_sentiment_backend.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685af93ef8e0832688b1581fff6c5ea2