### PR TITLE
Ensure affinity table creation

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -297,6 +297,14 @@ class DBManager:
             )
             """
         )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS affinity (
+                user_id TEXT PRIMARY KEY,
+                score INTEGER DEFAULT 0
+            )
+            """
+        )
         await self._db.commit()
 
     async def log_interaction(self, user_id: int, target_id: int) -> None:
@@ -957,7 +965,6 @@ class SocialGraphBot(discord.Client):
         _js_context = None
         _input_publisher = None
         await super().close()
-
 
 
 def run(token: str, monitor_channel_id: int) -> None:

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -22,3 +22,17 @@ async def test_persona_changes_with_affinity(tmp_path):
     assert await pm.get_persona(user) == "friendly"
 
     await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_affinity_adjustment_new_db(tmp_path):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg_new.db"))
+    await sg.db_manager.connect()
+    await sg.init_db()
+
+    user = "user1"
+    await sg.adjust_affinity(user, 1)
+    score = await sg.get_affinity(user)
+    assert score == 1
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- create the `affinity` table during DB initialization
- add regression test verifying affinity adjustments on a fresh DB

## Testing
- `black examples/social_graph_bot.py tests/test_persona_manager.py --line-length 120`
- `isort examples/social_graph_bot.py tests/test_persona_manager.py --profile black --line-length 120`
- `flake8 examples/social_graph_bot.py tests/test_persona_manager.py`
- `pytest tests/test_persona_manager.py -k affinity_adjustment_new_db -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e280f4dc8326b3cc2a99a2eb3016