### PR TITLE
Implement stable entity IDs

### DIFF
--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import uuid
 
 from .connector import GraphConnector
 
@@ -37,8 +38,12 @@ class GraphDAL:
             raise ValueError(f"Invalid identifier: {value!r}")
 
     def merge_entity(self, name: str) -> None:
-        """Ensure an Entity node exists with the given ``name``."""
-        self._connector.execute("MERGE (:Entity {name: $name})", {"name": name})
+        """Ensure an Entity node exists with the given ``name`` and stable ``id``."""
+        entity_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
+        self._connector.execute(
+            "MERGE (:Entity {id: $id, name: $name})",
+            {"id": entity_id, "name": name},
+        )
 
     def merge_next_edge(self, src: str, dst: str) -> None:
         """Ensure a NEXT edge exists from ``src`` to ``dst``."""
@@ -56,8 +61,8 @@ class GraphDAL:
 
         self._connector.execute(query, {"props": props})
 
-    def add_relationship(self, start_id: int, end_id: int, rel_type: str, props: dict) -> None:
-        """Create or merge a relationship of ``rel_type`` between two nodes."""
+    def add_relationship(self, start_id: str, end_id: str, rel_type: str, props: dict) -> None:
+        """Create or merge a relationship of ``rel_type`` between two nodes identified by ``id``."""
         self._validate_identifier(rel_type)
         query = "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:" f"{rel_type} $props]->(b)"
 

--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from deepthought.graph.dal import GraphDAL
@@ -21,15 +23,24 @@ def test_add_entity():
     assert connector.executed == [("MERGE (n:Person $props)", {"props": {"name": "Alice"}})]
 
 
+def test_merge_entity():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    dal.merge_entity("Alice")
+
+    expected_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, "Alice"))
+    assert connector.executed == [("MERGE (:Entity {id: $id, name: $name})", {"id": expected_id, "name": "Alice"})]
+
+
 def test_add_relationship():
     connector = DummyConnector()
     dal = GraphDAL(connector)
-    dal.add_relationship(1, 2, "KNOWS", {"since": 2020})
+    dal.add_relationship("1", "2", "KNOWS", {"since": 2020})
 
     assert connector.executed == [
         (
             "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:KNOWS $props]->(b)",
-            {"start_id": 1, "end_id": 2, "props": {"since": 2020}},
+            {"start_id": "1", "end_id": "2", "props": {"since": 2020}},
         )
     ]
 
@@ -45,7 +56,7 @@ def test_add_relationship_invalid_type():
     connector = DummyConnector()
     dal = GraphDAL(connector)
     with pytest.raises(ValueError):
-        dal.add_relationship(1, 2, "KNOWS DELETE *", {"since": 2020})
+        dal.add_relationship("1", "2", "KNOWS DELETE *", {"since": 2020})
 
 
 def test_get_entity():


### PR DESCRIPTION
## Summary
- use uuid5 in GraphDAL.merge_entity for stable IDs
- reference IDs in GraphDAL.add_relationship
- update unit tests for new behaviour

## Testing
- `flake8 src/deepthought/graph/dal.py tests/unit/test_graph_dal.py`
- `PYTHONPATH=src pytest -q tests/unit/test_graph_dal.py`

------
https://chatgpt.com/codex/tasks/task_e_68654e12a36c8326bcb142af79cde2c2