### PR TITLE
Implement timing aware trace replay

### DIFF
--- a/src/deepthought/harness/record.py
+++ b/src/deepthought/harness/record.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Tuple
+from typing import List
 
 
 @dataclass
@@ -12,7 +12,20 @@ class TraceEvent:
     reward: float
     latency: float
     timestamp: datetime
+    timestamp_delta: float
 
 
 def record_event(trace: List[TraceEvent], state: str, action: str, reward: float, latency: float) -> None:
-    trace.append(TraceEvent(state=state, action=action, reward=reward, latency=latency, timestamp=datetime.utcnow()))
+    """Append a :class:`TraceEvent` to ``trace`` with a computed timestamp delta."""
+    now = datetime.utcnow()
+    delta = (now - trace[-1].timestamp).total_seconds() if trace else 0.0
+    trace.append(
+        TraceEvent(
+            state=state,
+            action=action,
+            reward=reward,
+            latency=latency,
+            timestamp=now,
+            timestamp_delta=delta,
+        )
+    )

--- a/src/deepthought/harness/replay.py
+++ b/src/deepthought/harness/replay.py
@@ -1,7 +1,9 @@
 """Replay recorded traces for evaluation."""
 
-from typing import Iterable, Protocol
+import asyncio
+from typing import Iterable, Optional, Protocol
 
+from ..eda.publisher import Publisher
 from .record import TraceEvent
 
 
@@ -11,6 +13,10 @@ class Agent(Protocol):
         ...
 
 
-async def replay(trace: Iterable[TraceEvent], agent: Agent) -> None:
+async def replay(trace: Iterable[TraceEvent], agent: Agent, publisher: Optional[Publisher] = None) -> None:
+    """Replay a trace, preserving original timing."""
     for event in trace:
+        await asyncio.sleep(event.timestamp_delta)
+        if publisher is not None:
+            await publisher.publish("chat.raw", event.state)
         _ = await agent.act(event.state)

--- a/tests/unit/test_harness_record.py
+++ b/tests/unit/test_harness_record.py
@@ -1,12 +1,35 @@
+from datetime import datetime
+
+import deepthought.harness.record as record
 from deepthought.harness.record import TraceEvent, record_event
 
 
 def test_record_event():
     trace = []
-    record_event(trace, "state", "action", 0.5, 0.1)
-    assert len(trace) == 1
-    evt = trace[0]
-    assert evt.state == "state"
-    assert evt.action == "action"
-    assert evt.reward == 0.5
-    assert evt.latency == 0.1
+    times = [
+        datetime(2021, 1, 1, 0, 0, 0),
+        datetime(2021, 1, 1, 0, 0, 1),
+    ]
+
+    class DummyDT:
+        def utcnow(self):
+            return times.pop(0)
+
+    original_dt = record.datetime
+    record.datetime = DummyDT()  # type: ignore
+
+    try:
+        record_event(trace, "state", "action", 0.5, 0.1)
+        assert len(trace) == 1
+        evt = trace[0]
+        assert evt.state == "state"
+        assert evt.action == "action"
+        assert evt.reward == 0.5
+        assert evt.latency == 0.1
+        assert evt.timestamp_delta == 0.0
+
+        record_event(trace, "state2", "action2", 1.0, 0.2)
+        evt2 = trace[1]
+        assert evt2.timestamp_delta == 1.0
+    finally:
+        record.datetime = original_dt

--- a/tests/unit/test_harness_replay.py
+++ b/tests/unit/test_harness_replay.py
@@ -1,0 +1,62 @@
+import asyncio
+from datetime import datetime
+
+import pytest
+
+from deepthought.harness import replay as replay_mod
+from deepthought.harness.record import TraceEvent
+
+
+class DummyAgent:
+    def __init__(self):
+        self.states = []
+
+    async def act(self, state: str) -> str:
+        self.states.append(state)
+        return "ok"
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return None
+
+
+@pytest.mark.asyncio
+async def test_replay_uses_timestamp_delta(monkeypatch):
+    events = [
+        TraceEvent(
+            state="s1",
+            action="a1",
+            reward=0.0,
+            latency=0.0,
+            timestamp=datetime.utcnow(),
+            timestamp_delta=0.0,
+        ),
+        TraceEvent(
+            state="s2",
+            action="a2",
+            reward=0.0,
+            latency=0.0,
+            timestamp=datetime.utcnow(),
+            timestamp_delta=1.0,
+        ),
+    ]
+    agent = DummyAgent()
+    publisher = DummyPublisher()
+
+    slept = []
+
+    async def fake_sleep(val):
+        slept.append(val)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await replay_mod.replay(events, agent, publisher)
+
+    assert slept == [0.0, 1.0]
+    assert agent.states == ["s1", "s2"]
+    assert publisher.published == [("chat.raw", "s1"), ("chat.raw", "s2")]


### PR DESCRIPTION
## Summary
- store timestamp deltas in `TraceEvent`
- replay recorded traces with original timing and optional publication
- test harness record and replay behaviour

## Testing
- `pre-commit run --files src/deepthought/harness/record.py src/deepthought/harness/replay.py tests/unit/test_harness_record.py tests/unit/test_harness_replay.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c53e6b69c8326b78f047deef0ba20