### PR TITLE
Add token auth FastAPI Prism server

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,15 +249,19 @@ python bot.py
 
 ### Running the Prism Server
 
-To test Prism integration, start the simple Flask server:
+Prism integration now uses a small FastAPI server that requires an
+`Authorization` header. Configure one or more valid tokens with the
+`PRISM_TOKENS` environment variable:
 
 ```bash
+export PRISM_TOKENS=my-secret-token
 python examples/prism_server.py
 ```
 
 The bot's `send_to_prism` function posts JSON data to the endpoint
 defined by the `PRISM_ENDPOINT` environment variable (default:
-`http://localhost:5000/receive_data`).
+`http://localhost:5000/receive_data`) and includes the token in the
+`Authorization` header.
 
 ### Idle Channel Monitoring
 

--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -56,7 +56,7 @@ export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
 python examples/social_graph_bot.py
 ```
 
-The `examples/social_graph_bot.py` script logs user interactions in a SQLite database, monitors channel activity, and forwards data to a Prism endpoint implemented in `examples/prism_server.py`.
+The `examples/social_graph_bot.py` script logs user interactions in a SQLite database, monitors channel activity, and forwards data to a Prism endpoint implemented in `examples/prism_server.py`. The FastAPI server expects an `Authorization` header containing one of the tokens specified in the `PRISM_TOKENS` environment variable.
 
 The knowledge graph memory uses GraphDAL to persist data in Memgraph. Start Memgraph with `docker run --rm -p 7687:7687 memgraph/memgraph` and see [docs/graphdal.md](graphdal.md) for a full example service.
 

--- a/examples/prism_server.py
+++ b/examples/prism_server.py
@@ -1,14 +1,36 @@
-from flask import Flask, request
+"""Minimal Prism server implemented with FastAPI."""
 
-app = Flask(__name__)
+import os
+
+from fastapi import Depends, FastAPI, Header, HTTPException, status
 
 
-@app.route("/receive_data", methods=["POST"])
-def receive_data():
-    data = request.json
+app = FastAPI()
+
+
+def _get_valid_tokens() -> list[str]:
+    """Return the list of valid authorization tokens."""
+    tokens = os.getenv("PRISM_TOKENS") or os.getenv("PRISM_TOKEN") or ""
+    return [t.strip() for t in tokens.split(",") if t.strip()]
+
+
+def verify_authorization(authorization: str = Header(...)) -> None:
+    """FastAPI dependency that validates the ``Authorization`` header."""
+    valid_tokens = _get_valid_tokens()
+    token = authorization.replace("Bearer", "").strip()
+    if token not in valid_tokens:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+@app.post("/receive_data")
+async def receive_data(data: dict, _: None = Depends(verify_authorization)) -> dict:
+    """Receive a JSON payload from the Discord bot."""
     print(f"Received from bot: {data}")
-    return "Data received", 200
+    return {"detail": "Data received"}
 
 
 if __name__ == "__main__":
-    app.run(port=5000)
+    import uvicorn
+
+    port = int(os.getenv("PRISM_PORT", "5000"))
+    uvicorn.run(app, host="0.0.0.0", port=port)

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,6 +8,7 @@ pytest-asyncio==0.21.1
 flake8==6.1.0
 pydantic-settings==2.2.1
 aiohttp==3.12.3
+fastapi==0.111.0
 discord.py==2.5.2
 textblob==0.17.1
 pre-commit==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ nats-py
 pytest-asyncio
 aiosqlite
 aiohttp
-flask
+fastapi
 discord.py
 textblob
 networkx


### PR DESCRIPTION
## Summary
- rewrite `examples/prism_server.py` to use FastAPI
- validate `Authorization` header from `PRISM_TOKENS`
- document new usage in the README and phase report
- add `fastapi` to requirements

## Testing
- `flake8 src tests examples`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e6d10ef88326ba45bbd64ea95e7e