### PR TITLE
Add bus service init template with JetStream defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,16 @@ To create a new service based on this template run:
 dtrt init service <name>
 ```
 
+The same initializer is available under the `bus` command with JetStream
+persistence enabled by default:
+
+```bash
+dtrt bus init service <name>
+```
+
+This variant also creates an `nats.env.example` file alongside the
+`Dockerfile` showing how to configure credentials and mTLS settings.
+
 The command copies the template to `src/deepthought/services/<name>` and
 replaces `TemplateService` with a class named `<Name>Service`.
 

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -10,16 +10,15 @@ def _to_camel(name: str) -> str:
     return "".join(part.capitalize() for part in name.split("_"))
 
 
-def init_service(name: str) -> None:
+def init_service(name: str, *, template_name: str = "service") -> None:
     dest = Path("src/deepthought/services") / name
     if dest.exists():
         raise SystemExit(f"Service '{name}' already exists")
-    # templates live under ``templates/service`` during development
-    template = Path(__file__).resolve().parents[3] / "templates" / "service"
+    # templates live under ``templates/<template_name>`` during development
+    template = Path(__file__).resolve().parents[3] / "templates" / template_name
     if not template.exists():
         # fallback to package data when installed from a wheel
         template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
-
 
     shutil.copytree(template, dest)
     class_name = _to_camel(name) + "Service"
@@ -31,7 +30,7 @@ def init_service(name: str) -> None:
 
 
 def _cmd_init_service(args: argparse.Namespace) -> None:
-    init_service(args.name)
+    init_service(args.name, template_name=args.template)
 
 
 def _cmd_finetune(args: argparse.Namespace) -> int:
@@ -70,7 +69,17 @@ def _build_parser() -> argparse.ArgumentParser:
 
     svc_p = init_sub.add_parser("service")
     svc_p.add_argument("name")
-    svc_p.set_defaults(func=_cmd_init_service)
+    svc_p.set_defaults(func=_cmd_init_service, template="service")
+
+    bus_p = sub.add_parser("bus")
+    bus_sub = bus_p.add_subparsers(dest="bus_cmd")
+
+    bus_init = bus_sub.add_parser("init")
+    bus_init_sub = bus_init.add_subparsers(dest="target")
+
+    bus_svc = bus_init_sub.add_parser("service")
+    bus_svc.add_argument("name")
+    bus_svc.set_defaults(func=_cmd_init_service, template="bus_service")
 
     return parser
 

--- a/templates/bus_service/Dockerfile
+++ b/templates/bus_service/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . .
+RUN pip install -e ../../..
+# Example credentials file for NATS connection
+COPY nats.env.example /etc/nats.env
+CMD ["python", "-m", "template_service"]

--- a/templates/bus_service/nats.env.example
+++ b/templates/bus_service/nats.env.example
@@ -1,0 +1,7 @@
+# Example configuration for NATS credentials and mTLS
+NATS_URL=nats://localhost:4222
+NATS_USERNAME=example
+NATS_PASSWORD=secret
+NATS_TLS_CERT=/path/to/client-cert.pem
+NATS_TLS_KEY=/path/to/client-key.pem
+NATS_TLS_CA=/path/to/ca.pem

--- a/templates/bus_service/publisher.py
+++ b/templates/bus_service/publisher.py
@@ -1,0 +1,10 @@
+class TemplateServicePublisher:
+    """Example publisher using JetStream persistence."""
+
+    def __init__(self, nats_client, js_context):
+        from deepthought.eda.publisher import Publisher
+
+        self._publisher = Publisher(nats_client, js_context)
+
+    async def publish_example(self, subject: str, data: str) -> None:
+        await self._publisher.publish(subject, data, use_jetstream=True)

--- a/templates/bus_service/subscriber.py
+++ b/templates/bus_service/subscriber.py
@@ -1,0 +1,18 @@
+class TemplateServiceSubscriber:
+    """Example subscriber using JetStream persistence."""
+
+    def __init__(self, nats_client, js_context):
+        from deepthought.eda.subscriber import Subscriber
+
+        self._subscriber = Subscriber(nats_client, js_context)
+
+    async def start(self, subject: str) -> None:
+        await self._subscriber.subscribe(
+            subject,
+            self._handle,
+            use_jetstream=True,
+            durable="template",
+        )
+
+    async def _handle(self, msg):
+        await msg.ack()


### PR DESCRIPTION
## Summary
- create `bus_service` template with JetStream and mTLS placeholders
- add `dtrt bus init service` command
- document how to use the new generator

## Testing
- `pre-commit run --files docs/architecture.md src/deepthought/cli/__init__.py templates/bus_service/publisher.py templates/bus_service/subscriber.py templates/bus_service/Dockerfile templates/bus_service/nats.env.example`
- `flake8 src tests`
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869f03de50c83269edea6ac11528cc2