### PR TITLE
Add daily memory summarization job

### DIFF
--- a/tests/unit/services/test_scheduler.py
+++ b/tests/unit/services/test_scheduler.py
@@ -77,3 +77,43 @@ async def test_scheduler_summary_and_reminder(monkeypatch):
     assert subj == EventSubjects.REMINDER_TRIGGERED
     assert payload.message == "ping"
     assert payload.reminder_id == "r1"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_daily_summary(monkeypatch):
+    current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def now():
+        return current
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds):
+        nonlocal current
+        current += timedelta(seconds=seconds)
+        await real_sleep(0)
+
+    publisher = DummyPublisher()
+    memory = DummyMemoryDAL(["hello", "world", "another"])
+    graph = DummyGraphDAL()
+
+    service = SchedulerService(
+        publisher,
+        memory,
+        graph,
+        summary_interval=100.0,
+        daily_summary_interval=2.0,
+        now_func=now,
+        sleep_func=fake_sleep,
+    )
+
+    await service.start()
+    await fake_sleep(0)  # allow tasks to start
+    await fake_sleep(3)
+    await service.stop()
+
+    daily = [e for e in graph.entities if e[0] == "DailySummary"]
+    assert daily
+    label, props = daily[0]
+    assert label == "DailySummary"
+    assert "timestamp" in props


### PR DESCRIPTION
## Summary
- enhance `SchedulerService` with a daily summary loop
- store daily summaries using `generate_reflection`
- test that daily summaries are created

## Testing
- `flake8 src tests`
- `pytest -k scheduler -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e29322908326a95c0ca8f6669c10