### PR TITLE
Add Streamlit memory query UI

### DIFF
--- a/docs/ui_setup.md
+++ b/docs/ui_setup.md
@@ -1,0 +1,29 @@
+# UI Setup
+
+This document explains how to run the optional Streamlit interface for querying memory.
+
+## Prerequisites
+
+- Python 3.9 or later
+- A running backend that exposes the `/memory/query` endpoint
+
+## Installation
+
+1. Create a virtual environment (optional but recommended).
+2. Install the required packages:
+
+   ```bash
+   pip install -r ui/requirements.txt
+   ```
+
+## Running the App
+
+1. Ensure the backend service is running. By default the UI sends requests to `http://localhost:8000`. You can override this by setting the `MEMORY_API_URL` environment variable.
+2. Start the Streamlit app:
+
+   ```bash
+   streamlit run ui/app.py
+   ```
+
+3. Open the provided URL in your browser and query memory facts.
+

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,6 +7,7 @@ pytest-xdist==3.7.0
 pytest-asyncio==0.21.1
 flake8==6.1.0
 pydantic-settings==2.2.1
+pydantic==2.11.7
 aiohttp==3.12.3
 discord.py==2.5.2
 textblob==0.17.1

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,23 @@
+import os
+import requests
+import streamlit as st
+
+API_URL = os.getenv("MEMORY_API_URL", "http://localhost:8000")
+
+st.title("Memory Query UI")
+
+query = st.text_input("Enter query")
+
+if st.button("Search"):
+    if query:
+        try:
+            response = requests.post(f"{API_URL}/memory/query", json={"query": query})
+            response.raise_for_status()
+            data = response.json()
+            st.subheader("Retrieved Facts")
+            st.json(data)
+        except Exception as e:
+            st.error(f"Request failed: {e}")
+    else:
+        st.warning("Please enter a query first.")
+

--- a/ui/requirements.txt
+++ b/ui/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+requests


### PR DESCRIPTION
## Summary
- create `ui/` with a Streamlit app that queries `/memory/query`
- document UI setup steps
- pin pydantic in CI requirements for tests

## Testing
- `ruff check ui/app.py`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863e6cff03c8326900735f205c717eb