### PR TITLE
Flatten memory payload structure

### DIFF
--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -60,12 +60,7 @@ class InputHandler:
                     logger.error("Memory retrieval failed: %s", err, exc_info=True)
 
                 mem_payload = MemoryRetrievedPayload(
-                    retrieved_knowledge={
-                        "retrieved_knowledge": {
-                            "facts": context,
-                            "source": "hierarchical",
-                        }
-                    },
+                    retrieved_knowledge={"facts": context, "source": "hierarchical"},
                     input_id=input_id,
                     timestamp=datetime.now(timezone.utc).isoformat(),
                 )

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -76,26 +76,9 @@ class BaseLLM(ABC):
             if not isinstance(data, dict):
                 raise ValueError("MemoryRetrieved payload must be a dict")
             input_id = data.get("input_id")
-            retrieved = data.get("retrieved_knowledge")
-            if not isinstance(input_id, str) or retrieved is None:
+            knowledge = data.get("retrieved_knowledge")
+            if not isinstance(input_id, str) or not isinstance(knowledge, dict):
                 raise ValueError("Invalid memory payload fields")
-            if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
-                knowledge = retrieved.get("retrieved_knowledge", {})
-            elif isinstance(retrieved, dict):
-                knowledge = retrieved
-            else:
-                logger.error("retrieved_knowledge is not a dict for input_id %s", input_id)
-                if hasattr(msg, "nak") and callable(msg.nak):
-                    try:
-                        await msg.nak()
-                    except Exception:
-                        logger.error("Failed to NAK message", exc_info=True)
-                elif hasattr(msg, "ack") and callable(msg.ack):
-                    try:
-                        await msg.ack()
-                    except Exception:
-                        logger.error("Failed to ack message after error", exc_info=True)
-                return
 
             facts = knowledge.get("facts")
             if not isinstance(facts, list):

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -80,9 +80,8 @@ class BasicMemory:
 
             last_entries = history[-3:]
             facts = [entry["user_input"] for entry in last_entries]
-            memory_data = {"facts": facts, "source": "basic_memory"}
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"retrieved_knowledge": memory_data},
+                retrieved_knowledge={"facts": facts, "source": "basic_memory"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -107,9 +107,8 @@ class GraphMemory:
 
             self._add_interaction(user_input)
             facts = self._get_recent_facts()
-            memory_data = {"facts": facts, "source": "graph_memory"}
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"retrieved_knowledge": memory_data},
+                retrieved_knowledge={"facts": facts, "source": "graph_memory"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -56,7 +56,7 @@ class KnowledgeGraphMemory:
             self._store(nodes, edges)
 
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"retrieved_knowledge": {"facts": [], "source": "knowledge_graph"}},
+                retrieved_knowledge={"facts": [], "source": "knowledge_graph"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -97,10 +97,8 @@ class HierarchicalService:
             facts: Sequence[str] = self.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={
-                    "retrieved_knowledge": {
-                        "facts": facts,
-                        "source": "hierarchical_service",
-                    }
+                    "facts": facts,
+                    "source": "hierarchical_service",
                 },
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -20,6 +20,13 @@ class DummyChannel:
     async def send(self, content, reference=None):
         self.sent_messages.append(content)
 
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield  # pragma: no cover
+
+        return _gen()
+
     def typing(self):
         class DummyContext:
             async def __aenter__(self):

--- a/tests/test_monitor_channels.py
+++ b/tests/test_monitor_channels.py
@@ -176,12 +176,13 @@ async def test_monitor_channels_idle_prompt_old_message(monkeypatch):
     bot = DummyBot(channel)
 
     from datetime import timedelta
-
     from discord.utils import utcnow
+    from types import SimpleNamespace
 
     class DummyMessage:
         def __init__(self, created_at):
             self.created_at = created_at
+            self.author = SimpleNamespace(bot=False)
 
     async def history_gen():
         yield DummyMessage(utcnow() - timedelta(minutes=sg.IDLE_TIMEOUT_MINUTES + 1))

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -22,6 +22,13 @@ class DummyChannel:
     async def send(self, content, reference=None):
         self.sent_messages.append(content)
 
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield  # pragma: no cover
+
+        return _gen()
+
     def typing(self):
         class DummyContext:
             async def __aenter__(self):

--- a/tests/unit/modules/test_input_handler.py
+++ b/tests/unit/modules/test_input_handler.py
@@ -70,7 +70,7 @@ async def test_process_input_success():
     assert subject == EventSubjects.MEMORY_RETRIEVED
     memory_payload = json.loads(data.decode())
     assert memory_payload["input_id"] == input_id
-    assert memory_payload["retrieved_knowledge"]["retrieved_knowledge"]["facts"] == [
+    assert memory_payload["retrieved_knowledge"]["facts"] == [
         "fact1",
         "fact2",
     ]

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -159,13 +159,15 @@ async def test_handle_memory_event_non_dict(monkeypatch, caplog):
     llm = create_llm(monkeypatch)
     payload = MemoryRetrievedPayload(retrieved_knowledge="oops", input_id="xyz")
     msg = DummyMsg(payload.to_json())
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("not a dict" in r.getMessage() for r in caplog.records)
+    assert any(
+        "Invalid MemoryRetrieved payload" in r.getMessage() for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -152,13 +152,15 @@ async def test_handle_memory_event_non_dict(monkeypatch, caplog):
     llm = create_llm(monkeypatch)
     payload = MemoryRetrievedPayload(retrieved_knowledge=["x"], input_id="abc")
     msg = DummyMsg(payload.to_json())
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         await llm._handle_memory_event(msg)
 
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("not a dict" in r.getMessage() for r in caplog.records)
+    assert any(
+        "Invalid MemoryRetrieved payload" in r.getMessage() for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -90,7 +90,7 @@ async def test_handle_input_publishes_combined_context(monkeypatch):
     subject, sent_payload = service._publisher.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"
-    facts = sent_payload.retrieved_knowledge["retrieved_knowledge"]["facts"]
+    facts = sent_payload.retrieved_knowledge["facts"]
     assert "vec1" in facts and "graph1" in facts
     ts = sent_payload.timestamp
     assert datetime.fromisoformat(ts).tzinfo == timezone.utc


### PR DESCRIPTION
## Summary
- emit `MemoryRetrievedPayload` with a simple `{"facts": facts, "source": src}` dictionary
- adapt `BaseLLM` to expect this flattened format
- update hierarchical memory service and modules
- adjust related unit tests
- patch mock classes in tests to implement `history()` for channels
- update log assertions for invalid payloads

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860d9e783108326a6bb9e569d4473fd