### PR TITLE
Update relationship merge query

### DIFF
--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -13,7 +13,8 @@ def init_service(name: str) -> None:
     dest = Path("src/deepthought/services") / name
     if dest.exists():
         raise SystemExit(f"Service '{name}' already exists")
-    template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
+    # templates live at repo root/tools; navigate up to repository base
+    template = Path(__file__).resolve().parents[3] / "tools" / "template_service"
     shutil.copytree(template, dest)
     class_name = _to_camel(name) + "Service"
     for path in dest.rglob("*.py"):

--- a/src/deepthought/graph/dal.py
+++ b/src/deepthought/graph/dal.py
@@ -64,7 +64,7 @@ class GraphDAL:
     def add_relationship(self, start_id: str, end_id: str, rel_type: str, props: dict) -> None:
         """Create or merge a relationship of ``rel_type`` between two nodes identified by ``id``."""
         self._validate_identifier(rel_type)
-        query = "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:" f"{rel_type} $props]->(b)"
+        query = f"MATCH (a {{id: $start_id}}), (b {{id: $end_id}}) " f"MERGE (a)-[r:{rel_type}]->(b) SET r += $props"
 
         self._connector.execute(
             query,

--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -44,7 +44,7 @@ def test_add_relationship():
 
     assert connector.executed == [
         (
-            "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:KNOWS $props]->(b)",
+            "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:KNOWS]->(b) SET r += $props",
             {"start_id": "1", "end_id": "2", "props": {"since": 2020}},
         )
     ]


### PR DESCRIPTION
## Summary
- fix GraphDAL.add_relationship so relationship properties are merged via `SET r += $props`
- update unit test to validate new Cypher query
- correct `dtrt init service` template path

## Testing
- `pre-commit run --files src/deepthought/graph/dal.py tests/unit/test_graph_dal.py src/deepthought/cli/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866a158a89483268e01d88d0f40fad7