### PR TITLE
Handle missing NATS publisher

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -77,18 +77,20 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv(
-            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
-        )
+        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
         generator = _get_idle_generator()
         outputs = await asyncio.to_thread(
-            generator, gen_prompt, max_new_tokens=20, num_return_sequences=1
+            generator,
+            gen_prompt,
+            max_new_tokens=20,
+            num_return_sequences=1,
         )
         text = outputs[0]["generated_text"].strip()
         return text
     except Exception:  # pragma: no cover - optional dependency or runtime error
         logger.exception("Idle text generation failed")
         return None
+
 
 # Simple list of phrases considered bullying
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
@@ -479,6 +481,7 @@ async def publish_input_received(text: str) -> None:
     """Publish an INPUT_RECEIVED event using NATS JetStream."""
     await _ensure_nats()
     if _input_publisher is None:
+        logger.warning("Dropping INPUT_RECEIVED event because NATS is unavailable")
         return
     payload = InputReceivedPayload(
         user_input=text,


### PR DESCRIPTION
## Summary
- revert formatting of idle generator
- warn before dropping INPUT_RECEIVED when NATS is unavailable
- test that warning appears

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ad8ea5f7883268eb06f2b0c2f4a2c