### PR TITLE
Improve init service test

### DIFF
--- a/tests/unit/test_cli_init_service.py
+++ b/tests/unit/test_cli_init_service.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 
 def test_cli_init_service(tmp_path):
-    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
     service_name = "sample"
     subprocess.run(
         [sys.executable, "-m", "deepthought.cli", "init", "service", service_name],
@@ -20,3 +20,13 @@ def test_cli_init_service(tmp_path):
     assert (dest / "publisher.py").exists()
     assert (dest / "subscriber.py").exists()
     assert (dest / "Dockerfile").exists()
+
+    class_name = "SampleService"
+    pub_text = (dest / "publisher.py").read_text(encoding="utf-8")
+    sub_text = (dest / "subscriber.py").read_text(encoding="utf-8")
+    assert class_name + "Publisher" in pub_text
+    assert class_name + "Subscriber" in sub_text
+
+    import shutil
+
+    shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
## Summary
- assert that CLI service template uses the new class name
- clean up temporary directory used in the test

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q tests/unit/test_cli_init_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68686c74d4cc8326bd55db380f489317