### PR TITLE
Add replay timing test

### DIFF
--- a/src/deepthought/harness/replay.py
+++ b/src/deepthought/harness/replay.py
@@ -1,5 +1,6 @@
-"""Replay recorded traces for evaluation."""
+"""Utilities for replaying previously recorded agent traces."""
 
+import asyncio
 from typing import Iterable, Protocol
 
 from .record import TraceEvent
@@ -12,5 +13,15 @@ class Agent(Protocol):
 
 
 async def replay(trace: Iterable[TraceEvent], agent: Agent) -> None:
+    """Replay ``trace`` by invoking ``agent`` for each recorded state.
+
+    The ``latency`` field of each :class:`~deepthought.harness.record.TraceEvent`
+    indicates the delay before the next action should be replayed. This allows
+    re-simulating the timing of the original interaction when running tests or
+    evaluations.
+    """
+
     for event in trace:
-        _ = await agent.act(event.state)
+        await agent.act(event.state)
+        if event.latency:
+            await asyncio.sleep(event.latency)

--- a/tests/unit/test_harness_replay.py
+++ b/tests/unit/test_harness_replay.py
@@ -1,0 +1,36 @@
+import time
+from datetime import datetime
+
+import pytest
+
+from deepthought.harness import replay as harness_replay
+from deepthought.harness.record import TraceEvent
+
+
+class DummyAgent:
+    def __init__(self):
+        self.calls = []
+
+    async def act(self, state: str) -> str:
+        self.calls.append((state, time.monotonic()))
+        return "ok"
+
+
+@pytest.mark.asyncio
+async def test_replay_order_and_timing():
+    now = datetime.utcnow()
+    trace = [
+        TraceEvent(state="s1", action="a1", reward=0.0, latency=0.05, timestamp=now),
+        TraceEvent(state="s2", action="a2", reward=0.0, latency=0.05, timestamp=now),
+        TraceEvent(state="s3", action="a3", reward=0.0, latency=0.0, timestamp=now),
+    ]
+    agent = DummyAgent()
+    start = time.monotonic()
+    await harness_replay.replay(trace, agent)
+    states = [c[0] for c in agent.calls]
+    times = [c[1] for c in agent.calls]
+
+    assert states == ["s1", "s2", "s3"]
+    assert times[1] - times[0] >= trace[0].latency
+    assert times[2] - times[1] >= trace[1].latency
+    assert times[0] >= start


### PR DESCRIPTION
## Summary
- implement latency handling in replay
- add unit test verifying replay order and timing

## Testing
- `pre-commit run --files src/deepthought/harness/replay.py tests/unit/test_harness_replay.py`
- `pytest tests/unit/test_harness_replay.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53f635ac8326b38cd124f7d0619d