### PR TITLE
Add offline search with example config

### DIFF
--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -66,3 +66,26 @@ dot -Tpng graph_exports/graph.dot -o graph.png
 
 The `HierarchicalService` now relies on the `TieredMemory` layer for context retrieval. Create a `TieredMemory` instance and pass it to the service or use `HierarchicalService.from_chroma()` which constructs one automatically.
 
+## Offline Search
+
+You can optionally attach a lightweight document index (e.g. a local Wikipedia dump).
+Create a SQLite FTS index and point the service at the database file:
+
+```python
+from deepthought.search import OfflineSearch
+
+search = OfflineSearch.create_index(
+    "wiki.db",
+    [("Title1", "Article text..."), ("Title2", "More text...")],
+)
+service = HierarchicalService(DummyNATS(), DummyJS(), memory, search=search)
+```
+
+Set ``DT_SEARCH_DB`` in your configuration file to load the index automatically.
+
+Example ``config.yaml``:
+
+```yaml
+search_db: wiki.db
+```
+

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     db: DatabaseSettings = DatabaseSettings()
     model_path: str = "distilgpt2"
     memory_file: str = "memory.json"
+    search_db: str | None = None
     reward: RewardThresholds = RewardThresholds()
 
     model_config = SettingsConfigDict(env_prefix="DT_", env_nested_delimiter="__")

--- a/src/deepthought/search/__init__.py
+++ b/src/deepthought/search/__init__.py
@@ -1,0 +1,5 @@
+"""Search utilities."""
+
+from .offline_search import OfflineSearch
+
+__all__ = ["OfflineSearch"]

--- a/src/deepthought/search/offline_search.py
+++ b/src/deepthought/search/offline_search.py
@@ -1,0 +1,34 @@
+import sqlite3
+from typing import Iterable, List, Tuple
+
+
+class OfflineSearch:
+    """Very small wrapper around a SQLite FTS5 index."""
+
+    def __init__(self, db_path: str) -> None:
+        self._conn = sqlite3.connect(db_path)
+        self._conn.row_factory = sqlite3.Row
+
+    @classmethod
+    def create_index(
+        cls, db_path: str, docs: Iterable[Tuple[str, str]]
+    ) -> "OfflineSearch":
+        """Create or reuse an FTS5 index at ``db_path``."""
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS documents USING FTS5(title, content)"
+        )
+        conn.executemany(
+            "INSERT INTO documents(title, content) VALUES (?, ?)", list(docs)
+        )
+        conn.commit()
+        conn.close()
+        return cls(db_path)
+
+    def search(self, query: str, limit: int = 3) -> List[str]:
+        cur = self._conn.execute(
+            "SELECT content FROM documents WHERE documents MATCH ? LIMIT ?",
+            (query, limit),
+        )
+        rows = cur.fetchall()
+        return [str(r["content"]) for r in rows]

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -14,6 +14,7 @@ from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
 from ..memory.tiered import TieredMemory
 from ..memory.vector_store import create_vector_store
+from ..search import OfflineSearch
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,7 @@ class HierarchicalService:
         nats_client: NATS,
         js_context: JetStreamContext,
         memory: TieredMemory | None,
+        search: OfflineSearch | None = None,
         graph_dal: GraphDAL | None = None,
         top_k: int = 3,
 
@@ -33,6 +35,8 @@ class HierarchicalService:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._memory = memory
+        self._search = search
+        self._top_k = top_k
 
     def _vector_matches(self, prompt: str) -> List[str]:
         """Return vector matches using the underlying memory store."""
@@ -53,15 +57,30 @@ class HierarchicalService:
         persist_directory: Optional[str] = None,
         capacity: int = 100,
         top_k: int = 3,
+        search_db: Optional[str] = None,
     ) -> "HierarchicalService":
         """Instantiate with a new :class:`TieredMemory` using Chroma."""
         store = create_vector_store(collection_name, persist_directory)
         memory = TieredMemory(store, graph_dal, capacity=capacity, top_k=top_k)
-        return cls(nats_client, js_context, memory)
+        search = OfflineSearch(search_db) if search_db else None
+        return cls(nats_client, js_context, memory, search=search)
 
     def retrieve_context(self, prompt: str) -> List[str]:
-        """Return retrieved facts using :class:`TieredMemory`."""
-        return self._memory.retrieve_context(prompt)
+        """Return retrieved facts using :class:`TieredMemory` and optional search."""
+        memory_facts = self._memory.retrieve_context(prompt) if self._memory else []
+        search_facts: List[str] = []
+        if self._search:
+            try:
+                search_facts = self._search.search(prompt, limit=self._top_k)
+            except Exception:  # pragma: no cover - defensive
+                logger.error("Offline search failed", exc_info=True)
+        seen = set()
+        merged: List[str] = []
+        for item in memory_facts + search_facts:
+            if item not in seen:
+                seen.add(item)
+                merged.append(item)
+        return merged
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"


### PR DESCRIPTION
## Summary
- implement a SQLite-backed `OfflineSearch` helper
- extend `HierarchicalService` to merge offline search results
- support search DB path in settings
- document offline search usage and configuration
- test search integration

## Testing
- `flake8`
- `pytest tests/unit/services/test_hierarchical_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6860cbf46608832688aafaedd51b3824