### PR TITLE
Make BaseLLM abstract and format tests

### DIFF
--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -14,7 +15,7 @@ from ..eda.subscriber import Subscriber
 logger = logging.getLogger(__name__)
 
 
-class BaseLLM:
+class BaseLLM(ABC):
     """Base class providing shared LLM functionality."""
 
     def __init__(
@@ -28,6 +29,14 @@ class BaseLLM:
         self._subscriber = subscriber
         self._tokenizer = tokenizer
         self._model = model
+
+    @abstractmethod
+    async def start_listening(self, durable_name: str = "llm_listener") -> bool:
+        """Begin consuming events."""
+
+    @abstractmethod
+    async def stop_listening(self) -> None:
+        """Stop consuming events."""
 
     def _build_prompt(self, facts: List[str]) -> str:
         """Assemble a prompt from retrieved facts."""

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -194,7 +194,4 @@ async def test_start_listening_no_subscriber(monkeypatch, caplog):
         result = await llm.start_listening()
 
     assert result is False
-    assert any(
-        "Subscriber not initialized for BasicLLM." in r.getMessage() for r in caplog.records
-    )
-
+    assert any("Subscriber not initialized for BasicLLM." in r.getMessage() for r in caplog.records)

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -191,7 +191,4 @@ async def test_start_listening_no_subscriber(monkeypatch, caplog):
         result = await llm.start_listening()
 
     assert result is False
-    assert any(
-        "Subscriber not initialized for ProductionLLM." in r.getMessage() for r in caplog.records
-    )
-
+    assert any("Subscriber not initialized for ProductionLLM." in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- define BaseLLM as abstract with abstract `start_listening` and `stop_listening`
- run pre-commit formatting on unit tests

## Testing
- `pre-commit run --files src/deepthought/modules/llm_base.py src/deepthought/modules/llm_basic.py src/deepthought/modules/llm_prod.py tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py`
- `pytest -q tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py`


------
https://chatgpt.com/codex/tasks/task_e_685af93c673c8326b2160546d87eaf20