### PR TITLE
Fix hierarchical service init

### DIFF
--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -1,6 +1,6 @@
+import json
 import sys
 import types
-import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -121,7 +121,9 @@ class DummyGraphDAL:
 
 def test_dump_graph(tmp_path):
     dal = DummyGraphDAL()
-    service = HierarchicalService(DummyNATS(), DummyJS(), None, dal)
+    vec = DummyVector()
+    memory = TieredMemory(vec, dal, top_k=3)
+    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
 
     dot_file = service.dump_graph(str(tmp_path))
 


### PR DESCRIPTION
## Summary
- fix `HierarchicalService.__init__` to use a provided `TieredMemory`
- refer to memory internals when running graph/vector ops
- update the hierarchical service unit tests
- apply formatting fixes

## Testing
- `pre-commit run --files src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py` *(with `pytest` hook skipped)*
- `pytest tests/unit/services/test_hierarchical_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f60df09a883268696922495977399