### PR TITLE
Improve JetStreamSetupError handling

### DIFF
--- a/setup_jetstream.py
+++ b/setup_jetstream.py
@@ -91,12 +91,12 @@ async def setup_jetstream() -> None:
 
         logger.info("JetStream setup completed successfully")
 
-    except TimeoutError:
+    except TimeoutError as e:
         logger.error(f"Timed out connecting to NATS server at {NATS_URL}.")
         logger.error(
             "Please ensure your NATS server is running and JetStream is enabled (e.g., start with 'nats-server -js')."
         )
-        raise JetStreamSetupError("Timed out connecting to NATS")
+        raise JetStreamSetupError("Timed out connecting to NATS") from e
     except Exception as e:
         logger.error(f"Failed to set up JetStream: {e}")
         if "Connection refused" in str(e):  # This check is good
@@ -112,7 +112,7 @@ async def setup_jetstream() -> None:
                 "An unexpected error occurred. Ensure NATS is running, JetStream is enabled ('-js' flag), and the server is accessible at %s."
                 % NATS_URL
             )
-        raise JetStreamSetupError("Failed to set up JetStream")
+        raise JetStreamSetupError("Failed to set up JetStream") from e
     finally:
         # Close the connection
         if nats_client.is_connected:

--- a/tests/unit/test_setup_jetstream.py
+++ b/tests/unit/test_setup_jetstream.py
@@ -74,3 +74,40 @@ async def test_setup_updates_existing_stream(monkeypatch):
     assert js.add_called
     assert js.update_called
     assert nats.drain_called
+
+
+@pytest.mark.asyncio
+async def test_setup_connection_failure(monkeypatch):
+    class FailingNATS(DummyNATS):
+        async def connect(self, servers):
+            raise sj.TimeoutError()
+
+    js = DummyJetStream()
+    nats = FailingNATS(js)
+    monkeypatch.setattr(sj, "check_nats_server_running", lambda url=sj.NATS_URL: True)
+    monkeypatch.setattr(sj, "NATS", lambda: nats)
+
+    with pytest.raises(sj.JetStreamSetupError) as excinfo:
+        await sj.setup_jetstream()
+
+    assert isinstance(excinfo.value.__cause__, sj.TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_setup_stream_creation_failure(monkeypatch):
+    class ErrorJetStream(DummyJetStream):
+        async def add_stream(self, config):
+            raise Exception("boom")
+
+        async def update_stream(self, config):
+            raise Exception("kaboom")
+
+    js = ErrorJetStream()
+    nats = DummyNATS(js)
+    monkeypatch.setattr(sj, "check_nats_server_running", lambda url=sj.NATS_URL: True)
+    monkeypatch.setattr(sj, "NATS", lambda: nats)
+
+    with pytest.raises(sj.JetStreamSetupError) as excinfo:
+        await sj.setup_jetstream()
+
+    assert isinstance(excinfo.value.__cause__, Exception)


### PR DESCRIPTION
## Summary
- chain original cause when JetStream setup fails
- add unit tests for connection and stream creation failures

## Testing
- `pre-commit run --files setup_jetstream.py tests/unit/test_setup_jetstream.py`

------
https://chatgpt.com/codex/tasks/task_e_68654e136a9c832688dcb78f21484981