### PR TITLE
Add metrics server FastAPI test

### DIFF
--- a/tests/unit/test_metrics_server.py
+++ b/tests/unit/test_metrics_server.py
@@ -1,0 +1,14 @@
+from fastapi.testclient import TestClient
+from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client.parser import text_string_to_metric_families
+
+from deepthought.metrics_server import app
+
+
+def test_metrics_endpoint_text_format() -> None:
+    client = TestClient(app)
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == CONTENT_TYPE_LATEST
+    metrics = list(text_string_to_metric_families(response.text))
+    assert metrics


### PR DESCRIPTION
## Summary
- test FastAPI metrics endpoint text format more thoroughly

## Testing
- `flake8 tests/unit/test_metrics_server.py`
- `pytest tests/unit/test_metrics_server.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6865d9d2c40083268bcc2d36e6fa34ec