### PR TITLE
Implement echo template and validate generated service

### DIFF
--- a/tests/unit/test_cli_wheel.py
+++ b/tests/unit/test_cli_wheel.py
@@ -30,6 +30,70 @@ def test_dtrt_init_service_from_wheel(tmp_path: Path) -> None:
         )
         subprocess.run([str(dtrt), "init", "service", "demo"], cwd=tmp_path, check=True, env=env)
         assert (tmp_path / "src" / "deepthought" / "services" / "demo" / "service.py").exists()
+
+        # verify the generated service can be imported and started
+        script = """
+import asyncio, sys
+from pathlib import Path
+import importlib.util
+import types
+
+fake_nats = types.ModuleType('nats')
+fake_aio = types.ModuleType('aio')
+fake_client = types.ModuleType('client')
+setattr(fake_client, 'Client', object)
+fake_msg_mod = types.ModuleType('msg')
+setattr(fake_msg_mod, 'Msg', object)
+fake_aio.client = fake_client
+fake_aio.msg = fake_msg_mod
+fake_js = types.ModuleType('js')
+fake_js_client = types.ModuleType('client')
+setattr(fake_js_client, 'JetStreamContext', object)
+fake_js.client = fake_js_client
+fake_nats.aio = fake_aio
+fake_nats.js = fake_js
+sys.modules.setdefault('nats', fake_nats)
+sys.modules.setdefault('nats.aio', fake_aio)
+sys.modules.setdefault('nats.aio.client', fake_client)
+sys.modules.setdefault('nats.aio.msg', fake_msg_mod)
+sys.modules.setdefault('nats.js', fake_js)
+sys.modules.setdefault('nats.js.client', fake_js_client)
+
+svc_path = Path(r'{svc}')
+spec = importlib.util.spec_from_file_location('demo.service', svc_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+DemoService = module.DemoService
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+class DummyJS:
+    async def publish(self, *a, **k):
+        class Ack:
+            seq = 1
+            stream = 's'
+        return Ack()
+    async def subscribe(self, *a, **k):
+        class Sub:
+            async def unsubscribe(self):
+                pass
+        return Sub()
+
+async def main():
+    svc = DemoService(DummyNATS(), DummyJS())
+    await svc.start()
+    await svc.stop()
+
+asyncio.run(main())
+""".format(
+            svc=str((tmp_path / "src" / "deepthought" / "services" / "demo" / "service.py").resolve())
+        )
+        run_py = venv_dir / "bin" / "python"
+        script_file = tmp_path / "run_service.py"
+        script_file.write_text(script)
+        subprocess.run([str(run_py), str(script_file)], check=True, env=env)
     finally:
         shutil.rmtree(repo_root / "build", ignore_errors=True)
         shutil.rmtree(repo_root / "src" / "deepthought_rethought.egg-info", ignore_errors=True)

--- a/tools/template_service/service.py
+++ b/tools/template_service/service.py
@@ -20,8 +20,11 @@ class TemplateService:
 
     async def _handle_input(self, msg: Msg) -> None:
         logger.info("Handling message %s", msg.subject)
-        # TODO: add processing logic
-        await msg.ack()
+        # Echo the received data to an output subject
+        try:
+            await self._publisher.publish("dtr.template.output", msg.data, use_jetstream=True)
+        finally:
+            await msg.ack()
 
     async def start(self, durable_name: str = "template_service_listener") -> bool:
         await self._subscriber.subscribe(


### PR DESCRIPTION
## Summary
- implement echo-style behavior for template service
- ensure generated service imports and starts without modification

## Testing
- `pre-commit run --files tools/template_service/service.py tests/unit/test_cli_wheel.py`

------
https://chatgpt.com/codex/tasks/task_e_6869e805267c8326a54a5c40141506b1