### PR TITLE
Add cleanup for SocialGraphBot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -738,15 +738,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
         respond_to = None
         send_prompt = False
-        if (
-            last_message
-            and last_message.author.bot
-            and prev_message
-            and not prev_message.author.bot
-        ):
+        if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
             age = (
-                discord.utils.utcnow()
-                - prev_message.created_at.replace(tzinfo=timezone.utc)
+                discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
             ).total_seconds() / 60
             if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                 await asyncio.sleep(60)
@@ -756,8 +750,7 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
             send_prompt = True
         else:
             idle_minutes = (
-                discord.utils.utcnow()
-                - last_message.created_at.replace(tzinfo=timezone.utc)
+                discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
             ).total_seconds() / 60
             if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                 send_prompt = True
@@ -830,9 +823,10 @@ class SocialGraphBot(discord.Client):
 
         async with message.channel.typing():
             await asyncio.sleep(random.uniform(1, 3))
-            async for recent in message.channel.history(limit=1):
-                if recent.id != message.id and recent.author.bot:
-                    return
+            if hasattr(message.channel, "history"):
+                async for recent in message.channel.history(limit=1):
+                    if recent.id != message.id and getattr(recent.author, "bot", False):
+                        return
             await message.channel.send("I'm pondering your message...")
 
         # Publish event and forward to Prism
@@ -875,6 +869,20 @@ class SocialGraphBot(discord.Client):
 
         if hasattr(self, "process_commands"):
             await self.process_commands(message)
+
+    async def close(self) -> None:
+        """Close DB and NATS connections."""
+        await super().close()
+        await db_manager.close()
+        global _nats_client, _js_context, _input_publisher
+        if _nats_client is not None and not getattr(_nats_client, "is_closed", False):
+            try:
+                await _nats_client.close()
+            except Exception:  # pragma: no cover - closing failure
+                pass
+        _nats_client = None
+        _js_context = None
+        _input_publisher = None
 
 
 def run(token: str, monitor_channel_id: int) -> None:

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -1,12 +1,28 @@
 """DeepThought package initialization."""
 
+from __future__ import annotations
+
+import importlib
+
 __version__ = "0.1.0"
 
-# Re-export modules subpackage for convenient access
-from . import affinity  # noqa: F401
-from . import goal_scheduler  # noqa: F401
-from . import harness  # noqa: F401
-from . import learn  # noqa: F401
-from . import modules  # noqa: F401
-from . import motivate  # noqa: F401
-from . import persona  # noqa: F401
+# Lazily expose common subpackages without importing heavy dependencies on
+# module import.  ``__getattr__`` performs the actual import when an attribute is
+# accessed.  This keeps startup lightweight for tests that only need a subset of
+# the package.
+
+__all__ = [
+    "affinity",
+    "goal_scheduler",
+    "harness",
+    "learn",
+    "modules",
+    "motivate",
+    "persona",
+]
+
+
+def __getattr__(name: str) -> object:
+    if name in __all__:
+        return importlib.import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/test_bot_cleanup.py
+++ b/tests/test_bot_cleanup.py
@@ -1,0 +1,52 @@
+import asyncio
+
+import discord
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+class DummyNATS:
+    def __init__(self):
+        self.closed = False
+        self.is_closed = False
+
+    async def close(self):
+        self.closed = True
+        self.is_closed = True
+
+
+@pytest.mark.asyncio
+async def test_bot_cleanup_on_cancel(tmp_path, monkeypatch):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.init_db()
+
+    dummy_nats = DummyNATS()
+    sg._nats_client = dummy_nats
+    sg._js_context = object()
+    sg._input_publisher = object()
+
+    async def dummy_close(self):
+        pass
+
+    async def dummy_start(self, *args, **kwargs):
+        await asyncio.Future()
+
+    monkeypatch.setattr(discord.Client, "close", dummy_close, raising=False)
+    monkeypatch.setattr(discord.Client, "start", dummy_start, raising=False)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    task = asyncio.create_task(bot.start("token"))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await bot.close()
+
+    assert sg.db_manager._db is None
+    assert dummy_nats.closed
+    assert sg._nats_client is None
+    assert sg._js_context is None
+    assert sg._input_publisher is None


### PR DESCRIPTION
## Summary
- ensure SocialGraphBot closes DB and NATS connections
- lazily load heavy deepthought subpackages to avoid optional deps
- update test verifying cleanup when cancelling the bot
- handle channels lacking message history

## Testing
- `flake8 examples/social_graph_bot.py tests/test_bot_cleanup.py`
- `pytest tests/test_bot_cleanup.py tests/test_bullying_mock.py tests/test_on_message_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d9eb738c83269022e609be4ff23f