### PR TITLE
Add bot config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Specify the NATS server address with the `NATS_URL` environment variable. If not
 export NATS_URL=nats://my-nats:4222
 ```
 
+### Required environment variables
+
+* `DISCORD_TOKEN` - Discord bot token
+* `MONITOR_CHANNEL` - Channel ID the bot should monitor
+* `NATS_URL` - Address of the NATS server
+
 ## Running a Local NATS Server
 
 If you don't already have a NATS server running locally, you can start one easily.
@@ -205,6 +211,10 @@ export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
 export SENTIMENT_BACKEND=vader  # optional, defaults to textblob
 ```
+
+`DISCORD_TOKEN` and `MONITOR_CHANNEL` are required. `NATS_URL` must also be set
+to a valid NATS server address if the default `nats://localhost:4222` is not
+appropriate. All other variables are optional.
 
 Set `SENTIMENT_BACKEND` to either `textblob` or `vader` to choose the library
 used for sentiment analysis. Any other value falls back to `textblob`.

--- a/bot.py
+++ b/bot.py
@@ -1,14 +1,10 @@
-import os
-
 from examples.social_graph_bot import run
+from deepthought.config import load_bot_env
 
 
 def main() -> None:
-    token = os.getenv("DISCORD_TOKEN")
-    channel = os.getenv("MONITOR_CHANNEL")
-    if not token or not channel:
-        raise SystemExit("Please set DISCORD_TOKEN and MONITOR_CHANNEL environment variables")
-    run(token, int(channel))
+    env = load_bot_env()
+    run(env.DISCORD_TOKEN, env.MONITOR_CHANNEL)
 
 
 if __name__ == "__main__":

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -884,11 +884,7 @@ def run(token: str, monitor_channel_id: int) -> None:
 
 
 if __name__ == "__main__":
-    import os
+    from deepthought.config import load_bot_env
 
-    token = os.getenv("DISCORD_TOKEN")
-    channel_id = int(os.getenv("MONITOR_CHANNEL", "0"))
-    if not token or channel_id == 0:
-        print("Please set DISCORD_TOKEN and MONITOR_CHANNEL environment variables.")
-    else:
-        run(token, channel_id)
+    env = load_bot_env()
+    run(env.DISCORD_TOKEN, env.MONITOR_CHANNEL)

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from pydantic import AnyUrl, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 try:  # YAML support is optional
@@ -91,3 +92,23 @@ def get_settings(config_file: Optional[str] = None) -> Settings:
         _settings_cache = load_settings(config_file)
         _settings_path = path
     return _settings_cache
+
+
+class BotEnv(BaseSettings):
+    """Environment variables required for running the Discord bot."""
+
+    DISCORD_TOKEN: str
+    MONITOR_CHANNEL: int
+    NATS_URL: AnyUrl = "nats://localhost:4222"
+
+    model_config = SettingsConfigDict(env_prefix="")
+
+
+def load_bot_env() -> BotEnv:
+    """Return bot environment settings or exit with a clear error."""
+
+    try:
+        return BotEnv()
+    except ValidationError as exc:  # pragma: no cover - runtime validation
+        missing = ", ".join(err["loc"][0] for err in exc.errors())
+        raise SystemExit(f"Missing or invalid environment variables: {missing}") from exc

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,12 @@ import json
 import pytest
 import yaml
 
-from deepthought.config import get_settings, load_settings
+from deepthought.config import (
+    BotEnv,
+    get_settings,
+    load_settings,
+    load_bot_env,
+)
 
 
 def test_env_overrides(monkeypatch):
@@ -131,3 +136,29 @@ def test_load_settings_missing_yaml_module(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError):
         load_settings(str(cfg))
+
+
+def test_load_bot_env_success(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("MONITOR_CHANNEL", "42")
+
+    env = load_bot_env()
+    assert isinstance(env, BotEnv)
+    assert env.DISCORD_TOKEN == "abc"
+    assert env.MONITOR_CHANNEL == 42
+
+
+def test_load_bot_env_missing(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("MONITOR_CHANNEL", raising=False)
+
+    with pytest.raises(SystemExit):
+        load_bot_env()
+
+
+def test_load_bot_env_invalid_channel(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("MONITOR_CHANNEL", "x")
+
+    with pytest.raises(SystemExit):
+        load_bot_env()


### PR DESCRIPTION
## Summary
- add `load_bot_env` to validate required environment variables
- invoke loader in `bot.py` and `examples/social_graph_bot.py`
- document required variables in the README
- test new loader

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/test_config.py::test_load_bot_env_success tests/unit/test_config.py::test_load_bot_env_missing tests/unit/test_config.py::test_load_bot_env_invalid_channel -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d9ea07e08326bef4c95992558f02