### PR TITLE
Implement RewardManager with novelty and social scoring

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -11,3 +11,4 @@ discord.py==2.5.2
 textblob==0.17.1
 pre-commit==4.2.0
 vaderSentiment==3.3.2
+sentence-transformers==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ textblob
 networkx
 pydantic-settings
 vaderSentiment
+sentence-transformers

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -25,6 +25,14 @@ class DatabaseSettings(BaseSettings):
     name: str = "deepthought"
 
 
+class RewardThresholds(BaseSettings):
+    """Thresholds for scoring social and novelty rewards."""
+
+    novelty_threshold: float = 0.3
+    social_affinity_threshold: int = 1
+    window_size: int = 20
+
+
 class Settings(BaseSettings):
     """Application wide settings."""
 
@@ -33,6 +41,7 @@ class Settings(BaseSettings):
     db: DatabaseSettings = DatabaseSettings()
     model_path: str = "distilgpt2"
     memory_file: str = "memory.json"
+    reward: RewardThresholds = RewardThresholds()
 
     model_config = SettingsConfigDict(env_prefix="DT_", env_nested_delimiter="__")
 

--- a/src/deepthought/motivate/__init__.py
+++ b/src/deepthought/motivate/__init__.py
@@ -1,0 +1,5 @@
+"""Motivation utilities."""
+
+from .ledger import Ledger  # noqa: F401
+from .reward_manager import RewardManager  # noqa: F401
+

--- a/src/deepthought/motivate/reward_manager.py
+++ b/src/deepthought/motivate/reward_manager.py
@@ -1,0 +1,116 @@
+"""RewardManager subscribes to chat events and scores bot output."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import deque
+from typing import Deque, Optional
+
+import aiohttp
+import numpy as np
+from nats.aio.msg import Msg
+from sentence_transformers import SentenceTransformer, util
+
+from ..config import get_settings
+from ..eda.subscriber import Subscriber
+from .ledger import Ledger
+
+logger = logging.getLogger(__name__)
+
+
+class RewardManager:
+    """Subscribe to ``chat.bot`` messages and compute reward scores."""
+
+    def __init__(
+        self,
+        subscriber: Subscriber,
+        ledger: Ledger,
+        discord_token: str,
+    ) -> None:
+        self._subscriber = subscriber
+        self._ledger = ledger
+        self._token = discord_token
+
+        settings = get_settings().reward
+        self._novelty_threshold = settings.novelty_threshold
+        self._social_threshold = settings.social_affinity_threshold
+        self._window: Deque[np.ndarray] = deque(maxlen=settings.window_size)
+
+        self._model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    async def start_listening(self, durable_name: str = "reward_listener") -> bool:
+        """Begin consuming ``chat.bot`` messages."""
+        try:
+            await self._subscriber.subscribe(
+                subject="chat.bot",
+                handler=self._handle_chat_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            return True
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.error("RewardManager failed to subscribe: %s", exc, exc_info=True)
+            return False
+
+    async def stop_listening(self) -> None:
+        """Unsubscribe from all subjects."""
+        await self._subscriber.unsubscribe_all()
+
+    async def _handle_chat_event(self, msg: Msg) -> None:
+        """Process a bot message and publish the reward."""
+        prompt = ""
+        response = ""
+        channel_id = None
+        message_id = None
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("payload must be a dict")
+            prompt = str(data.get("prompt", ""))
+            response = str(data.get("response", data.get("content", "")))
+            channel_id = data.get("channel_id")
+            message_id = data.get("message_id")
+        except Exception as exc:  # pragma: no cover - bad payload
+            logger.error("Invalid chat.bot payload: %s", exc)
+            await msg.ack()
+            return
+
+        novelty = self._score_novelty(response)
+        social = await self._score_social(channel_id, message_id)
+        reward = float(novelty >= self._novelty_threshold) + float(social >= self._social_threshold)
+
+        try:
+            await self._ledger.publish(prompt, response, reward)
+            await msg.ack()
+        except Exception as exc:  # pragma: no cover - publish failure
+            logger.error("Failed to publish reward: %s", exc, exc_info=True)
+
+    def _score_novelty(self, text: str) -> float:
+        """Return novelty score based on cosine distance to previous messages."""
+        emb = self._model.encode(text, convert_to_numpy=True)
+        if not self._window:
+            self._window.append(emb)
+            return 1.0
+        sims = util.cos_sim(emb, np.stack(list(self._window))).flatten().tolist()
+        max_sim = max(sims) if sims else 0.0
+        self._window.append(emb)
+        return 1.0 - float(max_sim)
+
+    async def _score_social(self, channel_id: Optional[int], message_id: Optional[int]) -> int:
+        """Return the total reaction count for the Discord message."""
+        if channel_id is None or message_id is None:
+            return 0
+        url = f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}"
+        headers = {"Authorization": f"Bot {self._token}"}
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url, headers=headers) as resp:
+                    if resp.status != 200:
+                        return 0
+                    payload = await resp.json()
+                    reactions = payload.get("reactions", [])
+                    return int(sum(r.get("count", 0) for r in reactions))
+        except Exception as exc:  # pragma: no cover - network issues
+            logger.warning("Failed to fetch reactions: %s", exc)
+            return 0

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,12 +11,18 @@ def test_env_overrides(monkeypatch):
     monkeypatch.setenv("DT_DB__HOST", "db.example")
     monkeypatch.setenv("DT_MODEL_PATH", "a/model")
     monkeypatch.setenv("DT_MEMORY_FILE", "mem.txt")
+    monkeypatch.setenv("DT_REWARD__NOVELTY_THRESHOLD", "0.9")
+    monkeypatch.setenv("DT_REWARD__SOCIAL_AFFINITY_THRESHOLD", "5")
+    monkeypatch.setenv("DT_REWARD__WINDOW_SIZE", "10")
 
     settings = load_settings()
     assert settings.nats_url == "nats://example:1234"
     assert settings.db.host == "db.example"
     assert settings.model_path == "a/model"
     assert settings.memory_file == "mem.txt"
+    assert settings.reward.novelty_threshold == 0.9
+    assert settings.reward.social_affinity_threshold == 5
+    assert settings.reward.window_size == 10
 
 
 def test_file_load(tmp_path):
@@ -25,6 +31,7 @@ def test_file_load(tmp_path):
         "db": {"user": "fileuser", "password": "p", "host": "dbfile", "port": 123},
         "model_path": "file/model",
         "memory_file": "filemem.json",
+        "reward": {"novelty_threshold": 0.8, "social_affinity_threshold": 2, "window_size": 5},
     }
     cfg = tmp_path / "cfg.json"
     cfg.write_text(json.dumps(data))
@@ -34,6 +41,9 @@ def test_file_load(tmp_path):
     assert settings.db.port == 123
     assert settings.model_path == "file/model"
     assert settings.memory_file == "filemem.json"
+    assert settings.reward.novelty_threshold == 0.8
+    assert settings.reward.social_affinity_threshold == 2
+    assert settings.reward.window_size == 5
 
 
 def test_yaml_file_load(tmp_path):
@@ -42,6 +52,7 @@ def test_yaml_file_load(tmp_path):
         "db": {"user": "yamluser", "password": "p", "host": "dbyaml", "port": 456},
         "model_path": "yaml/model",
         "memory_file": "yaml.json",
+        "reward": {"novelty_threshold": 0.7, "social_affinity_threshold": 3, "window_size": 7},
     }
     cfg = tmp_path / "cfg.yaml"
     cfg.write_text(yaml.safe_dump(data))
@@ -51,6 +62,9 @@ def test_yaml_file_load(tmp_path):
     assert settings.db.port == 456
     assert settings.model_path == "yaml/model"
     assert settings.memory_file == "yaml.json"
+    assert settings.reward.novelty_threshold == 0.7
+    assert settings.reward.social_affinity_threshold == 3
+    assert settings.reward.window_size == 7
 
 
 def test_get_settings_reload(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add SentenceTransformers and reward manager
- publish reward events via ledger
- support reward thresholds in config
- test new config fields

## Testing
- `flake8 src/deepthought/motivate/reward_manager.py src/deepthought/config.py src/deepthought/motivate/__init__.py tests/unit/test_config.py`
- `pytest tests/unit/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_685c53e8ca7c83268fa59b43365a8b0f