### PR TITLE
Fix GraphDAL sanitization

### DIFF
--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -1,3 +1,5 @@
+import pytest
+
 from deepthought.graph.dal import GraphDAL
 
 
@@ -16,9 +18,7 @@ def test_add_entity():
     dal = GraphDAL(connector)
     dal.add_entity("Person", {"name": "Alice"})
 
-    assert connector.executed == [
-        ("MERGE (n:Person $props)", {"props": {"name": "Alice"}})
-    ]
+    assert connector.executed == [("MERGE (n:Person $props)", {"props": {"name": "Alice"}})]
 
 
 def test_add_relationship():
@@ -34,15 +34,27 @@ def test_add_relationship():
     ]
 
 
+def test_add_entity_invalid_label():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    with pytest.raises(ValueError):
+        dal.add_entity("Bad Label; MATCH (n)", {"name": "Alice"})
+
+
+def test_add_relationship_invalid_type():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    with pytest.raises(ValueError):
+        dal.add_relationship(1, 2, "KNOWS DELETE *", {"since": 2020})
+
+
 def test_get_entity():
     connector = DummyConnector(result=[{"name": "Alice"}])
     dal = GraphDAL(connector)
     result = dal.get_entity("Person", "name", "Alice")
 
     assert result == {"name": "Alice"}
-    assert connector.executed == [
-        ("MATCH (n:Person {name: $value}) RETURN n", {"value": "Alice"})
-    ]
+    assert connector.executed == [("MATCH (n:Person {name: $value}) RETURN n", {"value": "Alice"})]
 
 
 def test_query_subgraph():


### PR DESCRIPTION
## Summary
- validate labels and relationship types to avoid injection
- test invalid identifiers for entity and relationship creation

## Testing
- `pre-commit run --files src/deepthought/graph/dal.py tests/unit/test_graph_dal.py`
- `pytest -q tests/unit/test_graph_dal.py`

------
https://chatgpt.com/codex/tasks/task_e_685af938673c83268b65689d32a3c7f8