### PR TITLE
Add scheduler service with reminders

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -30,6 +30,9 @@ class EventSubjects:
     # Raw chat message events
     CHAT_RAW = "chat.raw"
 
+    # Scheduler events
+    REMINDER_TRIGGERED = "dtr.scheduler.reminder_triggered"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -81,3 +84,12 @@ class ResponseGeneratedPayload(EventPayload):
     input_id: Optional[str] = None
     timestamp: Optional[str] = None
     confidence: Optional[float] = None
+
+
+@dataclass
+class ReminderTriggeredPayload(EventPayload):
+    """Payload for scheduled reminder events."""
+
+    message: str
+    reminder_id: Optional[str] = None
+    timestamp: Optional[str] = None

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -3,5 +3,6 @@
 from .file_graph_dal import FileGraphDAL
 from .memory_service import MemoryService
 from .hierarchical_service import HierarchicalService
+from .scheduler import SchedulerService
 
-__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService"]
+__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService", "SchedulerService"]

--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -1,0 +1,103 @@
+"""Simple background scheduler for summaries and reminders."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, List, Optional
+
+from ..eda.events import EventSubjects, ReminderTriggeredPayload
+from ..eda.publisher import Publisher
+from ..motivate.caption import summarise_message
+from .file_graph_dal import FileGraphDAL
+from ..graph.dal import GraphDAL
+
+
+@dataclass
+class ScheduledReminder:
+    """Internal structure to hold reminder data."""
+
+    message: str
+    when: datetime
+    reminder_id: str
+
+
+class SchedulerService:
+    """Background tasks for summaries and scheduled reminders."""
+
+    def __init__(
+        self,
+        publisher: Publisher,
+        memory_dal: FileGraphDAL,
+        graph_dal: GraphDAL,
+        summary_interval: float = 60.0,
+        now_func: Callable[[], datetime] | None = None,
+        sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._publisher = publisher
+        self._memory_dal = memory_dal
+        self._graph_dal = graph_dal
+        self._summary_interval = summary_interval
+        self._now = now_func or (lambda: datetime.now(timezone.utc))
+        self._sleep = sleep_func
+        self._reminders: List[ScheduledReminder] = []
+        self._running = False
+        self._summary_task: Optional[asyncio.Task] = None
+        self._reminder_task: Optional[asyncio.Task] = None
+
+    def schedule_reminder(self, message: str, when: datetime, reminder_id: str) -> None:
+        """Schedule a reminder message for the future."""
+        self._reminders.append(ScheduledReminder(message, when, reminder_id))
+        self._reminders.sort(key=lambda r: r.when)
+
+    async def start(self) -> bool:
+        self._running = True
+        self._summary_task = asyncio.create_task(self._summary_loop())
+        self._reminder_task = asyncio.create_task(self._reminder_loop())
+        return True
+
+    async def stop(self) -> None:
+        self._running = False
+        tasks = [t for t in [self._summary_task, self._reminder_task] if t]
+        for task in tasks:
+            task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    async def _summary_loop(self) -> None:
+        while self._running:
+            await self._sleep(self._summary_interval)
+            await self._generate_summary()
+
+    async def _generate_summary(self) -> None:
+        facts = self._memory_dal.get_recent_facts()
+        text = " ".join(facts)
+        summary = summarise_message(text, max_words=10)
+        self._graph_dal.add_entity(
+            "Note",
+            {"text": summary, "timestamp": self._now().isoformat()},
+        )
+
+    async def _reminder_loop(self) -> None:
+        while self._running:
+            await self._sleep(1.0)
+            now = self._now()
+            due: List[ScheduledReminder] = [r for r in self._reminders if r.when <= now]
+            self._reminders = [r for r in self._reminders if r.when > now]
+            for r in due:
+                payload = ReminderTriggeredPayload(
+                    message=r.message,
+                    reminder_id=r.reminder_id,
+                    timestamp=now.isoformat(),
+                )
+                await self._publisher.publish(
+                    EventSubjects.REMINDER_TRIGGERED,
+                    payload,
+                    use_jetstream=True,
+                    timeout=10.0,
+                )
+

--- a/tests/unit/services/test_scheduler.py
+++ b/tests/unit/services/test_scheduler.py
@@ -1,0 +1,79 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.scheduler import SchedulerService
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+class DummyMemoryDAL:
+    def __init__(self, interactions):
+        self.interactions = interactions
+
+    def get_recent_facts(self, count=3):
+        return self.interactions[-count:]
+
+
+class DummyGraphDAL:
+    def __init__(self):
+        self.entities = []
+
+    def add_entity(self, label, props):
+        self.entities.append((label, props))
+
+
+@pytest.mark.asyncio
+async def test_scheduler_summary_and_reminder(monkeypatch):
+    current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def now():
+        return current
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds):
+        nonlocal current
+        current += timedelta(seconds=seconds)
+        await real_sleep(0)
+
+    publisher = DummyPublisher()
+    memory = DummyMemoryDAL(["hello world", "how are you"])
+    graph = DummyGraphDAL()
+
+    service = SchedulerService(
+        publisher,
+        memory,
+        graph,
+        summary_interval=2.0,
+        now_func=now,
+        sleep_func=fake_sleep,
+    )
+
+    await service.start()
+    await fake_sleep(0)  # allow tasks to start
+    service.schedule_reminder("ping", now() + timedelta(seconds=3), "r1")
+
+    await fake_sleep(4)
+    await service.stop()
+
+    # Summary stored
+    assert graph.entities
+    label, props = graph.entities[0]
+    assert label == "Note"
+    assert "timestamp" in props
+
+    # Reminder triggered
+    assert publisher.published
+    subj, payload = publisher.published[0]
+    assert subj == EventSubjects.REMINDER_TRIGGERED
+    assert payload.message == "ping"
+    assert payload.reminder_id == "r1"


### PR DESCRIPTION
## Summary
- add new scheduler service for periodic summaries and reminders
- allow scheduling reminders that publish an event
- export SchedulerService
- support reminder events in eda
- test scheduler using mocked time

## Testing
- `flake8`
- `pytest tests/unit/services/test_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cbf01e88832694aedf43036cd6b5