### PR TITLE
Add summary goal processing

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -10,14 +10,10 @@ import uuid
 from datetime import timedelta, timezone
 from typing import List, Tuple
 
-from deepthought.goal_scheduler import GoalScheduler
-from deepthought.services.file_graph_dal import FileGraphDAL
-from deepthought.graph.connector import GraphConnector
-from deepthought.graph.dal import GraphDAL
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from deepthought.services.scheduler import SchedulerService
+    from deepthought.services.scheduler import SchedulerService as _SchedulerService
 
 
 import aiohttp
@@ -226,92 +222,101 @@ MAX_MEMORY_LENGTH = 1000
 MAX_THEORY_LENGTH = 256
 MAX_PROMPT_LENGTH = 2000
 
-CREATE_TABLE_QUERIES = [
-    """
-    CREATE TABLE IF NOT EXISTS interactions (
-        user_id TEXT,
-        target_id TEXT,
-        timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS affinity (
-        user_id TEXT PRIMARY KEY,
-        score INTEGER DEFAULT 0
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS relationships (
-        source_id TEXT,
-        target_id TEXT,
-        interaction_count INTEGER DEFAULT 0,
-        sentiment_sum REAL DEFAULT 0,
-        PRIMARY KEY(source_id, target_id)
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS memories (
-        user_id TEXT,
-        topic TEXT,
-        memory TEXT,
-        sentiment_score REAL,
-        timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS theories (
-        subject_id TEXT,
-        theory TEXT,
-        confidence REAL,
-        updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY(subject_id, theory)
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS queued_tasks (
-        task_id INTEGER PRIMARY KEY,
-        user_id TEXT,
-        context TEXT,
-        prompt TEXT,
-        status TEXT DEFAULT 'pending',
-        created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS sentiment_trends (
-        user_id TEXT,
-        channel_id TEXT,
-        sentiment_sum REAL DEFAULT 0,
-        message_count INTEGER DEFAULT 0,
-        PRIMARY KEY(user_id, channel_id)
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS themes (
-        user_id TEXT,
-        channel_id TEXT,
-        theme TEXT,
-        updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-        PRIMARY KEY(user_id, channel_id)
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS user_flags (
-        user_id TEXT PRIMARY KEY,
-        do_not_mock INTEGER
-    )
-    """,
-    """
-    CREATE TABLE IF NOT EXISTS recent_topics (
-        topic TEXT PRIMARY KEY,
-        last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-    )
-    """,
-]
-
-
 class DBManager:
     """Lightweight wrapper managing a single aiosqlite connection."""
+
+    CREATE_TABLE_QUERIES = [
+        """
+        CREATE TABLE IF NOT EXISTS interactions (
+            user_id TEXT,
+            target_id TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS affinity (
+            user_id TEXT PRIMARY KEY,
+            score INTEGER DEFAULT 0
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS relationships (
+            source_id TEXT,
+            target_id TEXT,
+            interaction_count INTEGER DEFAULT 0,
+            sentiment_sum REAL DEFAULT 0,
+            PRIMARY KEY(source_id, target_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS memories (
+            user_id TEXT,
+            topic TEXT,
+            memory TEXT,
+            sentiment_score REAL,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS theories (
+            subject_id TEXT,
+            theory TEXT,
+            confidence REAL,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(subject_id, theory)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS queued_tasks (
+            task_id INTEGER PRIMARY KEY,
+            user_id TEXT,
+            context TEXT,
+            prompt TEXT,
+            status TEXT DEFAULT 'pending',
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS summary_goals (
+            task_id INTEGER PRIMARY KEY,
+            user_id TEXT,
+            context TEXT,
+            prompt TEXT,
+            status TEXT DEFAULT 'pending',
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS sentiment_trends (
+            user_id TEXT,
+            channel_id TEXT,
+            sentiment_sum REAL DEFAULT 0,
+            message_count INTEGER DEFAULT 0,
+            PRIMARY KEY(user_id, channel_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS themes (
+            user_id TEXT,
+            channel_id TEXT,
+            theme TEXT,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(user_id, channel_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS user_flags (
+            user_id TEXT PRIMARY KEY,
+            do_not_mock INTEGER
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS recent_topics (
+            topic TEXT PRIMARY KEY,
+            last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+    ]
 
     def __init__(self, db_path: str = DB_PATH) -> None:
         self.db_path = db_path
@@ -332,7 +337,7 @@ class DBManager:
     async def init_db(self) -> None:
         await self.connect()
         assert self._db
-        for query in CREATE_TABLE_QUERIES:
+        for query in self.CREATE_TABLE_QUERIES:
             await self._db.execute(query)
 
         await self._db.commit()
@@ -523,6 +528,45 @@ class DBManager:
         assert self._db
         await self._db.execute(
             "UPDATE queued_tasks SET status='done' WHERE task_id=?",
+            (task_id,),
+        )
+        await self._db.commit()
+
+    async def add_summary_goal(self, user_id: int, context: dict, prompt: str) -> int:
+        """Store a generated summary and goal using the queued task schema."""
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("prompt must be a non-empty string")
+        if not isinstance(context, dict):
+            raise ValueError("context must be a dictionary")
+        try:
+            context_json = json.dumps(context)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("context is not JSON serializable") from exc
+
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute(
+            "INSERT INTO summary_goals (user_id, context, prompt) VALUES (?, ?, ?)",
+            (str(user_id), context_json, prompt),
+        )
+        await self._db.commit()
+        return cur.lastrowid
+
+    async def list_pending_summary_goals(self):
+        """Return pending summary/goal tasks."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT task_id, user_id, context, prompt FROM summary_goals WHERE status='pending'"
+        ) as cur:
+            return await cur.fetchall()
+
+    async def mark_summary_goal_done(self, task_id: int) -> None:
+        """Mark a stored summary goal as completed."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "UPDATE summary_goals SET status='done' WHERE task_id=?",
             (task_id,),
         )
         await self._db.commit()
@@ -768,6 +812,19 @@ async def queue_deep_reflection(user_id: int, context: dict, prompt: str) -> int
     return await db_manager.queue_deep_reflection(user_id, context, prompt)
 
 
+async def add_summary_goal(user_id: int, context: dict, prompt: str) -> int:
+    """Add a generated summary and goal entry."""
+    return await db_manager.add_summary_goal(user_id, context, prompt)
+
+
+async def list_pending_summary_goals():
+    return await db_manager.list_pending_summary_goals()
+
+
+async def mark_summary_goal_done(task_id: int) -> None:
+    await db_manager.mark_summary_goal_done(task_id)
+
+
 async def set_do_not_mock(user_id: int, flag: bool = True) -> None:
     await db_manager.set_do_not_mock(user_id, flag)
 
@@ -997,10 +1054,12 @@ class SocialGraphBot(discord.Client):
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler()
         self.scheduler_service: SchedulerService | None = None
+        self.persona_manager = PersonaManager(db_manager)
 
     async def setup_hook(self) -> None:
         await db_manager.connect()
         await init_db()
+        self.persona_manager = PersonaManager(db_manager)
 
         self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
@@ -1048,7 +1107,7 @@ class SocialGraphBot(discord.Client):
                 async for recent in message.channel.history(limit=1):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
-            persona = await persona_manager.get_persona(message.author.id)
+            persona = await self.persona_manager.get_persona(message.author.id)
             reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             await message.channel.send(reply)
 

--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, List, Optional
@@ -33,6 +34,8 @@ class SchedulerService:
         graph_dal: GraphDAL,
         summary_interval: float = 60.0,
         daily_summary_interval: float = 24 * 60 * 60.0,
+        chat_summary_interval: float = 300.0,
+        summary_db=None,
         now_func: Callable[[], datetime] | None = None,
         sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
@@ -43,11 +46,15 @@ class SchedulerService:
         self._daily_summary_interval = daily_summary_interval
         self._now = now_func or (lambda: datetime.now(timezone.utc))
         self._sleep = sleep_func
+        self._summary_db = summary_db
+        self._chat_summary_interval = chat_summary_interval
         self._reminders: List[ScheduledReminder] = []
         self._running = False
         self._summary_task: Optional[asyncio.Task] = None
         self._reminder_task: Optional[asyncio.Task] = None
         self._daily_summary_task: Optional[asyncio.Task] = None
+        self._chat_summary_task: Optional[asyncio.Task] = None
+        self._goal_task: Optional[asyncio.Task] = None
 
     def schedule_reminder(self, message: str, when: datetime, reminder_id: str) -> None:
         """Schedule a reminder message for the future."""
@@ -59,11 +66,23 @@ class SchedulerService:
         self._summary_task = asyncio.create_task(self._summary_loop())
         self._daily_summary_task = asyncio.create_task(self._daily_summary_loop())
         self._reminder_task = asyncio.create_task(self._reminder_loop())
+        self._chat_summary_task = asyncio.create_task(self._chat_summary_loop())
+        self._goal_task = asyncio.create_task(self._goal_loop())
         return True
 
     async def stop(self) -> None:
         self._running = False
-        tasks = [t for t in [self._summary_task, self._daily_summary_task, self._reminder_task] if t]
+        tasks = [
+            t
+            for t in [
+                self._summary_task,
+                self._daily_summary_task,
+                self._reminder_task,
+                self._chat_summary_task,
+                self._goal_task,
+            ]
+            if t
+        ]
         for task in tasks:
             task.cancel()
         for task in tasks:
@@ -103,6 +122,21 @@ class SchedulerService:
             {"text": summary, "timestamp": self._now().isoformat()},
         )
 
+    async def _generate_chat_summary(self) -> None:
+        facts = self._memory_dal.get_recent_facts(20)
+        text = " ".join(facts)
+        summary = summarise_message(text, max_words=20)
+        self._graph_dal.add_entity(
+            "ChatSummary",
+            {"text": summary, "timestamp": self._now().isoformat()},
+        )
+        if self._summary_db is not None:
+            goal = {
+                "due": (self._now() + timedelta(seconds=60)).isoformat(),
+                "goal": f"Reflect on: {summary}",
+            }
+            await self._summary_db.add_summary_goal(0, goal, summary)
+
     async def _reminder_loop(self) -> None:
         while self._running:
             await self._sleep(1.0)
@@ -121,3 +155,44 @@ class SchedulerService:
                     use_jetstream=True,
                     timeout=10.0,
                 )
+
+    async def _chat_summary_loop(self) -> None:
+        while self._running:
+            await self._sleep(self._chat_summary_interval)
+            await self._generate_chat_summary()
+
+    async def _goal_loop(self) -> None:
+        if self._summary_db is None:
+            while self._running:
+                await self._sleep(1.0)
+            return
+        while self._running:
+            await self._sleep(1.0)
+            rows = await self._summary_db.list_pending_summary_goals()
+            now = self._now()
+            for task_id, _uid, ctx_json, prompt in rows:
+                try:
+                    ctx = json.loads(ctx_json)
+                except Exception:
+                    continue
+                due = ctx.get("due")
+                message = ctx.get("goal")
+                if not due or not message:
+                    continue
+                try:
+                    due_dt = datetime.fromisoformat(due)
+                except ValueError:
+                    continue
+                if due_dt <= now:
+                    payload = ReminderTriggeredPayload(
+                        message=message,
+                        reminder_id=str(task_id),
+                        timestamp=now.isoformat(),
+                    )
+                    await self._publisher.publish(
+                        EventSubjects.REMINDER_TRIGGERED,
+                        payload,
+                        use_jetstream=True,
+                        timeout=10.0,
+                    )
+                    await self._summary_db.mark_summary_goal_done(task_id)


### PR DESCRIPTION
## Summary
- extend SchedulerService to support chat summaries and goal reminders
- track summary goals in DB and expose helper methods
- migrate example DB schema for summary goals
- refresh PersonaManager when DB path changes

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68628913e65c8326812812979ea95d17