### PR TITLE
Track read errors in GraphMemory

### DIFF
--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -67,6 +67,7 @@ def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
     assert isinstance(mem._graph, nx.DiGraph)
     assert len(mem._graph.nodes) == 0
     assert mem.repaired
+    assert isinstance(mem.last_read_error, Exception)
     error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
     assert any("Failed to read graph file" in r.getMessage() for r in error_logs)
 
@@ -79,6 +80,7 @@ def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
     mem = create_memory(monkeypatch, graph_file)
     first_mtime = graph_file.stat().st_mtime
     assert mem.repaired
+    assert mem.last_read_error is not None
 
     error_logs = [r for r in caplog.records if "Failed to read graph file" in r.getMessage()]
     assert len(error_logs) == 1
@@ -92,6 +94,7 @@ def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
     second_mtime = graph_file.stat().st_mtime
 
     assert not mem2.repaired
+    assert mem2.last_read_error is None
     assert first_mtime == second_mtime
     assert not any("Failed to read graph file" in r.getMessage() for r in caplog.records)
 
@@ -102,6 +105,7 @@ def test_init_creates_directory(tmp_path, monkeypatch):
     assert graph_file.parent.is_dir()
     assert graph_file.exists()
     assert isinstance(mem._graph, nx.DiGraph)
+    assert mem.last_read_error is None
     with open(graph_file, "r", encoding="utf-8") as f:
         assert isinstance(json.load(f), dict)
 


### PR DESCRIPTION
## Summary
- add `_last_read_error` tracking in `GraphMemory`
- expose read-only `last_read_error` property
- test that the property is set when reading invalid JSON and cleared on success

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53e586cc832683df036717aa1f61