### PR TITLE
Add flake8 coverage for UI and basic test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,11 @@ repos:
   - repo: local
     hooks:
       - id: flake8-local
-        name: flake8 on src and tests
+        name: flake8 on src, tests, examples, scripts, and ui
         entry: python -m flake8
         language: system
         pass_filenames: false
-        files: "^(src|tests|examples|scripts)/"
+        files: "^(src|tests|examples|scripts|ui)/"
       - id: pytest
         name: pytest
         entry: pytest

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -20,3 +20,4 @@ PyYAML
 faiss-cpu
 prometheus-client
 setuptools
+streamlit

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -1,0 +1,10 @@
+import importlib
+import os
+import sys
+
+
+def test_ui_app_load(monkeypatch):
+    """Ensure the Streamlit UI script imports without errors."""
+    monkeypatch.setenv("MEMORY_API_URL", "http://test")
+    sys.modules.pop("ui.app", None)
+    importlib.import_module("ui.app")


### PR DESCRIPTION
## Summary
- expand flake8 local hook to include `ui/`
- add Streamlit to CI requirements
- test that `ui/app.py` imports without errors

## Testing
- `pre-commit run --files tests/unit/test_ui_app.py .pre-commit-config.yaml requirements-ci.txt`
- `pytest -q tests/unit/test_ui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_686d13d457c48326a89ee166c737bfca