### PR TITLE
Add metrics tests and update replay CLI tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,10 @@
 import sys
 from pathlib import Path
 import types
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import types
-import pytest
-
-<<<<<<< tino_swe/clean-up-test_harness_replay.py
 # Provide a lightweight stub of the social_graph_bot module. This allows tests
 # to run without installing optional heavy dependencies used by the full
 # example implementation.
@@ -25,7 +22,7 @@ sys.modules.setdefault("examples.social_graph_bot", sg_stub)
 # heavyweight dependencies like sentence-transformers during test collection.
 motivate_stub = types.ModuleType("deepthought.motivate")
 sys.modules.setdefault("deepthought.motivate", motivate_stub)
-=======
+
 # Provide a lightweight stub for sentence_transformers if the package is
 # missing so that modules importing RewardManager can be loaded without the
 # heavy optional dependency.
@@ -38,14 +35,12 @@ if "sentence_transformers" not in sys.modules:
 
         def encode(self, text, convert_to_numpy=True):
             import numpy as np
-
             return np.array([len(text)], dtype=float)
 
     st.SentenceTransformer = DummyModel
     st.util = types.SimpleNamespace(cos_sim=lambda a, b: [[0.0]])
     sys.modules["sentence_transformers"] = st
     sys.modules["sentence_transformers.util"] = st.util
->>>>>>> dev
 
 import examples.social_graph_bot as sg
 

--- a/tests/replay_basic.py
+++ b/tests/replay_basic.py
@@ -26,7 +26,43 @@ def test_replay_cli(tmp_path: Path) -> None:
     _write_trace(golden, ["hello world"])
 
     env = dict(os.environ)
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[1] / "src"),
+            str(Path(__file__).resolve().parent),
+        ]
+    )
+    result = subprocess.run(
+        [
+            "python",
+            str(Path(__file__).resolve().parents[1] / "tools" / "replay.py"),
+            str(trial),
+            str(golden),
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    out = result.stdout
+    assert "bleu:" in out
+    assert "rouge_l:" in out
+    assert "avg_latency:" in out
+    assert "actions_per_second:" in out
+
+def test_replay_cli_mismatch(tmp_path: Path) -> None:
+    trial = tmp_path / "trial_m.json"
+    golden = tmp_path / "golden_m.json"
+    _write_trace(trial, ["foo"])
+    _write_trace(golden, ["bar"])
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[1] / "src"),
+            str(Path(__file__).resolve().parent),
+        ]
+    )
     result = subprocess.run(
         [
             "python",

--- a/tests/sentence_transformers.py
+++ b/tests/sentence_transformers.py
@@ -1,0 +1,12 @@
+class SentenceTransformer:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def encode(self, text, convert_to_numpy=True):
+        import numpy as np
+        return np.array([len(text)], dtype=float)
+
+class util:
+    @staticmethod
+    def cos_sim(a, b):
+        return [[0.0]]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,43 @@
+import pytest
+from datetime import datetime
+
+from deepthought.metrics import bleu, rouge_l, average_latency, actions_per_second
+from deepthought.harness.record import TraceEvent
+
+
+def _event(latency: float) -> TraceEvent:
+    return TraceEvent(
+        state="",
+        action="",
+        reward=0.0,
+        latency=latency,
+        timestamp=datetime.utcnow(),
+        timestamp_delta=0.0,
+    )
+
+
+def test_bleu_identical() -> None:
+    text = "the cat is here"
+    assert bleu(text, text) == pytest.approx(1.0)
+
+
+def test_bleu_empty_candidate() -> None:
+    assert bleu("", "hello world") == pytest.approx(0.0)
+
+
+def test_rouge_l_identical() -> None:
+    assert rouge_l("a b c", "a b c") == pytest.approx(1.0)
+
+
+def test_rouge_l_no_match() -> None:
+    assert rouge_l("foo", "bar") == pytest.approx(0.0)
+
+
+def test_average_latency() -> None:
+    events = [_event(1.0), _event(2.0)]
+    assert average_latency(events) == pytest.approx(1.5)
+
+
+def test_actions_per_second() -> None:
+    events = [_event(1.0), _event(1.0)]
+    assert actions_per_second(events) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add new unit tests for bleu, rouge_l, average_latency, and actions_per_second
- stub out `sentence_transformers` for subprocesses
- update replay CLI tests to include stub path and add mismatch check
- clean up `tests/conftest.py` merge markers

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/replay_basic.py tests/unit/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685da20638988326b93e22c80483d637