### PR TITLE
Add mTLS placeholders and subscriber rate limit

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,6 +123,13 @@ NATS_USERNAME=example
 NATS_PASSWORD=secret
 ```
 
+These TLS variables are commented out in the generated `nats.env.example` file.
+Uncomment them and provide the paths to your certificates to enable mTLS.
+
+The generated `subscriber.py` includes a simple `rate_limit` decorator. Apply
+it to your message handler to throttle processing, e.g. `@rate_limit(10, 1)`
+will allow up to ten messages per second.
+
 The command copies the template to `src/deepthought/services/<name>` and
 replaces `TemplateService` with a class named `<Name>Service`.
 

--- a/templates/bus_service/Dockerfile
+++ b/templates/bus_service/Dockerfile
@@ -4,4 +4,8 @@ COPY . .
 RUN pip install -e ../../..
 # Example credentials file for NATS connection
 COPY nats.env.example /etc/nats.env
+# Uncomment and update these lines to enable mTLS inside the container
+# ENV NATS_TLS_CERT=/certs/client-cert.pem
+# ENV NATS_TLS_KEY=/certs/client-key.pem
+# ENV NATS_TLS_CA=/certs/ca.pem
 CMD ["python", "-m", "template_service"]

--- a/templates/bus_service/nats.env.example
+++ b/templates/bus_service/nats.env.example
@@ -3,6 +3,7 @@
 NATS_URL=nats://localhost:4222
 NATS_USERNAME=example
 NATS_PASSWORD=secret
-NATS_TLS_CERT=/path/to/client-cert.pem
-NATS_TLS_KEY=/path/to/client-key.pem
-NATS_TLS_CA=/path/to/ca.pem
+# Uncomment and set paths to enable mTLS
+# NATS_TLS_CERT=/path/to/client-cert.pem
+# NATS_TLS_KEY=/path/to/client-key.pem
+# NATS_TLS_CA=/path/to/ca.pem

--- a/templates/bus_service/subscriber.py
+++ b/templates/bus_service/subscriber.py
@@ -1,3 +1,37 @@
+import asyncio
+import time
+from typing import Any, Awaitable, Callable
+
+
+def rate_limit(
+    capacity: int, refill_interval: float
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Simple token bucket rate limiter."""
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        tokens = capacity
+        last = time.monotonic()
+        lock = asyncio.Lock()
+
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            nonlocal tokens, last
+            async with lock:
+                now = time.monotonic()
+                tokens = min(capacity, tokens + (now - last) / refill_interval)
+                last = now
+                if tokens < 1:
+                    await asyncio.sleep((1 - tokens) * refill_interval)
+                    now = time.monotonic()
+                    tokens = min(capacity, tokens + (now - last) / refill_interval)
+                    last = now
+                tokens -= 1
+            return await func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 class TemplateServiceSubscriber:
     """Example subscriber using JetStream persistence."""
 
@@ -14,5 +48,6 @@ class TemplateServiceSubscriber:
             durable="template",
         )
 
+    @rate_limit(10, 1)  # 10 messages per second
     async def _handle(self, msg):
         await msg.ack()


### PR DESCRIPTION
## Summary
- include commented TLS settings in bus service Dockerfile and env file
- add a token-bucket `rate_limit` decorator to the subscriber template
- document how to enable TLS and rate limiting

## Testing
- `pre-commit run --files templates/bus_service/Dockerfile templates/bus_service/nats.env.example templates/bus_service/subscriber.py docs/architecture.md`

------
https://chatgpt.com/codex/tasks/task_e_686d13d17a2c8326ad3a6554ff94e08b