### PR TITLE
Add JSONL trace support

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,24 @@
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import types
-import pytest
-
-<<<<<<< tino_swe/clean-up-test_harness_replay.py
-# Provide a lightweight stub of the social_graph_bot module. This allows tests
-# to run without installing optional heavy dependencies used by the full
-# example implementation.
+# Provide a lightweight stub of the social_graph_bot module used in examples.
 sg_stub = types.ModuleType("examples.social_graph_bot")
+
 
 async def _noop(*args, **kwargs):
     return None
 
+
 sg_stub.send_to_prism = _noop
 sg_stub.publish_input_received = _noop
-
 sys.modules.setdefault("examples.social_graph_bot", sg_stub)
 
-# Stub out the optional ``deepthought.motivate`` package to avoid importing
-# heavyweight dependencies like sentence-transformers during test collection.
-motivate_stub = types.ModuleType("deepthought.motivate")
-sys.modules.setdefault("deepthought.motivate", motivate_stub)
-=======
-# Provide a lightweight stub for sentence_transformers if the package is
-# missing so that modules importing RewardManager can be loaded without the
-# heavy optional dependency.
+# Provide a lightweight stub for sentence_transformers if missing.
 if "sentence_transformers" not in sys.modules:
     st = types.ModuleType("sentence_transformers")
 
@@ -45,7 +35,6 @@ if "sentence_transformers" not in sys.modules:
     st.util = types.SimpleNamespace(cos_sim=lambda a, b: [[0.0]])
     sys.modules["sentence_transformers"] = st
     sys.modules["sentence_transformers.util"] = st.util
->>>>>>> dev
 
 import examples.social_graph_bot as sg
 

--- a/tests/unit/test_harness_replay.py
+++ b/tests/unit/test_harness_replay.py
@@ -1,9 +1,12 @@
 import asyncio
+import json
 from datetime import datetime
 
 import pytest
 
+import tools.replay as tools_replay
 from deepthought.harness import replay as replay_mod
+from deepthought.harness import trace as trace_mod
 from deepthought.harness.record import TraceEvent
 
 
@@ -48,6 +51,84 @@ async def test_replay_uses_timestamp_delta(monkeypatch):
     agent = DummyAgent()
     publisher = DummyPublisher()
 
+    slept = []
+
+    async def fake_sleep(val):
+        slept.append(val)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await replay_mod.replay(events, agent, publisher)
+
+    assert slept == [0.0, 1.0]
+    assert agent.states == ["s1", "s2"]
+    assert publisher.published == [("chat.raw", "s1"), ("chat.raw", "s2")]
+
+
+@pytest.mark.asyncio
+async def test_trace_recorder_output_replays(monkeypatch, tmp_path):
+    class DummyNATS:
+        is_connected = True
+
+    class DummyJS:
+        pass
+
+    class DummySubscriber:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+
+        async def subscribe(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+
+        async def unsubscribe_all(self):
+            self.calls.clear()
+
+    class DummyMsg:
+        def __init__(self, data: str) -> None:
+            self.data = data.encode()
+            self.acked = False
+
+        async def ack(self):
+            self.acked = True
+
+    monkeypatch.setattr(trace_mod, "Subscriber", DummySubscriber)
+
+    outfile = tmp_path / "trace.jsonl"
+    recorder = trace_mod.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
+
+    now = datetime.utcnow().isoformat()
+    msg1 = DummyMsg(
+        json.dumps(
+            {
+                "state": "s1",
+                "action": "a1",
+                "reward": 0.0,
+                "latency": 0.0,
+                "timestamp": now,
+                "timestamp_delta": 0.0,
+            }
+        )
+    )
+    msg2 = DummyMsg(
+        json.dumps(
+            {
+                "state": "s2",
+                "action": "a2",
+                "reward": 0.0,
+                "latency": 0.0,
+                "timestamp": now,
+                "timestamp_delta": 1.0,
+            }
+        )
+    )
+
+    await recorder._handle_input(msg1)
+    await recorder._handle_input(msg2)
+
+    events = tools_replay._load_trace(outfile)
+
+    agent = DummyAgent()
+    publisher = DummyPublisher()
     slept = []
 
     async def fake_sleep(val):

--- a/tools/replay.py
+++ b/tools/replay.py
@@ -10,33 +10,36 @@ from pathlib import Path
 from typing import Iterable, List
 
 from deepthought.harness.record import TraceEvent
-from deepthought.metrics import (
-    actions_per_second,
-    average_latency,
-    bleu,
-    rouge_l,
-)
+from deepthought.metrics import (actions_per_second, average_latency, bleu,
+                                 rouge_l)
 
 
 def _load_trace(path: Path) -> List[TraceEvent]:
+    events: List[TraceEvent] = []
     with path.open("r", encoding="utf-8") as f:
-        data = json.load(f)
-    events = []
-    for item in data:
-        events.append(
-            TraceEvent(
-                state=item.get("state", ""),
-                action=item.get("action", ""),
-                reward=float(item.get("reward", 0.0)),
-                latency=float(item.get("latency", 0.0)),
-                timestamp=datetime.fromisoformat(item.get("timestamp")),
-                timestamp_delta=float(item.get("timestamp_delta", 0.0)),
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            item = json.loads(line)
+            if "payload" in item:
+                item = item["payload"]
+            events.append(
+                TraceEvent(
+                    state=item.get("state", ""),
+                    action=item.get("action", ""),
+                    reward=float(item.get("reward", 0.0)),
+                    latency=float(item.get("latency", 0.0)),
+                    timestamp=datetime.fromisoformat(item.get("timestamp")),
+                    timestamp_delta=float(item.get("timestamp_delta", 0.0)),
+                )
             )
-        )
     return events
 
 
-def _compare(golden: Iterable[TraceEvent], trial: Iterable[TraceEvent]) -> dict[str, float]:
+def _compare(
+    golden: Iterable[TraceEvent], trial: Iterable[TraceEvent]
+) -> dict[str, float]:
     bleu_scores = []
     rouge_scores = []
     for g, t in zip(golden, trial):


### PR DESCRIPTION
## Summary
- load newline-delimited trace records in tools/replay
- verify TraceRecorder output replays correctly
- clean up tests/conftest

## Testing
- `pytest tests/unit/test_harness_replay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685da1faa8848326a14b16c04f5827dd