### PR TITLE
Add Neo4j graph backend and tests

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     search_db: str | None = None
     vector_backend: str = "chroma"
     vector_use_gpu: bool = False
+    neo4j_host: str = "localhost"
+    neo4j_port: int = 7687
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "neo4j"
     reward: RewardThresholds = RewardThresholds()
     persona_descriptions: dict[str, str] = {
         "friendly": "You are a friendly assistant who responds warmly.",

--- a/src/deepthought/graph/__init__.py
+++ b/src/deepthought/graph/__init__.py
@@ -1,6 +1,6 @@
 """Graph utilities for DeepThought."""
 
-from .connector import GraphConnector
+from .connector import GraphConnector, Neo4jConnector
 from .dal import GraphDAL
 from .backend import (
     GraphBackend,
@@ -11,6 +11,7 @@ from .backend import (
 
 __all__ = [
     "GraphConnector",
+    "Neo4jConnector",
     "GraphDAL",
     "GraphBackend",
     "GraphDALBackend",

--- a/src/deepthought/graph/backend.py
+++ b/src/deepthought/graph/backend.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, List
 import os
 
-from .connector import GraphConnector
+from .connector import GraphConnector, Neo4jConnector
 from .dal import GraphDAL
 
 
@@ -48,12 +48,22 @@ class NoOpGraphBackend(GraphBackend):
 def create_graph_backend(name: str = "memgraph", **params: Any) -> GraphBackend:
     """Return a :class:`GraphBackend` implementation based on ``name``."""
     lower = name.lower()
-    if lower in {"memgraph", "neo4j"}:
+    if lower == "memgraph":
         host = params.get("host", os.getenv("MG_HOST", "localhost"))
         port = int(params.get("port", os.getenv("MG_PORT", 7687)))
         username = params.get("username", os.getenv("MG_USER", ""))
         password = params.get("password", os.getenv("MG_PASSWORD", ""))
         connector = GraphConnector(
+            host=host, port=port, username=username, password=password
+        )
+        dal = GraphDAL(connector)
+        return GraphDALBackend(dal)
+    if lower == "neo4j":
+        host = params.get("host", os.getenv("NEO4J_HOST", "localhost"))
+        port = int(params.get("port", os.getenv("NEO4J_PORT", 7687)))
+        username = params.get("username", os.getenv("NEO4J_USER", "neo4j"))
+        password = params.get("password", os.getenv("NEO4J_PASSWORD", "neo4j"))
+        connector = Neo4jConnector(
             host=host, port=port, username=username, password=password
         )
         dal = GraphDAL(connector)

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -1,8 +1,13 @@
-"""Minimal Memgraph connector using the :mod:`pymemgraph` driver."""
+"""Graph database connectors for Memgraph and Neo4j."""
 
 from __future__ import annotations
 
 from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    from neo4j import GraphDatabase
+except Exception:  # pragma: no cover - driver not installed
+    GraphDatabase = None  # type: ignore[assignment]
 
 try:  # pragma: no cover - optional dependency
     from pymemgraph import Memgraph
@@ -74,3 +79,39 @@ class GraphConnector:
             return rows
         finally:
             cur.close()
+
+
+class Neo4jConnector:
+    """Connector using the :mod:`neo4j` driver."""
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 7687,
+        username: str = "neo4j",
+        password: str = "neo4j",
+    ) -> None:
+        self._uri = f"bolt://{host}:{port}"
+        self._auth = (username, password)
+        self._driver: Optional[Any] = None
+
+    def connect(self) -> Any:
+        if not self._driver:
+            if GraphDatabase is None:
+                raise ImportError("neo4j-driver is not installed")
+            self._driver = GraphDatabase.driver(self._uri, auth=self._auth)
+        return self._driver
+
+    def close(self) -> None:
+        if self._driver:
+            self._driver.close()
+        self._driver = None
+
+    def execute(self, query: str, params: Optional[Dict[str, Any]] = None) -> list:
+        driver = self.connect()
+        with driver.session() as session:
+            result = session.run(query, params or {})
+            try:
+                return [record.data() for record in result]
+            except Exception:  # pragma: no cover - defensive
+                return list(result)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -49,3 +49,14 @@ def chroma_available(host: str | None = None, port: int | None = None) -> bool:
             return True
     except Exception:
         return False
+
+
+def neo4j_available(host: str | None = None, port: int | None = None) -> bool:
+    """Return ``True`` if a Neo4j server is reachable."""
+    host = host or os.getenv("NEO4J_HOST", "localhost")
+    port = int(port or os.getenv("NEO4J_PORT", 7687))
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except Exception:
+        return False

--- a/tests/integration/test_neo4j_integration.py
+++ b/tests/integration/test_neo4j_integration.py
@@ -1,0 +1,100 @@
+import os
+import shutil
+import subprocess
+import time
+import uuid
+
+import pytest
+
+from deepthought.graph import Neo4jConnector, GraphDAL
+from tests.helpers import neo4j_available
+
+try:  # optional dependency
+    import neo4j  # noqa: F401
+except Exception:  # pragma: no cover - dependency missing
+    neo4j = None
+
+pytestmark = pytest.mark.neo4j
+
+NEO4J_HOST = os.getenv("NEO4J_HOST", "localhost")
+NEO4J_PORT = int(os.getenv("NEO4J_PORT", 7687))
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "test")
+
+
+@pytest.fixture(scope="module")
+def neo4j_server():
+    """Start a Neo4j Docker container if needed and yield when ready."""
+    if neo4j is None:
+        pytest.skip("neo4j-driver not installed")
+    if shutil.which("docker") is None:
+        pytest.skip("Docker not available")
+
+    already_running = neo4j_available(NEO4J_HOST, NEO4J_PORT)
+    container_name = None
+
+    if not already_running:
+        container_name = f"pytest-neo4j-{uuid.uuid4().hex[:8]}"
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--rm",
+            "-p",
+            f"{NEO4J_PORT}:7687",
+            "-e",
+            f"NEO4J_AUTH={NEO4J_USER}/{NEO4J_PASSWORD}",
+            "--name",
+            container_name,
+            "neo4j:5",
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            pytest.skip(f"Could not start neo4j container: {proc.stderr}")
+
+        for _ in range(30):
+            if neo4j_available(NEO4J_HOST, NEO4J_PORT):
+                break
+            time.sleep(1)
+        else:
+            subprocess.run(["docker", "stop", container_name], capture_output=True)
+            pytest.skip("Neo4j container did not start")
+
+    try:
+        yield
+    finally:
+        if container_name:
+            subprocess.run(["docker", "stop", container_name], capture_output=True)
+
+
+def test_graphdal_live(neo4j_server):
+    """Ensure GraphDAL can interact with a live Neo4j instance."""
+    if not neo4j_available(NEO4J_HOST, NEO4J_PORT):
+        pytest.skip("Neo4j not reachable")
+
+    connector = Neo4jConnector(
+        host=NEO4J_HOST,
+        port=NEO4J_PORT,
+        username=NEO4J_USER,
+        password=NEO4J_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+
+    alice_id = str(uuid.uuid4())
+    bob_id = str(uuid.uuid4())
+    dal.add_entity("Person", {"id": alice_id, "name": "Alice"})
+    dal.add_entity("Person", {"id": bob_id, "name": "Bob"})
+    dal.add_relationship(alice_id, bob_id, "KNOWS", {"since": 2024})
+
+    result = dal.query_subgraph(
+        "MATCH (a:Person {id: $a_id})-[r:KNOWS]->(b:Person {id: $b_id}) RETURN a.name AS src, b.name AS dst",
+        {"a_id": alice_id, "b_id": bob_id},
+    )
+    assert result
+    row = result[0]
+    if isinstance(row, tuple):
+        assert row[0] == "Alice" and row[1] == "Bob"
+    else:
+        src = row["src"] if isinstance(row, dict) else row.get("src")
+        dst = row["dst"] if isinstance(row, dict) else row.get("dst")
+        assert src == "Alice" and dst == "Bob"


### PR DESCRIPTION
## Summary
- add Neo4jConnector alongside existing GraphConnector
- configure create_graph_backend for Neo4j
- expose Neo4j connection parameters in Settings
- extend helpers with `neo4j_available`
- add integration tests that run Neo4j in Docker

## Testing
- `flake8`
- `pytest tests/unit/test_graph_connector.py tests/unit/test_graph_dal.py tests/integration/test_memgraph_integration.py tests/integration/test_neo4j_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ec86fa4c8326992a1a80d113aa88