### PR TITLE
Fix PersonaSelector no match handling

### DIFF
--- a/src/deepthought/persona.py
+++ b/src/deepthought/persona.py
@@ -15,10 +15,10 @@ class PersonaSelector:
         """Return the persona with the most keyword matches."""
         text_low = text.lower()
         best = None
-        best_count = -1
+        best_count = 0
         for name, keywords in self._personas.items():
             count = sum(text_low.count(kw.lower()) for kw in keywords)
             if count > best_count:
                 best = name
                 best_count = count
-        return best
+        return best if best_count > 0 else None

--- a/tests/unit/test_persona_goal_affinity.py
+++ b/tests/unit/test_persona_goal_affinity.py
@@ -9,6 +9,7 @@ def test_persona_selection():
     selector = PersonaSelector({"friendly": ["hello", "hi"], "formal": ["dear", "regards"]})
     assert selector.choose("hello there") == "friendly"
     assert selector.choose("Dear sir, regards") == "formal"
+    assert selector.choose("no keywords here") is None
 
 
 def test_affinity_updates():


### PR DESCRIPTION
## Summary
- improve persona selection logic
- test no-match behavior for PersonaSelector

## Testing
- `python -m flake8 src/deepthought/persona.py tests/unit/test_persona_goal_affinity.py`
- `pytest tests/unit/test_persona_goal_affinity.py::test_persona_selection -q`
- `pytest tests/unit/test_persona_goal_affinity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686289042ce88326b0283508d630f9b4