### PR TITLE
Validate identifiers in GraphDAL.get_entity

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -14,6 +14,7 @@ from deepthought.goal_scheduler import GoalScheduler
 from deepthought.graph.connector import GraphConnector
 from deepthought.graph.dal import GraphDAL
 from deepthought.services.file_graph_dal import FileGraphDAL
+from deepthought.services.scheduler import SchedulerService
 
 
 
@@ -21,6 +22,7 @@ import aiohttp
 import aiosqlite
 
 from deepthought.services import PersonaManager
+from deepthought.services.moderation import is_allowed
 
 
 try:

--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -68,6 +68,8 @@ class GraphDAL:
 
     def get_entity(self, label: str, field: str, value):
         """Return the first node of ``label`` where ``field`` equals ``value``."""
+        self._validate_identifier(label)
+        self._validate_identifier(field)
         query = f"MATCH (n:{label} {{{field}: $value}}) RETURN n"
         rows = self._connector.execute(query, {"value": value})
         return rows[0] if rows else None

--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -57,6 +57,20 @@ def test_get_entity():
     assert connector.executed == [("MATCH (n:Person {name: $value}) RETURN n", {"value": "Alice"})]
 
 
+def test_get_entity_invalid_label():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    with pytest.raises(ValueError):
+        dal.get_entity("Bad Label;", "name", "Alice")
+
+
+def test_get_entity_invalid_field():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    with pytest.raises(ValueError):
+        dal.get_entity("Person", "na.me", "Alice")
+
+
 def test_query_subgraph():
     connector = DummyConnector(result=[{"id": 1}])
     dal = GraphDAL(connector)


### PR DESCRIPTION
## Summary
- validate `label` and `field` in `GraphDAL.get_entity`
- add tests for invalid inputs
- fix missing imports in `social_graph_bot` example

## Testing
- `flake8 src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862ff5e04708326ae7532326c2aad0c