### PR TITLE
Fix Persona tests with affinity table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ Specify the NATS server address with the `NATS_URL` environment variable. If not
 export NATS_URL=nats://my-nats:4222
 ```
 
+The optional offline search index used by `HierarchicalService` can be configured
+via `DT_SEARCH_DB`:
+
+```bash
+export DT_SEARCH_DB=/data/wiki.db
+```
+
+`SchedulerService` runs periodic summarization and reminder tasks. Adjust the interval
+between summaries with `DT_SCHEDULER_INTERVAL` (seconds):
+
+```bash
+export DT_SCHEDULER_INTERVAL=120
+```
+
 ### Required environment variables
 
 * `DISCORD_TOKEN` - Discord bot token

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -225,6 +225,14 @@ class DBManager:
         )
         await self._db.execute(
             """
+            CREATE TABLE IF NOT EXISTS affinity (
+                user_id TEXT PRIMARY KEY,
+                score INTEGER DEFAULT 0
+            )
+            """
+        )
+        await self._db.execute(
+            """
             CREATE TABLE IF NOT EXISTS memories (
                 user_id TEXT,
                 topic TEXT,

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -22,3 +22,30 @@ async def test_persona_changes_with_affinity(tmp_path):
     assert await pm.get_persona(user) == "friendly"
 
     await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_choose_prompt_uses_persona(tmp_path, monkeypatch):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.init_db()
+
+    pm = PersonaManager(sg.db_manager, friendly=2, playful=1)
+    user = "u1"
+    prompts = {"snarky": ["s"], "playful": ["p"], "friendly": ["f"], "default": ["d"]}
+
+    monkeypatch.setattr("random.choice", lambda opts: opts[0])
+
+    # default persona
+    assert await pm.choose_prompt(user, prompts) == "s"
+
+    await sg.adjust_affinity(user, 1)
+    assert await pm.choose_prompt(user, prompts) == "p"
+
+    await sg.adjust_affinity(user, 1)
+    assert await pm.choose_prompt(user, prompts) == "f"
+
+    # fallback to default when persona key missing
+    assert await pm.choose_prompt(user, {"default": ["x"]}) == "x"
+
+    await sg.db_manager.close()

--- a/tests/unit/test_file_graph_dal.py
+++ b/tests/unit/test_file_graph_dal.py
@@ -1,0 +1,21 @@
+import networkx as nx
+
+from deepthought.services.file_graph_dal import FileGraphDAL
+
+
+def test_add_interaction_creates_next_edge(tmp_path):
+    graph_file = tmp_path / "g.json"
+    dal = FileGraphDAL(str(graph_file))
+    first = dal.add_interaction("hello")
+    second = dal.add_interaction("world")
+    assert dal._graph.has_edge(first, second)
+    assert dal._graph[first][second]["relation"] == "next"
+
+
+def test_get_recent_facts_returns_latest(tmp_path):
+    graph_file = tmp_path / "g.json"
+    dal = FileGraphDAL(str(graph_file))
+    dal.add_interaction("a")
+    dal.add_interaction("b")
+    dal.add_interaction("c")
+    assert dal.get_recent_facts(2) == ["b", "c"]


### PR DESCRIPTION
## Summary
- ensure the social graph DB is created with an `affinity` table
- add unit test coverage for PersonaManager and FileGraphDAL
- refactor integration tests and document optional settings

## Testing
- `pytest tests/unit/test_file_graph_dal.py tests/test_persona_manager.py -q`
- `flake8 examples/social_graph_bot.py tests/test_persona_manager.py tests/unit/test_file_graph_dal.py`


------
https://chatgpt.com/codex/tasks/task_e_6861e29852188326a74c5869417961f0