### PR TITLE
Add multi-agent NATS demo

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -105,3 +105,21 @@ dtrt init service <name>
 The command copies the template to `src/deepthought/services/<name>` and
 replaces `TemplateService` with a class named `<Name>Service`.
 Customize the generated files to implement your service logic.
+
+## Multi-Agent Demo
+
+A simple demonstration of multiple agents communicating over NATS is provided in `examples/multi_agent_demo.py`.
+Run `setup_jetstream.py` first to create the required JetStream stream:
+
+```bash
+python -c "import asyncio, setup_jetstream; asyncio.run(setup_jetstream.setup_jetstream())"
+```
+
+Then launch the demo:
+
+```bash
+python examples/multi_agent_demo.py
+```
+
+This script spins up three agents that forward responses to each other in a round-robin fashion using the existing `InputHandler`, `BasicMemory`, `BasicLLM` (or `LLMStub`), and `OutputHandler` modules.
+Ensure a NATS server is running on `localhost:4222` or set the `NATS_URL` environment variable accordingly.

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -1,0 +1,89 @@
+import asyncio
+import logging
+import os
+import uuid
+
+import nats
+from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+
+from deepthought.modules import (
+    BasicLLM,
+    BasicMemory,
+    InputHandler,
+    LLMStub,
+    OutputHandler,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+STREAM_NAME = "deepthought_events"
+
+
+async def ensure_stream(js):
+    try:
+        await js.stream_info(STREAM_NAME)
+    except Exception:
+        config = StreamConfig(
+            name=STREAM_NAME,
+            subjects=["dtr.>"],
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.MEMORY,
+            max_msgs_per_subject=100,
+            discard=DiscardPolicy.OLD,
+        )
+        await js.add_stream(config)
+
+
+async def main() -> None:
+    url = os.getenv("NATS_URL", "nats://localhost:4222")
+    nc = await nats.connect(url)
+    js = nc.jetstream()
+
+    await ensure_stream(js)
+
+    memory = BasicMemory(nc, js)
+    try:
+        llm = BasicLLM(nc, js)
+    except ImportError:
+        logger.warning("BasicLLM dependencies missing; falling back to LLMStub")
+        llm = LLMStub(nc, js)
+
+    input_handlers = [InputHandler(nc, js) for _ in range(3)]
+    done = asyncio.Event()
+    msg_count = 0
+
+    def make_callback(idx: int):
+        def cb(input_id: str, text: str) -> None:
+            nonlocal msg_count
+            logger.info("Agent %s says: %s", idx + 1, text)
+            msg_count += 1
+            next_idx = (idx + 1) % 3
+            if msg_count >= 3:
+                done.set()
+            else:
+                asyncio.create_task(input_handlers[next_idx].process_input(text))
+
+        return cb
+
+    output_handlers = [OutputHandler(nc, js, output_callback=make_callback(i)) for i in range(3)]
+
+    await asyncio.gather(
+        memory.start_listening(durable_name=f"mem_demo_{uuid.uuid4()}"),
+        llm.start_listening(durable_name=f"llm_demo_{uuid.uuid4()}"),
+        *(oh.start_listening(durable_name=f"out_demo_{i}_{uuid.uuid4()}") for i, oh in enumerate(output_handlers)),
+    )
+
+    await asyncio.sleep(1.0)
+    await input_handlers[0].process_input("Hello from agent 1!")
+
+    await done.wait()
+
+    await memory.stop_listening()
+    await llm.stop_listening()
+    await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
+    await nc.drain()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/replay_basic.py
+++ b/tests/replay_basic.py
@@ -1,22 +1,32 @@
+import asyncio
 import json
 import os
 import subprocess
+import uuid
 from pathlib import Path
 
+import nats
+import pytest
+from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
-def _write_trace(path: Path, actions):
-    data = []
-    for action in actions:
-        data.append(
-            {
-                "state": "s",
-                "action": action,
-                "reward": 0.0,
-                "latency": 0.1,
-                "timestamp": "2024-01-01T00:00:00",
-            }
-        )
-    path.write_text(json.dumps(data))
+from deepthought.modules import BasicMemory, InputHandler, LLMStub, OutputHandler
+from tests.helpers import nats_server_available
+
+
+def _write_trace(path: Path, actions) -> None:
+    with path.open("w", encoding="utf-8") as f:
+        for action in actions:
+            json.dump(
+                {
+                    "state": "s",
+                    "action": action,
+                    "reward": 0.0,
+                    "latency": 0.1,
+                    "timestamp": "2024-01-01T00:00:00",
+                },
+                f,
+            )
+            f.write("\n")
 
 
 def test_replay_cli(tmp_path: Path) -> None:
@@ -50,6 +60,7 @@ def test_replay_cli(tmp_path: Path) -> None:
     assert "avg_latency:" in out
     assert "actions_per_second:" in out
 
+
 def test_replay_cli_mismatch(tmp_path: Path) -> None:
     trial = tmp_path / "trial_m.json"
     golden = tmp_path / "golden_m.json"
@@ -80,3 +91,70 @@ def test_replay_cli_mismatch(tmp_path: Path) -> None:
     assert "rouge_l:" in out
     assert "avg_latency:" in out
     assert "actions_per_second:" in out
+
+
+@pytest.mark.asyncio
+@pytest.mark.nats
+async def test_multi_agent_round_robin(tmp_path: Path) -> None:
+    """Agents should exchange at least one message using NATS."""
+    if not nats_server_available():
+        pytest.skip("NATS server not available")
+
+    nc = await nats.connect("nats://localhost:4222", name="pytest_multi_agent")
+    js = nc.jetstream()
+
+    try:
+        await js.stream_info("deepthought_events")
+    except Exception:
+        cfg = StreamConfig(
+            name="deepthought_events",
+            subjects=["dtr.>"],
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.MEMORY,
+            max_msgs_per_subject=100,
+            discard=DiscardPolicy.OLD,
+        )
+        await js.add_stream(cfg)
+
+    memory_file = tmp_path / "mem.json"
+    memory = BasicMemory(nc, js, memory_file=str(memory_file))
+    llm = LLMStub(nc, js)
+
+    input_handlers = [InputHandler(nc, js) for _ in range(3)]
+    received: list[str] = []
+    done = asyncio.Event()
+
+    def make_callback(idx: int):
+        def cb(input_id: str, text: str) -> None:
+            received.append(text)
+            next_idx = (idx + 1) % 3
+            if len(received) >= 3:
+                done.set()
+            else:
+                asyncio.create_task(input_handlers[next_idx].process_input(text))
+
+        return cb
+
+    output_handlers = [OutputHandler(nc, js, output_callback=make_callback(i)) for i in range(3)]
+
+    results = await asyncio.gather(
+        memory.start_listening(durable_name=f"mem_{uuid.uuid4()}"),
+        llm.start_listening(durable_name=f"llm_{uuid.uuid4()}"),
+        *(oh.start_listening(durable_name=f"out_{i}_{uuid.uuid4()}") for i, oh in enumerate(output_handlers)),
+        return_exceptions=True,
+    )
+    for result in results:
+        if result is False or isinstance(result, Exception):
+            pytest.fail(f"Listener failed: {result}")
+
+    await asyncio.sleep(0.5)
+    await input_handlers[0].process_input("hello")
+
+    await asyncio.wait_for(done.wait(), timeout=10.0)
+
+    assert len(received) >= 3
+
+    await memory.stop_listening()
+    await llm.stop_listening()
+    await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
+    await nc.drain()


### PR DESCRIPTION
## Summary
- demonstrate multiple agents in `examples/multi_agent_demo.py`
- document how to run the demo in `docs/architecture.md`
- expand `tests/replay_basic.py` with a multi-agent round robin test
- fix trace helper to emit JSON lines for `replay.py`

## Testing
- `pre-commit run --files examples/multi_agent_demo.py docs/architecture.md tests/replay_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d9d071208326a280bb4edae8fd7d