### PR TITLE
Add Discord replay CLI and record raw chat

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -100,3 +100,17 @@ The dashboard script aggregates metrics files from replay runs or training sessi
    python tools/dashboard.py path/to/metrics --show
    ```
    The plot is also saved as `dashboard.png` in the current directory.
+
+## Replaying Discord Logs
+
+`tools/discord_replay.py` replays traces recorded with `tools/record.py` by
+publishing each `chat.raw` message back to NATS and waiting for the bot's reply.
+The collected responses are written to a new trace file and summary metrics are
+saved as JSON.
+
+Example using the sample traces in `tests/traces/`:
+
+```bash
+PYTHONPATH=src python tools/discord_replay.py tests/traces/trial.json \
+    --output reply.jsonl --metrics metrics.json
+```

--- a/src/deepthought/harness/trace.py
+++ b/src/deepthought/harness/trace.py
@@ -12,9 +12,11 @@ logger = logging.getLogger(__name__)
 
 
 class TraceRecorder:
-    """Record INPUT_RECEIVED and RESPONSE_GENERATED events to a JSONL file."""
+    """Record agent events to a JSONL file."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, outfile: str) -> None:
+    def __init__(
+        self, nats_client: NATS, js_context: JetStreamContext, outfile: str
+    ) -> None:
         if not outfile:
             raise ValueError("outfile path must be provided")
         self._subscriber = Subscriber(nats_client, js_context)
@@ -48,11 +50,31 @@ class TraceRecorder:
                 except Exception:  # noqa: BLE001
                     logger.error("Failed to NAK message after error", exc_info=True)
 
+    async def _append_raw(self, event: str, msg: Msg) -> None:
+        data = msg.data.decode()
+        record = {"event": event, "payload": data}
+        try:
+            with open(self._outfile, "a", encoding="utf-8") as f:
+                json.dump(record, f)
+                f.write("\n")
+            await msg.ack()
+            logger.debug("Recorded %s event", event)
+        except Exception as e:  # noqa: BLE001
+            logger.error("Failed to record %s: %s", event, e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:  # noqa: BLE001
+                    logger.error("Failed to NAK message after error", exc_info=True)
+
     async def _handle_input(self, msg: Msg) -> None:
         await self._append("INPUT_RECEIVED", msg)
 
     async def _handle_response(self, msg: Msg) -> None:
         await self._append("RESPONSE_GENERATED", msg)
+
+    async def _handle_chat_raw(self, msg: Msg) -> None:
+        await self._append_raw("CHAT_RAW", msg)
 
     async def start(self, durable_name: str = "trace_recorder") -> bool:
         try:
@@ -67,6 +89,12 @@ class TraceRecorder:
                 handler=self._handle_response,
                 use_jetstream=True,
                 durable=f"{durable_name}_response",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.CHAT_RAW,
+                handler=self._handle_chat_raw,
+                use_jetstream=True,
+                durable=f"{durable_name}_chat_raw",
             )
             logger.info("TraceRecorder subscribed to events")
             return True

--- a/tests/unit/test_harness_trace.py
+++ b/tests/unit/test_harness_trace.py
@@ -51,3 +51,19 @@ async def test_handle_input_writes_file(monkeypatch, tmp_path):
     obj = json.loads(line)
     assert obj["event"] == "INPUT_RECEIVED"
     assert obj["payload"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_raw(monkeypatch, tmp_path):
+    monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    outfile = tmp_path / "trace.jsonl"
+    recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
+    msg = DummyMsg("hello")
+
+    await recorder._handle_chat_raw(msg)
+    assert msg.acked
+    with open(outfile, "r", encoding="utf-8") as f:
+        line = f.readline()
+    obj = json.loads(line)
+    assert obj["event"] == "CHAT_RAW"
+    assert obj["payload"] == "hello"

--- a/tools/discord_replay.py
+++ b/tools/discord_replay.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Replay chat logs through NATS and collect bot replies."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+
+from deepthought.eda.events import EventSubjects
+from deepthought.eda.publisher import Publisher
+from deepthought.eda.subscriber import Subscriber
+from deepthought.harness.record import TraceEvent, record_event
+from deepthought.metrics import actions_per_second, average_latency, bleu, rouge_l
+
+
+def _load_events(path: Path) -> List[dict]:
+    text = path.read_text(encoding="utf-8").strip()
+    events: List[dict] = []
+    if text.startswith("["):
+        data = json.loads(text)
+        if isinstance(data, list):
+            events.extend(data)
+    else:
+        for line in text.splitlines():
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    return events
+
+
+async def _replay(path: Path, output: Path, metrics: Path, nats_url: str) -> None:
+    events = _load_events(path)
+    inputs = [e["payload"] for e in events if e.get("event") == "CHAT_RAW"]
+    expected = [
+        e["payload"].get("final_response", "")
+        for e in events
+        if e.get("event") == "RESPONSE_GENERATED"
+    ]
+
+    nc = NATS()
+    await nc.connect(servers=[nats_url])
+    js = nc.jetstream()
+    publisher = Publisher(nc, js)
+    subscriber = Subscriber(nc, js)
+
+    responses: List[str] = []
+    trace: List[TraceEvent] = []
+    queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def handle_response(msg: Msg) -> None:
+        data = json.loads(msg.data.decode())
+        await msg.ack()
+        queue.put_nowait(data.get("final_response", ""))
+
+    await subscriber.subscribe(
+        subject=EventSubjects.RESPONSE_GENERATED,
+        handler=handle_response,
+        use_jetstream=True,
+        durable="discord_replay_response",
+    )
+
+    try:
+        for state in inputs:
+            start = datetime.utcnow()
+            await publisher.publish(
+                EventSubjects.CHAT_RAW, state, use_jetstream=True, timeout=10.0
+            )
+            action = await queue.get()
+            latency = (datetime.utcnow() - start).total_seconds()
+            record_event(trace, state, action, 0.0, latency)
+            responses.append(action)
+    finally:
+        await subscriber.unsubscribe_all()
+        await nc.drain()
+
+    with output.open("w", encoding="utf-8") as f:
+        for evt in trace:
+            json.dump(asdict(evt), f, default=str)
+            f.write("\n")
+
+    bleu_scores = [bleu(r, e) for r, e in zip(responses, expected)]
+    rouge_scores = [rouge_l(r, e) for r, e in zip(responses, expected)]
+    metrics_data = {
+        "bleu": sum(bleu_scores) / len(bleu_scores) if bleu_scores else 0.0,
+        "rouge_l": sum(rouge_scores) / len(rouge_scores) if rouge_scores else 0.0,
+        "avg_latency": average_latency(trace),
+        "actions_per_second": actions_per_second(trace),
+    }
+    metrics.write_text(json.dumps(metrics_data))
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("trace", type=Path, help="Recorded trace JSONL file")
+    parser.add_argument(
+        "--nats",
+        "-n",
+        default="nats://localhost:4222",
+        help="NATS server URL",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("replay.jsonl"),
+        help="Output file for collected replies",
+    )
+    parser.add_argument(
+        "--metrics",
+        "-m",
+        type=Path,
+        default=Path("metrics.json"),
+        help="Metrics output JSON",
+    )
+    args = parser.parse_args()
+
+    await _replay(args.trace, args.output, args.metrics, args.nats)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tools/record.py
+++ b/tools/record.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Record DeepThought events to a JSONL file."""
+"""Record DeepThought events to a JSONL file.
+
+This script now also captures raw Discord messages published on ``chat.raw``.
+"""
 
 import argparse
 import asyncio
@@ -12,12 +15,21 @@ from deepthought.harness.trace import TraceRecorder
 
 async def main() -> None:
     parser = argparse.ArgumentParser(description="Record events from NATS")
-    parser.add_argument("--output", "-o", default="trace.jsonl", help="Output JSONL file")
-    parser.add_argument("--nats", "-n", default="nats://localhost:4222", help="NATS server URL")
-    parser.add_argument("--durable", "-d", default="trace_recorder", help="Durable consumer name prefix")
+    parser.add_argument(
+        "--output", "-o", default="trace.jsonl", help="Output JSONL file"
+    )
+    parser.add_argument(
+        "--nats", "-n", default="nats://localhost:4222", help="NATS server URL"
+    )
+    parser.add_argument(
+        "--durable", "-d", default="trace_recorder", help="Durable consumer name prefix"
+    )
     args = parser.parse_args()
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     nc = NATS()
     await nc.connect(servers=[args.nats])


### PR DESCRIPTION
## Summary
- record chat.raw events in `TraceRecorder`
- extend `tools/record.py` docs
- implement `tools/discord_replay.py`
- add unit test for chat.raw handling
- document replay workflow in `docs/ci.md`

## Testing
- `pytest tests/unit/test_harness_trace.py::test_handle_chat_raw -q`
- `flake8 src/deepthought/harness/trace.py tests/unit/test_harness_trace.py tools/record.py tools/discord_replay.py`
- `black tools/discord_replay.py src/deepthought/harness/trace.py tests/unit/test_harness_trace.py tools/record.py`

------
https://chatgpt.com/codex/tasks/task_e_685f2fc461d4832698e1e42b542cdcca