### PR TITLE
Handle missing memory in HierarchicalService.dump_graph

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -201,6 +201,9 @@ class HierarchicalService:
         """Write the underlying graph to ``path`` in DOT format."""
         import os
 
+        if self._memory is None:
+            raise ValueError("Cannot dump graph without memory")
+
         os.makedirs(path, exist_ok=True)
         dot_path = os.path.join(path, "graph.dot")
 

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -141,6 +141,12 @@ def test_dump_graph(tmp_path):
     assert '"B" -> "C" [label="LIKES"]' in contents
 
 
+def test_dump_graph_no_memory(tmp_path):
+    service = HierarchicalService(DummyNATS(), DummyJS(), None)
+    with pytest.raises(ValueError):
+        service.dump_graph(str(tmp_path))
+
+
 def test_retrieve_context_with_search(tmp_path):
     vec = DummyVector()
     dal = DummyDAL()


### PR DESCRIPTION
## Summary
- handle the case when `HierarchicalService.dump_graph` is called with no memory
- cover this edge case with a unit test

## Testing
- `pre-commit run --files src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d5fe5378832686da0dde1ca7ddbc