### PR TITLE
Add Neo4j backend adapter and retrieval demo

### DIFF
--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -102,3 +102,22 @@ When using FAISS, ``DT_VECTOR_USE_GPU`` enables GPU acceleration if available.
 environment variables ``MG_HOST``, ``MG_PORT``, ``MG_USER`` and
 ``MG_PASSWORD``. Pass ``"noop"`` to disable graph persistence during testing.
 
+### Running with Neo4j
+
+To try the service with Neo4j instead of Memgraph start a Neo4j container:
+
+```bash
+docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/test neo4j:5
+```
+
+Set the corresponding variables so ``create_graph_backend("neo4j")`` can connect:
+
+```bash
+export NEO4J_HOST=localhost
+export NEO4J_PORT=7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=test
+```
+
+Then pass ``graph_backend_name="neo4j"`` to ``HierarchicalService.from_chroma``.
+

--- a/examples/neo4j_retrieval_demo.py
+++ b/examples/neo4j_retrieval_demo.py
@@ -1,0 +1,24 @@
+import logging
+
+from deepthought.graph import create_graph_backend
+from deepthought.memory.tiered import TieredMemory
+from deepthought.memory.vector_store import create_vector_store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    store = create_vector_store("faiss", collection_name="demo")
+    backend = create_graph_backend("neo4j")
+    memory = TieredMemory(store, backend, capacity=2, top_k=3)
+
+    for fact in ["Alice met Bob", "Bob met Carol", "Carol met Dave"]:
+        memory.store_interaction(fact)
+
+    ctx = memory.retrieve_context("Alice")
+    logger.info("Retrieved context: %s", ctx)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deepthought/graph/__init__.py
+++ b/src/deepthought/graph/__init__.py
@@ -1,13 +1,14 @@
 """Graph utilities for DeepThought."""
 
-from .connector import GraphConnector, Neo4jConnector
-from .dal import GraphDAL
 from .backend import (
     GraphBackend,
     GraphDALBackend,
+    Neo4jBackend,
     NoOpGraphBackend,
     create_graph_backend,
 )
+from .connector import GraphConnector, Neo4jConnector
+from .dal import GraphDAL
 
 __all__ = [
     "GraphConnector",
@@ -15,6 +16,7 @@ __all__ = [
     "GraphDAL",
     "GraphBackend",
     "GraphDALBackend",
+    "Neo4jBackend",
     "NoOpGraphBackend",
     "create_graph_backend",
 ]

--- a/src/deepthought/graph/backend.py
+++ b/src/deepthought/graph/backend.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 """Graph backend strategy interfaces."""
 
+import os
+import uuid
 from abc import ABC, abstractmethod
 from typing import Any, List
-import os
 
 from .connector import GraphConnector, Neo4jConnector
 from .dal import GraphDAL
@@ -35,6 +36,23 @@ class GraphDALBackend(GraphBackend):
         self._dal.merge_entity(name)
 
 
+class Neo4jBackend(GraphBackend):
+    """Direct backend using :class:`Neo4jConnector`."""
+
+    def __init__(self, connector: Neo4jConnector) -> None:
+        self._connector = connector
+
+    def query_subgraph(self, query: str, params: dict) -> List[Any]:
+        return self._connector.execute(query, params)
+
+    def merge_entity(self, name: str) -> None:
+        entity_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
+        self._connector.execute(
+            "MERGE (:Entity {id: $id, name: $name})",
+            {"id": entity_id, "name": name},
+        )
+
+
 class NoOpGraphBackend(GraphBackend):
     """Graph backend that does nothing."""
 
@@ -53,9 +71,7 @@ def create_graph_backend(name: str = "memgraph", **params: Any) -> GraphBackend:
         port = int(params.get("port", os.getenv("MG_PORT", 7687)))
         username = params.get("username", os.getenv("MG_USER", ""))
         password = params.get("password", os.getenv("MG_PASSWORD", ""))
-        connector = GraphConnector(
-            host=host, port=port, username=username, password=password
-        )
+        connector = GraphConnector(host=host, port=port, username=username, password=password)
         dal = GraphDAL(connector)
         return GraphDALBackend(dal)
     if lower == "neo4j":
@@ -63,12 +79,8 @@ def create_graph_backend(name: str = "memgraph", **params: Any) -> GraphBackend:
         port = int(params.get("port", os.getenv("NEO4J_PORT", 7687)))
         username = params.get("username", os.getenv("NEO4J_USER", "neo4j"))
         password = params.get("password", os.getenv("NEO4J_PASSWORD", "neo4j"))
-        connector = Neo4jConnector(
-            host=host, port=port, username=username, password=password
-        )
-        dal = GraphDAL(connector)
-        return GraphDALBackend(dal)
+        connector = Neo4jConnector(host=host, port=port, username=username, password=password)
+        return Neo4jBackend(connector)
     if lower in {"none", "noop", "stub"}:
         return NoOpGraphBackend()
     raise ValueError(f"Unknown graph backend: {name}")
-


### PR DESCRIPTION
## Summary
- support direct Neo4j access via `Neo4jBackend`
- document how to run hierarchical memory service with Neo4j
- expose `Neo4jBackend` from package
- add `examples/neo4j_retrieval_demo.py` demo

## Testing
- `pre-commit run --files src/deepthought/graph/backend.py src/deepthought/graph/__init__.py examples/neo4j_retrieval_demo.py docs/hierarchical_memory_service.md`

------
https://chatgpt.com/codex/tasks/task_e_6869f03f1a8c8326a53f6356f4ce62d7