### PR TITLE
Refactor MemoryService to use TieredMemory

### DIFF
--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -13,18 +13,42 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
-from .file_graph_dal import FileGraphDAL
+from ..memory.tiered import TieredMemory
+from ..memory.vector_store import create_vector_store
+from ..graph import create_graph_backend
 
 logger = logging.getLogger(__name__)
 
 
 class MemoryService:
-    """Service that stores user interactions in a graph using FileGraphDAL."""
+    """Service that stores and retrieves interactions using :class:`TieredMemory`."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, dal: Optional[FileGraphDAL] = None) -> None:
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        memory: Optional[TieredMemory] = None,
+        *,
+        graph_backend_name: str = "memgraph",
+        collection_name: str = "deepthought",
+        persist_directory: str | None = None,
+        vector_backend: str = "chroma",
+        use_gpu: bool = False,
+        capacity: int = 100,
+        top_k: int = 3,
+    ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._dal = dal or FileGraphDAL()
+        if memory is None:
+            store = create_vector_store(
+                backend=vector_backend,
+                collection_name=collection_name,
+                persist_directory=persist_directory,
+                use_gpu=use_gpu,
+            )
+            backend_obj = create_graph_backend(graph_backend_name)
+            memory = TieredMemory(store, backend_obj, capacity=capacity, top_k=top_k)
+        self._memory = memory
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -39,8 +63,8 @@ class MemoryService:
                 raise ValueError("Invalid input payload fields")
             logger.info("MemoryService received input event ID %s", input_id)
 
-            self._dal.add_interaction(user_input)
-            facts = self._dal.get_recent_facts()
+            self._memory.store_interaction(user_input)
+            facts = self._memory.retrieve_context(user_input)
             memory_data = {"facts": facts, "source": "memory_service"}
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge=memory_data,

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -5,6 +5,11 @@ from datetime import datetime, timezone
 from types import SimpleNamespace
 
 sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
+record_mod = types.ModuleType("record")
+class TraceEvent:
+    pass
+record_mod.TraceEvent = TraceEvent
+sys.modules.setdefault("deepthought.harness.record", record_mod)
 sys.modules.setdefault("deepthought.learn", types.ModuleType("learn"))
 sys.modules.setdefault("deepthought.modules", types.ModuleType("modules"))
 sys.modules.setdefault("deepthought.motivate", types.ModuleType("motivate"))
@@ -42,6 +47,8 @@ fake_ps = types.ModuleType("pydantic_settings")
 fake_ps.BaseSettings = object
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 fake_prom = types.ModuleType("prometheus_client")
 
 class _Metric:

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -1,8 +1,69 @@
 import json
+import sys
+import types
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
+
+sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
+record_mod = types.ModuleType("record")
+class TraceEvent:
+    pass
+record_mod.TraceEvent = TraceEvent
+sys.modules.setdefault("deepthought.harness.record", record_mod)
+fake_nx = types.ModuleType("networkx")
+setattr(fake_nx, "DiGraph", object)
+sys.modules.setdefault("networkx", fake_nx)
+sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+fake_ps.BaseSettings = object
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+fake_nats = types.ModuleType("nats")
+fake_nats.aio = types.ModuleType("aio")
+fake_client_mod = types.ModuleType("client")
+setattr(fake_client_mod, "Client", object)
+fake_nats.aio.client = fake_client_mod
+fake_msg_mod = types.ModuleType("msg")
+setattr(fake_msg_mod, "Msg", object)
+fake_nats.aio.msg = fake_msg_mod
+fake_nats.js = types.ModuleType("js")
+fake_js_client_mod = types.ModuleType("client")
+setattr(fake_js_client_mod, "JetStreamContext", object)
+fake_nats.js.client = fake_js_client_mod
+fake_errors_mod = types.ModuleType("errors")
+setattr(fake_errors_mod, "Error", Exception)
+fake_nats.errors = fake_errors_mod
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_client_mod)
+sys.modules.setdefault("nats.aio.msg", fake_msg_mod)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_js_client_mod)
+sys.modules.setdefault("nats.errors", fake_errors_mod)
+fake_prom = types.ModuleType("prometheus_client")
+
+class _Metric:
+    def labels(self, **kwargs):
+        return self
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+
+fake_prom.Counter = lambda *a, **k: _Metric()
+fake_prom.Histogram = lambda *a, **k: _Metric()
+sys.modules.setdefault("prometheus_client", fake_prom)
 
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
 from deepthought.services.memory_service import MemoryService
@@ -34,15 +95,15 @@ class DummySubscriber:
         pass
 
 
-class DummyDAL:
+class DummyMemory:
     def __init__(self):
         self.interactions = []
 
-    def add_interaction(self, text):
+    def store_interaction(self, text):
         self.interactions.append(text)
 
-    def get_recent_facts(self, count=3):
-        return self.interactions[-count:]
+    def retrieve_context(self, prompt: str):
+        return self.interactions[-3:]
 
 
 class DummyMsg:
@@ -56,10 +117,10 @@ class DummyMsg:
 
 @pytest.mark.asyncio
 async def test_handle_input_updates_graph_and_publishes(monkeypatch):
-    dal = DummyDAL()
+    memory = DummyMemory()
     monkeypatch.setattr(MemoryService, "_publisher", DummyPublisher(DummyNATS(), DummyJS()), raising=False)
     monkeypatch.setattr(MemoryService, "_subscriber", DummySubscriber(), raising=False)
-    service = MemoryService(DummyNATS(), DummyJS(), dal)
+    service = MemoryService(DummyNATS(), DummyJS(), memory)
     # replace publisher and subscriber with dummies
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
@@ -69,7 +130,7 @@ async def test_handle_input_updates_graph_and_publishes(monkeypatch):
     await service._handle_input(msg)
 
     assert msg.acked
-    assert dal.interactions == ["hello"]
+    assert memory.interactions == ["hello"]
     subject, sent_payload = service._publisher.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"


### PR DESCRIPTION
## Summary
- wire `MemoryService` up with `TieredMemory`
- update tests for new interface
- stub optional imports in tests so they run without extras

## Testing
- `pytest tests/unit/services/test_memory_service.py tests/unit/services/test_hierarchical_service.py -vv`
- `flake8 src tests`

------
https://chatgpt.com/codex/tasks/task_e_6869ec863f208326b39e2bbe72d0e5a3