### PR TITLE
Implement query endpoint

### DIFF
--- a/src/deepthought/api/server.py
+++ b/src/deepthought/api/server.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import nats
 from fastapi import FastAPI, HTTPException
@@ -56,6 +56,23 @@ class MemoryCache:
     def get(self, input_id: str) -> Optional[Dict]:
         return self._cache.get(input_id)
 
+    def search(self, query: str) -> List[Dict]:
+        """Return cached entries whose facts contain the query string."""
+        results: List[Dict] = []
+        q = query.lower()
+        for input_id, knowledge in self._cache.items():
+            data = knowledge
+            if isinstance(data, dict) and "retrieved_knowledge" in data:
+                data = data.get("retrieved_knowledge")
+            if not isinstance(data, dict):
+                continue
+            facts = data.get("facts")
+            if not isinstance(facts, list):
+                continue
+            if any(q in str(f).lower() for f in facts):
+                results.append({"input_id": input_id, "retrieved_knowledge": knowledge})
+        return results
+
     async def start(self, durable: str = "api_memory_cache") -> bool:
         try:
             await self._subscriber.subscribe(
@@ -75,6 +92,10 @@ class MemoryCache:
 
 class MemoryAddRequest(BaseModel):
     text: str
+
+
+class MemoryQueryRequest(BaseModel):
+    query: str
 
 
 @app.on_event("startup")
@@ -110,10 +131,8 @@ async def add_memory(req: MemoryAddRequest) -> Dict[str, str]:
         raise HTTPException(status_code=500, detail="Failed to process input")
 
 
-@app.get("/memory/query")
-async def query_memory(input_id: str) -> Dict:
-    result = app.state.memory_cache.get(input_id)
-    if result is None:
-        raise HTTPException(status_code=404, detail="Memory not found")
-    return {"input_id": input_id, "retrieved_knowledge": result}
+@app.post("/memory/query")
+async def query_memory(req: MemoryQueryRequest) -> Dict[str, List[Dict]]:
+    results = app.state.memory_cache.search(req.query)
+    return {"results": results}
 

--- a/tests/unit/test_api_server_memory.py
+++ b/tests/unit/test_api_server_memory.py
@@ -87,7 +87,14 @@ def test_memory_query_reads_cache(client):
     cache = server.app.state.memory_cache
     cache._cache["abc"] = {"facts": ["f1"], "source": "test"}
 
-    resp = client.get("/memory/query", params={"input_id": "abc"})
+    resp = client.post("/memory/query", json={"query": "f1"})
     assert resp.status_code == 200
-    assert resp.json()["retrieved_knowledge"] == {"facts": ["f1"], "source": "test"}
+    assert resp.json()["results"] == [
+        {"input_id": "abc", "retrieved_knowledge": {"facts": ["f1"], "source": "test"}}
+    ]
+
+def test_memory_query_no_match(client):
+    resp = client.post("/memory/query", json={"query": "nomatch"})
+    assert resp.status_code == 200
+    assert resp.json()["results"] == []
 


### PR DESCRIPTION
## Summary
- add search-based /memory/query endpoint
- remove GET variant so UI and API share semantics
- update unit tests for new query handler

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q tests/unit/test_api_server_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_686d0f3c9f1883268b01ed72e6350a01