### PR TITLE
Expose vector/graph retrieval API

### DIFF
--- a/src/deepthought/memory/tiered.py
+++ b/src/deepthought/memory/tiered.py
@@ -104,6 +104,17 @@ class TieredMemory:
             logger.error("Graph query failed: %s", exc, exc_info=True)
             return []
 
+    # ------------------------------------------------------------------
+    # Public API
+
+    def vector_matches(self, prompt: str) -> List[str]:
+        """Return vector matches for ``prompt``."""
+        return self._vector_matches(prompt)
+
+    def graph_facts(self, limit: int | None = None) -> List[str]:
+        """Return facts from the graph, defaulting to ``top_k`` when ``limit`` is ``None``."""
+        return self._graph_facts(limit if limit is not None else self._top_k)
+
     def store_interaction(self, text: str) -> None:
         self._add_to_vector(text)
         try:

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -49,11 +49,11 @@ class HierarchicalService:
 
     def _vector_matches(self, prompt: str) -> List[str]:
         """Return vector matches using the underlying memory store."""
-        return self._memory._vector_matches(prompt)
+        return self._memory.vector_matches(prompt)
 
     def _graph_facts(self) -> List[str]:
         """Return graph facts using the underlying memory store."""
-        return self._memory._graph_facts(self._memory._top_k)
+        return self._memory.graph_facts()
 
     @classmethod
     def from_chroma(
@@ -165,14 +165,20 @@ class HierarchicalService:
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info("HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            logger.info(
+                "HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED
+            )
             return True
         except NatsError as e:
 
-            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "HierarchicalService failed to subscribe: %s", e, exc_info=True
+            )
             return False
         except Exception as e:  # pragma: no cover - network failure
-            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "HierarchicalService failed to subscribe: %s", e, exc_info=True
+            )
             return False
 
     async def stop(self) -> None:

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -9,6 +9,8 @@ sys.modules.setdefault("deepthought.learn", types.ModuleType("learn"))
 sys.modules.setdefault("deepthought.modules", types.ModuleType("modules"))
 sys.modules.setdefault("deepthought.motivate", types.ModuleType("motivate"))
 
+from typing import List
+
 import pytest
 
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
@@ -165,3 +167,24 @@ def test_retrieve_context_from_config(monkeypatch, tmp_path):
     service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     ctx = service.retrieve_context("config")
     assert "via config" in ctx
+
+
+def test_service_uses_public_memory_interface():
+    class SpyMemory:
+        def __init__(self):
+            self.calls = []
+
+        def vector_matches(self, prompt: str) -> List[str]:
+            self.calls.append(("vector", prompt))
+            return ["v"]
+
+        def graph_facts(self) -> List[str]:
+            self.calls.append(("graph", None))
+            return ["g"]
+
+    mem = SpyMemory()
+    service = HierarchicalService(DummyNATS(), DummyJS(), mem)
+
+    assert service._vector_matches("hi") == ["v"]
+    assert service._graph_facts() == ["g"]
+    assert mem.calls == [("vector", "hi"), ("graph", None)]

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -66,3 +66,14 @@ def test_loads_from_graph():
     ctx = mem.retrieve_context("x")
     assert ctx == ["g1", "g2"]
     assert set(mem._lru.keys()) == {"g1", "g2"}
+
+
+def test_public_vector_and_graph_methods():
+    vec = DummyVector()
+    dal = DummyDAL([{"fact": "g1"}, {"fact": "g2"}])
+    mem = TieredMemory(vec, dal, capacity=3, top_k=1)
+    mem.store_interaction("v1")
+
+    assert mem.vector_matches("whatever") == ["v1"]
+    assert mem.graph_facts() == ["g1"]
+    assert mem.graph_facts(2) == ["g1", "g2"]


### PR DESCRIPTION
## Summary
- expose `vector_matches()` and `graph_facts()` on `TieredMemory`
- rely on these public APIs inside `HierarchicalService`
- unit tests for new public methods and service integration

## Testing
- `flake8 src/deepthought/memory/tiered.py src/deepthought/services/hierarchical_service.py tests/unit/test_tiered_memory.py tests/unit/services/test_hierarchical_service.py`
- `pytest tests/unit/test_tiered_memory.py tests/unit/services/test_hierarchical_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ff65ec408326aa76601eeb054513