### PR TITLE
Refactor hierarchical service retrieval logic

### DIFF
--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -21,10 +21,10 @@ logger = logging.getLogger(__name__)
 class InputHandler:
     """Handles user input and publishes InputReceived events."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, memory_service=None):
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, hierarchical_service=None):
         """Initialize with optional hierarchical memory service."""
         self._publisher = Publisher(nats_client, js_context)
-        self._memory_service = memory_service
+        self._memory_service = hierarchical_service
         logger.info("InputHandler initialized (JetStream enabled).")
 
     async def process_input(self, user_input: str) -> str:

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, List
+from typing import Any, List, Sequence
 
 import nats
 from nats.aio.client import Client as NATS
@@ -12,7 +12,6 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
-from ..memory.hierarchical import HierarchicalMemory
 
 logger = logging.getLogger(__name__)
 
@@ -30,11 +29,56 @@ class HierarchicalService:
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._memory = HierarchicalMemory(vector_store, graph_dal, top_k)
+        self._vector_store = vector_store
+        self._graph_dal = graph_dal
+        self._top_k = top_k
+
+    def _vector_matches(self, prompt: str) -> List[str]:
+        if self._vector_store is None:
+            return []
+        try:
+            result = self._vector_store.query(query_texts=[prompt], n_results=self._top_k)
+            docs: Sequence | None = None
+            if isinstance(result, dict):
+                docs = result.get("documents")
+            elif isinstance(result, Sequence):
+                docs = result
+            if not docs:
+                return []
+            matches: List[str] = []
+            for doc in docs:
+                if isinstance(doc, list):
+                    for d in doc:
+                        matches.append(str(getattr(d, "page_content", d)))
+                else:
+                    matches.append(str(getattr(doc, "page_content", doc)))
+            return matches
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Vector store query failed: %s", exc, exc_info=True)
+            return []
+
+    def _graph_facts(self) -> List[str]:
+        try:
+            rows = self._graph_dal.query_subgraph(
+                "MATCH (n:Entity) RETURN n.name AS fact LIMIT $limit",
+                {"limit": self._top_k},
+            )
+            return [str(r.get("fact")) for r in rows if r.get("fact")]
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Graph query failed: %s", exc, exc_info=True)
+            return []
 
     def retrieve_context(self, prompt: str) -> List[str]:
-        """Return context from vector store and graph."""
-        return self._memory.retrieve_context(prompt)
+        """Return merged vector matches and graph facts."""
+        vector = self._vector_matches(prompt)
+        graph = self._graph_facts()
+        seen = set()
+        merged: List[str] = []
+        for item in vector + graph:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+        return merged
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -50,9 +94,7 @@ class HierarchicalService:
 
             facts = self.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={
-                    "retrieved_knowledge": {"facts": facts, "source": "hierarchical_service"}
-                },
+                retrieved_knowledge={"retrieved_knowledge": {"facts": facts, "source": "hierarchical_service"}},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,75 @@
 import sys
-from pathlib import Path
 import types
+from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-import types
-import pytest
-
-<<<<<<< tino_swe/clean-up-test_harness_replay.py
-# Provide a lightweight stub of the social_graph_bot module. This allows tests
-# to run without installing optional heavy dependencies used by the full
-# example implementation.
+# Provide a lightweight stub of the social_graph_bot module so tests do not
+# require optional heavy dependencies from the full example implementation.
 sg_stub = types.ModuleType("examples.social_graph_bot")
+
 
 async def _noop(*args, **kwargs):
     return None
 
+
 sg_stub.send_to_prism = _noop
 sg_stub.publish_input_received = _noop
-
 sys.modules.setdefault("examples.social_graph_bot", sg_stub)
 
-# Stub out the optional ``deepthought.motivate`` package to avoid importing
-# heavyweight dependencies like sentence-transformers during test collection.
-motivate_stub = types.ModuleType("deepthought.motivate")
-sys.modules.setdefault("deepthought.motivate", motivate_stub)
-=======
-# Provide a lightweight stub for sentence_transformers if the package is
-# missing so that modules importing RewardManager can be loaded without the
-# heavy optional dependency.
+# Stub out optional dependencies so tests can run without installing them.
+if "nats" not in sys.modules:
+    nats_stub = types.ModuleType("nats")
+    nats_stub.errors = types.SimpleNamespace(Error=Exception, TimeoutError=Exception)
+    sys.modules["nats"] = nats_stub
+    aio_mod = types.ModuleType("nats.aio")
+    client_mod = types.ModuleType("nats.aio.client")
+    msg_mod = types.ModuleType("nats.aio.msg")
+
+    class DummyClient:
+        pass
+
+    class DummyMsg:
+        pass
+
+    client_mod.Client = DummyClient
+    msg_mod.Msg = DummyMsg
+    aio_mod.client = client_mod
+    sys.modules["nats.aio"] = aio_mod
+    sys.modules["nats.aio.client"] = client_mod
+    sys.modules["nats.aio.msg"] = msg_mod
+
+    js_mod = types.ModuleType("nats.js")
+    client_js_mod = types.ModuleType("nats.js.client")
+    api_mod = types.ModuleType("nats.js.api")
+
+    class DummyJetStreamContext:
+        pass
+
+    client_js_mod.JetStreamContext = DummyJetStreamContext
+    js_mod.client = client_js_mod
+    js_mod.JetStreamContext = DummyJetStreamContext
+    api_mod.DiscardPolicy = object
+    api_mod.RetentionPolicy = object
+    api_mod.StorageType = object
+    api_mod.StreamConfig = object
+    sys.modules["nats.js"] = js_mod
+    sys.modules["nats.js.client"] = client_js_mod
+    sys.modules["nats.js.api"] = api_mod
+
+if "aiosqlite" not in sys.modules:
+    aiosqlite_stub = types.ModuleType("aiosqlite")
+
+    async def connect(*args, **kwargs):
+        raise RuntimeError("aiosqlite stub used")
+
+    aiosqlite_stub.connect = connect
+    sys.modules["aiosqlite"] = aiosqlite_stub
+
+# Provide a stub for ``sentence_transformers`` if the package is missing so
+# that RewardManager can be imported without heavy dependencies.
 if "sentence_transformers" not in sys.modules:
     st = types.ModuleType("sentence_transformers")
 
@@ -45,7 +86,6 @@ if "sentence_transformers" not in sys.modules:
     st.util = types.SimpleNamespace(cos_sim=lambda a, b: [[0.0]])
     sys.modules["sentence_transformers"] = st
     sys.modules["sentence_transformers.util"] = st.util
->>>>>>> dev
 
 import examples.social_graph_bot as sg
 

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -146,7 +146,7 @@ async def test_full_module_flow():
         if os.path.exists(memory_file):
             os.remove(memory_file)
         memory_service = DummyMemory()
-        input_handler = InputHandler(nc, js, memory_service=memory_service)
+        input_handler = InputHandler(nc, js, hierarchical_service=memory_service)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:
             llm_module = llm_cls(nc, js)
@@ -279,7 +279,7 @@ async def test_full_module_flow_graph_memory():
         if os.path.exists(GRAPH_MEMORY_FILE):
             os.remove(GRAPH_MEMORY_FILE)
         memory_service = DummyMemory()
-        input_handler = InputHandler(nc, js, memory_service=memory_service)
+        input_handler = InputHandler(nc, js, hierarchical_service=memory_service)
         memory_module = GraphMemory(nc, js, graph_file=GRAPH_MEMORY_FILE)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -46,7 +46,7 @@ async def test_process_input_success():
     js = DummyJS()
     nc = DummyNATS()
     memory = DummyMemory()
-    handler = InputHandler(nc, js, memory_service=memory)
+    handler = InputHandler(nc, js, hierarchical_service=memory)
     input_id = await handler.process_input("hello")
 
     assert js.published

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -44,6 +44,16 @@ class DummyDAL:
         return [{"fact": "graph1"}]
 
 
+class FailingVector:
+    def query(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
+class FailingDAL:
+    def query_subgraph(self, *args, **kwargs):
+        raise RuntimeError("boom")
+
+
 class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
@@ -74,3 +84,17 @@ async def test_handle_input_publishes_combined_context(monkeypatch):
     assert "vec1" in facts and "graph1" in facts
     ts = sent_payload.timestamp
     assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+
+
+def test_retrieve_context_merges():
+    vec = DummyVector()
+    dal = DummyDAL()
+    service = HierarchicalService(DummyNATS(), DummyJS(), vec, dal)
+    ctx = service.retrieve_context("hi")
+    assert ctx == ["vec1", "vec2", "graph1"]
+
+
+def test_retrieve_context_failures():
+    service = HierarchicalService(DummyNATS(), DummyJS(), FailingVector(), FailingDAL())
+    ctx = service.retrieve_context("x")
+    assert ctx == []


### PR DESCRIPTION
## Summary
- inline hierarchical memory logic into `HierarchicalService`
- rename `InputHandler` optional dependency and call the new service
- adapt unit tests for the refactor
- clean up test fixtures
- stub optional dependencies so tests run without them

## Testing
- `black --line-length=120 tests/conftest.py`
- `isort --profile=black --line-length=120 tests/conftest.py`
- `flake8 tests/conftest.py`
- `pytest tests/unit/services/test_hierarchical_service.py tests/unit/modules/test_input_handler.py tests/test_module_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685da1ff67f883268c50503a4db7fedc