### PR TITLE
Add social graph memory

### DIFF
--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -1,8 +1,17 @@
 """Service utilities for DeepThought."""
 
 from .file_graph_dal import FileGraphDAL
-from .memory_service import MemoryService
 from .hierarchical_service import HierarchicalService
+from .memory_service import MemoryService
 from .persona_manager import PersonaManager
+from .social_graph_memory import SocialGraphMemory
+from .user_graph_dal import UserGraphDAL
 
-__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService", "PersonaManager"]
+__all__ = [
+    "FileGraphDAL",
+    "UserGraphDAL",
+    "MemoryService",
+    "HierarchicalService",
+    "SocialGraphMemory",
+    "PersonaManager",
+]

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -1,0 +1,36 @@
+import logging
+from typing import Optional
+
+from textblob import TextBlob
+
+from .user_graph_dal import UserGraphDAL
+
+logger = logging.getLogger(__name__)
+
+
+class SocialGraphMemory:
+    """Record messages and sentiment in a :class:`UserGraphDAL`."""
+
+    def __init__(self, dal: Optional[UserGraphDAL] = None) -> None:
+        self._dal = dal or UserGraphDAL()
+
+    def record_message(
+        self, source: str, text: str, target: Optional[str] = None
+    ) -> None:
+        """Analyze sentiment of ``text`` and store the interaction."""
+        try:
+            score = float(TextBlob(text).sentiment.polarity)
+        except Exception:  # pragma: no cover - TextBlob failure
+            logger.exception("Sentiment analysis failed")
+            score = 0.0
+        self._dal.add_message(source, target, sentiment_score=score)
+
+    # Expose some helper methods from the DAL
+    def get_affinity(self, user_id: str) -> int:
+        return self._dal.get_affinity(user_id)
+
+    def get_friendliness(self, source: str, target: str) -> float:
+        return self._dal.get_friendliness(source, target)
+
+    def get_hostility(self, source: str, target: str) -> float:
+        return self._dal.get_hostility(source, target)

--- a/src/deepthought/services/user_graph_dal.py
+++ b/src/deepthought/services/user_graph_dal.py
@@ -1,0 +1,69 @@
+import json
+import logging
+import os
+from typing import Optional, Tuple
+
+import networkx as nx
+
+from .file_graph_dal import FileGraphDAL
+
+logger = logging.getLogger(__name__)
+
+
+class UserGraphDAL(FileGraphDAL):
+    """File-backed graph tracking interactions between users."""
+
+    def __init__(self, graph_file: str = "user_graph.json") -> None:
+        super().__init__(graph_file)
+
+    def add_message(
+        self,
+        source: str,
+        target: Optional[str] = None,
+        sentiment_score: float | None = None,
+    ) -> None:
+        """Record a message from ``source`` to ``target`` with optional sentiment."""
+        self._graph.add_node(source, affinity=self.get_affinity(source) + 1)
+        if target is not None:
+            self._graph.add_node(target, affinity=self.get_affinity(target))
+            data = self._graph.get_edge_data(source, target, default={})
+            count = data.get("interaction_count", 0) + 1
+            sentiment_sum = data.get("sentiment_sum", 0.0) + float(
+                sentiment_score or 0.0
+            )
+            self._graph.add_edge(
+                source,
+                target,
+                interaction_count=count,
+                sentiment_sum=sentiment_sum,
+            )
+        self._write_graph()
+
+    def get_affinity(self, user_id: str) -> int:
+        """Return how many messages ``user_id`` has sent."""
+        return int(self._graph.nodes.get(user_id, {}).get("affinity", 0))
+
+    def get_relationship(self, source: str, target: str) -> Tuple[int, float]:
+        """Return ``(interaction_count, sentiment_sum)`` for the edge."""
+        data = self._graph.get_edge_data(source, target)
+        if not data:
+            return 0, 0.0
+        return int(data.get("interaction_count", 0)), float(
+            data.get("sentiment_sum", 0.0)
+        )
+
+    def _avg_sentiment(self, source: str, target: str) -> float:
+        count, ssum = self.get_relationship(source, target)
+        if not count:
+            return 0.0
+        return ssum / count
+
+    def get_friendliness(self, source: str, target: str) -> float:
+        """Return the average positive sentiment from ``source`` to ``target``."""
+        avg = self._avg_sentiment(source, target)
+        return max(0.0, avg)
+
+    def get_hostility(self, source: str, target: str) -> float:
+        """Return the average negative sentiment from ``source`` to ``target``."""
+        avg = self._avg_sentiment(source, target)
+        return min(0.0, avg)

--- a/tests/unit/services/test_user_graph_dal.py
+++ b/tests/unit/services/test_user_graph_dal.py
@@ -1,0 +1,23 @@
+from deepthought.services.user_graph_dal import UserGraphDAL
+
+
+def test_add_message_updates_edges(tmp_path):
+    path = tmp_path / "g.json"
+    dal = UserGraphDAL(str(path))
+    dal.add_message("u1", "u2", sentiment_score=0.5)
+    dal.add_message("u1", "u2", sentiment_score=-0.2)
+
+    assert dal.get_affinity("u1") == 2
+    count, ssum = dal.get_relationship("u1", "u2")
+    assert count == 2
+    assert ssum == 0.3
+
+
+def test_friendliness_and_hostility(tmp_path):
+    path = tmp_path / "g.json"
+    dal = UserGraphDAL(str(path))
+    dal.add_message("u1", "u2", sentiment_score=0.5)
+    dal.add_message("u1", "u2", sentiment_score=-1.0)
+
+    assert dal.get_friendliness("u1", "u2") == 0.0
+    assert dal.get_hostility("u1", "u2") < 0


### PR DESCRIPTION
## Summary
- create `UserGraphDAL` for per-user interaction tracking
- expose new social graph classes in service package
- implement `SocialGraphMemory` to record messages with sentiment
- add unit tests for new graph DAL

## Testing
- `isort src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py src/deepthought/services/__init__.py tests/unit/services/test_user_graph_dal.py`
- `black src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py src/deepthought/services/__init__.py tests/unit/services/test_user_graph_dal.py`
- `flake8 src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py src/deepthought/services/__init__.py tests/unit/services/test_user_graph_dal.py`
- `pytest tests/unit/services/test_user_graph_dal.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862891305d48326b767b3a75c86ff32