### PR TITLE
Add package metadata and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ DeepThought-ReThought is an experimental Artificial Intelligence (AI) project fo
 
 The project is hosted on GitHub: [https://github.com/d0tTino/DeepThought-ReThought](https://github.com/d0tTino/DeepThought-ReThought)
 
+## Installation
+
+Build a wheel and install it with pip:
+
+```bash
+python -m build
+pip install dist/*.whl
+```
+
+After installation, the `dtrt` CLI is available. View its commands with:
+
+```bash
+dtrt finetune --help
+```
+
 ## Goals
 
 * **Extreme Efficiency:** Develop AI components that minimize computational cost (CPU, memory, energy) and financial expenditure.
@@ -27,7 +42,7 @@ Key planned/in-progress components include:
 
 ### CLI Usage
 
-After installing the project (`pip install .`), you can launch fine-tuning:
+After installing the project (`pip install dist/*.whl`), you can launch fine-tuning:
 
 ```bash
 dtrt finetune --model-path <model-id>

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,20 @@ setup(
             "dtrt=deepthought.cli:main",
         ]
     },
-
     description="DeepThought reThought - experimental AI framework",
     license="MIT",
     url="https://github.com/d0tTino/DeepThought-ReThought",
     python_requires=">=3.8",
-
+    long_description=Path("README.md").read_text(encoding="utf-8"),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
 )

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 
 def test_cli_help(tmp_path):
-    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
     result = subprocess.run(
         [sys.executable, "-m", "deepthought.cli", "--help"],
         stdout=subprocess.PIPE,

--- a/tests/unit/test_cli_init_service.py
+++ b/tests/unit/test_cli_init_service.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 
 def test_cli_init_service(tmp_path):
-    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
     service_name = "sample"
     subprocess.run(
         [sys.executable, "-m", "deepthought.cli", "init", "service", service_name],

--- a/tests/unit/test_cli_wheel.py
+++ b/tests/unit/test_cli_wheel.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import subprocess
 import sys
@@ -20,8 +21,14 @@ def test_dtrt_init_service_from_wheel(tmp_path: Path) -> None:
         subprocess.run([sys.executable, "-m", "venv", str(venv_dir)], check=True)
         pip = venv_dir / "bin" / "pip"
         dtrt = venv_dir / "bin" / "dtrt"
-        subprocess.run([str(pip), "install", "--no-deps", str(wheel)], check=True)
-        subprocess.run([str(dtrt), "init", "service", "demo"], cwd=tmp_path, check=True)
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        subprocess.run(
+            [str(pip), "install", "--no-deps", "--no-build-isolation", str(wheel)],
+            check=True,
+            env=env,
+        )
+        subprocess.run([str(dtrt), "init", "service", "demo"], cwd=tmp_path, check=True, env=env)
         assert (tmp_path / "src" / "deepthought" / "services" / "demo" / "service.py").exists()
     finally:
         shutil.rmtree(repo_root / "build", ignore_errors=True)

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 
 def test_finetune_cli_help(tmp_path):
-    env = dict(**os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
     result = subprocess.run(
         [sys.executable, "-m", "deepthought.cli", "finetune", "--help"],
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- add wheel build instructions and CLI usage to README
- ensure setup.py exposes `dtrt` entry point and includes long description and classifiers
- fix CLI tests to work without PYTHONPATH

## Testing
- `pre-commit run --files tests/unit/test_cli_help.py tests/unit/test_cli_init_service.py tests/unit/test_finetune_cli.py tests/unit/test_cli_wheel.py setup.py README.md`
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`
- `python -m build`
- `pip install dist/*.whl`
- `dtrt finetune --help`


------
https://chatgpt.com/codex/tasks/task_e_68686c710c3883268307d92b4dae1994