### PR TITLE
Add Memgraph integration test

### DIFF
--- a/tests/integration/test_memgraph_integration.py
+++ b/tests/integration/test_memgraph_integration.py
@@ -1,0 +1,96 @@
+import os
+import shutil
+import subprocess
+import time
+import uuid
+
+import pytest
+
+from deepthought.graph import GraphConnector, GraphDAL
+from tests.helpers import memgraph_available
+
+try:  # Import optional dependency inside the module
+    import pymemgraph  # noqa: F401
+except Exception:  # pragma: no cover - dependency missing
+    pymemgraph = None
+
+pytestmark = pytest.mark.memgraph
+
+MG_HOST = os.getenv("MG_HOST", "localhost")
+MG_PORT = int(os.getenv("MG_PORT", 7687))
+MG_USER = os.getenv("MG_USER", "memgraph")
+MG_PASSWORD = os.getenv("MG_PASSWORD", "memgraph")
+
+
+@pytest.fixture(scope="module")
+def memgraph_server():
+    """Start a Memgraph Docker container if needed and yield when ready."""
+    if pymemgraph is None:
+        pytest.skip("pymemgraph not installed")
+    if shutil.which("docker") is None:
+        pytest.skip("Docker not available")
+
+    already_running = memgraph_available(MG_HOST, MG_PORT)
+    container_name = None
+
+    if not already_running:
+        container_name = f"pytest-memgraph-{uuid.uuid4().hex[:8]}"
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            f"{MG_PORT}:7687",
+            "--name",
+            container_name,
+            "memgraph/memgraph",
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            pytest.skip(f"Could not start memgraph container: {proc.stderr}")
+
+        for _ in range(30):
+            if memgraph_available(MG_HOST, MG_PORT):
+                break
+            time.sleep(1)
+        else:
+            subprocess.run(["docker", "stop", container_name], capture_output=True)
+            pytest.skip("Memgraph container did not start")
+
+    try:
+        yield
+    finally:
+        if container_name:
+            subprocess.run(["docker", "stop", container_name], capture_output=True)
+
+
+def test_graphdal_live(memgraph_server):
+    """Ensure GraphDAL can interact with a live Memgraph instance."""
+    if not memgraph_available(MG_HOST, MG_PORT):
+        pytest.skip("Memgraph not reachable")
+
+    connector = GraphConnector(
+        host=MG_HOST,
+        port=MG_PORT,
+        username=MG_USER,
+        password=MG_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+
+    alice_id = str(uuid.uuid4())
+    bob_id = str(uuid.uuid4())
+    dal.add_entity("Person", {"id": alice_id, "name": "Alice"})
+    dal.add_entity("Person", {"id": bob_id, "name": "Bob"})
+    dal.add_relationship(alice_id, bob_id, "KNOWS", {"since": 2024})
+
+    result = dal.query_subgraph(
+        "MATCH (a:Person {id: $a_id})-[r:KNOWS]->(b:Person {id: $b_id}) RETURN a.name AS src, b.name AS dst",
+        {"a_id": alice_id, "b_id": bob_id},
+    )
+    assert result
+    row = result[0]
+    if isinstance(row, tuple):
+        assert row[0] == "Alice" and row[1] == "Bob"
+    else:
+        assert row.get("src") == "Alice" and row.get("dst") == "Bob"


### PR DESCRIPTION
## Summary
- add integration test covering GraphDAL against a live Memgraph server

## Testing
- `pre-commit run --files tests/integration/test_memgraph_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d9d30f34832686658b8252a27ead