### PR TITLE
Add reward event test coverage

### DIFF
--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -163,3 +163,23 @@ async def test_handle_memory_event_missing_input_id(monkeypatch):
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
+
+
+@pytest.mark.asyncio
+async def test_handle_reward_event_appends_and_acks(monkeypatch):
+    stub = create_stub(monkeypatch)
+    msg = DummyMsg(json.dumps({"reward": 1.5}))
+    await stub._handle_reward_event(msg)
+
+    assert list(stub._recent_rewards) == [1.5]
+    assert msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_reward_event_invalid_payload(monkeypatch):
+    stub = create_stub(monkeypatch)
+    msg = DummyMsg("not-json")
+    await stub._handle_reward_event(msg)
+
+    assert list(stub._recent_rewards) == []
+    assert msg.acked

--- a/tests/unit/test_harness_replay.py
+++ b/tests/unit/test_harness_replay.py
@@ -65,6 +65,19 @@ async def test_replay_uses_timestamp_delta(monkeypatch):
     assert publisher.published == [("chat.raw", "s1"), ("chat.raw", "s2")]
 
 
+def test_load_trace_missing_file(tmp_path):
+    path = tmp_path / "missing.jsonl"
+    with pytest.raises(FileNotFoundError):
+        tools_replay._load_trace(path)
+
+
+def test_load_trace_invalid_json(tmp_path):
+    path = tmp_path / "bad.jsonl"
+    path.write_text("not-json")
+    with pytest.raises(json.JSONDecodeError):
+        tools_replay._load_trace(path)
+
+
 @pytest.mark.asyncio
 async def test_trace_recorder_output_replays(monkeypatch, tmp_path):
     class DummyNATS:

--- a/tests/unit/test_harness_trace.py
+++ b/tests/unit/test_harness_trace.py
@@ -51,3 +51,30 @@ async def test_handle_input_writes_file(monkeypatch, tmp_path):
     obj = json.loads(line)
     assert obj["event"] == "INPUT_RECEIVED"
     assert obj["payload"] == {"foo": "bar"}
+
+
+@pytest.mark.asyncio
+async def test_handle_input_bad_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    outfile = tmp_path / "trace.jsonl"
+    recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
+    msg = DummyMsg("not-json")
+
+    await recorder._handle_input(msg)
+    assert msg.nacked
+    assert not outfile.exists()
+
+
+@pytest.mark.asyncio
+async def test_handle_input_write_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    outfile = tmp_path / "trace.jsonl"
+    recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
+    msg = DummyMsg('{"foo": "bar"}')
+
+    def fail_open(*args, **kwargs):
+        raise IOError("boom")
+
+    monkeypatch.setattr(trace, "open", fail_open, raising=False)
+    await recorder._handle_input(msg)
+    assert msg.nacked


### PR DESCRIPTION
## Summary
- handle reward events in `LLMStub`
- test reward events for `LLMStub`
- add error path tests for `TraceRecorder` and `replay.py`
- patch trace recorder test to allow monkeypatching

## Testing
- `python -m pre_commit run --files src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_stub.py tests/unit/test_harness_trace.py tests/unit/test_harness_replay.py` *(fails: AttributeError due to missing modules)*
- `pytest tests/unit/modules/test_llm_stub.py tests/unit/test_harness_trace.py tests/unit/test_harness_replay.py`

------
https://chatgpt.com/codex/tasks/task_e_685f2fcb80e48326acc36b57e3821cde