### PR TITLE
Add tests for OfflineSearch and dashboard CLI

### DIFF
--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -1,0 +1,22 @@
+import json
+
+import pytest
+
+
+def test_dashboard_creates_output(tmp_path):
+    pytest.importorskip("matplotlib")
+    import matplotlib
+
+    matplotlib.use("Agg")
+    from tools import dashboard
+
+    m1 = tmp_path / "m1.json"
+    m2 = tmp_path / "m2.json"
+    m1.write_text(json.dumps({"bleu": 0.5, "rouge_l": 0.2, "avg_latency": 1.0}))
+    m2.write_text(json.dumps({"bleu": 0.6, "rouge_l": 0.3, "avg_latency": 1.2}))
+
+    output = tmp_path / "out.png"
+
+    dashboard.main([str(m1), str(m2), "--output", str(output)])
+
+    assert output.exists()

--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -16,3 +16,18 @@ def test_search_limit(tmp_path):
     search = OfflineSearch.create_index(str(path), docs)
     results = search.search("alpha OR beta", limit=2)
     assert results == ["alpha", "beta"]
+
+
+def test_create_index_existing_db(tmp_path):
+    """Calling ``create_index`` on an existing DB should not error."""
+    path = tmp_path / "existing.db"
+    docs1 = [("x", "foo")]
+    OfflineSearch.create_index(str(path), docs1)
+
+    docs2 = [("y", "bar")]
+    # Should not raise when the database already contains the table
+    search = OfflineSearch.create_index(str(path), docs2)
+
+    results = search.search("foo OR bar", limit=5)
+    assert "foo" in results
+    assert "bar" in results


### PR DESCRIPTION
## Summary
- cover reusing OfflineSearch index when DB exists
- test dashboard CLI plots metrics into an output file

## Testing
- `python -m flake8 tests/unit/test_offline_search.py tests/unit/test_dashboard.py`
- `pytest tests/unit/test_offline_search.py::test_create_index_existing_db tests/unit/test_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686d13d43acc832683275b9f7d2dbf97