### PR TITLE
Add reward handling to LLMStub

### DIFF
--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -91,7 +91,9 @@ async def test_handle_memory_success(monkeypatch, knowledge):
 @pytest.mark.asyncio
 async def test_handle_memory_error(monkeypatch):
     stub = create_stub(monkeypatch, FailingPublisher)
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"retrieved_knowledge": {}}, input_id="x")
+    payload = MemoryRetrievedPayload(
+        retrieved_knowledge={"retrieved_knowledge": {}}, input_id="x"
+    )
     msg = DummyMsg(payload.to_json())
     await stub._handle_memory_event(msg)
 
@@ -122,7 +124,10 @@ async def test_handle_memory_event_payload_not_dict(monkeypatch, caplog):
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
-    assert any("Unexpected MemoryRetrieved payload format" in r.getMessage() for r in caplog.records)
+    assert any(
+        "Unexpected MemoryRetrieved payload format" in r.getMessage()
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -163,3 +168,13 @@ async def test_handle_memory_event_missing_input_id(monkeypatch):
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
+
+
+@pytest.mark.asyncio
+async def test_handle_reward_event_appends(monkeypatch):
+    stub = create_stub(monkeypatch)
+    msg = DummyMsg(json.dumps({"reward": 1.2}))
+    await stub._handle_reward_event(msg)
+
+    assert list(stub._recent_rewards) == [1.2]
+    assert msg.acked


### PR DESCRIPTION
## Summary
- support reward events in LLMStub
- track rewards in deque
- test reward processing logic

## Testing
- `black --check src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_stub.py`
- `isort --check src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_stub.py`
- `flake8 src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_stub.py`
- `pytest tests/unit/modules/test_llm_stub.py::test_handle_reward_event_appends -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2fb6fcd083269a680912ba407dd9