### PR TITLE
Use graph_dal in dump_graph

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -38,9 +38,7 @@ class HierarchicalService:
         if self._vector_store is None:
             return []
         try:
-            result = self._vector_store.query(
-                query_texts=[prompt], n_results=self._top_k
-            )
+            result = self._vector_store.query(query_texts=[prompt], n_results=self._top_k)
             docs: Sequence | None = None
             if isinstance(result, dict):
                 docs = result.get("documents")
@@ -191,9 +189,12 @@ class HierarchicalService:
         os.makedirs(path, exist_ok=True)
         dot_path = os.path.join(path, "graph.dot")
 
-        rows = self._memory._dal.query_subgraph(
-            "MATCH (a)-[r]->(b) RETURN id(a) AS src_id, coalesce(a.name, '') AS src, "
-            "type(r) AS rel, id(b) AS dst_id, coalesce(b.name, '') AS dst",
+        rows = self._graph_dal.query_subgraph(
+            (
+                "MATCH (a)-[r]->(b) RETURN id(a) AS src_id, "
+                "coalesce(a.name, '') AS src, type(r) AS rel, "
+                "id(b) AS dst_id, coalesce(b.name, '') AS dst"
+            ),
             {},
         )
 

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -108,16 +108,9 @@ class DummyGraphDAL:
         ]
 
 
-class DummyMemory:
-    def __init__(self, dal):
-        self._dal = dal
-
-
 def test_dump_graph(tmp_path):
     dal = DummyGraphDAL()
     service = HierarchicalService(DummyNATS(), DummyJS(), None, dal)
-    service._memory = DummyMemory(dal)
-
     dot_file = service.dump_graph(str(tmp_path))
 
     assert dot_file == str(tmp_path / "graph.dot")


### PR DESCRIPTION
## Summary
- use graph_dal directly in `dump_graph`
- update tests accordingly
- clean up multi-line query in `dump_graph`

## Testing
- `pytest tests/unit/services/test_hierarchical_service.py::test_dump_graph -q`
- `flake8 src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py`


------
https://chatgpt.com/codex/tasks/task_e_685f2fb4bc5c83269929e33739167a42