### PR TITLE
Add memory hierarchy and reward docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ Key planned/in-progress components include:
 
 1.  **Core EDA Framework:** (Functional) Publishers, Subscribers, and Event definitions using NATS.
 2.  **Optimized Language Model:** (In Progress) Utilizing small, open-source LLMs (< 3B parameters, e.g., Llama 3.2 3B Instruct) fine-tuned using Parameter-Efficient Fine-Tuning (PEFT) techniques like QLoRA and further optimized with post-training quantization (e.g., AWQ). The `train_script.py` is provided for LLM fine-tuning. Running this script requires a suitable environment with a GPU and necessary CUDA libraries. It can be used to replicate the fine-tuning process described in `LLM_Fine_Tuning_Report.md`.
-3.  **Knowledge Graph Memory:** `GraphMemory` currently uses the lightweight `networkx` library as an embedded graph store. See [`src/deepthought/modules/memory_graph.py`](src/deepthought/modules/memory_graph.py) for implementation details.
-4.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.
-5.  **Neuromorphic Processing:** (Long-Term Research) Investigating brain-inspired computing principles via simulation (e.g., using Nengo).
+3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
+4.  **Reward Manager:** publishes user feedback as `RewardEvent` messages via JetStream, enabling future reinforcement or preference-based training. See [docs/reward_manager.md](docs/reward_manager.md).
+5.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.
+6.  **Neuromorphic Processing:** (Long-Term Research) Investigating brain-inspired computing principles via simulation (e.g., using Nengo).
 
 ## Current Status
 
@@ -80,8 +81,18 @@ Users would typically incorporate these scripts into their Unity projects and us
         ```bash
         python setup_jetstream.py
         ```
-5.  **Run Components/Tests:** (Specific instructions TBD as components are developed)
-6.  **CI-style setup:** A helper script mirrors the project\'s continuous integration workflow.
+5.  **Start Additional Services:**
+    *   Launch Chroma for vector memory:
+        ```bash
+        docker run --rm -p 8000:8000 chromadb/chroma
+        ```
+    *   Launch Memgraph for knowledge graph storage:
+        ```bash
+        docker run --rm -p 7687:7687 memgraph/memgraph
+        ```
+    Set the GraphDAL environment variables as shown in [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
+6.  **Run Components/Tests:** (Specific instructions TBD as components are developed)
+7.  **CI-style setup:** A helper script mirrors the project\'s continuous integration workflow.
     It installs dependencies, starts a temporary NATS server, initializes JetStream, and runs
     linters and tests only when code changes are detected:
     ```bash

--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -1,0 +1,38 @@
+# Hierarchical Memory Service
+
+This document outlines the design of the experimental hierarchical memory system used in DeepThought-ReThought. The goal is to combine several storage backends so the agent can recall both recent interactions and long-term knowledge.
+
+## Memory Layers
+
+1. **BasicMemory** – stores recent messages in a JSON file on disk.
+2. **VectorMemory** – persists embeddings in a Chroma database for semantic search.
+3. **KnowledgeGraphMemory** – persists structured facts in Memgraph using the GraphDAL layer.
+
+The `MemoryService` coordinates these layers. When an `INPUT_RECEIVED` event arrives the service updates each layer and aggregates their retrieved facts into a single `MEMORY_RETRIEVED` event.
+
+## Running the Service
+
+Make sure the following services are available before starting the memory service:
+
+### Chroma
+
+```bash
+docker run --rm -p 8000:8000 chromadb/chroma
+```
+
+### Memgraph
+
+```bash
+docker run --rm -p 7687:7687 memgraph/memgraph
+```
+
+Set the environment variables used by GraphDAL when connecting to Memgraph:
+
+```bash
+export MG_HOST=localhost
+export MG_PORT=7687
+export MG_USER=memgraph
+export MG_PASSWORD=memgraph
+```
+
+With these services running you can start your application and the memory service will connect automatically as long as it receives the proper NATS events.

--- a/docs/reward_manager.md
+++ b/docs/reward_manager.md
@@ -1,0 +1,18 @@
+# Reward Manager
+
+The reward manager is a small utility that records the quality of generated responses. It publishes `RewardEvent` messages through JetStream so other modules can learn from user feedback.
+
+## Publishing Rewards
+
+The `Ledger` class in `deepthought.motivate.ledger` exposes a `publish` method:
+
+```python
+ledger = Ledger(nc, js)
+await ledger.publish(prompt, response, reward)
+```
+
+Each event stores the prompt, the generated response, a numeric reward and a timestamp. Consumers can subscribe to the `motivation` subject to process the data.
+
+## Intended Usage
+
+A future training service will gather these events and periodically fine‑tune the language model with preference based learning techniques.


### PR DESCRIPTION
## Summary
- document how the hierarchical memory service works
- describe the reward manager
- explain how to run Chroma and Memgraph
- mention new modules in the architecture section

## Testing
- `pre-commit` hooks and tests were not run because only documentation was changed

------
https://chatgpt.com/codex/tasks/task_e_685c53f73a488326ac05baf6dded8baa