### PR TITLE
Improve bot handoff detection

### DIFF
--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -60,7 +60,7 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch, input_events):
         return None
 
     f = asyncio.Future()
-    f.set_result((set(), set()))
+    f.set_result((set(), set(), {}))
     monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)
@@ -96,7 +96,7 @@ async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch, input_events):
         return None
 
     f = asyncio.Future()
-    f.set_result((set(), set()))
+    f.set_result((set(), set(), {}))
     monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)

--- a/tests/test_monitor_channels.py
+++ b/tests/test_monitor_channels.py
@@ -172,7 +172,7 @@ async def test_monitor_channels_only_bots(monkeypatch):
     channel.history = history_gen
 
     f = asyncio.Future()
-    f.set_result(({1}, set()))
+    f.set_result(({1}, set(), {1: None}))
     monkeypatch.setattr(sg, "who_is_active", lambda channel, limit=20: f)
 
     monkeypatch.setattr(sg, "BOT_CHAT_ENABLED", True)
@@ -202,8 +202,9 @@ async def test_monitor_channels_idle_prompt_old_message(monkeypatch):
     bot = DummyBot(channel)
 
     from datetime import timedelta
-    from discord.utils import utcnow
     from types import SimpleNamespace
+
+    from discord.utils import utcnow
 
     class DummyMessage:
         def __init__(self, created_at):
@@ -306,7 +307,7 @@ async def test_monitor_channels_playful_waits_for_humans(monkeypatch):
     from types import SimpleNamespace
 
     f = asyncio.Future()
-    f.set_result(({1}, set()))
+    f.set_result(({1}, set(), {1: None}))
     monkeypatch.setattr(sg, "who_is_active", lambda channel, limit=20: f)
     monkeypatch.setattr(sg, "BOT_CHAT_ENABLED", True)
     monkeypatch.setattr(sg, "PLAYFUL_REPLY_TIMEOUT_MINUTES", 5)


### PR DESCRIPTION
## Summary
- track recent bot chatter in `who_is_active`
- skip responding if another bot recently spoke
- create missing `affinity` table
- test overlapping bot scenarios

## Testing
- `pytest -vv tests/test_bullying_mock.py::test_bullying_triggers_sarcasm tests/test_bullying_mock.py::test_do_not_mock_blocks_sarcasm tests/test_monitor_channels.py::test_monitor_channels_only_bots tests/test_on_message_memory.py::test_on_message_waits_for_other_bot`
- `PRE_COMMIT_COLOR=always SKIP=pytest pre-commit run --files examples/social_graph_bot.py tests/test_bullying_mock.py tests/test_monitor_channels.py tests/test_on_message_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6861e2960d5c83269061946f2b8499f4