### PR TITLE
Add CLI for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Key planned/in-progress components include:
 
 1.  **Core EDA Framework:** (Functional) Publishers, Subscribers, and Event definitions using NATS.
 2.  **Optimized Language Model:** (In Progress) Utilizing small, open-source LLMs (< 3B parameters, e.g., Llama 3.2 3B Instruct) fine-tuned using Parameter-Efficient Fine-Tuning (PEFT) techniques like QLoRA and further optimized with post-training quantization (e.g., AWQ). The `train_script.py` is provided for LLM fine-tuning. Running this script requires a suitable environment with a GPU and necessary CUDA libraries. It can be used to replicate the fine-tuning process described in `LLM_Fine_Tuning_Report.md`.
+
+### CLI Usage
+
+After installing the project (`pip install -e .`), use the ``dtrt`` command to launch training:
+
+```bash
+dtrt --model <model-id> --dataset <dataset> --bits 4 --output-dir ./results
+```
+
+Run ``dtrt --help`` to see all available options.
 3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
 4.  **Reward Manager:** publishes user feedback as `RewardEvent` messages via JetStream, enabling future reinforcement or preference-based training. See [docs/reward_manager.md](docs/reward_manager.md).
 5.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     install_requires=requirements,
+    entry_points={
+        "console_scripts": [
+            "dtrt = deepthought.cli:main",
+        ]
+    },
     description="DeepThought reThought - experimental AI framework",
     license="MIT",
     url="https://github.com/d0tTino/DeepThought-ReThought",

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -16,10 +16,13 @@ from . import learn  # noqa: F401
 if not os.environ.get("DEEPTHOUGHT_LIGHT_IMPORT"):
     try:  # pragma: no cover - optional dependency may be missing
         from . import modules  # type: ignore  # noqa: F401
+        from . import train_script  # noqa: F401
     except Exception:  # pragma: no cover - optional dependency may be missing
         modules = None  # type: ignore
+        train_script = None  # type: ignore
 else:  # pragma: no cover - skip heavy optional import
     modules = None  # type: ignore
+    train_script = None  # type: ignore
 # motivate requires NATS, which may not be installed in test environments
 try:  # pragma: no cover - optional dependency may be missing
     from . import motivate  # type: ignore  # noqa: F401

--- a/src/deepthought/cli.py
+++ b/src/deepthought/cli.py
@@ -1,0 +1,37 @@
+"""Command line interface for DeepThought-ReThought."""
+
+from __future__ import annotations
+
+import argparse
+
+from . import __version__
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="DeepThought training utilities")
+    parser.add_argument("--model", dest="model_path", default=None, help="Model ID or local path")
+    parser.add_argument(
+        "--dataset",
+        dest="dataset_path",
+        default="databricks/databricks-dolly-15k",
+        help="Dataset path or HF dataset identifier",
+    )
+    parser.add_argument("--bits", type=int, choices=[4, 8], default=4, help="Quantization bits")
+    parser.add_argument(
+        "--output-dir", dest="output_dir", default="./results/lora-adapter", help="Directory to save results"
+    )
+    parser.add_argument("--resume", action="store_true", help="Resume training from last checkpoint")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    from . import train_script
+
+    return train_script.run(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/src/deepthought/train_script.py
+++ b/src/deepthought/train_script.py
@@ -1,6 +1,8 @@
 # Combined training script for fine-tuning with LoRA
 # This script implements Subtask 5 from the instruction
 
+from __future__ import annotations
+
 import argparse
 import gc
 import os
@@ -19,7 +21,7 @@ from transformers import (
 )
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Fine-tune a language model with LoRA")
     parser.add_argument(
         "--model-path",
@@ -32,15 +34,27 @@ def parse_args() -> argparse.Namespace:
         help="Dataset path or HF dataset identifier",
     )
     parser.add_argument(
+        "--bits",
+        type=int,
+        default=4,
+        choices=[4, 8],
+        help="Quantization bits for loading the model",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="./results/lora-adapter",
+        help="Directory to save results",
+    )
+    parser.add_argument(
         "--resume",
         action="store_true",
         help="Resume training from the last checkpoint",
     )
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
-def main() -> int:
-    args = parse_args()
+def run(args: argparse.Namespace) -> int:
+    """Run training with the provided arguments."""
     print("\n=== Starting Fine-tuning Process ===\n")
 
     # ===== Step 1: Load Model & Tokenizer =====
@@ -51,9 +65,10 @@ def main() -> int:
         base_model_id = args.model_path or "meta-llama/Llama-3.2-3B-Instruct"
         print(f"Attempting to load model: {base_model_id}")
 
-        # Configure 4-bit quantization for memory efficiency
+        # Configure quantization for memory efficiency
         quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
+            load_in_4bit=args.bits == 4,
+            load_in_8bit=args.bits == 8,
             bnb_4bit_quant_type="nf4",
             bnb_4bit_use_double_quant=True,
             bnb_4bit_compute_dtype=torch.bfloat16,
@@ -75,9 +90,10 @@ def main() -> int:
         print(f"Attempting to load model: {base_model_id}")
         print("Note: Using Zephyr-7B instead of Llama 3.2 due to access restrictions")
 
-        # Configure 4-bit quantization for memory efficiency
+        # Configure quantization for memory efficiency
         quantization_config = BitsAndBytesConfig(
-            load_in_4bit=True,
+            load_in_4bit=args.bits == 4,
+            load_in_8bit=args.bits == 8,
             bnb_4bit_quant_type="nf4",
             bnb_4bit_use_double_quant=True,
             bnb_4bit_compute_dtype=torch.bfloat16,
@@ -201,7 +217,7 @@ def main() -> int:
     print("\nStep 4: Setting training arguments...")
 
     # Define output directory
-    output_dir = "./results/lora-adapter"
+    output_dir = args.output_dir
     os.makedirs(output_dir, exist_ok=True)
     print(f"Output directory: {output_dir}")
 
@@ -337,6 +353,11 @@ def main() -> int:
     torch.cuda.empty_cache()
     print("CUDA cache cleared post-training (attempted).")
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    return run(parse_args(argv))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_help(tmp_path):
+    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    result = subprocess.run(
+        [sys.executable, "-m", "deepthought.cli", "--help"],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add `dtrt` command entry point and CLI implementation
- make `train_script.py` callable and move into package
- document the new command
- test CLI `--help` output

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_cli_help.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686555d21edc8326a865310f2605c6d2