### PR TITLE
Add trace replay CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ python tools/record.py --output traces.jsonl
 ```
 Press Ctrl+C to stop recording. Each line in the file is a JSON object with the event name and payload.
 
+## Replaying Event Traces
+
+Use `tools/replay.py` to send a recorded trace back through NATS and compare it against a golden reference:
+
+```bash
+python tools/replay.py trial.jsonl golden.jsonl --nats nats://localhost:4222
+```
+
+Pass `--nats ""` to disable publishing. The script prints BLEU and ROUGE-L metrics.
+
 
 ## Graph Memory Backend
 

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -6,4 +6,8 @@ __version__ = "0.1.0"
 from . import harness  # noqa: F401
 from . import learn  # noqa: F401
 from . import modules  # noqa: F401
-from . import motivate  # noqa: F401
+
+try:
+    from . import motivate  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency may be missing
+    pass

--- a/src/deepthought/motivate/__init__.py
+++ b/src/deepthought/motivate/__init__.py
@@ -1,5 +1,8 @@
 """Motivation utilities."""
 
 from .ledger import Ledger  # noqa: F401
-from .reward_manager import RewardManager  # noqa: F401
 
+try:
+    from .reward_manager import RewardManager  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency may be missing
+    RewardManager = None  # type: ignore

--- a/tests/replay_basic.py
+++ b/tests/replay_basic.py
@@ -4,24 +4,19 @@ import subprocess
 from pathlib import Path
 
 
-def _write_trace(path: Path, actions):
-    data = []
-    for action in actions:
-        data.append(
-            {
-                "state": "s",
-                "action": action,
-                "reward": 0.0,
-                "latency": 0.1,
-                "timestamp": "2024-01-01T00:00:00",
+def _write_trace(path: Path, responses):
+    with path.open("w", encoding="utf-8") as f:
+        for resp in responses:
+            obj = {
+                "event": "RESPONSE_GENERATED",
+                "payload": {"final_response": resp, "timestamp": "2024-01-01T00:00:00"},
             }
-        )
-    path.write_text(json.dumps(data))
+            f.write(json.dumps(obj) + "\n")
 
 
 def test_replay_cli(tmp_path: Path) -> None:
-    trial = tmp_path / "trial.json"
-    golden = tmp_path / "golden.json"
+    trial = tmp_path / "trial.jsonl"
+    golden = tmp_path / "golden.jsonl"
     _write_trace(trial, ["hello world"])
     _write_trace(golden, ["hello world"])
 
@@ -33,6 +28,8 @@ def test_replay_cli(tmp_path: Path) -> None:
             str(Path(__file__).resolve().parents[1] / "tools" / "replay.py"),
             str(trial),
             str(golden),
+            "--nats",
+            "",
         ],
         stdout=subprocess.PIPE,
         text=True,
@@ -42,5 +39,3 @@ def test_replay_cli(tmp_path: Path) -> None:
     out = result.stdout
     assert "bleu:" in out
     assert "rouge_l:" in out
-    assert "avg_latency:" in out
-    assert "actions_per_second:" in out

--- a/tests/unit/test_harness_replay.py
+++ b/tests/unit/test_harness_replay.py
@@ -8,8 +8,8 @@ from deepthought.harness.record import TraceEvent
 
 
 class DummyAgent:
-    def __init__(self):
-        self.states = []
+    def __init__(self) -> None:
+        self.states: list[str] = []
 
     async def act(self, state: str) -> str:
         self.states.append(state)
@@ -17,16 +17,22 @@ class DummyAgent:
 
 
 class DummyPublisher:
-    def __init__(self):
-        self.published = []
+    def __init__(self) -> None:
+        self.published: list[tuple[str, str]] = []
 
-    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+    async def publish(
+        self,
+        subject: str,
+        payload: str,
+        use_jetstream: bool = True,
+        timeout: float = 10.0,
+    ):
         self.published.append((subject, payload))
         return None
 
 
 @pytest.mark.asyncio
-async def test_replay_uses_timestamp_delta(monkeypatch):
+async def test_replay_uses_timestamp_delta(monkeypatch) -> None:
     events = [
         TraceEvent(
             state="s1",
@@ -48,9 +54,9 @@ async def test_replay_uses_timestamp_delta(monkeypatch):
     agent = DummyAgent()
     publisher = DummyPublisher()
 
-    slept = []
+    slept: list[float] = []
 
-    async def fake_sleep(val):
+    async def fake_sleep(val: float) -> None:
         slept.append(val)
 
     monkeypatch.setattr(asyncio, "sleep", fake_sleep)

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -1,66 +1,98 @@
 #!/usr/bin/env python3
-"""Compare bot output trace against a golden reference."""
+"""Replay a recorded trace and compute text similarity metrics."""
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List
 
-from deepthought.harness.record import TraceEvent
-from deepthought.metrics import (
-    actions_per_second,
-    average_latency,
-    bleu,
-    rouge_l,
-)
+from nats.aio.client import Client as NATS
+
+from deepthought.eda.events import EventSubjects
+from deepthought.eda.publisher import Publisher
+from deepthought.metrics import bleu, rouge_l
 
 
-def _load_trace(path: Path) -> List[TraceEvent]:
+def _load_jsonl(path: Path) -> List[dict]:
+    events: List[dict] = []
     with path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
-    events = []
-    for item in data:
-        events.append(
-            TraceEvent(
-                state=item.get("state", ""),
-                action=item.get("action", ""),
-                reward=float(item.get("reward", 0.0)),
-                latency=float(item.get("latency", 0.0)),
-                timestamp=datetime.fromisoformat(item.get("timestamp")),
-            )
-        )
+        for line in f:
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
     return events
 
 
-def _compare(golden: Iterable[TraceEvent], trial: Iterable[TraceEvent]) -> dict[str, float]:
-    bleu_scores = []
-    rouge_scores = []
-    for g, t in zip(golden, trial):
-        bleu_scores.append(bleu(t.action, g.action))
-        rouge_scores.append(rouge_l(t.action, g.action))
+def _extract_responses(events: Iterable[dict]) -> List[str]:
+    responses = []
+    for rec in events:
+        if rec.get("event") == "RESPONSE_GENERATED":
+            payload = rec.get("payload", {})
+            responses.append(str(payload.get("final_response", "")))
+    return responses
+
+
+def _compute_metrics(golden: Iterable[dict], trial: Iterable[dict]) -> dict[str, float]:
+    g_responses = _extract_responses(golden)
+    t_responses = _extract_responses(trial)
+    bleu_scores = [bleu(t, g) for t, g in zip(t_responses, g_responses)]
+    rouge_scores = [rouge_l(t, g) for t, g in zip(t_responses, g_responses)]
     return {
         "bleu": sum(bleu_scores) / len(bleu_scores) if bleu_scores else 0.0,
         "rouge_l": sum(rouge_scores) / len(rouge_scores) if rouge_scores else 0.0,
-        "avg_latency": average_latency(trial),
-        "actions_per_second": actions_per_second(trial),
     }
 
 
-def main(argv: List[str] | None = None) -> None:
+def _map_subject(event: str) -> str | None:
+    if event == "INPUT_RECEIVED":
+        return EventSubjects.INPUT_RECEIVED
+    if event == "RESPONSE_GENERATED":
+        return EventSubjects.RESPONSE_GENERATED
+    return None
+
+
+async def _publish_events(events: Iterable[dict], publisher: Publisher) -> None:
+    prev_ts: datetime | None = None
+    for rec in events:
+        payload = rec.get("payload", {})
+        ts_str = payload.get("timestamp")
+        ts = datetime.fromisoformat(ts_str) if ts_str else None
+        if prev_ts and ts:
+            delta = (ts - prev_ts).total_seconds()
+            if delta > 0:
+                await asyncio.sleep(delta)
+        subj = _map_subject(rec.get("event", ""))
+        if subj:
+            await publisher.publish(subj, payload)
+        if ts:
+            prev_ts = ts
+
+
+async def main(argv: List[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("trial", type=Path, help="Path to trial trace JSON")
-    parser.add_argument("golden", type=Path, help="Path to golden trace JSON")
+    parser.add_argument("trial", type=Path, help="Path to trial trace JSONL")
+    parser.add_argument("golden", type=Path, help="Path to golden trace JSONL")
+    parser.add_argument("--nats", default="", help="NATS server URL; empty to disable publishing")
     args = parser.parse_args(argv)
 
-    trial = _load_trace(args.trial)
-    golden = _load_trace(args.golden)
-    metrics = _compare(golden, trial)
+    trial_events = _load_jsonl(args.trial)
+    golden_events = _load_jsonl(args.golden)
+    metrics = _compute_metrics(golden_events, trial_events)
     for key, value in metrics.items():
         print(f"{key}: {value:.4f}")
 
+    if args.nats:
+        nc = NATS()
+        await nc.connect(servers=[args.nats])
+        js = nc.jetstream()
+        publisher = Publisher(nc, js)
+        await _publish_events(trial_events, publisher)
+        await nc.drain()
+
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- ensure TraceRecorder test coverage for subscriptions and response handling
- provide CLI for replaying JSONL traces and computing metrics
- document how to use replay tool
- update tests for new CLI format
- make motivate optional and fix replay unit test

## Testing
- `flake8 README.md tests/replay_basic.py tests/unit/test_harness_trace.py tools/replay.py src/deepthought/__init__.py src/deepthought/motivate/__init__.py tests/unit/test_harness_replay.py`
- `pytest tests/replay_basic.py tests/unit/test_harness_trace.py tests/unit/test_harness_replay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7e4c1490832685b5d70187bf73dc