### PR TITLE
Add user affinity and PersonaManager

### DIFF
--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -3,5 +3,6 @@
 from .file_graph_dal import FileGraphDAL
 from .memory_service import MemoryService
 from .hierarchical_service import HierarchicalService
+from .persona_manager import PersonaManager
 
-__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService"]
+__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService", "PersonaManager"]

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import random
+
+from examples import social_graph_bot as sg
+
+
+class PersonaManager:
+    """Select prompts based on user affinity."""
+
+    def __init__(self, db_manager: sg.DBManager, friendly: int = 5, playful: int = 2) -> None:
+        self._db = db_manager
+        self._friendly = friendly
+        self._playful = playful
+
+    async def get_persona(self, user_id: int) -> str:
+        affinity = await self._db.get_affinity(user_id)
+        if affinity >= self._friendly:
+            return "friendly"
+        if affinity >= self._playful:
+            return "playful"
+        return "snarky"
+
+    async def choose_prompt(self, user_id: int, prompts: dict[str, list[str]]) -> str:
+        persona = await self.get_persona(user_id)
+        options = prompts.get(persona) or prompts.get("default") or []
+        if not options:
+            return ""
+        return random.choice(options)

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -1,0 +1,24 @@
+import pytest
+
+import examples.social_graph_bot as sg
+from deepthought.services import PersonaManager
+
+
+@pytest.mark.asyncio
+async def test_persona_changes_with_affinity(tmp_path):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.init_db()
+
+    pm = PersonaManager(sg.db_manager, friendly=5, playful=2)
+    user = "u1"
+
+    assert await pm.get_persona(user) == "snarky"
+
+    await sg.adjust_affinity(user, 2)
+    assert await pm.get_persona(user) == "playful"
+
+    await sg.adjust_affinity(user, 3)
+    assert await pm.get_persona(user) == "friendly"
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- track affinity per user in social_graph_bot database
- adjust affinity whenever interactions are logged
- expose affinity helpers and new PersonaManager service
- choose persona based on affinity and return prompts
- test persona selection with changing affinity

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860cbf0541083268f8147387bf65a03