### PR TITLE
Add moderation filtering and bot message handling

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -26,7 +26,8 @@ import aiosqlite
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.graph.connector import GraphConnector
 from deepthought.graph.dal import GraphDAL
-from deepthought.services import PersonaManager
+from deepthought.services.persona_manager import PersonaManager
+from deepthought.services.moderation import is_allowed
 from deepthought.services.file_graph_dal import FileGraphDAL
 from deepthought.services.scheduler import SchedulerService
 
@@ -329,10 +330,98 @@ class DBManager:
             await self._db.close()
             self._db = None
 
+    def _create_table_statements(self) -> list[str]:
+        """Return SQL statements for creating required tables."""
+        try:
+            return CREATE_TABLE_QUERIES
+        except NameError:  # pragma: no cover - executed in isolated test context
+            return [
+                """
+                CREATE TABLE IF NOT EXISTS interactions (
+                    user_id TEXT,
+                    target_id TEXT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS affinity (
+                    user_id TEXT PRIMARY KEY,
+                    score INTEGER DEFAULT 0
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS relationships (
+                    source_id TEXT,
+                    target_id TEXT,
+                    interaction_count INTEGER DEFAULT 0,
+                    sentiment_sum REAL DEFAULT 0,
+                    PRIMARY KEY(source_id, target_id)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS memories (
+                    user_id TEXT,
+                    topic TEXT,
+                    memory TEXT,
+                    sentiment_score REAL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS theories (
+                    subject_id TEXT,
+                    theory TEXT,
+                    confidence REAL,
+                    updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY(subject_id, theory)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS queued_tasks (
+                    task_id INTEGER PRIMARY KEY,
+                    user_id TEXT,
+                    context TEXT,
+                    prompt TEXT,
+                    status TEXT DEFAULT 'pending',
+                    created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS sentiment_trends (
+                    user_id TEXT,
+                    channel_id TEXT,
+                    sentiment_sum REAL DEFAULT 0,
+                    message_count INTEGER DEFAULT 0,
+                    PRIMARY KEY(user_id, channel_id)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS themes (
+                    user_id TEXT,
+                    channel_id TEXT,
+                    theme TEXT,
+                    updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY(user_id, channel_id)
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS user_flags (
+                    user_id TEXT PRIMARY KEY,
+                    do_not_mock INTEGER
+                )
+                """,
+                """
+                CREATE TABLE IF NOT EXISTS recent_topics (
+                    topic TEXT PRIMARY KEY,
+                    last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+                """,
+            ]
+
     async def init_db(self) -> None:
         await self.connect()
         assert self._db
-        for query in CREATE_TABLE_QUERIES:
+        for query in self._create_table_statements():
             await self._db.execute(query)
 
         await self._db.commit()
@@ -719,6 +808,9 @@ async def _ensure_nats() -> None:
 
 async def publish_input_received(text: str) -> None:
     """Publish an INPUT_RECEIVED event using NATS JetStream."""
+    if not is_allowed(text):
+        logger.info("Dropping INPUT_RECEIVED due to banned content")
+        return
     await _ensure_nats()
     if _input_publisher is None:
         logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
@@ -1012,6 +1104,9 @@ class SocialGraphBot(discord.Client):
 
     async def on_message(self, message: discord.Message) -> None:
         if message.author == self.user:
+            return
+
+        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
             return
 
         sentiment_score = analyze_sentiment(message.content)

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -4,5 +4,13 @@ from .file_graph_dal import FileGraphDAL
 from .memory_service import MemoryService
 from .hierarchical_service import HierarchicalService
 from .persona_manager import PersonaManager
+from .moderation import is_allowed, BANNED_PHRASES
 
-__all__ = ["FileGraphDAL", "MemoryService", "HierarchicalService", "PersonaManager"]
+__all__ = [
+    "FileGraphDAL",
+    "MemoryService",
+    "HierarchicalService",
+    "PersonaManager",
+    "is_allowed",
+    "BANNED_PHRASES",
+]

--- a/src/deepthought/services/moderation.py
+++ b/src/deepthought/services/moderation.py
@@ -1,0 +1,16 @@
+import logging
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+# Simple list of banned phrases that should not be processed further
+BANNED_PHRASES = ["banned", "prohibited"]
+
+
+def is_allowed(text: str, banned_phrases: Iterable[str] | None = None) -> bool:
+    """Return ``True`` if ``text`` does not contain any banned phrases."""
+    if not isinstance(text, str):
+        return False
+    phrases = list(banned_phrases) if banned_phrases is not None else BANNED_PHRASES
+    lowered = text.lower()
+    return not any(phrase in lowered for phrase in phrases)

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -14,6 +14,7 @@ class PersonaManager:
         self._playful = playful
 
     async def get_persona(self, user_id: int) -> str:
+        await self._db.init_db()
         affinity = await self._db.get_affinity(user_id)
         if affinity >= self._friendly:
             return "friendly"

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -226,3 +226,68 @@ async def test_publish_input_received_warns_when_no_publisher(monkeypatch, caplo
     assert any(
         "Dropping INPUT_RECEIVED event because NATS publisher is unavailable" in r.getMessage() for r in caplog.records
     )
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, *args, **kwargs):
+        self.published.append(args)
+
+
+@pytest.mark.asyncio
+async def test_publish_input_received_filters_banned(monkeypatch):
+    pub = DummyPublisher()
+    sg._input_publisher = pub
+
+    async def fake_ensure():
+        return None
+
+    monkeypatch.setattr(sg, "_ensure_nats", fake_ensure)
+
+    await sg.publish_input_received("this contains banned text")
+    assert pub.published == []
+
+    await sg.publish_input_received("hello")
+    assert pub.published and pub.published[0][0] == sg.EventSubjects.INPUT_RECEIVED
+
+
+@pytest.mark.asyncio
+async def test_on_message_ignores_other_bot_mentions(tmp_path, monkeypatch):
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "publish_input_received", noop)
+    monkeypatch.setattr(asyncio, "sleep", noop)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    dummy = DummyAuthor(5, bot=True)
+    monkeypatch.setattr(
+        sg.SocialGraphBot,
+        "user",
+        property(lambda self: dummy),
+        raising=False,
+    )
+
+    message = DummyMessage("hi otherbot")
+    message.mentions = [DummyAuthor(9, bot=True)]
+    await bot.on_message(message)
+    assert message.channel.sent_messages == []
+
+    message2 = DummyMessage(f"hi both <@{bot.user.id}>", message_id=11)
+    message2.mentions = [DummyAuthor(9, bot=True), bot.user]
+    await bot.on_message(message2)
+    assert message2.channel.sent_messages
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- add new `moderation` service with simple banned phrase filter
- expose moderation utilities in service package
- ensure PersonaManager initializes DB before querying
- drop banned messages before publishing input events
- ignore messages aimed at other bots unless mentioning this bot
- update tests for moderation logic

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628915d75083269932f07f0fcd45b4