### PR TITLE
Speed up async tests with monkeypatched sleep

### DIFF
--- a/tests/test_eda_flow.py
+++ b/tests/test_eda_flow.py
@@ -75,7 +75,7 @@ async def test_nats_connection_fixture(nats_connection):
 
 # The test function using an ephemeral consumer
 @pytest.mark.asyncio
-async def test_full_flow_direct_subscribe(nats_connection):
+async def test_full_flow_direct_subscribe(nats_connection, monkeypatch):
     """
     Test the full EDA flow using JetStream publish and a direct ephemeral subscribe.
     1. Publish a task request.
@@ -89,6 +89,14 @@ async def test_full_flow_direct_subscribe(nats_connection):
         if not nc.is_connected:
             pytest.fail("NATS connection is not connected")
         logger.info("NATS connection from fixture is connected.")
+
+        # Patch asyncio.sleep to speed up the test
+        original_sleep = asyncio.sleep
+
+        async def fast_sleep(*args, **kwargs):
+            await original_sleep(0)
+
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
 
         # --- Existing Test Logic START ---
         logger.info("Starting test_full_flow_direct_subscribe...")

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -92,7 +92,7 @@ async def ensure_stream_exists(js: JetStreamContext, stream_name: str) -> bool:
 
 # The integration test function
 @pytest.mark.asyncio
-async def test_full_module_flow():
+async def test_full_module_flow(monkeypatch):
     """
     Test the full event flow using hierarchical memory via InputHandler.
     1. Input -> InputHandler publishes INPUT_RECEIVED
@@ -114,6 +114,14 @@ async def test_full_module_flow():
         if not nc.is_connected:
             pytest.fail("NATS connection failed")
         logger.info("NATS connection successful.")
+
+        # Patch asyncio.sleep to speed up the test
+        original_sleep = asyncio.sleep
+
+        async def fast_sleep(*args, **kwargs):
+            await original_sleep(0)
+
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
 
         # --- Get JetStream context ---
         logger.info("Getting JetStream context...")
@@ -246,7 +254,7 @@ async def test_full_module_flow():
 
 
 @pytest.mark.asyncio
-async def test_full_module_flow_graph_memory():
+async def test_full_module_flow_graph_memory(monkeypatch):
     """Same as test_full_module_flow but using GraphMemory module."""
     if not nats_server_available(get_nats_url()):
         pytest.skip("NATS server not available")
@@ -264,6 +272,14 @@ async def test_full_module_flow_graph_memory():
         js = nc.jetstream(timeout=30.0)
         if not js:
             pytest.fail("Failed to get JetStream context.")
+
+        # Patch asyncio.sleep to speed up the test
+        original_sleep = asyncio.sleep
+
+        async def fast_sleep(*args, **kwargs):
+            await original_sleep(0)
+
+        monkeypatch.setattr(asyncio, "sleep", fast_sleep)
 
         if not await ensure_stream_exists(js, STREAM_NAME):
             pytest.fail(f"Failed to ensure stream '{STREAM_NAME}' exists.")


### PR DESCRIPTION
## Summary
- patch `asyncio.sleep` with a zero-delay helper
- do the same for module flow and graph memory tests

## Testing
- `pytest tests/test_eda_flow.py::test_full_flow_direct_subscribe -vv`
- `pytest tests/test_module_integration.py::test_full_module_flow -vv`
- `pytest tests/test_module_integration.py::test_full_module_flow_graph_memory -vv`
- `black tests/test_eda_flow.py tests/test_module_integration.py --line-length 120`
- `isort tests/test_eda_flow.py tests/test_module_integration.py --profile black --line-length 120`
- `python -m flake8 tests/test_eda_flow.py tests/test_module_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_685de0c61c3c8326a0131049eb61fa29