### PR TITLE
Add mixed docs/code change test

### DIFF
--- a/tests/unit/test_check_code_changes.py
+++ b/tests/unit/test_check_code_changes.py
@@ -46,3 +46,14 @@ def test_actual_code_change(tmp_path):
     subprocess.run(["git", "add", "code.py"], cwd=repo, check=True)
     subprocess.run(["git", "commit", "-m", "code"], cwd=repo, check=True)
     assert _run_script(repo) == "true"
+
+
+def test_mixed_docs_and_code_change(tmp_path):
+    repo = tmp_path / "repo_mixed"
+    repo.mkdir()
+    _init_repo(repo)
+    (repo / "README.md").write_text("docs\n")
+    (repo / "code.py").write_text("print('hi there')\n")
+    subprocess.run(["git", "add", "README.md", "code.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "docs and code"], cwd=repo, check=True)
+    assert _run_script(repo) == "true"


### PR DESCRIPTION
## Summary
- extend `test_check_code_changes` with a mixed docs and code edit case
- verify the `check_code_changes.py` script properly reports code changes

## Testing
- `python -m flake8 scripts/check_code_changes.py tests/unit/test_check_code_changes.py`
- `pytest tests/unit/test_check_code_changes.py::test_mixed_docs_and_code_change -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7e55611883268da02b4a2566a65e