### PR TITLE
Add graph memory demo

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -59,6 +59,13 @@ Alternatively, run the example script directly:
 python examples/memgraph_memory_service.py
 ```
 
+Another demo using a Neo4j backend is available:
+
+```bash
+python examples/graph_memory_demo.py
+```
+
+
 ## Hierarchical Memory Wrapper
 
 `HierarchicalMemory` combines vector search (using a store like Chroma) with

--- a/examples/graph_memory_demo.py
+++ b/examples/graph_memory_demo.py
@@ -1,0 +1,28 @@
+import logging
+
+from deepthought.graph import create_graph_backend
+from deepthought.memory.tiered import TieredMemory
+from deepthought.memory.vector_store import create_vector_store
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    store = create_vector_store("faiss", collection_name="graph_demo")
+    backend = create_graph_backend("neo4j")
+    memory = TieredMemory(store, backend, capacity=3, top_k=2)
+
+    for fact in [
+        "Alice met Bob",
+        "Bob chatted with Carol",
+        "Carol saw Dave",
+    ]:
+        memory.store_interaction(fact)
+
+    ctx = memory.retrieve_context("Alice")
+    logger.info("Retrieved context: %s", ctx)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_graph_memory_demo.py
+++ b/tests/unit/test_graph_memory_demo.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+import examples.graph_memory_demo as demo
+
+
+class DummyStore:
+    def __init__(self):
+        self.added = []
+
+    def add_texts(self, texts, ids=None, metadatas=None):
+        self.added.extend(texts)
+
+    def query(self, query_texts, n_results=3):
+        return {"documents": [[t] for t in self.added[:n_results]]}
+
+    class Collection:
+        def __init__(self, outer):
+            self.outer = outer
+
+        def delete(self, ids):
+            pass
+
+    @property
+    def collection(self):
+        return DummyStore.Collection(self)
+
+
+class DummyBackend:
+    def __init__(self):
+        self.entities = []
+
+    def query_subgraph(self, query, params):
+        return [{"fact": "g1"}]
+
+    def merge_entity(self, name):
+        self.entities.append(name)
+
+
+def test_main(monkeypatch):
+    store = DummyStore()
+    backend = DummyBackend()
+    importlib.reload(demo)
+    monkeypatch.setattr(demo, "create_vector_store", lambda *a, **k: store)
+    monkeypatch.setattr(demo, "create_graph_backend", lambda *a, **k: backend)
+
+    captured = {}
+    monkeypatch.setattr(demo.logger, "info", lambda msg, ctx: captured.setdefault("ctx", ctx))
+
+    demo.main()
+
+    assert store.added
+    assert backend.entities
+    assert captured.get("ctx")


### PR DESCRIPTION
## Summary
- provide `graph_memory_demo.py` demonstrating Neo4j backed TieredMemory
- document the new demo in `docs/graphdal.md`
- add unit test for the demo

## Testing
- `pre-commit run --files docs/graphdal.md examples/graph_memory_demo.py tests/unit/test_graph_memory_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_686d13d23b0c8326a4e271ba7275fa1e