### PR TITLE
Add basic persona, affinity, and goal scheduler modules

### DIFF
--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -3,7 +3,10 @@
 __version__ = "0.1.0"
 
 # Re-export modules subpackage for convenient access
+from . import affinity  # noqa: F401
+from . import goal_scheduler  # noqa: F401
 from . import harness  # noqa: F401
 from . import learn  # noqa: F401
 from . import modules  # noqa: F401
 from . import motivate  # noqa: F401
+from . import persona  # noqa: F401

--- a/src/deepthought/affinity.py
+++ b/src/deepthought/affinity.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Track social affinity scores per persona."""
+
+from typing import Dict
+
+
+class AffinityTracker:
+    """Simple in-memory affinity tracker."""
+
+    def __init__(self) -> None:
+        self._scores: Dict[str, int] = {}
+
+    def update(self, persona: str, delta: int = 1) -> None:
+        """Increment ``persona`` affinity by ``delta``."""
+        self._scores[persona] = self._scores.get(persona, 0) + delta
+
+    def get(self, persona: str) -> int:
+        """Return current affinity score for ``persona``."""
+        return self._scores.get(persona, 0)

--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simple priority-based goal scheduler."""
+
+import heapq
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass(order=True)
+class ScheduledGoal:
+    priority: int
+    goal: str = field(compare=False)
+
+
+class GoalScheduler:
+    """Maintain a priority queue of goals."""
+
+    def __init__(self) -> None:
+        self._heap: List[ScheduledGoal] = []
+
+    def add_goal(self, goal: str, priority: int) -> None:
+        """Schedule ``goal`` with ``priority`` (higher runs first)."""
+        heapq.heappush(self._heap, ScheduledGoal(-priority, goal))
+
+    def next_goal(self) -> str | None:
+        """Pop the highest priority goal or ``None``."""
+        if not self._heap:
+            return None
+        return heapq.heappop(self._heap).goal

--- a/src/deepthought/persona.py
+++ b/src/deepthought/persona.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Simple persona selection utilities."""
+
+from typing import Dict, Sequence
+
+
+class PersonaSelector:
+    """Select a persona based on keyword matches."""
+
+    def __init__(self, personas: Dict[str, Sequence[str]]) -> None:
+        self._personas = {k: list(v) for k, v in personas.items()}
+
+    def choose(self, text: str) -> str | None:
+        """Return the persona with the most keyword matches."""
+        text_low = text.lower()
+        best = None
+        best_count = -1
+        for name, keywords in self._personas.items():
+            count = sum(text_low.count(kw.lower()) for kw in keywords)
+            if count > best_count:
+                best = name
+                best_count = count
+        return best

--- a/tests/unit/test_persona_goal_affinity.py
+++ b/tests/unit/test_persona_goal_affinity.py
@@ -1,0 +1,31 @@
+import pytest
+
+from deepthought.affinity import AffinityTracker
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.persona import PersonaSelector
+
+
+def test_persona_selection():
+    selector = PersonaSelector({"friendly": ["hello", "hi"], "formal": ["dear", "regards"]})
+    assert selector.choose("hello there") == "friendly"
+    assert selector.choose("Dear sir, regards") == "formal"
+
+
+def test_affinity_updates():
+    tracker = AffinityTracker()
+    tracker.update("friendly")
+    tracker.update("friendly", 2)
+    tracker.update("formal")
+    assert tracker.get("friendly") == 3
+    assert tracker.get("formal") == 1
+
+
+def test_goal_scheduler_order():
+    sched = GoalScheduler()
+    sched.add_goal("low", priority=1)
+    sched.add_goal("high", priority=5)
+    sched.add_goal("mid", priority=3)
+    assert sched.next_goal() == "high"
+    assert sched.next_goal() == "mid"
+    assert sched.next_goal() == "low"
+    assert sched.next_goal() is None


### PR DESCRIPTION
## Summary
- add minimal modules for persona selection, affinity tracking, and goal scheduling
- expose new modules in `deepthought` package
- test the new logic

## Testing
- `PYTEST_ADDOPTS="tests/unit/test_persona_goal_affinity.py" pre-commit run --files src/deepthought/affinity.py src/deepthought/goal_scheduler.py src/deepthought/persona.py src/deepthought/__init__.py tests/unit/test_persona_goal_affinity.py`

------
https://chatgpt.com/codex/tasks/task_e_6860cbf6901483268bbe96f532b507ae