### PR TITLE
Add knowledge graph memory unit tests

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, List, Sequence
+from typing import Any, List, Sequence, Optional
 
 
 import nats
@@ -13,6 +13,7 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
+from ..memory import create_vector_store
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/modules/test_memory_kg.py
+++ b/tests/unit/modules/test_memory_kg.py
@@ -121,3 +121,23 @@ async def test_handle_input_missing_fields(monkeypatch):
 
     assert msg.nacked
     assert not msg.acked
+
+
+def test_parse_input(monkeypatch):
+    dal = DummyDAL()
+    mem = create_memory(monkeypatch, dal)
+    nodes, edges = mem._parse_input("a b a c")
+
+    assert nodes == ["a", "b", "c"]
+    assert edges == [("a", "b"), ("b", "a"), ("a", "c")]
+
+
+def test_store(monkeypatch):
+    dal = DummyDAL()
+    mem = create_memory(monkeypatch, dal)
+    nodes = ["x", "y"]
+    edges = [("x", "y"), ("y", "x")]
+    mem._store(nodes, edges)
+
+    assert dal.merge_entity_calls == nodes
+    assert dal.merge_edge_calls == edges


### PR DESCRIPTION
## Summary
- add direct tests for `_parse_input` and `_store` in `KnowledgeGraphMemory`
- fix `HierarchicalService` import errors preventing flake8 from passing

## Testing
- `flake8`
- `pytest -q tests/unit/modules/test_memory_kg.py`


------
https://chatgpt.com/codex/tasks/task_e_685de0c5414c832698fa20d719d64a9d