### PR TITLE
Add optional memory publishing in InputHandler

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -58,3 +58,28 @@ Alternatively, run the example script directly:
 ```bash
 python examples/memgraph_memory_service.py
 ```
+
+## Hierarchical Memory Wrapper
+
+`HierarchicalMemory` combines vector search (using a store like Chroma) with
+graph lookups through `GraphDAL`. Instantiate it with a vector store and an
+existing `GraphDAL` instance:
+
+```python
+from deepthought.memory.hierarchical import HierarchicalMemory
+from deepthought.graph import GraphConnector, GraphDAL
+import chromadb
+
+# Initialize vector store and graph connection
+client = chromadb.Client()
+collection = client.create_collection("my_vectors")
+connector = GraphConnector()
+dal = GraphDAL(connector)
+
+memory = HierarchicalMemory(collection, dal)
+context = memory.retrieve_context("Where was I yesterday?")
+print(context)
+```
+
+`retrieve_context()` returns a list of strings merging the top matches from the
+vector store with recent facts from the graph.

--- a/src/deepthought/memory/hierarchical.py
+++ b/src/deepthought/memory/hierarchical.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Hierarchical memory retrieval mixing vector and graph lookups."""
+
+import logging
+from typing import Any, List, Sequence
+
+from ..graph import GraphDAL
+
+logger = logging.getLogger(__name__)
+
+
+class HierarchicalMemory:
+    """Combine vector store search with graph facts."""
+
+    def __init__(self, vector_store: Any, graph_dal: GraphDAL, top_k: int = 3) -> None:
+        self._vector_store = vector_store
+        self._dal = graph_dal
+        self._top_k = top_k
+
+    def _vector_matches(self, prompt: str) -> List[str]:
+        if self._vector_store is None:
+            return []
+        try:
+            result = self._vector_store.query(query_texts=[prompt], n_results=self._top_k)
+            docs: Sequence | None = None
+            if isinstance(result, dict):
+                docs = result.get("documents")
+            elif isinstance(result, Sequence):
+                docs = result
+            if not docs:
+                return []
+            matches: List[str] = []
+            for doc in docs:
+                if isinstance(doc, list):
+                    for d in doc:
+                        matches.append(str(getattr(d, "page_content", d)))
+                else:
+                    matches.append(str(getattr(doc, "page_content", doc)))
+            return matches
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Vector store query failed: %s", exc, exc_info=True)
+            return []
+
+    def _graph_facts(self) -> List[str]:
+        try:
+            rows = self._dal.query_subgraph(
+                "MATCH (n:Entity) RETURN n.name AS fact LIMIT $limit",
+                {"limit": self._top_k},
+            )
+            return [str(r.get("fact")) for r in rows if r.get("fact")]
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Graph query failed: %s", exc, exc_info=True)
+            return []
+
+    def retrieve_context(self, prompt: str) -> List[str]:
+        """Return merged vector matches and graph facts."""
+        vector = self._vector_matches(prompt)
+        graph = self._graph_facts()
+        seen = set()
+        merged: List[str] = []
+        for item in vector + graph:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+        return merged

--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -8,7 +8,11 @@ from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
 # Assuming eda modules are in parent dir relative to modules dir
-from ..eda.events import EventSubjects, InputReceivedPayload
+from ..eda.events import (
+    EventSubjects,
+    InputReceivedPayload,
+    MemoryRetrievedPayload,
+)
 from ..eda.publisher import Publisher
 
 logger = logging.getLogger(__name__)
@@ -17,9 +21,10 @@ logger = logging.getLogger(__name__)
 class InputHandler:
     """Handles user input and publishes InputReceived event via JetStream."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext):
-        """Initialize with shared NATS client and JetStream context."""
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, memory=None):
+        """Initialize with optional hierarchical memory service."""
         self._publisher = Publisher(nats_client, js_context)
+        self._memory = memory
         logger.info("InputHandler initialized (JetStream enabled).")
 
     async def process_input(self, user_input: str) -> str:
@@ -34,9 +39,33 @@ class InputHandler:
         try:
             # Always use JetStream for input events in this version
             await self._publisher.publish(
-                EventSubjects.INPUT_RECEIVED, payload, use_jetstream=True, timeout=10.0  # Use JS, increased timeout
+                EventSubjects.INPUT_RECEIVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
             )
-            logger.info(f"Published input ID {input_id} (JetStream)")
+            logger.info("Published input ID %s (JetStream)", input_id)
+
+            if self._memory is not None:
+                context = []
+                try:
+                    context = self._memory.retrieve_context(user_input)
+                except Exception as err:  # pragma: no cover - defensive
+                    logger.error("Memory retrieval failed: %s", err, exc_info=True)
+
+                mem_payload = MemoryRetrievedPayload(
+                    retrieved_knowledge={"retrieved_knowledge": {"facts": context, "source": "hierarchical"}},
+                    input_id=input_id,
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                )
+
+                await self._publisher.publish(
+                    EventSubjects.MEMORY_RETRIEVED,
+                    mem_payload,
+                    use_jetstream=True,
+                    timeout=10.0,
+                )
+                logger.info("Published memory for input ID %s", input_id)
             return input_id
         except nats.errors.TimeoutError as e:
             logger.error(f"NATS timeout publishing input: {e}", exc_info=True)

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -8,6 +8,15 @@ from deepthought.eda.events import EventSubjects
 from deepthought.modules.input_handler import InputHandler
 
 
+class DummyMemory:
+    def __init__(self):
+        self.prompt = None
+
+    def retrieve_context(self, prompt):
+        self.prompt = prompt
+        return ["fact1", "fact2"]
+
+
 class DummyNATS:
     def __init__(self):
         self.is_connected = True
@@ -30,19 +39,31 @@ class DummyJS:
 async def test_process_input_success():
     js = DummyJS()
     nc = DummyNATS()
-    handler = InputHandler(nc, js)
+    memory = DummyMemory()
+    handler = InputHandler(nc, js, memory=memory)
     input_id = await handler.process_input("hello")
 
     assert js.published
+    # First publish: INPUT_RECEIVED
     subject, data = js.published[0]
     assert subject == EventSubjects.INPUT_RECEIVED
     payload = json.loads(data.decode())
     assert payload["user_input"] == "hello"
     assert payload["input_id"] == input_id
-    # Timestamp should be timezone-aware UTC
     ts = payload["timestamp"]
     parsed = datetime.fromisoformat(ts)
     assert parsed.tzinfo == timezone.utc
+
+    # Second publish: MEMORY_RETRIEVED
+    subject, data = js.published[1]
+    assert subject == EventSubjects.MEMORY_RETRIEVED
+    memory_payload = json.loads(data.decode())
+    assert memory_payload["input_id"] == input_id
+    assert memory_payload["retrieved_knowledge"]["retrieved_knowledge"]["facts"] == [
+        "fact1",
+        "fact2",
+    ]
+    assert memory.prompt == "hello"
 
 
 class FailingJS(DummyJS):
@@ -66,3 +87,15 @@ async def test_process_input_invalid_type():
     handler = InputHandler(nc, js)
     with pytest.raises(ValueError):
         await handler.process_input(123)
+
+
+@pytest.mark.asyncio
+async def test_process_input_no_memory():
+    js = DummyJS()
+    nc = DummyNATS()
+    handler = InputHandler(nc, js)
+    input_id = await handler.process_input("hello")
+    assert len(js.published) == 1
+    subject, _ = js.published[0]
+    assert subject == EventSubjects.INPUT_RECEIVED
+    assert input_id


### PR DESCRIPTION
## Summary
- implement `HierarchicalMemory` wrapper querying vectors and graph facts
- integrate the memory wrapper into `InputHandler`
- only publish MEMORY_RETRIEVED when a memory service is provided
- extend unit tests for the optional path

## Testing
- `pre-commit run --files src/deepthought/modules/input_handler.py tests/unit/modules/test_input_handler.py`
- `flake8 src/deepthought/modules/input_handler.py tests/unit/modules/test_input_handler.py`
- `PYTHONPATH=src pytest tests/unit/modules/test_input_handler.py tests/test_module_integration.py::test_full_module_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_685c53e7a52883268dcbb4060008510f