### PR TITLE
Add replay metrics and workflow

### DIFF
--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -1,0 +1,31 @@
+name: Replay
+
+on:
+  pull_request:
+    paths:
+      - 'tools/**'
+      - 'src/**'
+      - 'tests/replay_basic.py'
+      - '.github/workflows/replay.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  replay:
+    runs-on: ['self-hosted', 'linux']
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-ci.txt
+      - run: pip install -e . --no-deps
+      - env:
+          PYTHONPATH: src
+        run: pytest tests/replay_basic.py

--- a/src/deepthought/metrics/__init__.py
+++ b/src/deepthought/metrics/__init__.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Simple metrics for DeepThought reThought."""
+
+import math
+from collections import Counter
+from statistics import mean
+from typing import Iterable, List, Tuple
+
+from ..harness.record import TraceEvent
+
+
+def _ngrams(tokens: List[str], n: int) -> Counter[Tuple[str, ...]]:
+    return Counter(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))  # noqa: E203
+
+
+def bleu(candidate: str, reference: str, max_n: int = 4) -> float:
+    """Compute a simple BLEU score for a single pair of strings."""
+    cand_tokens = candidate.split()
+    ref_tokens = reference.split()
+    precisions = []
+    for n in range(1, max_n + 1):
+        cand_grams = _ngrams(cand_tokens, n)
+        ref_grams = _ngrams(ref_tokens, n)
+        if not cand_grams:
+            precisions.append(0.0)
+            continue
+        overlap = sum(min(count, cand_grams.get(g, 0)) for g, count in ref_grams.items())
+        precisions.append(overlap / sum(cand_grams.values()))
+    if not precisions or any(p == 0 for p in precisions):
+        return 0.0
+    log_prec = sum(math.log(p) for p in precisions) / max_n
+    bp = 1.0
+    if len(cand_tokens) < len(ref_tokens):
+        bp = math.exp(1 - len(ref_tokens) / max(len(cand_tokens), 1))
+    return math.exp(log_prec) * bp
+
+
+def rouge_l(candidate: str, reference: str) -> float:
+    """Return ROUGE-L F1 score between ``candidate`` and ``reference``."""
+    cand_tokens = candidate.split()
+    ref_tokens = reference.split()
+    m, n = len(ref_tokens), len(cand_tokens)
+    if not m or not n:
+        return 0.0
+    dp = [[0] * (n + 1) for _ in range(m + 1)]
+    for i in range(m):
+        for j in range(n):
+            if ref_tokens[i] == cand_tokens[j]:
+                dp[i + 1][j + 1] = dp[i][j] + 1
+            else:
+                dp[i + 1][j + 1] = max(dp[i][j + 1], dp[i + 1][j])
+    lcs = dp[m][n]
+    recall = lcs / m
+    precision = lcs / n
+    if recall + precision == 0:
+        return 0.0
+    return 2 * recall * precision / (recall + precision)
+
+
+def average_latency(trace: Iterable[TraceEvent]) -> float:
+    """Return the average latency of events in ``trace``."""
+    latencies = [e.latency for e in trace]
+    return mean(latencies) if latencies else 0.0
+
+
+def actions_per_second(trace: Iterable[TraceEvent]) -> float:
+    """Return throughput (actions per second) for ``trace``."""
+    latencies = [e.latency for e in trace]
+    total = sum(latencies)
+    return len(latencies) / total if total > 0 else 0.0
+
+
+__all__ = ["bleu", "rouge_l", "average_latency", "actions_per_second"]

--- a/tests/replay_basic.py
+++ b/tests/replay_basic.py
@@ -1,0 +1,46 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def _write_trace(path: Path, actions):
+    data = []
+    for action in actions:
+        data.append(
+            {
+                "state": "s",
+                "action": action,
+                "reward": 0.0,
+                "latency": 0.1,
+                "timestamp": "2024-01-01T00:00:00",
+            }
+        )
+    path.write_text(json.dumps(data))
+
+
+def test_replay_cli(tmp_path: Path) -> None:
+    trial = tmp_path / "trial.json"
+    golden = tmp_path / "golden.json"
+    _write_trace(trial, ["hello world"])
+    _write_trace(golden, ["hello world"])
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    result = subprocess.run(
+        [
+            "python",
+            str(Path(__file__).resolve().parents[1] / "tools" / "replay.py"),
+            str(trial),
+            str(golden),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    out = result.stdout
+    assert "bleu:" in out
+    assert "rouge_l:" in out
+    assert "avg_latency:" in out
+    assert "actions_per_second:" in out

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Compare bot output trace against a golden reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
+
+from deepthought.harness.record import TraceEvent
+from deepthought.metrics import (
+    actions_per_second,
+    average_latency,
+    bleu,
+    rouge_l,
+)
+
+
+def _load_trace(path: Path) -> List[TraceEvent]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    events = []
+    for item in data:
+        events.append(
+            TraceEvent(
+                state=item.get("state", ""),
+                action=item.get("action", ""),
+                reward=float(item.get("reward", 0.0)),
+                latency=float(item.get("latency", 0.0)),
+                timestamp=datetime.fromisoformat(item.get("timestamp")),
+            )
+        )
+    return events
+
+
+def _compare(golden: Iterable[TraceEvent], trial: Iterable[TraceEvent]) -> dict[str, float]:
+    bleu_scores = []
+    rouge_scores = []
+    for g, t in zip(golden, trial):
+        bleu_scores.append(bleu(t.action, g.action))
+        rouge_scores.append(rouge_l(t.action, g.action))
+    return {
+        "bleu": sum(bleu_scores) / len(bleu_scores) if bleu_scores else 0.0,
+        "rouge_l": sum(rouge_scores) / len(rouge_scores) if rouge_scores else 0.0,
+        "avg_latency": average_latency(trial),
+        "actions_per_second": actions_per_second(trial),
+    }
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trial", type=Path, help="Path to trial trace JSON")
+    parser.add_argument("golden", type=Path, help="Path to golden trace JSON")
+    args = parser.parse_args(argv)
+
+    trial = _load_trace(args.trial)
+    golden = _load_trace(args.golden)
+    metrics = _compare(golden, trial)
+    for key, value in metrics.items():
+        print(f"{key}: {value:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add BLEU/ROUGE metrics and reaction-rate helpers
- create CLI tool to compare traces
- test replay CLI
- run replay test in CI

## Testing
- `pre-commit run --files .github/workflows/replay.yml src/deepthought/metrics/__init__.py tools/replay.py tests/replay_basic.py`
- `pytest -q tests/replay_basic.py tests/unit/test_harness_record.py`


------
https://chatgpt.com/codex/tasks/task_e_685c53f3ca688326a784df94107d40cc