### PR TITLE
Add experimental neuromorphic stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Key planned/in-progress components include:
 3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
 4.  **Reward Manager:** publishes user feedback as `RewardEvent` messages via JetStream, enabling future reinforcement or preference-based training. See [docs/reward_manager.md](docs/reward_manager.md).
 5.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.
-6.  **Neuromorphic Processing:** (Long-Term Research) Investigating brain-inspired computing principles via simulation (e.g., using Nengo).
+6.  **Neuromorphic Processing:** (Long-Term Research) Investigating brain-inspired computing principles via simulation (e.g., using Nengo). An experimental stub is provided in `deepthought.neuromorphic` with an example at `examples/neuromorphic_nats_demo.py`.
 
 ## Current Status
 

--- a/examples/neuromorphic_nats_demo.py
+++ b/examples/neuromorphic_nats_demo.py
@@ -1,0 +1,53 @@
+"""Example showing neuromorphic processing with NATS events."""
+
+import asyncio
+import json
+import logging
+import uuid
+
+import nats
+
+from deepthought.eda.publisher import Publisher
+from deepthought.eda.subscriber import Subscriber
+from deepthought.neuromorphic import NeuromorphicProcessor
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    nc = await nats.connect("nats://localhost:4222")
+    js = nc.jetstream()
+
+    processor = NeuromorphicProcessor()
+    publisher = Publisher(nc, js)
+    subscriber = Subscriber(nc, js)
+
+    async def handle_input(msg: nats.aio.msg.Msg) -> None:
+        data = json.loads(msg.data.decode())
+        value = float(data.get("value", 0))
+        result = processor.run(value)
+        payload = {"result": result, "input_id": data.get("input_id", str(uuid.uuid4()))}
+        await publisher.publish("dtr.neuro.output", payload, use_jetstream=True)
+        await msg.ack()
+        logger.info("Processed value %s -> %s", value, result)
+
+    await subscriber.subscribe(
+        "dtr.neuro.input",
+        handler=handle_input,
+        use_jetstream=True,
+        durable="neuromorphic_demo",
+    )
+
+    logger.info("Waiting for dtr.neuro.input events. Press Ctrl+C to exit.")
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+    await subscriber.unsubscribe_all()
+    await nc.drain()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -22,4 +22,9 @@ try:  # pragma: no cover - optional dependency may be missing
 except Exception:  # pragma: no cover - optional dependency may be missing
     motivate = None  # type: ignore
 from . import persona  # noqa: F401
+# neuromorphic uses optional nengo dependency
+try:  # pragma: no cover - optional dependency may be missing
+    from . import neuromorphic  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency may be missing
+    neuromorphic = None  # type: ignore
 

--- a/src/deepthought/neuromorphic/__init__.py
+++ b/src/deepthought/neuromorphic/__init__.py
@@ -1,0 +1,36 @@
+"""Experimental neuromorphic processing utilities."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+try:  # pragma: no cover - optional dependency may be missing
+    import nengo  # type: ignore
+    _HAVE_NENGO = True
+except Exception:  # pragma: no cover - optional dependency may be missing
+    nengo = None  # type: ignore
+    _HAVE_NENGO = False
+
+logger = logging.getLogger(__name__)
+
+
+class NeuromorphicProcessor:
+    """Simple neuromorphic processor stub."""
+
+    def __init__(self) -> None:
+        self._use_nengo = _HAVE_NENGO
+
+    def run(self, value: float) -> float:
+        """Process ``value`` and return the result."""
+        if self._use_nengo:
+            with nengo.Network(label="NeuromorphicProcessor") as model:
+                input_node = nengo.Node(output=lambda t: value)
+                output = nengo.Node(size_in=1)
+                nengo.Connection(input_node, output, transform=2.0)
+                probe = nengo.Probe(output)
+            with nengo.Simulator(model) as sim:
+                sim.run_steps(1)
+                return float(sim.data[probe][-1])
+        # Fallback mock implementation
+        return value * 2


### PR DESCRIPTION
## Summary
- add new `deepthought.neuromorphic` package with a minimal stub using `nengo` when available
- export the neuromorphic module in the package init
- demonstrate usage in `examples/neuromorphic_nats_demo.py`
- document the experimental module in the README

## Testing
- `flake8 src tests examples | head`
- `pytest -q` *(fails: 34 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862ff7435848326a0cc43fd11525961