### PR TITLE
Add TLS options for NATS helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Specify the NATS server address with the `NATS_URL` environment variable. If not
 ```bash
 export NATS_URL=nats://my-nats:4222
 ```
+Use `NATS_TLS_CERT` and `NATS_TLS_KEY` to provide a client certificate and key when connecting to a secure server. Optional variables `NATS_TLS_CA`, `NATS_USERNAME`, and `NATS_PASSWORD` can configure a custom certificate authority and basic authentication.
 
 The optional offline search index used by `HierarchicalService` can be configured
 via `DT_SEARCH_DB`:
@@ -195,6 +196,18 @@ python -c "import asyncio, setup_jetstream; asyncio.run(setup_jetstream.setup_je
 ```
 
 This step is necessary before running the tests below.
+
+## Running a Secure NATS Server
+
+To run NATS with TLS enabled, supply the server with certificate and key files. A Docker example is shown below:
+
+```bash
+docker run --rm -p 4222:4222 -p 8222:8222 \
+  -v $PWD/certs:/certs nats:latest -js \
+  --tlscert /certs/server-cert.pem --tlskey /certs/server-key.pem --tlsverify
+```
+
+Clients can then connect using the `NATS_TLS_CERT` and `NATS_TLS_KEY` environment variables along with `NATS_URL`. Optionally set `NATS_TLS_CA` if your server uses a custom CA certificate.
 
 ## Recording Event Traces
 

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -1,5 +1,7 @@
 # File: src/deepthought/eda/publisher.py
 import logging
+import os
+import ssl
 from typing import Any, Dict, Optional, Union
 
 import nats
@@ -67,3 +69,41 @@ class Publisher:
             message = f"Failed to publish to '{subject}' with payload {payload_summary}: {e}"
             logger.error(message, exc_info=True)  # Log traceback
             raise type(e)(message) from e
+
+
+async def connect(
+    nats_url: str | None = None,
+    *,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    name: str = "dtrt_publisher",
+) -> "Publisher":
+    """Create a :class:`Publisher` connected to ``nats_url`` with optional TLS."""
+
+    nats_url = nats_url or os.getenv("NATS_URL", "nats://localhost:4222")
+    tls_cert = tls_cert or os.getenv("NATS_TLS_CERT")
+    tls_key = tls_key or os.getenv("NATS_TLS_KEY")
+    tls_ca = tls_ca or os.getenv("NATS_TLS_CA")
+    user = user or os.getenv("NATS_USERNAME")
+    password = password or os.getenv("NATS_PASSWORD")
+
+    ssl_ctx = None
+    if tls_cert and tls_key:
+        ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        if tls_ca:
+            ssl_ctx.load_verify_locations(tls_ca)
+        ssl_ctx.load_cert_chain(tls_cert, tls_key)
+
+    nc = NATS()
+    await nc.connect(
+        servers=[nats_url],
+        tls=ssl_ctx,
+        user=user,
+        password=password,
+        name=name,
+    )
+    js = nc.jetstream()
+    return Publisher(nc, js)

--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -1,6 +1,8 @@
 # File: src/deepthought/eda/subscriber.py
 import asyncio
 import logging
+import os
+import ssl
 from typing import Awaitable, Callable, Optional
 
 import nats
@@ -91,3 +93,41 @@ class Subscriber:
             except nats.errors.Error as e:
                 logger.error(f"Error acking message in default handler: {e}")
         # Basic NATS messages don't need ack.
+
+
+async def connect(
+    nats_url: str | None = None,
+    *,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    name: str = "dtrt_subscriber",
+) -> "Subscriber":
+    """Create a :class:`Subscriber` connected to ``nats_url`` with optional TLS."""
+
+    nats_url = nats_url or os.getenv("NATS_URL", "nats://localhost:4222")
+    tls_cert = tls_cert or os.getenv("NATS_TLS_CERT")
+    tls_key = tls_key or os.getenv("NATS_TLS_KEY")
+    tls_ca = tls_ca or os.getenv("NATS_TLS_CA")
+    user = user or os.getenv("NATS_USERNAME")
+    password = password or os.getenv("NATS_PASSWORD")
+
+    ssl_ctx = None
+    if tls_cert and tls_key:
+        ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        if tls_ca:
+            ssl_ctx.load_verify_locations(tls_ca)
+        ssl_ctx.load_cert_chain(tls_cert, tls_key)
+
+    nc = NATS()
+    await nc.connect(
+        servers=[nats_url],
+        tls=ssl_ctx,
+        user=user,
+        password=password,
+        name=name,
+    )
+    js = nc.jetstream()
+    return Subscriber(nc, js)


### PR DESCRIPTION
## Summary
- extend `Publisher.connect` and `Subscriber.connect` helpers to accept TLS options and credentials
- read new environment variables (`NATS_TLS_CERT`, `NATS_TLS_KEY`, etc.)
- document secure NATS usage in README

## Testing
- `pre-commit run --files src/deepthought/eda/publisher.py src/deepthought/eda/subscriber.py README.md`
- `PYTHONPATH=src pytest -m "not nats"`

------
https://chatgpt.com/codex/tasks/task_e_6869e804ebfc8326aa91a50826600686