### PR TITLE
Consolidate CLI commands

### DIFF
--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import shutil
+from importlib import import_module
 from pathlib import Path
 
 
@@ -13,7 +14,7 @@ def init_service(name: str) -> None:
     dest = Path("src/deepthought/services") / name
     if dest.exists():
         raise SystemExit(f"Service '{name}' already exists")
-    template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
+    template = Path(__file__).resolve().parents[3] / "templates" / "service"
     shutil.copytree(template, dest)
     class_name = _to_camel(name) + "Service"
     for path in dest.rglob("*.py"):
@@ -23,23 +24,61 @@ def init_service(name: str) -> None:
         path.write_text(text, encoding="utf-8")
 
 
-def main(argv: list[str] | None = None) -> None:
+def _cmd_init_service(args: argparse.Namespace) -> None:
+    init_service(args.name)
+
+
+def _cmd_finetune(args: argparse.Namespace) -> int:
+    train_script = import_module("deepthought.train_script")
+    return train_script.run(args)
+
+
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="dtrt")
     sub = parser.add_subparsers(dest="command")
+
+    finetune_p = sub.add_parser("finetune", description="Fine-tune a language model with LoRA")
+    finetune_p.add_argument("--model-path", default=None, help="Model ID or local path to the base model")
+    finetune_p.add_argument(
+        "--dataset-path",
+        default="databricks/databricks-dolly-15k",
+        help="Dataset path or HF dataset identifier",
+    )
+    finetune_p.add_argument(
+        "--bits",
+        type=int,
+        default=4,
+        choices=[4, 8],
+        help="Quantization bits for loading the model",
+    )
+    finetune_p.add_argument(
+        "--output-dir",
+        default="./results/lora-adapter",
+        help="Directory to save results",
+    )
+    finetune_p.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
+    finetune_p.set_defaults(func=_cmd_finetune)
 
     init_p = sub.add_parser("init")
     init_sub = init_p.add_subparsers(dest="target")
 
     svc_p = init_sub.add_parser("service")
     svc_p.add_argument("name")
+    svc_p.set_defaults(func=_cmd_init_service)
 
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
     args = parser.parse_args(argv)
 
-    if args.command == "init" and args.target == "service":
-        init_service(args.name)
-    else:
-        parser.print_help()
+    if hasattr(args, "func"):
+        return args.func(args) or 0
+
+    parser.print_help()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/deepthought/cli/bus.py
+++ b/src/deepthought/cli/bus.py
@@ -1,45 +1,11 @@
 from __future__ import annotations
 
-import argparse
-import shutil
-from pathlib import Path
+from . import main as cli_main
 
 
-def _to_camel(name: str) -> str:
-    return "".join(part.capitalize() for part in name.split("_"))
-
-
-def init_service(name: str) -> None:
-    dest = Path("src/deepthought/services") / name
-    if dest.exists():
-        raise SystemExit(f"Service '{name}' already exists")
-    template = Path(__file__).resolve().parents[3] / "templates" / "service"
-    shutil.copytree(template, dest)
-    class_name = _to_camel(name) + "Service"
-    for path in dest.rglob("*.py"):
-        text = path.read_text(encoding="utf-8")
-        text = text.replace("TemplateService", class_name)
-        text = text.replace("template_service", name)
-        path.write_text(text, encoding="utf-8")
-
-
-def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(prog="dtrt")
-    sub = parser.add_subparsers(dest="command")
-
-    init_p = sub.add_parser("init")
-    init_sub = init_p.add_subparsers(dest="target")
-
-    svc_p = init_sub.add_parser("service")
-    svc_p.add_argument("name")
-
-    args = parser.parse_args(argv)
-
-    if args.command == "init" and args.target == "service":
-        init_service(args.name)
-    else:
-        parser.print_help()
+def main(argv: list[str] | None = None) -> int:
+    return cli_main(argv)
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/deepthought/cli/finetune.py
+++ b/src/deepthought/cli/finetune.py
@@ -1,35 +1,10 @@
 from __future__ import annotations
 
-import argparse
-from importlib import import_module
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="dtrt finetune", description="Fine-tune a language model with LoRA")
-    parser.add_argument("--model-path", default=None, help="Model ID or local path to the base model")
-    parser.add_argument(
-        "--dataset-path",
-        default="databricks/databricks-dolly-15k",
-        help="Dataset path or HF dataset identifier",
-    )
-    parser.add_argument(
-        "--bits",
-        type=int,
-        default=4,
-        choices=[4, 8],
-        help="Quantization bits for loading the model",
-    )
-    parser.add_argument("--output-dir", default="./results/lora-adapter", help="Directory to save results")
-    parser.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
-    return parser
+from . import main as cli_main
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Entry point for fine-tuning."""
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-    train_script = import_module("deepthought.train_script")
-    return train_script.run(args)
+    return cli_main(["finetune", *(argv or [])])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli_entrypoint.py
+++ b/tests/unit/test_cli_entrypoint.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _run_dtrt(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    return subprocess.run(
+        [sys.executable, "-m", "deepthought.cli", *args],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+
+def test_entrypoint_finetune_help(tmp_path: Path) -> None:
+    result = _run_dtrt(tmp_path, "finetune", "--help")
+    combined = result.stdout.lower() + result.stderr.lower()
+    assert "usage" in combined
+
+
+def test_entrypoint_init_service_foo(tmp_path: Path) -> None:
+    result = _run_dtrt(tmp_path, "init", "service", "foo")
+    assert result.returncode == 0
+    dest = tmp_path / "src" / "deepthought" / "services" / "foo"
+    assert dest.is_dir()

--- a/tests/unit/test_cli_init_service.py
+++ b/tests/unit/test_cli_init_service.py
@@ -8,7 +8,7 @@ def test_cli_init_service(tmp_path):
     env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
     service_name = "sample"
     subprocess.run(
-        [sys.executable, "-m", "deepthought.cli.bus", "init", "service", service_name],
+        [sys.executable, "-m", "deepthought.cli", "init", "service", service_name],
         cwd=tmp_path,
         stdout=subprocess.PIPE,
         text=True,

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 def test_finetune_cli_help(tmp_path):
     env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
     result = subprocess.run(
-        [sys.executable, "-m", "deepthought.cli.finetune", "--help"],
+        [sys.executable, "-m", "deepthought.cli", "finetune", "--help"],
         stdout=subprocess.PIPE,
         text=True,
         check=True,


### PR DESCRIPTION
## Summary
- unify CLI commands under `deepthought.cli` and provide wrappers
- support `dtrt finetune` and `dtrt init service` subcommands
- keep entry point mapping
- update tests for the new CLI layout
- add new CLI entrypoint tests

## Testing
- `pre-commit run --files src/deepthought/cli/__init__.py src/deepthought/cli/bus.py src/deepthought/cli/finetune.py tests/unit/test_cli_init_service.py tests/unit/test_finetune_cli.py tests/unit/test_cli_entrypoint.py`
- `pytest tests/unit/test_cli_init_service.py tests/unit/test_finetune_cli.py tests/unit/test_cli_entrypoint.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a158ce0883268455e780499b571b