### PR TITLE
Add edge_server integration test

### DIFF
--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -1,0 +1,38 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.slow
+def test_generate_with_distilgpt2(monkeypatch):
+    try:
+        import torch  # noqa: F401
+        import transformers  # noqa: F401
+    except Exception:
+        pytest.skip("transformers or torch not installed")
+
+    import transformers as _tf
+
+    real_load = _tf.AutoModelForCausalLM.from_pretrained
+
+    def load_model(model_name, *args, **kwargs):
+        kwargs.pop("load_in_4bit", None)
+        return real_load(model_name, *args, **kwargs)
+
+    monkeypatch.setattr(_tf.AutoModelForCausalLM, "from_pretrained", load_model)
+    monkeypatch.setenv("MODEL_PATH", "distilgpt2")
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+    import edge_server
+
+    importlib.reload(edge_server)
+
+    with TestClient(edge_server.app) as client:
+        resp = client.post("/generate", json={"text": "Hello"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data.get("text"), str)
+        assert data["text"]


### PR DESCRIPTION
## Summary
- test `edge_server` using a lightweight distilgpt2 model

## Testing
- `pre-commit run --files tests/integration/test_edge_server_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_6869f617e2a0832681b78cf793594ebd