### PR TITLE
Implement persona-aware prompts

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -8,27 +8,19 @@ import sys
 import types
 import uuid
 from datetime import timedelta, timezone
-from typing import List, Tuple
-
-from deepthought.goal_scheduler import GoalScheduler
-from deepthought.services.file_graph_dal import FileGraphDAL
-from deepthought.graph.connector import GraphConnector
-from deepthought.graph.dal import GraphDAL
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from deepthought.services.scheduler import SchedulerService
-
-
-import aiohttp
-import aiosqlite
+from typing import TYPE_CHECKING, List, Tuple
 
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.graph.connector import GraphConnector
 from deepthought.graph.dal import GraphDAL
 from deepthought.services import PersonaManager
 from deepthought.services.file_graph_dal import FileGraphDAL
-from deepthought.services.scheduler import SchedulerService
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from deepthought.services.scheduler import SchedulerService
+
+import aiohttp
+import aiosqlite
 
 try:
     import discord
@@ -193,15 +185,11 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv(
-            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
-        )
+        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
                 gen_prompt = ", ".join(topics) + ": " + gen_prompt
-
-
 
         generator = _get_idle_generator()
         outputs = await asyncio.to_thread(

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -47,6 +47,11 @@ class Settings(BaseSettings):
     memory_file: str = "memory.json"
     search_db: str | None = None
     reward: RewardThresholds = RewardThresholds()
+    persona_descriptions: dict[str, str] = {
+        "friendly": "You are a friendly assistant who responds warmly.",
+        "playful": "You like to joke around in your answers.",
+        "snarky": "You reply with terse, witty sarcasm.",
+    }
 
     model_config = SettingsConfigDict(env_prefix="DT_", env_nested_delimiter="__")
 

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -2,19 +2,18 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections import deque
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Deque, List, Optional
 
 import nats
 import torch
-from contextlib import contextmanager
 from nats.aio.msg import Msg
 
 from ..config import get_settings
 from ..eda.events import EventSubjects, ResponseGeneratedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
-
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +42,7 @@ class BaseLLM(ABC):
         tokenizer,
         model,
         reward_buffer_size: Optional[int] = None,
+        persona_manager=None,
     ) -> None:
         self._publisher = publisher
         self._subscriber = subscriber
@@ -50,6 +50,8 @@ class BaseLLM(ABC):
         self._model = model
         buffer_size = reward_buffer_size or get_settings().reward.buffer_size
         self._recent_rewards: Deque[float] = deque(maxlen=buffer_size)
+        self._persona_manager = persona_manager
+        self._persona_descriptions = get_settings().persona_descriptions
 
     @abstractmethod
     async def start_listening(self, durable_name: str = "llm_listener") -> bool:
@@ -59,14 +61,17 @@ class BaseLLM(ABC):
     async def stop_listening(self) -> None:
         """Stop consuming events."""
 
-    def _build_prompt(self, facts: List[str]) -> str:
-        """Assemble a prompt from retrieved facts and recent rewards."""
+    def _build_prompt(self, facts: List[str], persona_desc: str | None = None) -> str:
+        """Assemble a prompt from persona, retrieved facts and rewards."""
         reward_part = ""
         if self._recent_rewards:
             avg = sum(self._recent_rewards) / len(self._recent_rewards)
             reward_part = f"[avg_reward: {avg:.2f}]\n"
         base = "\n".join(facts) + "\nResponse:" if facts else "Response:"
-        return reward_part + base
+        prompt = reward_part + base
+        if persona_desc:
+            prompt = persona_desc.strip() + "\n" + prompt
+        return prompt
 
     async def _handle_memory_event(self, msg: Msg) -> None:
         """Common handler for MEMORY_RETRIEVED events."""
@@ -97,7 +102,14 @@ class BaseLLM(ABC):
 
             logger.info("%s received memory event ID %s", self.__class__.__name__, input_id)
 
-            prompt = self._build_prompt([str(f) for f in facts])
+            persona_desc = ""
+            if self._persona_manager is not None:
+                try:
+                    persona_desc = await self._persona_manager.get_description(int(input_id))
+                except Exception:
+                    logger.error("Persona selection failed", exc_info=True)
+
+            prompt = self._build_prompt([str(f) for f in facts], persona_desc)
             inputs = self._tokenizer(prompt, return_tensors="pt")
             with _safe_no_grad():
                 outputs = self._model.generate(

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -23,6 +23,7 @@ class BasicLLM(BaseLLM):
         nats_client: Optional[NATS] = None,
         js_context: Optional[JetStreamContext] = None,
         model_name: Optional[str] = None,
+        persona_manager=None,
     ) -> None:
         model_name = model_name or get_settings().model_path
         if nats_client is not None and js_context is not None:
@@ -33,7 +34,7 @@ class BasicLLM(BaseLLM):
             subscriber = None
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model = AutoModelForCausalLM.from_pretrained(model_name)
-        super().__init__(publisher, subscriber, tokenizer, model)
+        super().__init__(publisher, subscriber, tokenizer, model, persona_manager=persona_manager)
         logger.info("BasicLLM initialized with model %s", model_name)
 
     async def start_listening(self, durable_name: str = "llm_basic_listener") -> bool:

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -26,6 +26,7 @@ class ProductionLLM(BaseLLM):
         js_context: JetStreamContext,
         model_name: Optional[str] = None,
         adapter_dir: str = "./results/lora-adapter",
+        persona_manager=None,
     ) -> None:
         model_name = model_name or get_settings().model_path
         publisher = Publisher(nats_client, js_context)
@@ -42,7 +43,7 @@ class ProductionLLM(BaseLLM):
                 adapter_dir,
             )
             model = base_model
-        super().__init__(publisher, subscriber, tokenizer, model)
+        super().__init__(publisher, subscriber, tokenizer, model, persona_manager=persona_manager)
         logger.info("ProductionLLM initialized with model %s", model_name)
 
     async def start_listening(self, durable_name: str = "llm_prod_listener") -> bool:

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -28,12 +28,15 @@ class LLMStub:
         nats_client: NATS,
         js_context: JetStreamContext,
         reward_buffer_size: Optional[int] = None,
+        persona_manager=None,
     ):
         """Initialize with shared NATS client and JetStream context."""
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         buffer_size = reward_buffer_size or get_settings().reward.buffer_size
         self._recent_rewards: Deque[float] = deque(maxlen=buffer_size)
+        self._persona_manager = persona_manager
+        self._persona_descriptions = get_settings().persona_descriptions
         logger.info("LLMStub initialized (JetStream enabled).")
 
     async def _handle_memory_event(self, msg: Msg) -> None:
@@ -43,9 +46,7 @@ class LLMStub:
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
-                raise ValueError(
-                    f"Unexpected MemoryRetrieved payload format: {type(data)}"
-                )
+                raise ValueError(f"Unexpected MemoryRetrieved payload format: {type(data)}")
             input_id = data.get("input_id")
             retrieved = data.get("retrieved_knowledge")
             if not isinstance(input_id, str) or retrieved is None:
@@ -55,9 +56,7 @@ class LLMStub:
             elif isinstance(retrieved, dict):
                 knowledge = retrieved
             else:
-                logger.error(
-                    "retrieved_knowledge is not a dict for input_id %s", input_id
-                )
+                logger.error("retrieved_knowledge is not a dict for input_id %s", input_id)
                 if hasattr(msg, "nak") and callable(msg.nak):
                     try:
                         await msg.nak()
@@ -72,9 +71,7 @@ class LLMStub:
 
             facts = knowledge.get("facts")
             if not isinstance(facts, list):
-                logger.error(
-                    "retrieved_knowledge missing facts list for input_id %s", input_id
-                )
+                logger.error("retrieved_knowledge missing facts list for input_id %s", input_id)
                 if hasattr(msg, "nak") and callable(msg.nak):
                     try:
                         await msg.nak()
@@ -92,8 +89,17 @@ class LLMStub:
             await asyncio.sleep(0.5)  # Simulate work
 
             facts_str = ", ".join(map(str, facts))
+            persona_desc = ""
+            if self._persona_manager is not None:
+                try:
+                    persona_desc = await self._persona_manager.get_description(int(input_id))
+                except Exception:
+                    logger.error("Persona selection failed", exc_info=True)
             # Use timezone-aware UTC timestamps
-            response = f"Based on: {facts_str}, this is a stub response. [TS: {datetime.now(timezone.utc).isoformat()}]"
+            intro = persona_desc + "\n" if persona_desc else ""
+            response = (
+                f"{intro}Based on: {facts_str}, this is a stub response. [TS: {datetime.now(timezone.utc).isoformat()}]"
+            )
             payload = ResponseGeneratedPayload(
                 final_response=response,
                 input_id=input_id,
@@ -101,9 +107,7 @@ class LLMStub:
                 confidence=0.95,
             )
 
-            logger.info(
-                f"LLMStub: Publishing RESPONSE_GENERATED for input_id: {input_id}"
-            )
+            logger.info(f"LLMStub: Publishing RESPONSE_GENERATED for input_id: {input_id}")
             try:
                 await self._publisher.publish(
                     EventSubjects.RESPONSE_GENERATED,
@@ -111,9 +115,7 @@ class LLMStub:
                     use_jetstream=True,
                     timeout=10.0,
                 )
-                logger.debug(
-                    f"LLMStub: Successfully published RESPONSE_GENERATED for {input_id}"
-                )
+                logger.debug(f"LLMStub: Successfully published RESPONSE_GENERATED for {input_id}")
                 await msg.ack()
                 logger.debug(f"LLMStub: Acked message for {input_id} in LLMStub")
             except nats.errors.TimeoutError as e:
@@ -191,9 +193,7 @@ class LLMStub:
                 use_jetstream=True,
                 durable=f"{durable_name}_reward",
             )
-            logger.info(
-                f"LLMStub successfully subscribed to {EventSubjects.MEMORY_RETRIEVED}."
-            )
+            logger.info(f"LLMStub successfully subscribed to {EventSubjects.MEMORY_RETRIEVED}.")
             return True
         except nats.errors.Error as e:
             logger.error(f"LLMStub failed to subscribe: {e}", exc_info=True)

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -8,10 +8,17 @@ from examples import social_graph_bot as sg
 class PersonaManager:
     """Select prompts based on user affinity."""
 
-    def __init__(self, db_manager: sg.DBManager, friendly: int = 5, playful: int = 2) -> None:
+    def __init__(
+        self,
+        db_manager: sg.DBManager,
+        friendly: int = 5,
+        playful: int = 2,
+        descriptions: dict[str, str] | None = None,
+    ) -> None:
         self._db = db_manager
         self._friendly = friendly
         self._playful = playful
+        self._descriptions = descriptions or {}
 
     async def get_persona(self, user_id: int) -> str:
         affinity = await self._db.get_affinity(user_id)
@@ -27,3 +34,8 @@ class PersonaManager:
         if not options:
             return ""
         return random.choice(options)
+
+    async def get_description(self, user_id: int) -> str:
+        """Return a persona description for ``user_id`` if available."""
+        persona = await self.get_persona(user_id)
+        return self._descriptions.get(persona, "")

--- a/tests/unit/modules/test_llm_base.py
+++ b/tests/unit/modules/test_llm_base.py
@@ -54,6 +54,12 @@ def test_build_prompt_with_rewards(monkeypatch: pytest.MonkeyPatch):
     assert prompt == "[avg_reward: 1.50]\nfact1\nfact2\nResponse:"
 
 
+def test_build_prompt_with_persona(monkeypatch: pytest.MonkeyPatch):
+    llm = create_llm(monkeypatch)
+    prompt = llm._build_prompt(["fact"], persona_desc="Be nice")
+    assert prompt.startswith("Be nice")
+
+
 @pytest.mark.asyncio
 async def test_handle_reward_event_appends_and_acks(monkeypatch: pytest.MonkeyPatch):
     llm = create_llm(monkeypatch)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,8 +6,8 @@ import yaml
 from deepthought.config import (
     BotEnv,
     get_settings,
-    load_settings,
     load_bot_env,
+    load_settings,
 )
 
 
@@ -96,6 +96,14 @@ def test_yaml_file_load(tmp_path):
     assert settings.reward.novelty_weight == 0.9
     assert settings.reward.social_weight == 0.8
     assert settings.reward.buffer_size == 25
+
+
+def test_persona_descriptions_file(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"persona_descriptions": {"friendly": "hello"}}))
+
+    settings = load_settings(str(cfg))
+    assert settings.persona_descriptions["friendly"] == "hello"
 
 
 def test_get_settings_reload(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- extend configuration with `persona_descriptions`
- allow `PersonaManager` to return descriptions
- inject persona info into LLM modules when building prompts
- adjust stub and production LLMs to accept a persona manager
- update example bot imports
- test persona prompt building and config parsing

## Testing
- `pre-commit run --files examples/social_graph_bot.py src/deepthought/config.py src/deepthought/services/persona_manager.py src/deepthought/modules/llm_base.py src/deepthought/modules/llm_basic.py src/deepthought/modules/llm_prod.py src/deepthought/modules/llm_stub.py tests/unit/modules/test_llm_base.py tests/unit/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6862890c781083269fe0748ce8ec97a6