### PR TITLE
Add Prometheus metrics and FastAPI endpoint

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -13,3 +13,6 @@ textblob==0.17.1
 pre-commit==4.2.0
 vaderSentiment==3.3.2
 sentence-transformers==2.7.0
+fastapi==0.115.14
+prometheus-client==0.22.1
+httpx==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ networkx
 pydantic-settings
 vaderSentiment
 sentence-transformers
+fastapi
+prometheus-client
+httpx

--- a/src/deepthought/metrics/__init__.py
+++ b/src/deepthought/metrics/__init__.py
@@ -71,4 +71,13 @@ def actions_per_second(trace: Iterable[TraceEvent]) -> float:
     return len(latencies) / total if total > 0 else 0.0
 
 
-__all__ = ["bleu", "rouge_l", "average_latency", "actions_per_second"]
+from .prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+
+__all__ = [
+    "bleu",
+    "rouge_l",
+    "average_latency",
+    "actions_per_second",
+    "INPUTS_TOTAL",
+    "INPUT_LATENCY_SECONDS",
+]

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -1,0 +1,15 @@
+from prometheus_client import Counter, Histogram
+
+INPUTS_TOTAL = Counter(
+    "inputs_total",
+    "Total number of input events processed",
+    labelnames=["service"],
+)
+
+INPUT_LATENCY_SECONDS = Histogram(
+    "input_latency_seconds",
+    "Latency for processing input events",
+    labelnames=["service"],
+)
+
+__all__ = ["INPUTS_TOTAL", "INPUT_LATENCY_SECONDS"]

--- a/src/deepthought/metrics_server.py
+++ b/src/deepthought/metrics_server.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+app = FastAPI()
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    data = generate_latest()
+    return Response(data, media_type=CONTENT_TYPE_LATEST)

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import time
 from datetime import datetime, timezone
 from typing import List, Optional, Sequence
 
@@ -16,6 +17,7 @@ from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
 from ..memory.tiered import TieredMemory
 from ..memory.vector_store import create_vector_store
+from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..search import OfflineSearch
 
 logger = logging.getLogger(__name__)
@@ -99,6 +101,7 @@ class HierarchicalService:
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
+        start = time.perf_counter()
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
@@ -152,6 +155,10 @@ class HierarchicalService:
                     await msg.ack()
                 except NatsError:
                     logger.error("Failed to ack message after error", exc_info=True)
+        finally:
+            duration = time.perf_counter() - start
+            INPUTS_TOTAL.labels(service="hierarchical_service").inc()
+            INPUT_LATENCY_SECONDS.labels(service="hierarchical_service").observe(duration)
 
     async def start(self, durable_name: str = "hierarchical_service_listener") -> bool:
         """Start listening for input events."""
@@ -165,20 +172,14 @@ class HierarchicalService:
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info(
-                "HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED
-            )
+            logger.info("HierarchicalService subscribed to %s", EventSubjects.INPUT_RECEIVED)
             return True
         except NatsError as e:
 
-            logger.error(
-                "HierarchicalService failed to subscribe: %s", e, exc_info=True
-            )
+            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
             return False
         except Exception as e:  # pragma: no cover - network failure
-            logger.error(
-                "HierarchicalService failed to subscribe: %s", e, exc_info=True
-            )
+            logger.error("HierarchicalService failed to subscribe: %s", e, exc_info=True)
             return False
 
     async def stop(self) -> None:

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -11,6 +12,7 @@ from nats.js.client import JetStreamContext
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from .file_graph_dal import FileGraphDAL
 
 logger = logging.getLogger(__name__)
@@ -26,6 +28,7 @@ class MemoryService:
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
+        start = time.perf_counter()
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
@@ -73,6 +76,10 @@ class MemoryService:
                     await msg.ack()
                 except nats.errors.Error:
                     logger.error("Failed to ack message after error", exc_info=True)
+        finally:
+            duration = time.perf_counter() - start
+            INPUTS_TOTAL.labels(service="memory_service").inc()
+            INPUT_LATENCY_SECONDS.labels(service="memory_service").observe(duration)
 
     async def start(self, durable_name: str = "memory_service_listener") -> bool:
         if self._subscriber is None:

--- a/tests/unit/test_metrics_prometheus.py
+++ b/tests/unit/test_metrics_prometheus.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+
+from deepthought.metrics.prometheus import INPUTS_TOTAL
+from deepthought.metrics_server import app
+
+
+def test_metrics_endpoint_returns_data() -> None:
+    INPUTS_TOTAL.labels(service="test").inc()
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert b"inputs_total" in response.content


### PR DESCRIPTION
## Summary
- add FastAPI and Prometheus client dependencies
- expose Prometheus counters and histograms
- record metrics in HierarchicalService and MemoryService
- serve metrics over a new FastAPI app
- test the metrics endpoint

## Testing
- `pre-commit run --files requirements-ci.txt requirements.txt src/deepthought/metrics/__init__.py src/deepthought/services/hierarchical_service.py src/deepthought/services/memory_service.py src/deepthought/metrics/prometheus.py src/deepthought/metrics_server.py tests/unit/test_metrics_prometheus.py`
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e6cf1140832688ed28a6f654a0a6