### PR TITLE
Handle optional test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ Tests are implemented using the `pytest` framework. To run the tests:
     ```
     The pinned versions in this file match the CI environment.
     (Use `requirements.txt` instead if you plan to run the full application.)
+
+    A few tests cover optional integrations. They are skipped unless the
+    corresponding packages are installed. Install them if you wish to run the
+    entire suite:
+    ```bash
+    pip install chromadb pymemgraph deepthought-motivate
+    ```
 4.  Run pytest with the project root added to `PYTHONPATH` so the `src` modules
     are discoverable:
     ```bash

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Test Suite
+
+The automated tests rely on the packages listed in `requirements-ci.txt`. You can install them with:
+
+```bash
+pip install -r requirements-ci.txt
+```
+
+A few integration tests require additional optional dependencies. These tests are skipped automatically when the packages are missing:
+
+- `chromadb` for `test_chroma_service.py` (requires a running Chroma service)
+- `pymemgraph` for `test_memgraph_service.py` (requires a Memgraph instance)
+- `deepthought.motivate` for `test_motivation.py` and `test_reward_manager.py`
+
+Install these extras if you want to run the entire suite:
+
+```bash
+pip install chromadb pymemgraph deepthought-motivate
+```

--- a/tests/test_chroma_service.py
+++ b/tests/test_chroma_service.py
@@ -4,17 +4,13 @@ import pytest
 
 from tests.helpers import chroma_available
 
-try:
-    import chromadb
-except Exception:  # pragma: no cover - optional dependency
-    chromadb = None
+# Skip the test entirely when the optional chromadb package is missing
+chromadb = pytest.importorskip("chromadb")
 
 pytestmark = pytest.mark.chroma
 
 
 def test_chroma_running():
-    if chromadb is None:
-        pytest.skip("chromadb not installed")
     if not chroma_available():
         pytest.skip("Chroma service not available")
     client = chromadb.HttpClient(host=os.getenv("CHROMA_HOST", "localhost"), port=int(os.getenv("CHROMA_PORT", 8000)))

--- a/tests/test_memgraph_service.py
+++ b/tests/test_memgraph_service.py
@@ -4,17 +4,14 @@ import pytest
 
 from tests.helpers import memgraph_available
 
-try:
-    from pymemgraph import Memgraph
-except Exception:  # pragma: no cover - optional dependency
-    Memgraph = None
+# Skip this test when ``pymemgraph`` is not installed
+pymemgraph = pytest.importorskip("pymemgraph")
+Memgraph = pymemgraph.Memgraph
 
 pytestmark = pytest.mark.memgraph
 
 
 def test_memgraph_running():
-    if Memgraph is None:
-        pytest.skip("pymemgraph not installed")
     if not memgraph_available():
         pytest.skip("Memgraph not available")
     mg = Memgraph(

--- a/tests/unit/test_motivation.py
+++ b/tests/unit/test_motivation.py
@@ -1,3 +1,6 @@
+import pytest
+
+pytest.importorskip("deepthought.motivate")
 from deepthought.motivate.caption import summarise_message
 from deepthought.motivate.scorer import score_caption
 

--- a/tests/unit/test_reward_manager.py
+++ b/tests/unit/test_reward_manager.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from deepthought.motivate import reward_manager as rm_mod
+rm_mod = pytest.importorskip("deepthought.motivate.reward_manager")
 
 
 class DummySubscriber:
@@ -50,9 +50,7 @@ class DummyMsg:
 @pytest.mark.asyncio
 async def test_start_listening_subscribes():
     sub = DummySubscriber()
-    mgr = rm_mod.RewardManager(
-        sub, DummyLedger(), DummyPublisher(), "tok", model=DummyModel()
-    )
+    mgr = rm_mod.RewardManager(sub, DummyLedger(), DummyPublisher(), "tok", model=DummyModel())
     result = await mgr.start_listening()
     assert result is True
     assert sub.calls
@@ -86,9 +84,7 @@ async def test_handle_chat_event_publishes(monkeypatch):
 @pytest.mark.asyncio
 async def test_score_social_returns_zero_on_exception(monkeypatch):
     """_score_social should return 0 when the HTTP request fails."""
-    mgr = rm_mod.RewardManager(
-        DummySubscriber(), DummyLedger(), DummyPublisher(), "tok", model=DummyModel()
-    )
+    mgr = rm_mod.RewardManager(DummySubscriber(), DummyLedger(), DummyPublisher(), "tok", model=DummyModel())
 
     class DummySession:
         async def __aenter__(self):
@@ -109,9 +105,7 @@ async def test_score_social_returns_zero_on_exception(monkeypatch):
 @pytest.mark.asyncio
 async def test_score_social_returns_zero_on_500(monkeypatch):
     """_score_social should return 0 when the HTTP status is not 200."""
-    mgr = rm_mod.RewardManager(
-        DummySubscriber(), DummyLedger(), DummyPublisher(), "tok", model=DummyModel()
-    )
+    mgr = rm_mod.RewardManager(DummySubscriber(), DummyLedger(), DummyPublisher(), "tok", model=DummyModel())
 
     class DummyResp:
         def __init__(self, status):
@@ -139,9 +133,7 @@ async def test_score_social_returns_zero_on_500(monkeypatch):
         def get(self, *args, **kwargs):
             return self.resp
 
-    monkeypatch.setattr(
-        rm_mod.aiohttp, "ClientSession", lambda: DummySession(DummyResp(500))
-    )
+    monkeypatch.setattr(rm_mod.aiohttp, "ClientSession", lambda: DummySession(DummyResp(500)))
 
     result = await mgr._score_social(1, 2)
     assert result == 0


### PR DESCRIPTION
## Summary
- use `pytest.importorskip` in tests that rely on optional packages
- document optional test requirements
- describe optional packages in the main README

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_motivation.py tests/unit/test_reward_manager.py tests/test_chroma_service.py tests/test_memgraph_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6862890490448326ba8775ba35cd283f