### PR TITLE
Add offline search and FaissVectorStore tests

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -1,5 +1,6 @@
 """Memory utilities."""
 
+from .faiss_vector_store import FaissVectorStore
 from .hierarchical import HierarchicalMemory
 from .tiered import TieredMemory
 from .vector_store import SimpleEmbeddingFunction, VectorStore, create_vector_store
@@ -7,6 +8,7 @@ from .vector_store import SimpleEmbeddingFunction, VectorStore, create_vector_st
 __all__ = [
     "HierarchicalMemory",
     "VectorStore",
+    "FaissVectorStore",
     "create_vector_store",
     "SimpleEmbeddingFunction",
     "TieredMemory",

--- a/src/deepthought/memory/faiss_vector_store.py
+++ b/src/deepthought/memory/faiss_vector_store.py
@@ -1,0 +1,32 @@
+import uuid
+from typing import Optional, Sequence
+
+import faiss
+import numpy as np
+
+from .vector_store import SimpleEmbeddingFunction
+
+
+class FaissVectorStore:
+    """Minimal FAISS-backed vector store using an embedding function."""
+
+    def __init__(self, embedding_dim: int = 8, embedding_function: Optional[SimpleEmbeddingFunction] = None) -> None:
+        self._dim = embedding_dim
+        self._embedding = embedding_function or SimpleEmbeddingFunction()
+        self._index = faiss.IndexFlatL2(embedding_dim)
+        self._id_map: list[str] = []
+        self._docs: dict[str, str] = {}
+
+    def add_texts(self, texts: Sequence[str], ids: Optional[Sequence[str]] = None) -> None:
+        ids = list(ids) if ids is not None else [str(uuid.uuid4()) for _ in texts]
+        vectors = np.asarray(self._embedding(list(texts)), dtype="float32")
+        self._index.add(vectors)
+        for _id, text in zip(ids, texts):
+            self._id_map.append(_id)
+            self._docs[_id] = text
+
+    def query(self, query_texts: Sequence[str], n_results: int = 3):
+        vectors = np.asarray(self._embedding(list(query_texts)), dtype="float32")
+        _, indices = self._index.search(vectors, n_results)
+        docs = [[self._docs[self._id_map[i]] for i in idx if i < len(self._id_map)] for idx in indices]
+        return {"documents": docs}

--- a/tests/unit/test_faiss_vector_store.py
+++ b/tests/unit/test_faiss_vector_store.py
@@ -1,0 +1,10 @@
+from deepthought.memory.faiss_vector_store import FaissVectorStore
+from deepthought.memory.vector_store import SimpleEmbeddingFunction
+
+
+def test_add_and_query_neighbors():
+    store = FaissVectorStore(embedding_dim=8, embedding_function=SimpleEmbeddingFunction())
+    store.add_texts(["hello world", "goodbye", "hello there"], ids=["1", "2", "3"])
+    res = store.query(["hello"], n_results=2)
+    assert res["documents"][0][0] in {"hello world", "hello there"}
+    assert len(res["documents"][0]) == 2

--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -1,0 +1,18 @@
+from deepthought.search.offline_search import OfflineSearch
+
+
+def test_create_index_and_search(tmp_path):
+    path = tmp_path / "index.db"
+    docs = [("t1", "hello world"), ("t2", "goodbye world")]
+    search = OfflineSearch.create_index(str(path), docs)
+    assert path.exists()
+    results = search.search("hello")
+    assert results == ["hello world"]
+
+
+def test_search_limit(tmp_path):
+    path = tmp_path / "idx.db"
+    docs = [("a", "alpha"), ("b", "beta"), ("c", "gamma")]
+    search = OfflineSearch.create_index(str(path), docs)
+    results = search.search("alpha OR beta", limit=2)
+    assert results == ["alpha", "beta"]


### PR DESCRIPTION
## Summary
- implement `FaissVectorStore` using FAISS
- expose `FaissVectorStore` in memory package
- add tests for offline search index creation and querying
- test FAISS vector store neighbour lookups

## Testing
- `pre-commit run --files src/deepthought/memory/faiss_vector_store.py src/deepthought/memory/__init__.py tests/unit/test_offline_search.py tests/unit/test_faiss_vector_store.py`
- `pytest -q tests/unit/test_offline_search.py tests/unit/test_faiss_vector_store.py`

------
https://chatgpt.com/codex/tasks/task_e_6863e6d42ae883268590a45deb2c0070