### PR TITLE
Add trace recorder utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ python setup_jetstream.py
 
 This step is necessary before running the tests below.
 
+## Recording Event Traces
+
+Use `tools/record.py` to capture `INPUT_RECEIVED` and `RESPONSE_GENERATED` events:
+```bash
+python tools/record.py --output traces.jsonl
+```
+Press Ctrl+C to stop recording. Each line in the file is a JSON object with the event name and payload.
+
+
 ## Graph Memory Backend
 
 The `GraphMemory` module uses the lightweight `networkx` library as an

--- a/src/deepthought/harness/trace.py
+++ b/src/deepthought/harness/trace.py
@@ -1,0 +1,80 @@
+import json
+import logging
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TraceRecorder:
+    """Record INPUT_RECEIVED and RESPONSE_GENERATED events to a JSONL file."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, outfile: str) -> None:
+        if not outfile:
+            raise ValueError("outfile path must be provided")
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._outfile = outfile
+        logger.info("TraceRecorder will write events to %s", outfile)
+
+    async def _append(self, event: str, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to decode %s payload: %s", event, e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:  # noqa: BLE001
+                    logger.error("Failed to NAK message", exc_info=True)
+            return
+
+        record = {"event": event, "payload": data}
+        try:
+            with open(self._outfile, "a", encoding="utf-8") as f:
+                json.dump(record, f)
+                f.write("\n")
+            await msg.ack()
+            logger.debug("Recorded %s event", event)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to record %s: %s", event, e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:  # noqa: BLE001
+                    logger.error("Failed to NAK message after error", exc_info=True)
+
+    async def _handle_input(self, msg: Msg) -> None:
+        await self._append("INPUT_RECEIVED", msg)
+
+    async def _handle_response(self, msg: Msg) -> None:
+        await self._append("RESPONSE_GENERATED", msg)
+
+    async def start(self, durable_name: str = "trace_recorder") -> bool:
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input,
+                use_jetstream=True,
+                durable=f"{durable_name}_input",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.RESPONSE_GENERATED,
+                handler=self._handle_response,
+                use_jetstream=True,
+                durable=f"{durable_name}_response",
+            )
+            logger.info("TraceRecorder subscribed to events")
+            return True
+        except Exception as e:  # noqa: BLE001
+            logger.error("TraceRecorder failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("TraceRecorder stopped listening")

--- a/tests/unit/test_harness_trace.py
+++ b/tests/unit/test_harness_trace.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+
+import deepthought.harness.trace as trace
+
+
+class DummyNATS:
+    is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    async def subscribe(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+    async def unsubscribe_all(self):
+        self.calls.clear()
+
+
+class DummyMsg:
+    def __init__(self, data: str) -> None:
+        self.data = data.encode()
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+@pytest.mark.asyncio
+async def test_handle_input_writes_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    outfile = tmp_path / "trace.jsonl"
+    recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
+    msg = DummyMsg('{"foo": "bar"}')
+
+    await recorder._handle_input(msg)
+    assert msg.acked
+    with open(outfile, "r", encoding="utf-8") as f:
+        line = f.readline()
+    obj = json.loads(line)
+    assert obj["event"] == "INPUT_RECEIVED"
+    assert obj["payload"] == {"foo": "bar"}

--- a/tools/record.py
+++ b/tools/record.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Record DeepThought events to a JSONL file."""
+
+import argparse
+import asyncio
+import logging
+
+from nats.aio.client import Client as NATS
+
+from deepthought.harness.trace import TraceRecorder
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Record events from NATS")
+    parser.add_argument("--output", "-o", default="trace.jsonl", help="Output JSONL file")
+    parser.add_argument("--nats", "-n", default="nats://localhost:4222", help="NATS server URL")
+    parser.add_argument("--durable", "-d", default="trace_recorder", help="Durable consumer name prefix")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+
+    nc = NATS()
+    await nc.connect(servers=[args.nats])
+    js = nc.jetstream()
+
+    recorder = TraceRecorder(nc, js, args.output)
+    if not await recorder.start(durable_name=args.durable):
+        raise SystemExit("Failed to start recorder")
+
+    print("Recording events... Press Ctrl+C to stop.")
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await recorder.stop()
+        await nc.drain()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- capture `INPUT_RECEIVED` and `RESPONSE_GENERATED` events to a JSONL file
- provide a CLI tool to record events from NATS
- document how to use the recorder
- test trace file writing

## Testing
- `pre-commit run --files tests/unit/test_harness_trace.py src/deepthought/harness/trace.py tools/record.py`
- `flake8 src/deepthought/harness/trace.py tools/record.py tests/unit/test_harness_trace.py`
- `PYTHONPATH=src pytest tests/unit/test_harness_trace.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53f23cbc8326ae0d908e39adff6f