### PR TITLE
Add CHAT_RAW event publishing

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -27,6 +27,9 @@ class EventSubjects:
     # LLM events
     RESPONSE_GENERATED = "dtr.llm.response_generated"
 
+    # Raw chat message events
+    CHAT_RAW = "chat.raw"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"

--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -8,11 +8,8 @@ from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
 # Assuming eda modules are in parent dir relative to modules dir
-from ..eda.events import (
-    EventSubjects,
-    InputReceivedPayload,
-    MemoryRetrievedPayload,
-)
+from ..eda.events import (EventSubjects, InputReceivedPayload,
+                          MemoryRetrievedPayload)
 from ..eda.publisher import Publisher
 
 logger = logging.getLogger(__name__)
@@ -21,7 +18,9 @@ logger = logging.getLogger(__name__)
 class InputHandler:
     """Handles user input and publishes InputReceived events."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, memory_service=None):
+    def __init__(
+        self, nats_client: NATS, js_context: JetStreamContext, memory_service=None
+    ):
         """Initialize with optional hierarchical memory service."""
         self._publisher = Publisher(nats_client, js_context)
         self._memory_service = memory_service
@@ -35,12 +34,20 @@ class InputHandler:
         input_id = str(uuid.uuid4())
         # Use timezone-aware UTC timestamp
         timestamp = datetime.now(timezone.utc).isoformat()
-        payload = InputReceivedPayload(user_input=user_input, input_id=input_id, timestamp=timestamp)
+        payload = InputReceivedPayload(
+            user_input=user_input, input_id=input_id, timestamp=timestamp
+        )
         try:
             # Always use JetStream for input events in this version
             await self._publisher.publish(
                 EventSubjects.INPUT_RECEIVED,
                 payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            await self._publisher.publish(
+                EventSubjects.CHAT_RAW,
+                user_input,
                 use_jetstream=True,
                 timeout=10.0,
             )
@@ -54,7 +61,12 @@ class InputHandler:
                     logger.error("Memory retrieval failed: %s", err, exc_info=True)
 
                 mem_payload = MemoryRetrievedPayload(
-                    retrieved_knowledge={"retrieved_knowledge": {"facts": context, "source": "hierarchical"}},
+                    retrieved_knowledge={
+                        "retrieved_knowledge": {
+                            "facts": context,
+                            "source": "hierarchical",
+                        }
+                    },
                     input_id=input_id,
                     timestamp=datetime.now(timezone.utc).isoformat(),
                 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,14 @@
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import types
 import pytest
 
-<<<<<<< tino_swe/clean-up-test_harness_replay.py
-# Provide a lightweight stub of the social_graph_bot module. This allows tests
-# to run without installing optional heavy dependencies used by the full
-# example implementation.
-sg_stub = types.ModuleType("examples.social_graph_bot")
-
-async def _noop(*args, **kwargs):
-    return None
-
-sg_stub.send_to_prism = _noop
-sg_stub.publish_input_received = _noop
-
-sys.modules.setdefault("examples.social_graph_bot", sg_stub)
-
-# Stub out the optional ``deepthought.motivate`` package to avoid importing
-# heavyweight dependencies like sentence-transformers during test collection.
-motivate_stub = types.ModuleType("deepthought.motivate")
-sys.modules.setdefault("deepthought.motivate", motivate_stub)
-=======
-# Provide a lightweight stub for sentence_transformers if the package is
-# missing so that modules importing RewardManager can be loaded without the
-# heavy optional dependency.
+# Provide a lightweight stub for sentence_transformers if the package is missing
+# so that modules importing RewardManager can be loaded without the heavy
+# optional dependency.
 if "sentence_transformers" not in sys.modules:
     st = types.ModuleType("sentence_transformers")
 
@@ -45,7 +25,6 @@ if "sentence_transformers" not in sys.modules:
     st.util = types.SimpleNamespace(cos_sim=lambda a, b: [[0.0]])
     sys.modules["sentence_transformers"] = st
     sys.modules["sentence_transformers.util"] = st.util
->>>>>>> dev
 
 import examples.social_graph_bot as sg
 

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -60,8 +60,13 @@ async def test_process_input_success():
     parsed = datetime.fromisoformat(ts)
     assert parsed.tzinfo == timezone.utc
 
-    # Second publish: MEMORY_RETRIEVED
+    # Second publish: CHAT_RAW
     subject, data = js.published[1]
+    assert subject == EventSubjects.CHAT_RAW
+    assert data.decode() == "hello"
+
+    # Third publish: MEMORY_RETRIEVED
+    subject, data = js.published[2]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     memory_payload = json.loads(data.decode())
     assert memory_payload["input_id"] == input_id
@@ -101,7 +106,10 @@ async def test_process_input_no_memory():
     nc = DummyNATS()
     handler = InputHandler(nc, js)
     input_id = await handler.process_input("hello")
-    assert len(js.published) == 1
+    assert len(js.published) == 2
     subject, _ = js.published[0]
     assert subject == EventSubjects.INPUT_RECEIVED
+    subject, data = js.published[1]
+    assert subject == EventSubjects.CHAT_RAW
+    assert data.decode() == "hello"
     assert input_id


### PR DESCRIPTION
## Summary
- introduce `CHAT_RAW` event subject
- publish raw chat messages when handling input
- adjust input handler tests
- clean up test fixtures with real imports

## Testing
- `pytest tests/unit/modules/test_input_handler.py tests/unit/test_motivation.py tests/unit/test_reward_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685da204a1808326a331bc7cb273abef