### PR TITLE
Add VRAM estimator and sequence packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ After installing the project (`pip install dist/*.whl`), you can launch fine-tun
 ```bash
 dtrt finetune --model-path <model-id>
 ```
+You can also estimate the VRAM requirement before launching training:
+
+```bash
+dtrt finetune --estimate-vram
+```
+
+Enable sequence packing to reduce padding:
+
+```bash
+dtrt finetune --pack-sequences --max-seq-length 2048
+```
 
 Run ``dtrt finetune --help`` to see all available options.
 3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -20,7 +20,6 @@ def init_service(name: str) -> None:
         # fallback to package data when installed from a wheel
         template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
 
-
     shutil.copytree(template, dest)
     class_name = _to_camel(name) + "Service"
     for path in dest.rglob("*.py"):
@@ -36,6 +35,17 @@ def _cmd_init_service(args: argparse.Namespace) -> None:
 
 def _cmd_finetune(args: argparse.Namespace) -> int:
     training = import_module("deepthought.train")
+    if args.estimate_vram:
+        model, _ = training.load_model(args.model_path, args.bits)
+        vram = training.estimate_vram(
+            model,
+            batch_size=2,
+            seq_length=args.max_seq_length,
+            gradient_accumulation_steps=8,
+            bits=args.bits,
+        )
+        print(f"Estimated VRAM requirement: {vram:.2f} GB")
+        return 0
     return training.run(args)
 
 
@@ -61,6 +71,22 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output-dir",
         default="./results/lora-adapter",
         help="Directory to save results",
+    )
+    finetune_p.add_argument(
+        "--max-seq-length",
+        type=int,
+        default=2048,
+        help="Maximum sequence length",
+    )
+    finetune_p.add_argument(
+        "--pack-sequences",
+        action="store_true",
+        help="Pack multiple sequences to reduce padding",
+    )
+    finetune_p.add_argument(
+        "--estimate-vram",
+        action="store_true",
+        help="Estimate VRAM requirements and exit",
     )
     finetune_p.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
     finetune_p.set_defaults(func=_cmd_finetune)

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -7,7 +7,7 @@ import os
 from typing import Tuple
 
 import torch
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 from transformers import (
     AutoModelForCausalLM,
@@ -23,6 +23,7 @@ __all__ = [
     "load_dataset",
     "create_trainer",
     "run",
+    "estimate_vram",
 ]
 
 
@@ -38,13 +39,19 @@ def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM,
     )
     try:
         model = AutoModelForCausalLM.from_pretrained(
-            base_model_id, quantization_config=quantization_config, device_map="auto", trust_remote_code=True
+            base_model_id,
+            quantization_config=quantization_config,
+            device_map="auto",
+            trust_remote_code=True,
         )
         tokenizer = AutoTokenizer.from_pretrained(base_model_id, trust_remote_code=True)
     except Exception:
         base_model_id = "HuggingFaceH4/zephyr-7b-beta"
         model = AutoModelForCausalLM.from_pretrained(
-            base_model_id, quantization_config=quantization_config, device_map="auto", trust_remote_code=True
+            base_model_id,
+            quantization_config=quantization_config,
+            device_map="auto",
+            trust_remote_code=True,
         )
         tokenizer = AutoTokenizer.from_pretrained(base_model_id, trust_remote_code=True)
 
@@ -53,7 +60,12 @@ def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM,
     return model, tokenizer
 
 
-def load_dataset(dataset_path: str, tokenizer: AutoTokenizer, max_seq_length: int = 2048):
+def load_dataset(
+    dataset_path: str,
+    tokenizer: AutoTokenizer,
+    max_seq_length: int = 2048,
+    pack_sequences: bool = False,
+):
     """Load and tokenize the dataset used for fine-tuning."""
     raw_dataset = load_dataset(dataset_path)
 
@@ -77,12 +89,36 @@ def load_dataset(dataset_path: str, tokenizer: AutoTokenizer, max_seq_length: in
     formatted_dataset = raw_dataset["train"].map(format_prompt)
 
     def tokenize_function(examples):
-        return tokenizer(examples["text"], truncation=True, max_length=max_seq_length, padding="max_length")
+        return tokenizer(
+            examples["text"],
+            truncation=True,
+            max_length=max_seq_length,
+            padding="max_length",
+        )
 
     tokenized_dataset = formatted_dataset.map(tokenize_function, batched=True, remove_columns=["text"])
-    filtered_dataset = tokenized_dataset.filter(lambda ex: len(ex["input_ids"]) <= max_seq_length)
-    split_dataset = filtered_dataset.train_test_split(test_size=0.05, seed=42)
-    return split_dataset["train"], split_dataset["test"]
+
+    if pack_sequences:
+
+        def _pack(ds: Dataset) -> Dataset:
+            flat_ids = [tid for ids in ds["input_ids"] for tid in ids]
+            flat_mask = [m for mask in ds["attention_mask"] for m in mask]
+            total = len(flat_ids) // max_seq_length
+            input_ids = [flat_ids[i * max_seq_length : (i + 1) * max_seq_length] for i in range(total)]  # noqa: E203
+            attention_mask = [
+                flat_mask[i * max_seq_length : (i + 1) * max_seq_length] for i in range(total)  # noqa: E203
+            ]
+            return Dataset.from_dict({"input_ids": input_ids, "attention_mask": attention_mask})
+
+        split_dataset = tokenized_dataset.train_test_split(test_size=0.05, seed=42)
+        train_ds = _pack(split_dataset["train"])
+        eval_ds = _pack(split_dataset["test"])
+    else:
+        filtered_dataset = tokenized_dataset.filter(lambda ex: len(ex["input_ids"]) <= max_seq_length)
+        split_dataset = filtered_dataset.train_test_split(test_size=0.05, seed=42)
+        train_ds, eval_ds = split_dataset["train"], split_dataset["test"]
+
+    return train_ds, eval_ds
 
 
 def create_trainer(
@@ -131,10 +167,30 @@ def create_trainer(
     return trainer, training_args
 
 
+def estimate_vram(
+    model: AutoModelForCausalLM,
+    batch_size: int,
+    seq_length: int,
+    gradient_accumulation_steps: int = 1,
+    bits: int = 16,
+) -> float:
+    """Roughly estimate VRAM (in GB) required for training."""
+    params = sum(p.numel() for p in model.parameters())
+    param_bytes = params * bits / 8
+    hidden_size = getattr(model.config, "hidden_size", 0)
+    activation_bytes = batch_size * gradient_accumulation_steps * seq_length * hidden_size * 2
+    return (param_bytes + activation_bytes) / (1024**3)
+
+
 def run(args: argparse.Namespace) -> int:
     """Execute training using high level helper functions."""
     model, tokenizer = load_model(args.model_path, args.bits)
-    train_ds, eval_ds = load_dataset(args.dataset_path, tokenizer)
+    train_ds, eval_ds = load_dataset(
+        args.dataset_path,
+        tokenizer,
+        max_seq_length=args.max_seq_length,
+        pack_sequences=args.pack_sequences,
+    )
     trainer, _ = create_trainer(model, tokenizer, train_ds, eval_ds, args.output_dir)
     trainer.train(resume_from_checkpoint=args.resume)
     trainer.save_model()

--- a/tests/unit/test_estimate_vram.py
+++ b/tests/unit/test_estimate_vram.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+import types
+
+if "datasets" not in sys.modules:
+    datasets_stub = types.ModuleType("datasets")
+    datasets_stub.Dataset = object
+
+    def load_dataset(*args, **kwargs):
+        raise RuntimeError("load_dataset called")
+
+    datasets_stub.load_dataset = load_dataset
+    sys.modules["datasets"] = datasets_stub
+
+if "peft" not in sys.modules:
+    peft_stub = types.ModuleType("peft")
+    peft_stub.LoraConfig = object
+    peft_stub.get_peft_model = lambda *a, **k: None
+    peft_stub.prepare_model_for_kbit_training = lambda m: m
+    sys.modules["peft"] = peft_stub
+
+
+def test_estimate_vram_simple():
+    train = importlib.import_module("deepthought.train")
+    from transformers import AutoModelForCausalLM, GPT2Config
+
+    cfg = GPT2Config(n_embd=4, n_layer=1, n_head=1, vocab_size=10)
+    model = AutoModelForCausalLM.from_config(cfg)
+    vram = train.estimate_vram(model, batch_size=1, seq_length=2, bits=4)
+    assert vram > 0

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -15,3 +15,5 @@ def test_finetune_cli_help(tmp_path):
         env=env,
     )
     assert "usage" in result.stdout.lower()
+    assert "--estimate-vram" in result.stdout
+    assert "--pack-sequences" in result.stdout


### PR DESCRIPTION
## Summary
- add VRAM estimation helper for fine-tuning
- make dataset loader optionally pack sequences
- expose new CLI flags `--estimate-vram`, `--max-seq-length`, `--pack-sequences`
- document VRAM estimation and sequence packing
- test new CLI flags and VRAM estimator

## Testing
- `pre-commit run --files README.md src/deepthought/cli/__init__.py src/deepthought/train/__init__.py tests/unit/test_finetune_cli.py tests/unit/test_estimate_vram.py`

------
https://chatgpt.com/codex/tasks/task_e_6869f03df4d88326ac71d1fc7375afa4