### PR TITLE
Improve publisher error messages

### DIFF
--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -44,6 +44,10 @@ class Publisher:
         else:
             data = str(payload).encode()
 
+        payload_summary = str(payload)
+        if len(payload_summary) > 100:
+            payload_summary = payload_summary[:97] + "..."
+
         try:
             if use_jetstream:
                 # Use JetStream publish with timeout
@@ -56,8 +60,10 @@ class Publisher:
                 logger.debug(f"Published basic NATS message to '{subject}'")
                 return None
         except nats.errors.TimeoutError as e:
-            logger.error(f"Publish timeout for '{subject}': {e}", exc_info=True)
-            raise e
+            message = f"Publish timeout for '{subject}' with payload {payload_summary}: {e}"
+            logger.error(message, exc_info=True)
+            raise type(e)(message) from e
         except Exception as e:
-            logger.error(f"Failed to publish to '{subject}': {e}", exc_info=True)  # Log traceback
-            raise e
+            message = f"Failed to publish to '{subject}' with payload {payload_summary}: {e}"
+            logger.error(message, exc_info=True)  # Log traceback
+            raise type(e)(message) from e

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -30,7 +30,10 @@ class DummyPublisher:
 
 class FailingPublisher(DummyPublisher):
     async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
-        raise RuntimeError("boom")
+        summary = str(payload)
+        if len(summary) > 50:
+            summary = summary[:47] + "..."
+        raise RuntimeError(f"Failed to publish to '{subject}' with payload {summary}")
 
 
 class DummySubscriber:
@@ -85,12 +88,13 @@ async def test_handle_input_success(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_input_error(tmp_path, monkeypatch):
+async def test_handle_input_error(tmp_path, monkeypatch, caplog):
     mem_file = tmp_path / "mem.json"
     mem = create_memory(monkeypatch, mem_file, FailingPublisher)
     payload = InputReceivedPayload(user_input="boom", input_id="99")
     msg = DummyMsg(payload.to_json())
-    await mem._handle_input_event(msg)
+    with caplog.at_level(logging.ERROR):
+        await mem._handle_input_event(msg)
 
     assert msg.nacked
     assert not msg.acked
@@ -98,6 +102,7 @@ async def test_handle_input_error(tmp_path, monkeypatch):
     with open(mem_file, "r", encoding="utf-8") as f:
         history = json.load(f)
     assert history[-1]["user_input"] == "boom"
+    assert any("Failed to publish to 'dtr.memory.retrieved'" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_pubsub.py
+++ b/tests/unit/test_pubsub.py
@@ -180,3 +180,22 @@ async def test_subscriber_requires_durable():
 
     with pytest.raises(ValueError):
         await sub.subscribe("topic", handler, use_jetstream=True)
+
+
+class FailingJS(DummyJS):
+    async def publish(self, subject, data, timeout=10.0):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_publish_exception_message():
+    nc = DummyNATS()
+    js = FailingJS()
+    pub = Publisher(nc, js)
+    payload = {"foo": "bar"}
+    with pytest.raises(RuntimeError) as exc:
+        await pub.publish("test.subject", payload)
+
+    msg = str(exc.value)
+    assert "test.subject" in msg
+    assert "foo" in msg


### PR DESCRIPTION
## Summary
- include subject and payload summary in Publisher error messages
- expect new failure text in `test_memory_basic`
- cover `Publisher` exception formatting in `test_pubsub`

## Testing
- `pre-commit run --files src/deepthought/eda/publisher.py tests/unit/modules/test_memory_basic.py tests/unit/test_pubsub.py`

------
https://chatgpt.com/codex/tasks/task_e_6863e6c029ac8326b404160c91256cdf