### PR TITLE
Add finetune CLI wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Key planned/in-progress components include:
 
 ### CLI Usage
 
-After installing the project (`pip install -e .`), use the ``dtrt`` command to launch training:
+After installing the project (`pip install .`), you can launch fine-tuning:
 
 ```bash
-dtrt --model <model-id> --dataset <dataset> --bits 4 --output-dir ./results
+dtrt finetune --model-path <model-id>
 ```
 
-Run ``dtrt --help`` to see all available options.
+Run ``dtrt finetune --help`` to see all available options.
 3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
 4.  **Reward Manager:** publishes user feedback as `RewardEvent` messages via JetStream, enabling future reinforcement or preference-based training. See [docs/reward_manager.md](docs/reward_manager.md).
 5.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,6 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     install_requires=requirements,
-    entry_points={
-        "console_scripts": [
-            "dtrt = deepthought.cli:main",
-        ]
-    },
     description="DeepThought reThought - experimental AI framework",
     license="MIT",
     url="https://github.com/d0tTino/DeepThought-ReThought",
@@ -37,6 +32,7 @@ setup(
     entry_points={
         "console_scripts": [
             "dtrt=deepthought.cli:main",
+            "deepthought-rethought=deepthought.cli.finetune:main",
         ]
     },
 )

--- a/src/deepthought/cli/finetune.py
+++ b/src/deepthought/cli/finetune.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+from importlib import import_module
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="dtrt finetune", description="Fine-tune a language model with LoRA")
+    parser.add_argument("--model-path", default=None, help="Model ID or local path to the base model")
+    parser.add_argument(
+        "--dataset-path",
+        default="databricks/databricks-dolly-15k",
+        help="Dataset path or HF dataset identifier",
+    )
+    parser.add_argument(
+        "--bits",
+        type=int,
+        default=4,
+        choices=[4, 8],
+        help="Quantization bits for loading the model",
+    )
+    parser.add_argument("--output-dir", default="./results/lora-adapter", help="Directory to save results")
+    parser.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for fine-tuning."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    train_script = import_module("deepthought.train_script")
+    return train_script.run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_finetune_cli_help(tmp_path):
+    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    result = subprocess.run(
+        [sys.executable, "-m", "deepthought.cli.finetune", "--help"],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert "usage" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add `finetune` CLI package that forwards to `train_script`
- expose new executable `deepthought-rethought`
- document finetune CLI usage in README
- test that the finetune CLI can show help

## Testing
- `pre-commit run --files README.md setup.py src/deepthought/cli/__init__.py src/deepthought/cli/finetune.py tests/unit/test_finetune_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d9ce1fac83269b8b2b2d409e8d9c