### PR TITLE
Add service template and CLI generator

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,3 +91,17 @@ Execution traces from bots or training runs can be replayed and analyzed.
   ```
 
 The generated `dashboard.png` illustrates BLEU, ROUGE‑L and average latency over time.
+
+## Service Template
+
+A minimal skeleton is available under `tools/template_service/`. It demonstrates
+how to use the shared `Publisher` and `Subscriber` helpers.
+To create a new service based on this template run:
+
+```bash
+dtrt init service <name>
+```
+
+The command copies the template to `src/deepthought/services/<name>` and
+replaces `TemplateService` with a class named `<Name>Service`.
+Customize the generated files to implement your service logic.

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -19,4 +19,6 @@ sentence-transformers==2.7.0
 fastapi
 uvicorn
 PyYAML
+faiss-cpu
+prometheus-client
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,6 @@ sentence-transformers
 fastapi
 uvicorn
 pyyaml
+faiss-cpu
+prometheus-client
 

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,9 @@ setup(
     license="MIT",
     url="https://github.com/d0tTino/DeepThought-ReThought",
     python_requires=">=3.8",
+    entry_points={
+        "console_scripts": [
+            "dtrt=deepthought.cli:main",
+        ]
+    },
 )

--- a/src/deepthought/cli.py
+++ b/src/deepthought/cli.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+
+def _to_camel(name: str) -> str:
+    return "".join(part.capitalize() for part in name.split("_"))
+
+
+def init_service(name: str) -> None:
+    dest = Path("src/deepthought/services") / name
+    if dest.exists():
+        raise SystemExit(f"Service '{name}' already exists")
+    template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
+    shutil.copytree(template, dest)
+    class_name = _to_camel(name) + "Service"
+    for path in dest.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        text = text.replace("TemplateService", class_name)
+        text = text.replace("template_service", name)
+        path.write_text(text, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="dtrt")
+    sub = parser.add_subparsers(dest="command")
+
+    init_p = sub.add_parser("init")
+    init_sub = init_p.add_subparsers(dest="target")
+
+    svc_p = init_sub.add_parser("service")
+    svc_p.add_argument("name")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "init" and args.target == "service":
+        init_service(args.name)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/template_service/README.md
+++ b/tools/template_service/README.md
@@ -1,0 +1,5 @@
+# Template Service
+
+This directory provides a minimal service skeleton using the shared
+`Publisher` and `Subscriber` helpers. It serves as a starting point for
+new services.

--- a/tools/template_service/__init__.py
+++ b/tools/template_service/__init__.py
@@ -1,0 +1,1 @@
+from .service import TemplateService

--- a/tools/template_service/service.py
+++ b/tools/template_service/service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import logging
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from deepthought.eda import Publisher, Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TemplateService:
+    """Skeleton service using Publisher and Subscriber."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+
+    async def _handle_input(self, msg: Msg) -> None:
+        logger.info("Handling message %s", msg.subject)
+        # TODO: add processing logic
+        await msg.ack()
+
+    async def start(self, durable_name: str = "template_service_listener") -> bool:
+        await self._subscriber.subscribe(
+            subject="dtr.template.input",
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        return True
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()


### PR DESCRIPTION
## Summary
- add minimal service template with shared publisher/subscriber
- implement `dtrt init service <name>` CLI for scaffolding services
- expose CLI entry point in setup.py
- document workflow in architecture guide
- pin faiss and prometheus dependencies for tests

## Testing
- `pre-commit run --files requirements-ci.txt requirements.txt docs/architecture.md setup.py src/deepthought/cli.py tools/template_service/service.py tools/template_service/README.md tools/template_service/__init__.py`
- `pytest -m "not nats"`

------
https://chatgpt.com/codex/tasks/task_e_686555d321108326808abeacbbb98d63