### PR TITLE
Handle missing NATS publisher

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -493,6 +493,7 @@ async def publish_input_received(text: str) -> None:
     """Publish an INPUT_RECEIVED event using NATS JetStream."""
     await _ensure_nats()
     if _input_publisher is None:
+        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
         return
     payload = InputReceivedPayload(
         user_input=text,

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import random
 
 import aiosqlite
@@ -171,3 +172,21 @@ async def test_on_message_updates_sentiment_trend(tmp_path, monkeypatch, input_e
     expected = sg.analyze_sentiment(message.content)
     assert trend == (expected, 1)
     await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_publish_input_received_warns_when_no_publisher(monkeypatch, caplog):
+    """publish_input_received should warn if NATS is unavailable."""
+    sg._input_publisher = None
+
+    async def fake_ensure():
+        sg._input_publisher = None
+
+    monkeypatch.setattr(sg, "_ensure_nats", fake_ensure)
+
+    with caplog.at_level(logging.WARNING):
+        await sg.publish_input_received("hello")
+
+    assert any(
+        "Dropping INPUT_RECEIVED event because NATS publisher is unavailable" in r.getMessage() for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- warn in `publish_input_received` when NATS publisher is unavailable
- test warning for missing NATS publisher

## Testing
- `pre-commit run --files examples/social_graph_bot.py tests/test_on_message_memory.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685af939638c8326860b146b84ad9bc1