### PR TITLE
Ensure train_script uses train module

### DIFF
--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+"""Training utilities for fine-tuning language models."""
+
 import argparse
 import os
 from typing import Tuple
@@ -15,6 +17,13 @@ from transformers import (
     Trainer,
     TrainingArguments,
 )
+
+__all__ = [
+    "load_model",
+    "load_dataset",
+    "create_trainer",
+    "run",
+]
 
 
 def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:

--- a/tests/unit/test_train_script_run.py
+++ b/tests/unit/test_train_script_run.py
@@ -1,0 +1,14 @@
+import importlib
+import types
+from unittest import mock
+
+train_script = importlib.import_module('deepthought.train_script')
+
+
+def test_run_delegates_to_train_module(monkeypatch):
+    dummy_args = mock.Mock()
+    dummy_run = mock.Mock(return_value=42)
+    monkeypatch.setattr(train_script, 'train_utils', types.SimpleNamespace(run=dummy_run))
+    result = train_script.run(dummy_args)
+    dummy_run.assert_called_once_with(dummy_args)
+    assert result == 42


### PR DESCRIPTION
## Summary
- add a regression test showing train_script.run delegates to deepthought.train
- expose helper functions with an __all__ list

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_train_script_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68686a959a688326b6ba304f393e0fbe