### PR TITLE
Add test for missing PyYAML

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -66,6 +66,8 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
                 data = yaml.safe_load(content)
             else:
                 data = json.loads(content)
+        except RuntimeError:
+            raise
         except Exception as e:
             raise ValueError(f"Invalid config structure: {e}") from e
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -120,3 +120,14 @@ def test_load_settings_invalid_structure(tmp_path):
     cfg.write_text(yaml.safe_dump([1, 2, 3]))
     with pytest.raises(ValueError):
         load_settings(str(cfg))
+
+
+def test_load_settings_missing_yaml_module(monkeypatch, tmp_path):
+    """load_settings should raise when PyYAML is unavailable and a YAML file is passed."""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("nats_url: nats://nope:4222\n")
+
+    monkeypatch.setattr("deepthought.config.yaml", None)
+
+    with pytest.raises(RuntimeError):
+        load_settings(str(cfg))


### PR DESCRIPTION
## Summary
- check `load_settings()` error when PyYAML isn't available
- surface `RuntimeError` in `load_settings`

## Testing
- `flake8 src/deepthought/config.py tests/unit/test_config.py`
- `pytest tests/unit/test_config.py::test_load_settings_missing_yaml_module -q`


------
https://chatgpt.com/codex/tasks/task_e_685de0c418d88326acb999e4a482948e