### PR TITLE
Fix duplicate affinity table creation

### DIFF
--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -9,10 +9,9 @@ from typing import Awaitable, Callable, List, Optional
 
 from ..eda.events import EventSubjects, ReminderTriggeredPayload
 from ..eda.publisher import Publisher
-from ..motivate.caption import summarise_message
-from examples.social_graph_bot import generate_reflection
-from .file_graph_dal import FileGraphDAL
 from ..graph.dal import GraphDAL
+from ..motivate.caption import summarise_message
+from .file_graph_dal import FileGraphDAL
 
 
 @dataclass
@@ -64,11 +63,7 @@ class SchedulerService:
 
     async def stop(self) -> None:
         self._running = False
-        tasks = [
-            t
-            for t in [self._summary_task, self._daily_summary_task, self._reminder_task]
-            if t
-        ]
+        tasks = [t for t in [self._summary_task, self._daily_summary_task, self._reminder_task] if t]
         for task in tasks:
             task.cancel()
         for task in tasks:
@@ -97,6 +92,8 @@ class SchedulerService:
         )
 
     async def _generate_daily_summary(self) -> None:
+        from examples.social_graph_bot import generate_reflection
+
         facts = self._memory_dal.get_recent_facts(50)
         text = " ".join(facts)
         summary = generate_reflection(text)
@@ -123,4 +120,3 @@ class SchedulerService:
                     use_jetstream=True,
                     timeout=10.0,
                 )
-


### PR DESCRIPTION
## Summary
- tidy imports in `examples/social_graph_bot.py`
- keep just one `CREATE TABLE IF NOT EXISTS affinity` statement
- stub `sentence_transformers` if missing
- avoid DB lookups when idle generator DB isn't initialized
- handle varying return shapes from `who_is_active`
- resolve circular import in scheduler

## Testing
- `pre-commit run --files examples/social_graph_bot.py src/deepthought/services/scheduler.py`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6861f5c0cc9483268e797ff76d7b1e95