### PR TITLE
Refactor social graph utilities

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -57,23 +57,24 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
-SENTIMENT_BACKEND = os.getenv("SENTIMENT_BACKEND", "textblob").lower()
-if SENTIMENT_BACKEND == "vader":
-    from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
-
-    _sentiment = SentimentIntensityAnalyzer()
-
-    def analyze_sentiment(text: str) -> float:
-        """Return the compound sentiment score using VADER."""
-        return _sentiment.polarity_scores(text)["compound"]
-
-else:
-    from textblob import TextBlob
-
-    def analyze_sentiment(text: str) -> float:
-        """Return the sentiment polarity using TextBlob."""
-        return TextBlob(text).sentiment.polarity
-
+from deepthought import social_graph as sg
+from deepthought.social_graph import (BOT_CHAT_ENABLED, BULLYING_PHRASES,
+                                      CURRENT_DB_PATH, DB_PATH,
+                                      IDLE_TIMEOUT_MINUTES, MAX_MEMORY_LENGTH,
+                                      MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH,
+                                      PLAYFUL_REPLY_TIMEOUT_MINUTES,
+                                      REFLECTION_CHECK_SECONDS, DBManager,
+                                      SocialGraphService, adjust_affinity,
+                                      analyze_sentiment,
+                                      generate_idle_response, get_affinity,
+                                      get_all_sentiment_trends,
+                                      get_recent_topics, get_sentiment_trend,
+                                      get_theme, get_theories,
+                                      idle_response_candidates, init_db,
+                                      is_do_not_mock, log_interaction,
+                                      queue_deep_reflection, recall_user,
+                                      set_do_not_mock, set_theme, store_memory,
+                                      store_theory, update_sentiment_trend)
 
 try:
     from deepthought.config import get_settings
@@ -104,490 +105,17 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
-DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
-CURRENT_DB_PATH = DB_PATH
-
-
-# Endpoint for forwarding collected data
 PRISM_ENDPOINT = os.getenv("PRISM_ENDPOINT", "http://localhost:5000/receive_data")
-
-# NATS configuration for publishing events
 NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
-_nats_client: nats.aio.client.Client | None = None
-_js_context: JetStreamContext | None = None
-_input_publisher: Publisher | None = None
-
-# Configuration values
+sg._nats_client = None
+sg._js_context = None
+sg._input_publisher = None
 MAX_BOT_SPEAKERS = int(os.getenv("MAX_BOT_SPEAKERS", "2"))
-IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
-PLAYFUL_REPLY_TIMEOUT_MINUTES = int(os.getenv("PLAYFUL_REPLY_TIMEOUT_MINUTES", "5"))
-REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
 SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
-
-# Optional bot-to-bot chatter configuration
-# Accepts values like "true", "1", or "yes" (case-insensitive)
-BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
-    "true",
-    "1",
-    "yes",
-}
-
-# Candidate prompts used when the bot speaks after a period of silence
-idle_response_candidates = [
-    "Ever feel like everyone vanished?",
-    "I'm still here if anyone wants to chat!",
-    "Silence can be golden, but conversation is better.",
-]
-
-# -----------------------------
-# Idle text generation helpers
-# -----------------------------
-_idle_text_generator = None
-
-
-def _get_idle_generator():
-    """Return a cached HuggingFace text-generation pipeline."""
-    global _idle_text_generator
-    if _idle_text_generator is None:
-        from transformers import pipeline
-
-        model_name = os.getenv("IDLE_MODEL_NAME", "distilgpt2")
-        _idle_text_generator = pipeline("text-generation", model=model_name)
-    return _idle_text_generator
-
-
-async def generate_idle_response(prompt: str | None = None) -> str | None:
-    """Generate a prompt to send when the channel has been idle.
-
-    The seed text can be provided via ``prompt`` or the ``IDLE_GENERATOR_PROMPT``
-    environment variable. ``None`` is returned if generation fails for any
-    reason.
-    """
-    try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
-
-        generator = _get_idle_generator()
-        outputs = await asyncio.to_thread(
-            generator,
-            gen_prompt,
-            max_new_tokens=20,
-            num_return_sequences=1,
-        )
-
-        text = outputs[0]["generated_text"].strip()
-        return text
-    except Exception:  # pragma: no cover - optional dependency or runtime error
-        logger.exception("Idle text generation failed")
-        return None
-
-
-# Simple list of phrases considered bullying
-BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
-
-# Limits used when validating inputs
-MAX_MEMORY_LENGTH = 1000
-MAX_THEORY_LENGTH = 256
-MAX_PROMPT_LENGTH = 2000
-
-
-class DBManager:
-    """Lightweight wrapper managing a single aiosqlite connection."""
-
-    def __init__(self, db_path: str = DB_PATH) -> None:
-        self.db_path = db_path
-        self._db: aiosqlite.Connection | None = None
-
-    async def connect(self) -> None:
-        if self._db is None:
-            dir_path = os.path.dirname(self.db_path)
-            if dir_path:
-                os.makedirs(dir_path, exist_ok=True)
-            self._db = await aiosqlite.connect(self.db_path)
-
-    async def close(self) -> None:
-        if self._db is not None:
-            await self._db.close()
-            self._db = None
-
-    async def init_db(self) -> None:
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS interactions (
-                user_id TEXT,
-                target_id TEXT,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS memories (
-                user_id TEXT,
-                topic TEXT,
-                memory TEXT,
-                sentiment_score REAL,
-                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS theories (
-                subject_id TEXT,
-                theory TEXT,
-                confidence REAL,
-                updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY(subject_id, theory)
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS queued_tasks (
-                task_id INTEGER PRIMARY KEY,
-                user_id TEXT,
-                context TEXT,
-                prompt TEXT,
-                status TEXT DEFAULT 'pending',
-                created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS sentiment_trends (
-                user_id TEXT,
-                channel_id TEXT,
-                sentiment_sum REAL DEFAULT 0,
-                message_count INTEGER DEFAULT 0,
-                PRIMARY KEY(user_id, channel_id)
-
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS themes (
-                user_id TEXT,
-                channel_id TEXT,
-                theme TEXT,
-                updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                PRIMARY KEY(user_id, channel_id)
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS user_flags (
-                user_id TEXT PRIMARY KEY,
-                do_not_mock INTEGER
-            )
-            """
-        )
-        await self._db.execute(
-            """
-            CREATE TABLE IF NOT EXISTS recent_topics (
-                topic TEXT PRIMARY KEY,
-                last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-
-            )
-            """
-        )
-        await self._db.commit()
-
-    async def log_interaction(self, user_id: int, target_id: int) -> None:
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
-            (str(user_id), str(target_id)),
-        )
-        await self._db.execute(
-            """
-            INSERT INTO affinity (user_id, score)
-            VALUES (?, 1)
-            ON CONFLICT(user_id) DO UPDATE SET score=affinity.score + 1
-            """,
-            (str(user_id),),
-        )
-        await self._db.commit()
-
-    async def recall_user(self, user_id: int):
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT topic, memory FROM memories WHERE user_id= ?",
-            (str(user_id),),
-        ) as cur:
-            return await cur.fetchall()
-
-    async def store_memory(
-        self,
-        user_id: int,
-        memory: str,
-        topic: str = "",
-        sentiment_score: float | None = None,
-    ) -> None:
-        if not isinstance(memory, str) or not memory.strip():
-            raise ValueError("memory must be a non-empty string")
-        if len(memory) > MAX_MEMORY_LENGTH:
-            raise ValueError("memory exceeds maximum length")
-        if not isinstance(topic, str):
-            raise ValueError("topic must be a string")
-        if sentiment_score is not None:
-            if not isinstance(sentiment_score, (int, float)):
-                raise ValueError("sentiment_score must be numeric")
-            if not -1 <= float(sentiment_score) <= 1:
-                raise ValueError("sentiment_score out of range")
-
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            "INSERT INTO memories (user_id, topic, memory, sentiment_score) VALUES (?, ?, ?, ?)",
-            (str(user_id), topic, memory, sentiment_score),
-        )
-        if topic:
-            await self._db.execute(
-                """
-                INSERT INTO recent_topics (topic, last_used)
-                VALUES (?, CURRENT_TIMESTAMP)
-                ON CONFLICT(topic) DO UPDATE SET last_used=CURRENT_TIMESTAMP
-                """,
-                (topic,),
-            )
-        await self._db.commit()
-
-    async def store_theory(self, subject_id: int, theory: str, confidence: float) -> None:
-        if not isinstance(theory, str) or not theory.strip():
-            raise ValueError("theory must be a non-empty string")
-        if len(theory) > MAX_THEORY_LENGTH:
-            raise ValueError("theory exceeds maximum length")
-        if not isinstance(confidence, (int, float)):
-            raise ValueError("confidence must be numeric")
-        if not 0 <= float(confidence) <= 1:
-            raise ValueError("confidence out of range")
-
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            INSERT INTO theories (subject_id, theory, confidence)
-            VALUES (?, ?, ?)
-            ON CONFLICT(subject_id, theory) DO UPDATE SET
-                confidence=excluded.confidence,
-                updated=CURRENT_TIMESTAMP
-            """,
-            (str(subject_id), theory, confidence),
-        )
-        await self._db.commit()
-
-    async def get_theories(self, subject_id: int):
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT theory, confidence FROM theories WHERE subject_id=?",
-            (str(subject_id),),
-        ) as cur:
-            return await cur.fetchall()
-
-    async def update_sentiment_trend(
-        self,
-        user_id: int,
-        channel_id: int,
-        sentiment_score: float,
-    ) -> None:
-        if not isinstance(sentiment_score, (int, float)):
-            raise ValueError("sentiment_score must be numeric")
-        if not -1 <= float(sentiment_score) <= 1:
-            raise ValueError("sentiment_score out of range")
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            INSERT INTO sentiment_trends (user_id, channel_id, sentiment_sum, message_count)
-            VALUES (?, ?, ?, 1)
-            ON CONFLICT(user_id, channel_id) DO UPDATE SET
-                sentiment_sum=sentiment_trends.sentiment_sum + excluded.sentiment_sum,
-                message_count=sentiment_trends.message_count + 1
-            """,
-            (str(user_id), str(channel_id), sentiment_score),
-        )
-        await self._db.commit()
-
-    async def get_sentiment_trend(self, user_id: int, channel_id: int):
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT sentiment_sum, message_count FROM sentiment_trends WHERE user_id=? AND channel_id=?",
-            (str(user_id), str(channel_id)),
-        ) as cur:
-            return await cur.fetchone()
-
-    async def queue_deep_reflection(self, user_id: int, context: dict, prompt: str) -> int:
-
-        if not isinstance(prompt, str) or not prompt.strip():
-            raise ValueError("prompt must be a non-empty string")
-        if len(prompt) > MAX_PROMPT_LENGTH:
-            raise ValueError("prompt exceeds maximum length")
-        if not isinstance(context, dict):
-            raise ValueError("context must be a dictionary")
-        try:
-            context_json = json.dumps(context)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("context is not JSON serializable") from exc
-
-        await self.connect()
-        assert self._db
-        cur = await self._db.execute(
-            "INSERT INTO queued_tasks (user_id, context, prompt) VALUES (?, ?, ?)",
-            (str(user_id), context_json, prompt),
-        )
-        await self._db.commit()
-        return cur.lastrowid
-
-    async def list_pending_tasks(self):
-        """Return pending reflection tasks."""
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT task_id, user_id, context, prompt FROM queued_tasks WHERE status='pending'"
-        ) as cur:
-            return await cur.fetchall()
-
-    async def mark_task_done(self, task_id: int) -> None:
-        """Mark a queued task as completed."""
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            "UPDATE queued_tasks SET status='done' WHERE task_id=?",
-            (task_id,),
-        )
-        await self._db.commit()
-
-    async def set_do_not_mock(self, user_id: int, flag: bool = True) -> None:
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            INSERT INTO user_flags (user_id, do_not_mock)
-            VALUES (?, ?)
-            ON CONFLICT(user_id) DO UPDATE SET do_not_mock=excluded.do_not_mock
-            """,
-            (str(user_id), int(flag)),
-        )
-        await self._db.commit()
-
-    async def is_do_not_mock(self, user_id: int) -> bool:
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT do_not_mock FROM user_flags WHERE user_id=?",
-            (str(user_id),),
-        ) as cur:
-            row = await cur.fetchone()
-            return bool(row[0]) if row else False
-
-    async def adjust_affinity(self, user_id: int, delta: int) -> None:
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            INSERT INTO affinity (user_id, score)
-            VALUES (?, ?)
-            ON CONFLICT(user_id) DO UPDATE SET score=affinity.score + ?
-            """,
-            (str(user_id), delta, delta),
-        )
-        await self._db.commit()
-
-    async def get_affinity(self, user_id: int) -> int:
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT score FROM affinity WHERE user_id=?",
-            (str(user_id),),
-        ) as cur:
-            row = await cur.fetchone()
-            return int(row[0]) if row else 0
-
-    async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
-        if not isinstance(theme, str) or not theme.strip():
-            raise ValueError("theme must be a non-empty string")
-        await self.connect()
-        assert self._db
-        await self._db.execute(
-            """
-            INSERT INTO themes (user_id, channel_id, theme)
-            VALUES (?, ?, ?)
-            ON CONFLICT(user_id, channel_id) DO UPDATE SET
-                theme=excluded.theme,
-                updated=CURRENT_TIMESTAMP
-            """,
-            (str(user_id), str(channel_id), theme),
-        )
-        await self._db.commit()
-
-    async def get_theme(self, user_id: int, channel_id: int):
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT theme FROM themes WHERE user_id=? AND channel_id=?",
-            (str(user_id), str(channel_id)),
-        ) as cur:
-            row = await cur.fetchone()
-            return row[0] if row else None
-
-    async def get_all_sentiment_trends(self):
-        await self.connect()
-        assert self._db
-        async with self._db.execute(
-            "SELECT user_id, channel_id, sentiment_sum, message_count FROM sentiment_trends"
-        ) as cur:
-            return await cur.fetchall()
-
-
-DEFAULT_DB_PATH = DB_PATH
-db_manager = DBManager()
-
-
-async def init_db(db_path: str | None = None) -> None:
-    """Initialize the database, recreating the manager when the path changes."""
-    global db_manager, CURRENT_DB_PATH
-
-    target_path = (
-        db_path
-        if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
-    )
-
-    if db_manager.db_path != target_path:
-        if db_manager._db is not None:
-            await db_manager.close()
-        db_manager = DBManager(target_path)
-
-    await db_manager.init_db()
-    CURRENT_DB_PATH = db_manager.db_path
-
-
-async def log_interaction(user_id: int, target_id: int) -> None:
-    await db_manager.log_interaction(user_id, target_id)
-
-
-async def recall_user(user_id: int):
-    return await db_manager.recall_user(user_id)
-
-
-async def store_memory(
-    user_id: int,
-    memory: str,
-    topic: str = "",
-    sentiment_score: float | None = None,
-) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
 
 
 async def send_to_prism(data: dict) -> None:
@@ -605,24 +133,25 @@ async def send_to_prism(data: dict) -> None:
 
 async def _ensure_nats() -> None:
     """Initialize NATS client and publisher if not already connected."""
-    global _nats_client, _js_context, _input_publisher
-    if _input_publisher is not None:
+    if sg._input_publisher is not None:
         return
     try:
         settings = get_settings()
-        _nats_client = await nats.connect(servers=[settings.nats_url])
-        _js_context = _nats_client.jetstream()
-        _input_publisher = Publisher(_nats_client, _js_context)
+        sg._nats_client = await nats.connect(servers=[settings.nats_url])
+        sg._js_context = sg._nats_client.jetstream()
+        sg._input_publisher = Publisher(sg._nats_client, sg._js_context)
     except Exception as exc:  # pragma: no cover - connection issues
         logger.warning("Failed to connect to NATS: %s", exc)
-        _input_publisher = None
+        sg._input_publisher = None
 
 
 async def publish_input_received(text: str) -> None:
     """Publish an INPUT_RECEIVED event using NATS JetStream."""
     await _ensure_nats()
-    if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+    if sg._input_publisher is None:
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -631,7 +160,7 @@ async def publish_input_received(text: str) -> None:
         timestamp=discord.utils.utcnow().replace(tzinfo=timezone.utc).isoformat(),
     )
     try:
-        await _input_publisher.publish(
+        await sg._input_publisher.publish(
             EventSubjects.INPUT_RECEIVED,
             payload,
             use_jetstream=True,
@@ -641,62 +170,9 @@ async def publish_input_received(text: str) -> None:
         logger.warning("Failed to publish INPUT_RECEIVED: %s", exc)
 
 
-async def store_theory(subject_id: int, theory: str, confidence: float) -> None:
-    return await db_manager.store_theory(subject_id, theory, confidence)
-
-
-async def get_theories(subject_id: int):
-    return await db_manager.get_theories(subject_id)
-
-
-async def update_sentiment_trend(
-    user_id: int,
-    channel_id: int,
-    sentiment_score: float,
-) -> None:
-    await db_manager.update_sentiment_trend(user_id, channel_id, sentiment_score)
-
-
-async def get_sentiment_trend(user_id: int, channel_id: int):
-    return await db_manager.get_sentiment_trend(user_id, channel_id)
-
-
-async def get_recent_topics(limit: int = 3) -> list[str]:
-    return await db_manager.get_recent_topics(limit)
-
-
-async def queue_deep_reflection(user_id: int, context: dict, prompt: str) -> int:
-    return await db_manager.queue_deep_reflection(user_id, context, prompt)
-
-
-async def set_do_not_mock(user_id: int, flag: bool = True) -> None:
-    await db_manager.set_do_not_mock(user_id, flag)
-
-
-async def is_do_not_mock(user_id: int) -> bool:
-    return await db_manager.is_do_not_mock(user_id)
-
-
-async def adjust_affinity(user_id: int, delta: int) -> None:
-    await db_manager.adjust_affinity(user_id, delta)
-
-
-async def get_affinity(user_id: int) -> int:
-    return await db_manager.get_affinity(user_id)
-
-
-async def set_theme(user_id: int, channel_id: int, theme: str) -> None:
-    await db_manager.set_theme(user_id, channel_id, theme)
-
-
-async def get_theme(user_id: int, channel_id: int):
-    """Return the last assigned theme for a user/channel pair."""
-    return await db_manager.get_theme(user_id, channel_id)
-
-
 async def assign_themes() -> None:
     """Update the theme for each user/channel based on sentiment trends."""
-    rows = await db_manager.get_all_sentiment_trends()
+    rows = await sg.db_manager.get_all_sentiment_trends()
     for user_id, channel_id, ssum, count in rows:
         if not count:
             continue
@@ -707,53 +183,7 @@ async def assign_themes() -> None:
             theme = "negative"
         else:
             theme = "neutral"
-        await db_manager.set_theme(user_id, channel_id, theme)
-
-
-def generate_reflection(prompt: str) -> str:
-    """Return a simple reflection string based on sentiment analysis."""
-    polarity = analyze_sentiment(prompt)
-    if polarity > 0.1:
-        mood = "positive"
-    elif polarity < -0.1:
-        mood = "negative"
-    else:
-        mood = "neutral"
-    return f"Your message felt {mood}."
-
-
-async def process_deep_reflections(bot: discord.Client) -> None:
-    """Background task to process queued reflections."""
-    await bot.wait_until_ready()
-    while not bot.is_closed():
-        try:
-            rows = await db_manager.list_pending_tasks()
-            if not rows:
-                logger.debug("No queued reflections to process")
-            for task_id, user_id, ctx_json, prompt in rows:
-                context = json.loads(ctx_json)
-                channel = bot.get_channel(int(context.get("channel_id")))
-                msg_id = context.get("message_id")
-                ref = None
-                if channel and msg_id:
-                    try:
-                        ref = await channel.fetch_message(int(msg_id))
-                    except Exception:
-                        ref = None
-                if channel:
-                    await asyncio.sleep(2)
-                    reflection = generate_reflection(prompt)
-                    logger.info(f"Posting deep reflection for task {task_id}")
-                    await channel.send(
-                        f"After some thought... {reflection}",
-                        reference=ref,
-                    )
-                await db_manager.mark_task_done(task_id)
-            await assign_themes()
-            await asyncio.sleep(REFLECTION_CHECK_SECONDS)
-        except asyncio.CancelledError:
-            logger.info("process_deep_reflections cancelled")
-            break
+        await sg.db_manager.set_theme(user_id, channel_id, theme)
 
 
 def evaluate_triggers(message: discord.Message) -> List[Tuple[str, float]]:
@@ -767,89 +197,6 @@ def evaluate_triggers(message: discord.Message) -> List[Tuple[str, float]]:
     return theories
 
 
-async def who_is_active(channel: discord.TextChannel, limit: int = 20):
-    """Return sets of bot and human authors from recent messages."""
-    bots = set()
-    humans = set()
-    async for msg in channel.history(limit=limit):
-        if msg.author.bot:
-            bots.add(msg.author.id)
-        else:
-            humans.add(msg.author.id)
-    return bots, humans
-
-
-async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
-    """Return minutes since the most recent human message or ``None`` if none."""
-    async for msg in channel.history(limit=limit):
-        if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
-    return None
-
-
-async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
-    """Monitor a channel and occasionally speak during idle periods."""
-    await bot.wait_until_ready()
-    channel = bot.get_channel(channel_id)
-    if channel is None:
-        logger.error("Channel %s does not exist", channel_id)
-        return
-    while not bot.is_closed():
-        try:
-            last_message = None
-            prev_message = None
-            idx = 0
-            async for msg in channel.history(limit=2):
-                if idx == 0:
-                    last_message = msg
-                elif idx == 1:
-                    prev_message = msg
-                idx += 1
-
-            respond_to = None
-            send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
-                age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
-                ).total_seconds() / 60
-                if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
-                    await asyncio.sleep(60)
-                    continue
-
-            if not last_message:
-
-                send_prompt = True
-            else:
-                idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
-                ).total_seconds() / 60
-                if idle_minutes >= IDLE_TIMEOUT_MINUTES:
-                    send_prompt = True
-                elif BOT_CHAT_ENABLED:
-                    bots, humans = await who_is_active(channel)
-                    if bots and not humans:
-                        age = await last_human_message_age(channel)
-                        if age is None or age >= PLAYFUL_REPLY_TIMEOUT_MINUTES:
-                            send_prompt = True
-                            if last_message.author.bot:
-                                respond_to = last_message
-
-            if send_prompt:
-                prompt = await generate_idle_response()
-                if not prompt:
-                    prompt = random.choice(idle_response_candidates)
-                async with channel.typing():
-                    await asyncio.sleep(random.uniform(3, 10))
-                    if respond_to is not None:
-                        await channel.send(prompt, reference=respond_to)
-                    else:
-                        await channel.send(prompt)
-            await asyncio.sleep(60)
-        except asyncio.CancelledError:
-            logger.info("monitor_channels cancelled")
-            break
-
-
 class SocialGraphBot(discord.Client):
     """Discord bot that records interactions and demonstrates simple awareness."""
 
@@ -861,12 +208,19 @@ class SocialGraphBot(discord.Client):
         super().__init__(*args, intents=intents, **kwargs)
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
+        self.service = SocialGraphService(sg.db_manager)
 
     async def setup_hook(self) -> None:
-        await db_manager.connect()
+        await sg.db_manager.connect()
         await init_db()
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
-        self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
+        self._bg_tasks.append(
+            self.loop.create_task(
+                self.service.monitor_channels(self, self.monitor_channel_id)
+            )
+        )
+        self._bg_tasks.append(
+            self.loop.create_task(self.service.process_deep_reflections(self))
+        )
 
     async def on_ready(self) -> None:
         """Log basic information once the bot connects."""
@@ -884,11 +238,12 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
-        bots, _ = await who_is_active(message.channel)
+        bots, _ = await self.service.who_is_active(message.channel)
         if len(bots) > MAX_BOT_SPEAKERS and self.user not in message.mentions:
-            # Too many bots talking and we're not addressed directly
             return
 
         # Log the interaction
@@ -949,15 +304,13 @@ class SocialGraphBot(discord.Client):
             task.cancel()
         await asyncio.gather(*self._bg_tasks, return_exceptions=True)
         self._bg_tasks.clear()
-        await db_manager.close()
-        global _nats_client, _js_context, _input_publisher
-        if _nats_client is not None and not _nats_client.is_closed:
-            await _nats_client.close()
-        _nats_client = None
-        _js_context = None
-        _input_publisher = None
+        await sg.db_manager.close()
+        if sg._nats_client is not None and not sg._nats_client.is_closed:
+            await sg._nats_client.close()
+        sg._nats_client = None
+        sg._js_context = None
+        sg._input_publisher = None
         await super().close()
-
 
 
 def run(token: str, monitor_channel_id: int) -> None:

--- a/src/deepthought/social_graph/__init__.py
+++ b/src/deepthought/social_graph/__init__.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from . import constants
+from . import db_manager as db_module
+from .constants import *  # noqa: F401,F403
+from .db_manager import *  # noqa: F401,F403
+from .idle import _get_idle_generator, generate_idle_response
+from .service import SocialGraphService
+from .utils import analyze_sentiment
+
+try:
+    from examples import social_graph_bot as _bot_mod
+except Exception:  # pragma: no cover - optional example missing deps
+    _bot_mod = None
+
+_nats_client = None
+_js_context = None
+_input_publisher = None
+
+
+async def send_to_prism(data: dict) -> None:
+    if _bot_mod and hasattr(_bot_mod, "send_to_prism"):
+        await _bot_mod.send_to_prism(data)
+
+
+async def publish_input_received(text: str) -> None:
+    if _bot_mod and hasattr(_bot_mod, "publish_input_received"):
+        await _bot_mod.publish_input_received(text)
+
+
+def evaluate_triggers(message):
+    if _bot_mod and hasattr(_bot_mod, "evaluate_triggers"):
+        return _bot_mod.evaluate_triggers(message)
+    return []
+
+
+__all__ = [
+    "SocialGraphService",
+    "generate_idle_response",
+    "_get_idle_generator",
+    "send_to_prism",
+    "publish_input_received",
+    "evaluate_triggers",
+    "analyze_sentiment",
+    *constants.__all__,  # type: ignore[list-item]
+    *db_module.__all__,  # type: ignore[list-item]
+]

--- a/src/deepthought/social_graph/constants.py
+++ b/src/deepthought/social_graph/constants.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import os
+
+DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+CURRENT_DB_PATH = DB_PATH
+
+BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
+
+MAX_MEMORY_LENGTH = 1000
+MAX_THEORY_LENGTH = 256
+MAX_PROMPT_LENGTH = 2000
+
+# Idle/monitoring configuration
+IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
+PLAYFUL_REPLY_TIMEOUT_MINUTES = int(os.getenv("PLAYFUL_REPLY_TIMEOUT_MINUTES", "5"))
+REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
+BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
+    "true",
+    "1",
+    "yes",
+}
+
+idle_response_candidates = [
+    "Ever feel like everyone vanished?",
+    "I'm still here if anyone wants to chat!",
+    "Silence can be golden, but conversation is better.",
+]
+
+__all__ = [
+    "DB_PATH",
+    "CURRENT_DB_PATH",
+    "BULLYING_PHRASES",
+    "MAX_MEMORY_LENGTH",
+    "MAX_THEORY_LENGTH",
+    "MAX_PROMPT_LENGTH",
+    "IDLE_TIMEOUT_MINUTES",
+    "PLAYFUL_REPLY_TIMEOUT_MINUTES",
+    "REFLECTION_CHECK_SECONDS",
+    "BOT_CHAT_ENABLED",
+    "idle_response_candidates",
+]

--- a/src/deepthought/social_graph/db_manager.py
+++ b/src/deepthought/social_graph/db_manager.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Optional
+
+import aiosqlite
+
+from .constants import (CURRENT_DB_PATH, DB_PATH, MAX_MEMORY_LENGTH,
+                        MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH)
+
+
+class DBManager:
+    """Lightweight wrapper managing a single aiosqlite connection."""
+
+    def __init__(self, db_path: str = DB_PATH) -> None:
+        self.db_path = db_path
+        self._db: aiosqlite.Connection | None = None
+
+    async def connect(self) -> None:
+        if self._db is None:
+            dir_path = os.path.dirname(self.db_path)
+            if dir_path:
+                os.makedirs(dir_path, exist_ok=True)
+            self._db = await aiosqlite.connect(self.db_path)
+
+    async def close(self) -> None:
+        if self._db is not None:
+            await self._db.close()
+            self._db = None
+
+    async def init_db(self) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                user_id TEXT,
+                target_id TEXT,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS affinity (
+                user_id TEXT PRIMARY KEY,
+                score INTEGER DEFAULT 0
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS memories (
+                user_id TEXT,
+                topic TEXT,
+                memory TEXT,
+                sentiment_score REAL,
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS theories (
+                subject_id TEXT,
+                theory TEXT,
+                confidence REAL,
+                updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY(subject_id, theory)
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS queued_tasks (
+                task_id INTEGER PRIMARY KEY,
+                user_id TEXT,
+                context TEXT,
+                prompt TEXT,
+                status TEXT DEFAULT 'pending',
+                created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sentiment_trends (
+                user_id TEXT,
+                channel_id TEXT,
+                sentiment_sum REAL DEFAULT 0,
+                message_count INTEGER DEFAULT 0,
+                PRIMARY KEY(user_id, channel_id)
+
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS themes (
+                user_id TEXT,
+                channel_id TEXT,
+                theme TEXT,
+                updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY(user_id, channel_id)
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_flags (
+                user_id TEXT PRIMARY KEY,
+                do_not_mock INTEGER
+            )
+            """
+        )
+        await self._db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recent_topics (
+                topic TEXT PRIMARY KEY,
+                last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+            )
+            """
+        )
+        await self._db.commit()
+
+    async def log_interaction(self, user_id: int, target_id: int) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
+            (str(user_id), str(target_id)),
+        )
+        await self._db.execute(
+            """
+            INSERT INTO affinity (user_id, score)
+            VALUES (?, 1)
+            ON CONFLICT(user_id) DO UPDATE SET score=affinity.score + 1
+            """,
+            (str(user_id),),
+        )
+        await self._db.commit()
+
+    async def recall_user(self, user_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT topic, memory FROM memories WHERE user_id= ?",
+            (str(user_id),),
+        ) as cur:
+            return await cur.fetchall()
+
+    async def store_memory(
+        self,
+        user_id: int,
+        memory: str,
+        topic: str = "",
+        sentiment_score: float | None = None,
+    ) -> None:
+        if not isinstance(memory, str) or not memory.strip():
+            raise ValueError("memory must be a non-empty string")
+        if len(memory) > MAX_MEMORY_LENGTH:
+            raise ValueError("memory exceeds maximum length")
+        if not isinstance(topic, str):
+            raise ValueError("topic must be a string")
+        if sentiment_score is not None:
+            if not isinstance(sentiment_score, (int, float)):
+                raise ValueError("sentiment_score must be numeric")
+            if not -1 <= float(sentiment_score) <= 1:
+                raise ValueError("sentiment_score out of range")
+
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO memories (user_id, topic, memory, sentiment_score) VALUES (?, ?, ?, ?)",
+            (str(user_id), topic, memory, sentiment_score),
+        )
+        if topic:
+            await self._db.execute(
+                """
+                INSERT INTO recent_topics (topic, last_used)
+                VALUES (?, CURRENT_TIMESTAMP)
+                ON CONFLICT(topic) DO UPDATE SET last_used=CURRENT_TIMESTAMP
+                """,
+                (topic,),
+            )
+        await self._db.commit()
+
+    async def store_theory(
+        self, subject_id: int, theory: str, confidence: float
+    ) -> None:
+        if not isinstance(theory, str) or not theory.strip():
+            raise ValueError("theory must be a non-empty string")
+        if len(theory) > MAX_THEORY_LENGTH:
+            raise ValueError("theory exceeds maximum length")
+        if not isinstance(confidence, (int, float)):
+            raise ValueError("confidence must be numeric")
+        if not 0 <= float(confidence) <= 1:
+            raise ValueError("confidence out of range")
+
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO theories (subject_id, theory, confidence)
+            VALUES (?, ?, ?)
+            ON CONFLICT(subject_id, theory) DO UPDATE SET
+                confidence=excluded.confidence,
+                updated=CURRENT_TIMESTAMP
+            """,
+            (str(subject_id), theory, confidence),
+        )
+        await self._db.commit()
+
+    async def get_theories(self, subject_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT theory, confidence FROM theories WHERE subject_id=?",
+            (str(subject_id),),
+        ) as cur:
+            return await cur.fetchall()
+
+    async def update_sentiment_trend(
+        self,
+        user_id: int,
+        channel_id: int,
+        sentiment_score: float,
+    ) -> None:
+        if not isinstance(sentiment_score, (int, float)):
+            raise ValueError("sentiment_score must be numeric")
+        if not -1 <= float(sentiment_score) <= 1:
+            raise ValueError("sentiment_score out of range")
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO sentiment_trends (user_id, channel_id, sentiment_sum, message_count)
+            VALUES (?, ?, ?, 1)
+            ON CONFLICT(user_id, channel_id) DO UPDATE SET
+                sentiment_sum=sentiment_trends.sentiment_sum + excluded.sentiment_sum,
+                message_count=sentiment_trends.message_count + 1
+            """,
+            (str(user_id), str(channel_id), sentiment_score),
+        )
+        await self._db.commit()
+
+    async def get_sentiment_trend(self, user_id: int, channel_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT sentiment_sum, message_count FROM sentiment_trends WHERE user_id=? AND channel_id=?",
+            (str(user_id), str(channel_id)),
+        ) as cur:
+            return await cur.fetchone()
+
+    async def get_recent_topics(self, limit: int = 3) -> list[str]:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT topic FROM recent_topics ORDER BY last_used DESC LIMIT ?",
+            (limit,),
+        ) as cur:
+            rows = await cur.fetchall()
+            return [r[0] for r in rows]
+
+    async def queue_deep_reflection(
+        self, user_id: int, context: dict, prompt: str
+    ) -> int:
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        if len(prompt) > MAX_PROMPT_LENGTH:
+            raise ValueError("prompt exceeds maximum length")
+        if not isinstance(context, dict):
+            raise ValueError("context must be a dictionary")
+        try:
+            context_json = json.dumps(context)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("context is not JSON serializable") from exc
+
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute(
+            "INSERT INTO queued_tasks (user_id, context, prompt) VALUES (?, ?, ?)",
+            (str(user_id), context_json, prompt),
+        )
+        await self._db.commit()
+        return cur.lastrowid
+
+    async def list_pending_tasks(self):
+        """Return pending reflection tasks."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT task_id, user_id, context, prompt FROM queued_tasks WHERE status='pending'"
+        ) as cur:
+            return await cur.fetchall()
+
+    async def mark_task_done(self, task_id: int) -> None:
+        """Mark a queued task as completed."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "UPDATE queued_tasks SET status='done' WHERE task_id=?",
+            (task_id,),
+        )
+        await self._db.commit()
+
+    async def set_do_not_mock(self, user_id: int, flag: bool = True) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO user_flags (user_id, do_not_mock)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET do_not_mock=excluded.do_not_mock
+            """,
+            (str(user_id), int(flag)),
+        )
+        await self._db.commit()
+
+    async def is_do_not_mock(self, user_id: int) -> bool:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT do_not_mock FROM user_flags WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+            return bool(row[0]) if row else False
+
+    async def adjust_affinity(self, user_id: int, delta: int) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO affinity (user_id, score)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET score=affinity.score + ?
+            """,
+            (str(user_id), delta, delta),
+        )
+        await self._db.commit()
+
+    async def get_affinity(self, user_id: int) -> int:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT score FROM affinity WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+            return int(row[0]) if row else 0
+
+    async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
+        if not isinstance(theme, str) or not theme.strip():
+            raise ValueError("theme must be a non-empty string")
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO themes (user_id, channel_id, theme)
+            VALUES (?, ?, ?)
+            ON CONFLICT(user_id, channel_id) DO UPDATE SET
+                theme=excluded.theme,
+                updated=CURRENT_TIMESTAMP
+            """,
+            (str(user_id), str(channel_id), theme),
+        )
+        await self._db.commit()
+
+    async def get_theme(self, user_id: int, channel_id: int):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT theme FROM themes WHERE user_id=? AND channel_id=?",
+            (str(user_id), str(channel_id)),
+        ) as cur:
+            row = await cur.fetchone()
+            return row[0] if row else None
+
+    async def get_all_sentiment_trends(self):
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT user_id, channel_id, sentiment_sum, message_count FROM sentiment_trends"
+        ) as cur:
+            return await cur.fetchall()
+
+
+db_manager = DBManager()
+
+
+async def init_db(db_path: str | None = None) -> None:
+    """Initialize the database, recreating the manager when the path changes."""
+    global db_manager, CURRENT_DB_PATH
+
+    target_path = (
+        db_path
+        if db_path is not None
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
+    )
+
+    if db_manager.db_path != target_path:
+        if db_manager._db is not None:
+            await db_manager.close()
+        db_manager = DBManager(target_path)
+
+    await db_manager.init_db()
+    CURRENT_DB_PATH = db_manager.db_path
+
+
+async def log_interaction(user_id: int, target_id: int) -> None:
+    await db_manager.log_interaction(user_id, target_id)
+
+
+async def recall_user(user_id: int):
+    return await db_manager.recall_user(user_id)
+
+
+async def store_memory(
+    user_id: int,
+    memory: str,
+    topic: str = "",
+    sentiment_score: float | None = None,
+) -> None:
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
+
+
+async def store_theory(subject_id: int, theory: str, confidence: float) -> None:
+    return await db_manager.store_theory(subject_id, theory, confidence)
+
+
+async def get_theories(subject_id: int):
+    return await db_manager.get_theories(subject_id)
+
+
+async def update_sentiment_trend(
+    user_id: int,
+    channel_id: int,
+    sentiment_score: float,
+) -> None:
+    await db_manager.update_sentiment_trend(user_id, channel_id, sentiment_score)
+
+
+async def get_sentiment_trend(user_id: int, channel_id: int):
+    return await db_manager.get_sentiment_trend(user_id, channel_id)
+
+
+async def get_recent_topics(limit: int = 3) -> list[str]:
+    return await db_manager.get_recent_topics(limit)
+
+
+async def queue_deep_reflection(user_id: int, context: dict, prompt: str) -> int:
+    return await db_manager.queue_deep_reflection(user_id, context, prompt)
+
+
+async def list_pending_tasks():
+    return await db_manager.list_pending_tasks()
+
+
+async def mark_task_done(task_id: int) -> None:
+    await db_manager.mark_task_done(task_id)
+
+
+async def set_do_not_mock(user_id: int, flag: bool = True) -> None:
+    await db_manager.set_do_not_mock(user_id, flag)
+
+
+async def is_do_not_mock(user_id: int) -> bool:
+    return await db_manager.is_do_not_mock(user_id)
+
+
+async def adjust_affinity(user_id: int, delta: int) -> None:
+    await db_manager.adjust_affinity(user_id, delta)
+
+
+async def get_affinity(user_id: int) -> int:
+    return await db_manager.get_affinity(user_id)
+
+
+async def set_theme(user_id: int, channel_id: int, theme: str) -> None:
+    await db_manager.set_theme(user_id, channel_id, theme)
+
+
+async def get_theme(user_id: int, channel_id: int):
+    return await db_manager.get_theme(user_id, channel_id)
+
+
+async def get_all_sentiment_trends():
+    return await db_manager.get_all_sentiment_trends()
+
+
+__all__ = [
+    "DBManager",
+    "db_manager",
+    "init_db",
+    "log_interaction",
+    "recall_user",
+    "store_memory",
+    "store_theory",
+    "get_theories",
+    "update_sentiment_trend",
+    "get_sentiment_trend",
+    "get_recent_topics",
+    "queue_deep_reflection",
+    "list_pending_tasks",
+    "mark_task_done",
+    "set_do_not_mock",
+    "is_do_not_mock",
+    "adjust_affinity",
+    "get_affinity",
+    "set_theme",
+    "get_theme",
+    "get_all_sentiment_trends",
+]

--- a/src/deepthought/social_graph/idle.py
+++ b/src/deepthought/social_graph/idle.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any
+
+_idle_text_generator: Any | None = None
+
+
+def _get_idle_generator():
+    """Return a cached HuggingFace text-generation pipeline."""
+    global _idle_text_generator
+    if _idle_text_generator is None:
+        from transformers import pipeline
+
+        model_name = os.getenv("IDLE_MODEL_NAME", "distilgpt2")
+        _idle_text_generator = pipeline("text-generation", model=model_name)
+    return _idle_text_generator
+
+
+async def generate_idle_response(prompt: str | None = None) -> str | None:
+    """Generate a prompt to send when the channel has been idle."""
+    try:
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
+
+        generator = _get_idle_generator()
+        outputs = await asyncio.to_thread(
+            generator,
+            gen_prompt,
+            max_new_tokens=20,
+            num_return_sequences=1,
+        )
+
+        text = outputs[0]["generated_text"].strip()
+        return text
+    except Exception:  # pragma: no cover - optional dependency or runtime error
+        import logging
+
+        logging.getLogger(__name__).exception("Idle text generation failed")
+        return None
+
+
+__all__ = ["generate_idle_response", "_get_idle_generator"]

--- a/src/deepthought/social_graph/service.py
+++ b/src/deepthought/social_graph/service.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import random
+from datetime import timezone
+from typing import Tuple
+
+import discord
+
+from . import db_manager as global_db
+from .constants import (BOT_CHAT_ENABLED, IDLE_TIMEOUT_MINUTES,
+                        PLAYFUL_REPLY_TIMEOUT_MINUTES,
+                        REFLECTION_CHECK_SECONDS, idle_response_candidates)
+from .db_manager import DBManager
+from .utils import analyze_sentiment
+
+logger = logging.getLogger(__name__)
+
+
+class SocialGraphService:
+    """Background tasks for monitoring channels and processing reflections."""
+
+    def __init__(self, db_manager: DBManager | None = None) -> None:
+        self.db = db_manager or global_db.db_manager
+
+    async def assign_themes(self) -> None:
+        rows = await self.db.get_all_sentiment_trends()
+        for user_id, channel_id, ssum, count in rows:
+            if not count:
+                continue
+            avg = ssum / count
+            if avg > 0.2:
+                theme = "positive"
+            elif avg < -0.2:
+                theme = "negative"
+            else:
+                theme = "neutral"
+            await self.db.set_theme(user_id, channel_id, theme)
+
+    def generate_reflection(self, prompt: str) -> str:
+        polarity = analyze_sentiment(prompt)
+        if polarity > 0.1:
+            mood = "positive"
+        elif polarity < -0.1:
+            mood = "negative"
+        else:
+            mood = "neutral"
+        return f"Your message felt {mood}."
+
+    async def process_deep_reflections(self, bot: discord.Client) -> None:
+        await bot.wait_until_ready()
+        while not bot.is_closed():
+            try:
+                rows = await self.db.list_pending_tasks()
+                if not rows:
+                    logger.debug("No queued reflections to process")
+                for task_id, user_id, ctx_json, prompt in rows:
+                    context = json.loads(ctx_json)
+                    channel = bot.get_channel(int(context.get("channel_id")))
+                    msg_id = context.get("message_id")
+                    ref = None
+                    if channel and msg_id:
+                        try:
+                            ref = await channel.fetch_message(int(msg_id))
+                        except Exception:
+                            ref = None
+                    if channel:
+                        await asyncio.sleep(2)
+                        reflection = self.generate_reflection(prompt)
+                        logger.info("Posting deep reflection for task %s", task_id)
+                        await channel.send(
+                            f"After some thought... {reflection}",
+                            reference=ref,
+                        )
+                    await self.db.mark_task_done(task_id)
+                await self.assign_themes()
+                await asyncio.sleep(REFLECTION_CHECK_SECONDS)
+            except asyncio.CancelledError:
+                logger.info("process_deep_reflections cancelled")
+                break
+
+    async def who_is_active(
+        self, channel: discord.TextChannel, limit: int = 20
+    ) -> Tuple[set, set]:
+        bots = set()
+        humans = set()
+        async for msg in channel.history(limit=limit):
+            if msg.author.bot:
+                bots.add(msg.author.id)
+            else:
+                humans.add(msg.author.id)
+        return bots, humans
+
+    async def last_human_message_age(
+        self, channel: discord.TextChannel, limit: int = 50
+    ):
+        async for msg in channel.history(limit=limit):
+            if not msg.author.bot:
+                return (
+                    discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+                ).total_seconds() / 60
+        return None
+
+    async def monitor_channels(self, bot: discord.Client, channel_id: int) -> None:
+        await bot.wait_until_ready()
+        channel = bot.get_channel(channel_id)
+        if channel is None:
+            logger.error("Channel %s does not exist", channel_id)
+            return
+        while not bot.is_closed():
+            try:
+                last_message = None
+                prev_message = None
+                idx = 0
+                async for msg in channel.history(limit=2):
+                    if idx == 0:
+                        last_message = msg
+                    elif idx == 1:
+                        prev_message = msg
+                    idx += 1
+
+                respond_to = None
+                send_prompt = False
+                # fmt: off
+                if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+                    age = (
+                        discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    ).total_seconds() / 60
+                    if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
+                        await asyncio.sleep(60)
+                        continue
+                # fmt: on
+
+                if not last_message:
+                    send_prompt = True
+                else:
+                    # fmt: off
+                    idle_minutes = (
+                        discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    ).total_seconds() / 60
+                    # fmt: on
+                    if idle_minutes >= IDLE_TIMEOUT_MINUTES:
+                        send_prompt = True
+                    elif BOT_CHAT_ENABLED:
+                        bots, humans = await self.who_is_active(channel)
+                        if bots and not humans:
+                            age = await self.last_human_message_age(channel)
+                            if age is None or age >= PLAYFUL_REPLY_TIMEOUT_MINUTES:
+                                send_prompt = True
+                                if last_message.author.bot:
+                                    respond_to = last_message
+
+                if send_prompt:
+                    from . import generate_idle_response
+
+                    prompt = await generate_idle_response()
+                    if not prompt:
+                        prompt = random.choice(idle_response_candidates)
+                    async with channel.typing():
+                        await asyncio.sleep(random.uniform(3, 10))
+                        if respond_to is not None:
+                            await channel.send(prompt, reference=respond_to)
+                        else:
+                            await channel.send(prompt)
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                logger.info("monitor_channels cancelled")
+                break
+
+
+__all__ = ["SocialGraphService"]

--- a/src/deepthought/social_graph/utils.py
+++ b/src/deepthought/social_graph/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+SENTIMENT_BACKEND = os.getenv("SENTIMENT_BACKEND", "textblob").lower()
+
+if SENTIMENT_BACKEND == "vader":
+    from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+    _sentiment = SentimentIntensityAnalyzer()
+
+    def analyze_sentiment(text: str) -> float:
+        """Return the compound sentiment score using VADER."""
+        return _sentiment.polarity_scores(text)["compound"]
+
+else:
+    from textblob import TextBlob
+
+    def analyze_sentiment(text: str) -> float:
+        """Return the sentiment polarity using TextBlob."""
+        return TextBlob(text).sentiment.polarity
+
+
+__all__ = ["analyze_sentiment"]

--- a/tests/test_bot_cleanup.py
+++ b/tests/test_bot_cleanup.py
@@ -3,7 +3,8 @@ import asyncio
 import discord
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
+import examples.social_graph_bot as bot_mod
 
 
 class DummyNATS:
@@ -36,7 +37,7 @@ async def test_bot_cleanup_on_cancel(tmp_path, monkeypatch):
     monkeypatch.setattr(discord.Client, "close", dummy_close, raising=False)
     monkeypatch.setattr(discord.Client, "start", dummy_start, raising=False)
 
-    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    bot = bot_mod.SocialGraphBot(monitor_channel_id=1)
     task = asyncio.create_task(bot.start("token"))
     await asyncio.sleep(0)
     task.cancel()

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -3,7 +3,9 @@ import random
 
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
+import examples.social_graph_bot as bot_mod
+from deepthought.social_graph import SocialGraphService
 
 
 class DummyAuthor:
@@ -61,7 +63,7 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch, input_events):
 
     f = asyncio.Future()
     f.set_result((set(), set()))
-    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(SocialGraphService, "who_is_active", lambda self, channel: f)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)
     monkeypatch.setattr(sg, "queue_deep_reflection", noop)
@@ -75,7 +77,7 @@ async def test_bullying_triggers_sarcasm(tmp_path, monkeypatch, input_events):
 
     monkeypatch.setattr(sg, "is_do_not_mock", allow_mock)
 
-    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    bot = bot_mod.SocialGraphBot(monitor_channel_id=1)
     assert bot.intents.members
     assert bot.intents.presences
 
@@ -97,7 +99,7 @@ async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch, input_events):
 
     f = asyncio.Future()
     f.set_result((set(), set()))
-    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(SocialGraphService, "who_is_active", lambda self, channel: f)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)
     monkeypatch.setattr(sg, "queue_deep_reflection", noop)
@@ -111,7 +113,7 @@ async def test_do_not_mock_blocks_sarcasm(tmp_path, monkeypatch, input_events):
 
     monkeypatch.setattr(sg, "is_do_not_mock", prevent_mock)
 
-    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    bot = bot_mod.SocialGraphBot(monitor_channel_id=1)
     assert bot.intents.members
     assert bot.intents.presences
 

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -1,6 +1,7 @@
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
+import examples.social_graph_bot as bot_mod
 from deepthought.services import PersonaManager
 
 

--- a/tests/test_queue_dbmanager.py
+++ b/tests/test_queue_dbmanager.py
@@ -4,7 +4,7 @@ import json
 import aiosqlite
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
 
 
 @pytest.mark.asyncio

--- a/tests/test_user_flags.py
+++ b/tests/test_user_flags.py
@@ -1,7 +1,7 @@
 import aiosqlite
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
 
 
 @pytest.mark.asyncio
@@ -11,7 +11,9 @@ async def test_user_flags_table_and_functions(tmp_path):
     await sg.init_db()
 
     async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
-        async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='user_flags'") as cur:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='user_flags'"
+        ) as cur:
             row = await cur.fetchone()
     assert row is not None, "user_flags table should exist"
 

--- a/tests/unit/modules/test_dbmanager.py
+++ b/tests/unit/modules/test_dbmanager.py
@@ -4,7 +4,7 @@ import os
 import aiosqlite
 import pytest
 
-import examples.social_graph_bot as sg
+import deepthought.social_graph as sg
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_send_to_prism.py
+++ b/tests/unit/test_send_to_prism.py
@@ -4,7 +4,7 @@ import logging
 import aiohttp
 import pytest
 
-import examples.social_graph_bot as sg
+import examples.social_graph_bot as bot_mod
 
 
 class DummySession:
@@ -31,25 +31,25 @@ class TimeoutSession:
 
 @pytest.mark.asyncio
 async def test_send_to_prism_client_error(monkeypatch, caplog):
-    monkeypatch.setattr(sg.aiohttp, "ClientSession", lambda: DummySession())
+    monkeypatch.setattr(bot_mod.aiohttp, "ClientSession", lambda: DummySession())
     with caplog.at_level(logging.WARNING):
-        await sg.send_to_prism({"x": 1})
+        await bot_mod.send_to_prism({"x": 1})
     assert any("ClientError" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_send_to_prism_timeout(monkeypatch, caplog):
-    monkeypatch.setattr(sg.aiohttp, "ClientSession", lambda: TimeoutSession())
+    monkeypatch.setattr(bot_mod.aiohttp, "ClientSession", lambda: TimeoutSession())
     with caplog.at_level(logging.WARNING):
-        await sg.send_to_prism({"x": 1})
+        await bot_mod.send_to_prism({"x": 1})
     assert any("TimeoutError" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_send_to_prism_timeout_message(monkeypatch, caplog):
     """Ensure the timeout warning includes the expected text."""
-    monkeypatch.setattr(sg.aiohttp, "ClientSession", lambda: TimeoutSession())
+    monkeypatch.setattr(bot_mod.aiohttp, "ClientSession", lambda: TimeoutSession())
     with caplog.at_level(logging.WARNING):
-        await sg.send_to_prism({"x": 1})
+        await bot_mod.send_to_prism({"x": 1})
     messages = [rec.getMessage() for rec in caplog.records]
     assert any("TimeoutError sending data to Prism" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- move DB helpers under new social_graph package and expose via `__init__`
- introduce `SocialGraphService` with optional DB manager
- clean up example bot and tests to use the service
- export stubs for example helpers and create `affinity` table
- share global NATS objects between package and example

## Testing
- `black examples/social_graph_bot.py src/deepthought/social_graph/__init__.py`
- `isort examples/social_graph_bot.py src/deepthought/social_graph/__init__.py`
- `flake8 examples/social_graph_bot.py src/deepthought/social_graph/__init__.py`
- `pytest tests/test_bot_cleanup.py::test_bot_cleanup_on_cancel -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e281dce08326934e44b932d7cdb1