### PR TITLE
Add template-based code generation service

### DIFF
--- a/docs/code_generation_service.md
+++ b/docs/code_generation_service.md
@@ -1,0 +1,22 @@
+# Code Generation Service
+
+The **CodeGenerationService** provides a minimal example of template based code
+generation. It listens for `dtr.codegen.template_request` events and publishes
+the executed result on `dtr.codegen.generated`.
+
+A request payload should look like:
+
+```json
+{
+  "template": "result = ${x} + ${y}",
+  "variables": {"x": 1, "y": 2},
+  "input_id": "42"
+}
+```
+
+The service substitutes the variables into the template, executes the generated
+code and publishes a `CodeGeneratedPayload` containing the final code and result.
+
+This example is intentionally simple and intended as a starting point for more
+advanced JIT or template based generation experiments.
+

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -10,18 +10,16 @@ import uuid
 from datetime import timedelta, timezone
 from typing import TYPE_CHECKING, List, Tuple
 
-from deepthought.goal_scheduler import GoalScheduler
-from deepthought.graph.connector import GraphConnector
-from deepthought.graph.dal import GraphDAL
-from deepthought.services.file_graph_dal import FileGraphDAL
-
-
-
 import aiohttp
 import aiosqlite
 
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.graph.connector import GraphConnector
+from deepthought.graph.dal import GraphDAL
 from deepthought.services import PersonaManager
-
+from deepthought.services.file_graph_dal import FileGraphDAL
+from deepthought.services.moderation import is_allowed
+from deepthought.services.scheduler import SchedulerService
 
 try:
     import discord
@@ -214,6 +212,7 @@ BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
 MAX_MEMORY_LENGTH = 1000
 MAX_THEORY_LENGTH = 256
 MAX_PROMPT_LENGTH = 2000
+
 
 class DBManager:
     """Lightweight wrapper managing a single aiosqlite connection."""

--- a/src/deepthought/eda/__init__.py
+++ b/src/deepthought/eda/__init__.py
@@ -6,7 +6,15 @@ different modules of the DeepThought reThought system using NATS as
 the message broker.
 """
 
-from .events import EventPayload, EventSubjects, InputReceivedPayload, MemoryRetrievedPayload, ResponseGeneratedPayload
+from .events import (
+    CodeGeneratedPayload,
+    CodeTemplatePayload,
+    EventPayload,
+    EventSubjects,
+    InputReceivedPayload,
+    MemoryRetrievedPayload,
+    ResponseGeneratedPayload,
+)
 from .publisher import Publisher
 from .subscriber import Subscriber
 
@@ -16,6 +24,8 @@ __all__ = [
     "InputReceivedPayload",
     "MemoryRetrievedPayload",
     "ResponseGeneratedPayload",
+    "CodeTemplatePayload",
+    "CodeGeneratedPayload",
     "Publisher",
     "Subscriber",
 ]

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -33,6 +33,10 @@ class EventSubjects:
     # Scheduler events
     REMINDER_TRIGGERED = "dtr.scheduler.reminder_triggered"
 
+    # Code generation events
+    CODE_TEMPLATE_REQUEST = "dtr.codegen.template_request"
+    CODE_GENERATED = "dtr.codegen.generated"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -92,4 +96,24 @@ class ReminderTriggeredPayload(EventPayload):
 
     message: str
     reminder_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class CodeTemplatePayload(EventPayload):
+    """Payload for requesting code generation from a template."""
+
+    template: str
+    variables: Dict[str, Any]
+    input_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class CodeGeneratedPayload(EventPayload):
+    """Payload for returning generated code and result."""
+
+    code: str
+    result: str
+    input_id: Optional[str] = None
     timestamp: Optional[str] = None

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -1,5 +1,6 @@
 """Service utilities for DeepThought."""
 
+from .code_generation_service import CodeGenerationService
 from .file_graph_dal import FileGraphDAL
 from .hierarchical_service import HierarchicalService
 from .memory_service import MemoryService
@@ -12,5 +13,5 @@ __all__ = [
     "HierarchicalService",
     "PersonaManager",
     "SocialGraphService",
-
+    "CodeGenerationService",
 ]

--- a/src/deepthought/services/code_generation_service.py
+++ b/src/deepthought/services/code_generation_service.py
@@ -1,0 +1,112 @@
+import json
+import logging
+from datetime import datetime, timezone
+from string import Template
+from typing import Any, Dict, Optional
+
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import (
+    CodeGeneratedPayload,
+    CodeTemplatePayload,
+    EventSubjects,
+)
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class CodeGenerationService:
+    """Simple template-based code generation service."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+
+    async def _handle_template_request(self, msg: Msg) -> None:
+        request_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("CodeTemplate payload must be a dict")
+            request_id = data.get("input_id")
+            template_text = data.get("template")
+            variables = data.get("variables", {})
+            if not isinstance(template_text, str) or not isinstance(variables, dict):
+                raise ValueError("Invalid template payload fields")
+            logger.info("CodeGenerationService received request ID %s", request_id)
+
+            code = Template(template_text).safe_substitute(**variables)
+            local_ns: Dict[str, Any] = {}
+            exec(code, {}, local_ns)
+            result = local_ns.get("result")
+
+            payload = CodeGeneratedPayload(
+                code=code,
+                result=str(result),
+                input_id=request_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+            await self._publisher.publish(
+                EventSubjects.CODE_GENERATED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            logger.info("CodeGenerationService published generated code event ID %s", request_id)
+            await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Invalid CodeTemplate payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+        except Exception as e:  # pragma: no cover - unexpected failures
+            logger.error("Error in CodeGenerationService handler: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
+    async def start(self, durable_name: str = "codegen_listener") -> bool:
+        if self._subscriber is None:
+            logger.error("Subscriber not initialized for CodeGenerationService.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.CODE_TEMPLATE_REQUEST,
+                handler=self._handle_template_request,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("CodeGenerationService subscribed to %s", EventSubjects.CODE_TEMPLATE_REQUEST)
+            return True
+        except nats.errors.Error as e:
+            logger.error("CodeGenerationService failed to subscribe: %s", e, exc_info=True)
+            return False
+        except Exception as e:
+            logger.error("CodeGenerationService failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("CodeGenerationService stopped listening.")
+        else:
+            logger.warning("Cannot stop listening - no subscriber available.")

--- a/tests/unit/services/test_code_generation_service.py
+++ b/tests/unit/services/test_code_generation_service.py
@@ -1,0 +1,61 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought.eda.events import CodeTemplatePayload, EventSubjects
+from deepthought.services.code_generation_service import CodeGenerationService
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_handle_template_request(monkeypatch):
+    service = CodeGenerationService(DummyNATS(), DummyJS())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = CodeTemplatePayload(template="result = ${x} + ${y}", variables={"x": 1, "y": 2}, input_id="a")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_template_request(msg)
+
+    assert msg.acked
+    pub = service._publisher
+    assert pub.published
+    subject, sent_payload = pub.published[0]
+    assert subject == EventSubjects.CODE_GENERATED
+    assert sent_payload.input_id == "a"
+    assert sent_payload.result == "3"


### PR DESCRIPTION
## Summary
- add `CodeGenerationService` for templated code execution
- extend event system with codegen events and payloads
- document the new service
- test code generation workflow
- fix examples to satisfy linter

## Testing
- `pre-commit run --files src/deepthought/eda/events.py src/deepthought/eda/__init__.py src/deepthought/services/__init__.py src/deepthought/services/code_generation_service.py tests/unit/services/test_code_generation_service.py docs/code_generation_service.md examples/social_graph_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ff6d56248326b43de329d33af480