### PR TITLE
Fix duplicate FastAPI dependency

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -8,7 +8,6 @@ pytest-asyncio==0.21.1
 flake8==6.1.0
 pydantic-settings==2.2.1
 pydantic
-
 aiohttp==3.12.3
 fastapi==0.111.0
 discord.py==2.5.2
@@ -16,9 +15,7 @@ textblob==0.17.1
 pre-commit==4.2.0
 vaderSentiment==3.3.2
 sentence-transformers==2.7.0
-fastapi
 uvicorn
 PyYAML
 faiss-cpu
 prometheus-client
-

--- a/tools/template_service/Dockerfile
+++ b/tools/template_service/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /service
+COPY . /service
+
+# Install runtime dependencies if a requirements file is provided
+RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; fi
+
+CMD ["python", "service.py"]

--- a/tools/template_service/publisher.py
+++ b/tools/template_service/publisher.py
@@ -1,0 +1,8 @@
+"""Publisher stub for TemplateService."""
+
+
+class TemplatePublisher:
+    """Placeholder publisher implementation."""
+
+    def __init__(self) -> None:
+        pass

--- a/tools/template_service/subscriber.py
+++ b/tools/template_service/subscriber.py
@@ -1,0 +1,8 @@
+"""Subscriber stub for TemplateService."""
+
+
+class TemplateSubscriber:
+    """Placeholder subscriber implementation."""
+
+    def __init__(self) -> None:
+        pass


### PR DESCRIPTION
## Summary
- clean up `requirements-ci.txt` by removing extra blank lines and the duplicate `fastapi` line
- add missing template files so CLI-generated services include `publisher.py`, `subscriber.py`, and a `Dockerfile`

## Testing
- `pre-commit run --files tools/template_service/publisher.py tools/template_service/subscriber.py tools/template_service/Dockerfile tools/template_service/README.md tools/template_service/service.py tools/template_service/__init__.py tests/unit/test_cli_init_service.py requirements-ci.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68685b68ca2c8326abad9bc26f590567