### PR TITLE
Split unit and NATS tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,38 @@ jobs:
           python scripts/check_code_changes.py | tee result.txt
           echo "changed=$(cat result.txt)" >> "$GITHUB_OUTPUT"
 
-  lint_and_test:
+  lint_and_unit_tests:
     needs: detect_changes
+    if: needs.detect_changes.outputs.code_changed == 'true'
+    runs-on: ["self-hosted", "linux"]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements-ci.txt
+      - run: pip install -e . --no-deps
+      - name: Run pre-commit
+        if: matrix.python-version == '3.11'
+        run: pre-commit run --all-files
+      - env:
+          PYTHONPATH: src
+        run: pytest --cov=src --cov-report=xml -m "not nats"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage.xml
+
+  integration_tests:
+    needs: lint_and_unit_tests
     if: needs.detect_changes.outputs.code_changed == 'true'
     runs-on: ["self-hosted", "linux"]
     strategy:
@@ -75,18 +105,11 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
       - run: pip install -e . --no-deps
-      - name: Run pre-commit
-        if: matrix.python-version == '3.11'
-        run: pre-commit run --all-files
       - name: Setup JetStream
         run: python setup_jetstream.py
       - env:
           PYTHONPATH: src
-        run: pytest --cov=src --cov-report=xml
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coverage
-          path: coverage.xml
+        run: pytest -m "nats"
       - name: Cleanup NATS container
         if: always()
         run: docker rm -f dtr_nats

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -1,8 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, List, Sequence
-
+from typing import Any, List, Optional, Sequence
 
 import nats
 from nats.aio.client import Client as NATS
@@ -13,6 +12,7 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
+from ..memory.vector_store import create_vector_store
 
 logger = logging.getLogger(__name__)
 
@@ -109,8 +109,12 @@ class HierarchicalService:
 
             facts = self.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"retrieved_knowledge": {"facts": facts, "source": "hierarchical_service"}},
-
+                retrieved_knowledge={
+                    "retrieved_knowledge": {
+                        "facts": facts,
+                        "source": "hierarchical_service",
+                    }
+                },
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
@@ -161,19 +165,13 @@ class HierarchicalService:
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info(
-                "HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED
-            )
+            logger.info("HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED)
             return True
         except nats.errors.Error as e:
-            logger.error(
-                "HierarchicalService failed to subscribe: %s", e, exc_info=True
-            )
+            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
             return False
         except Exception as e:  # pragma: no cover - network failure
-            logger.error(
-                "HierarchicalService failed to subscribe: %s", e, exc_info=True
-            )
+            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
             return False
 
     async def stop(self) -> None:


### PR DESCRIPTION
## Summary
- adjust CI workflow so unit tests run separately from NATS integration tests
- fix HierarchicalService missing imports and adjust log formatting

## Testing
- `SKIP=pytest pre-commit run --files .github/workflows/ci.yml src/deepthought/services/hierarchical_service.py`
- `pytest tests/unit/services/test_hierarchical_service.py::test_retrieve_context_merges -q`
- `pytest tests/unit/services/test_hierarchical_service.py::test_handle_input_publishes_combined_context -q`


------
https://chatgpt.com/codex/tasks/task_e_685de0c6cba88326af2e5424e6baf7bb