### PR TITLE
Add JetStream setup tests

### DIFF
--- a/tests/unit/test_setup_jetstream.py
+++ b/tests/unit/test_setup_jetstream.py
@@ -1,0 +1,76 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import setup_jetstream as sj
+
+
+class DummyStream(SimpleNamespace):
+    pass
+
+
+class DummyJetStream:
+    def __init__(self, add_error: bool = False):
+        self.add_called = False
+        self.update_called = False
+        self.add_error = add_error
+
+    async def add_stream(self, config):
+        self.add_called = True
+        if self.add_error:
+            raise Exception("exists")
+        return DummyStream(config=config)
+
+    async def update_stream(self, config):
+        self.update_called = True
+        return DummyStream(config=config)
+
+
+class DummyNATS:
+    def __init__(self, js: DummyJetStream):
+        self._js = js
+        self.connected = False
+        self.drain_called = False
+
+    async def connect(self, servers):
+        self.connected = True
+
+    def jetstream(self):
+        return self._js
+
+    async def drain(self):
+        self.drain_called = True
+        self.connected = False
+
+    @property
+    def is_connected(self):
+        return self.connected
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_stream(monkeypatch):
+    js = DummyJetStream()
+    nats = DummyNATS(js)
+    monkeypatch.setattr(sj, "check_nats_server_running", lambda url=sj.NATS_URL: True)
+    monkeypatch.setattr(sj, "NATS", lambda: nats)
+
+    await sj.setup_jetstream()
+
+    assert js.add_called
+    assert not js.update_called
+    assert nats.drain_called
+
+
+@pytest.mark.asyncio
+async def test_setup_updates_existing_stream(monkeypatch):
+    js = DummyJetStream(add_error=True)
+    nats = DummyNATS(js)
+    monkeypatch.setattr(sj, "check_nats_server_running", lambda url=sj.NATS_URL: True)
+    monkeypatch.setattr(sj, "NATS", lambda: nats)
+
+    await sj.setup_jetstream()
+
+    assert js.add_called
+    assert js.update_called
+    assert nats.drain_called


### PR DESCRIPTION
## Summary
- test `setup_jetstream` using mocked NATS and JetStream classes

## Testing
- `black tests/unit/test_setup_jetstream.py --line-length=120`
- `isort tests/unit/test_setup_jetstream.py --profile=black --line-length=120`
- `flake8 tests/unit/test_setup_jetstream.py`
- `pytest tests/unit/test_setup_jetstream.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ff78090c8326a566447a1cef5d46