### PR TITLE
Introduce TieredMemory for hierarchical service

### DIFF
--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -59,3 +59,8 @@ You can visualize the resulting DOT file with Graphviz:
 ```bash
 dot -Tpng graph_exports/graph.dot -o graph.png
 ```
+
+## Migration to TieredMemory
+
+The `HierarchicalService` now relies on the `TieredMemory` layer for context retrieval. Create a `TieredMemory` instance and pass it to the service or use `HierarchicalService.from_chroma()` which constructs one automatically.
+

--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -1,6 +1,13 @@
 """Memory utilities."""
 
 from .hierarchical import HierarchicalMemory
-from .vector_store import VectorStore, create_vector_store, SimpleEmbeddingFunction
+from .tiered import TieredMemory
+from .vector_store import SimpleEmbeddingFunction, VectorStore, create_vector_store
 
-__all__ = ["HierarchicalMemory", "VectorStore", "create_vector_store", "SimpleEmbeddingFunction"]
+__all__ = [
+    "HierarchicalMemory",
+    "VectorStore",
+    "create_vector_store",
+    "SimpleEmbeddingFunction",
+    "TieredMemory",
+]

--- a/src/deepthought/memory/tiered.py
+++ b/src/deepthought/memory/tiered.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+"""Tiered memory mixing short-term vectors with long-term graph storage."""
+
+import logging
+from collections import OrderedDict
+from typing import List, Sequence
+
+from ..graph import GraphDAL
+from .vector_store import VectorStore, create_vector_store
+
+logger = logging.getLogger(__name__)
+
+
+class TieredMemory:
+    """Short term vector memory backed by long term graph storage."""
+
+    def __init__(
+        self,
+        vector_store: VectorStore,
+        graph_dal: GraphDAL,
+        capacity: int = 100,
+        top_k: int = 3,
+    ) -> None:
+        self._store = vector_store
+        self._dal = graph_dal
+        self._capacity = capacity
+        self._top_k = top_k
+        self._counter = 0
+        self._lru: OrderedDict[str, str] = OrderedDict()
+
+    @classmethod
+    def from_chroma(
+        cls,
+        graph_dal: GraphDAL,
+        collection_name: str = "deepthought",
+        persist_directory: str | None = None,
+        capacity: int = 100,
+        top_k: int = 3,
+    ) -> "TieredMemory":
+        store = create_vector_store(collection_name, persist_directory)
+        return cls(store, graph_dal, capacity=capacity, top_k=top_k)
+
+    # internal helpers
+    def _evict_if_needed(self) -> None:
+        while len(self._lru) > self._capacity:
+            text, doc_id = self._lru.popitem(last=False)
+            try:
+                self._store.collection.delete([doc_id])
+            except Exception:  # pragma: no cover - defensive
+                logger.error(
+                    "Failed to delete %s from vector store", doc_id, exc_info=True
+                )
+
+    def _add_to_vector(self, text: str) -> None:
+        if text in self._lru:
+            self._lru.move_to_end(text)
+            return
+        doc_id = str(self._counter)
+        self._counter += 1
+        try:
+            self._store.add_texts([text], ids=[doc_id])
+            self._lru[text] = doc_id
+            self._evict_if_needed()
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to add text to vector store", exc_info=True)
+
+    def _vector_matches(self, prompt: str) -> List[str]:
+        try:
+            result = self._store.query([prompt], n_results=self._top_k)
+            docs: Sequence | None = None
+            if isinstance(result, dict):
+                docs = result.get("documents")
+            elif isinstance(result, Sequence):
+                docs = result
+            if not docs:
+                return []
+            matches: List[str] = []
+            for doc in docs:
+                if isinstance(doc, list):
+                    for d in doc:
+                        text = str(getattr(d, "page_content", d))
+                        matches.append(text)
+                        if text in self._lru:
+                            self._lru.move_to_end(text)
+                else:
+                    text = str(getattr(doc, "page_content", doc))
+                    matches.append(text)
+                    if text in self._lru:
+                        self._lru.move_to_end(text)
+            return matches
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Vector store query failed: %s", exc, exc_info=True)
+            return []
+
+    def _graph_facts(self, limit: int) -> List[str]:
+        try:
+            rows = self._dal.query_subgraph(
+                "MATCH (n:Entity) RETURN n.name AS fact LIMIT $limit",
+                {"limit": limit},
+            )
+            return [str(r.get("fact")) for r in rows if r.get("fact")]
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Graph query failed: %s", exc, exc_info=True)
+            return []
+
+    def store_interaction(self, text: str) -> None:
+        self._add_to_vector(text)
+        try:
+            self._dal.merge_entity(text)
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to store interaction in graph", exc_info=True)
+
+    def retrieve_context(self, prompt: str) -> List[str]:
+        """Return relevant facts, loading from graph when needed."""
+        vector = self._vector_matches(prompt)
+        if len(vector) < self._top_k:
+            graph = self._graph_facts(self._top_k - len(vector))
+            for fact in graph:
+                self._add_to_vector(fact)
+            vector.extend(graph)
+        seen = set()
+        merged: List[str] = []
+        for item in vector:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+        return merged

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from datetime import datetime, timezone
-from typing import Any, List, Optional, Sequence
+from typing import List, Optional
 
 import nats
 from nats.aio.client import Client as NATS
@@ -12,6 +12,7 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
+from ..memory.tiered import TieredMemory
 from ..memory.vector_store import create_vector_store
 
 logger = logging.getLogger(__name__)
@@ -24,52 +25,11 @@ class HierarchicalService:
         self,
         nats_client: NATS,
         js_context: JetStreamContext,
-        vector_store: Any,
-        graph_dal: GraphDAL,
-        top_k: int = 3,
+        memory: TieredMemory,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._vector_store = vector_store
-        self._graph_dal = graph_dal
-        self._top_k = top_k
-
-    def _vector_matches(self, prompt: str) -> List[str]:
-        if self._vector_store is None:
-            return []
-        try:
-            result = self._vector_store.query(
-                query_texts=[prompt], n_results=self._top_k
-            )
-            docs: Sequence | None = None
-            if isinstance(result, dict):
-                docs = result.get("documents")
-            elif isinstance(result, Sequence):
-                docs = result
-            if not docs:
-                return []
-            matches: List[str] = []
-            for doc in docs:
-                if isinstance(doc, list):
-                    for d in doc:
-                        matches.append(str(getattr(d, "page_content", d)))
-                else:
-                    matches.append(str(getattr(doc, "page_content", doc)))
-            return matches
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Vector store query failed: %s", exc, exc_info=True)
-            return []
-
-    def _graph_facts(self) -> List[str]:
-        try:
-            rows = self._graph_dal.query_subgraph(
-                "MATCH (n:Entity) RETURN n.name AS fact LIMIT $limit",
-                {"limit": self._top_k},
-            )
-            return [str(r.get("fact")) for r in rows if r.get("fact")]
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Graph query failed: %s", exc, exc_info=True)
-            return []
+        self._memory = memory
 
     @classmethod
     def from_chroma(
@@ -79,23 +39,17 @@ class HierarchicalService:
         graph_dal: GraphDAL,
         collection_name: str = "deepthought",
         persist_directory: Optional[str] = None,
+        capacity: int = 100,
         top_k: int = 3,
     ) -> "HierarchicalService":
-        """Instantiate with a new :class:`VectorStore` using Chroma."""
+        """Instantiate with a new :class:`TieredMemory` using Chroma."""
         store = create_vector_store(collection_name, persist_directory)
-        return cls(nats_client, js_context, store, graph_dal, top_k)
+        memory = TieredMemory(store, graph_dal, capacity=capacity, top_k=top_k)
+        return cls(nats_client, js_context, memory)
 
     def retrieve_context(self, prompt: str) -> List[str]:
-        """Return merged vector matches and graph facts."""
-        vector = self._vector_matches(prompt)
-        graph = self._graph_facts()
-        seen = set()
-        merged: List[str] = []
-        for item in vector + graph:
-            if item not in seen:
-                seen.add(item)
-                merged.append(item)
-        return merged
+        """Return retrieved facts using :class:`TieredMemory`."""
+        return self._memory.retrieve_context(prompt)
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -167,13 +121,19 @@ class HierarchicalService:
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info("HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            logger.info(
+                "HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED
+            )
             return True
         except nats.errors.Error as e:
-            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "HierarchicalService failed to subscribe: %s", e, exc_info=True
+            )
             return False
         except Exception as e:  # pragma: no cover - network failure
-            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "HierarchicalService failed to subscribe: %s", e, exc_info=True
+            )
             return False
 
     async def stop(self) -> None:

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -1,10 +1,18 @@
+import sys
+import types
 import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
+sys.modules.setdefault("deepthought.learn", types.ModuleType("learn"))
+sys.modules.setdefault("deepthought.modules", types.ModuleType("modules"))
+sys.modules.setdefault("deepthought.motivate", types.ModuleType("motivate"))
+
 import pytest
 
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.memory.tiered import TieredMemory
 from deepthought.services.hierarchical_service import HierarchicalService
 
 
@@ -67,7 +75,8 @@ class DummyMsg:
 async def test_handle_input_publishes_combined_context(monkeypatch):
     vec = DummyVector()
     dal = DummyDAL()
-    service = HierarchicalService(DummyNATS(), DummyJS(), vec, dal)
+    memory = TieredMemory(vec, dal, top_k=3)
+    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
@@ -89,13 +98,15 @@ async def test_handle_input_publishes_combined_context(monkeypatch):
 def test_retrieve_context_merges():
     vec = DummyVector()
     dal = DummyDAL()
-    service = HierarchicalService(DummyNATS(), DummyJS(), vec, dal)
+    memory = TieredMemory(vec, dal, top_k=3)
+    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     ctx = service.retrieve_context("hi")
     assert ctx == ["vec1", "vec2", "graph1"]
 
 
 def test_retrieve_context_failures():
-    service = HierarchicalService(DummyNATS(), DummyJS(), FailingVector(), FailingDAL())
+    memory = TieredMemory(FailingVector(), FailingDAL(), top_k=3)
+    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     ctx = service.retrieve_context("x")
     assert ctx == []
 
@@ -115,8 +126,8 @@ class DummyMemory:
 
 def test_dump_graph(tmp_path):
     dal = DummyGraphDAL()
-    service = HierarchicalService(DummyNATS(), DummyJS(), None, dal)
-    service._memory = DummyMemory(dal)
+    memory = DummyMemory(dal)
+    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
 
     dot_file = service.dump_graph(str(tmp_path))
 

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -1,0 +1,68 @@
+import sys
+import types
+
+sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
+sys.modules.setdefault("deepthought.learn", types.ModuleType("learn"))
+sys.modules.setdefault("deepthought.modules", types.ModuleType("modules"))
+sys.modules.setdefault("deepthought.motivate", types.ModuleType("motivate"))
+
+from deepthought.memory.tiered import TieredMemory
+
+
+class DummyVector:
+    def __init__(self):
+        self.docs = {}
+
+    def add_texts(self, texts, ids=None, metadatas=None):
+        ids = ids or [str(i) for i in range(len(texts))]
+        for i, text in zip(ids, texts):
+            self.docs[i] = text
+
+    def query(self, query_texts, n_results=3):
+        vals = list(self.docs.values())[:n_results]
+        return {"documents": [[v] for v in vals]}
+
+    class Collection:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def delete(self, ids):
+            for i in ids:
+                self.outer.docs.pop(i, None)
+
+    @property
+    def collection(self):
+        return DummyVector.Collection(self)
+
+
+class DummyDAL:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.merged = []
+
+    def query_subgraph(self, query, params):
+        limit = params.get("limit", len(self.rows))
+        return self.rows[:limit]
+
+    def merge_entity(self, name):
+        self.merged.append(name)
+
+
+def test_eviction_lru():
+    vec = DummyVector()
+    dal = DummyDAL()
+    mem = TieredMemory(vec, dal, capacity=2, top_k=2)
+    mem.store_interaction("a")
+    mem.store_interaction("b")
+    mem.store_interaction("c")
+    assert list(mem._lru.keys()) == ["b", "c"]
+    assert list(vec.docs.values()) == ["b", "c"]
+
+
+def test_loads_from_graph():
+    vec = DummyVector()
+    dal = DummyDAL([{"fact": "g1"}, {"fact": "g2"}])
+    mem = TieredMemory(vec, dal, capacity=3, top_k=2)
+    ctx = mem.retrieve_context("x")
+    assert ctx == ["g1", "g2"]
+    assert set(mem._lru.keys()) == {"g1", "g2"}


### PR DESCRIPTION
## Summary
- implement TieredMemory combining vector store and graph with LRU paging
- integrate TieredMemory in HierarchicalService
- document migration to TieredMemory
- add unit tests for TieredMemory and update service tests

## Testing
- `flake8 src/deepthought/memory/tiered.py src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py tests/unit/test_tiered_memory.py src/deepthought/memory/__init__.py`
- `black src/deepthought/memory/tiered.py src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py tests/unit/test_tiered_memory.py src/deepthought/memory/__init__.py`
- `pytest tests/unit/test_tiered_memory.py tests/unit/services/test_hierarchical_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2fc196308326a6020d87b977f295