### PR TITLE
Add finetune Docker image and CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+  push:
+    tags: ['*']
 
 permissions:
   contents: read
@@ -117,3 +119,11 @@ jobs:
       - name: Cleanup NATS container
         if: always()
         run: docker rm -f dtr_nats
+
+  docker_finetune_image:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build finetune image
+        run: docker build -f docker/Dockerfile.finetune -t dtrt-finetune .

--- a/README.md
+++ b/README.md
@@ -60,6 +60,19 @@ dtrt finetune --pack-sequences --max-seq-length 2048
 ```
 
 Run ``dtrt finetune --help`` to see all available options.
+
+The CLI is also available as ``dtrt-finetune`` for convenience.
+
+### Docker Finetune
+
+Build and run the CUDA-enabled image:
+
+```bash
+docker build -f docker/Dockerfile.finetune -t dtrt-finetune .
+docker run --gpus all dtrt-finetune \
+    --dataset-path databricks/databricks-dolly-15k \
+    --model-path meta-llama/Llama-3.2-3B-Instruct
+```
 3.  **Hierarchical Memory Service:** combines `BasicMemory`, a planned Chroma-backed vector memory, and `KnowledgeGraphMemory` using Memgraph. These layers are orchestrated by the `MemoryService` to produce aggregated `MEMORY_RETRIEVED` events. See [docs/hierarchical_memory_service.md](docs/hierarchical_memory_service.md).
 4.  **Reward Manager:** publishes user feedback as `RewardEvent` messages via JetStream, enabling future reinforcement or preference-based training. See [docs/reward_manager.md](docs/reward_manager.md).
 5.  **Adaptive Code Generation:** (Future Goal) Exploring techniques like template engines or JIT compilation (e.g., using AsmJit) for dynamic code optimization.

--- a/docker/Dockerfile.finetune
+++ b/docker/Dockerfile.finetune
@@ -1,0 +1,9 @@
+FROM pytorch/pytorch:2.2.1-cuda11.8-cudnn8-runtime
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir .
+
+ENTRYPOINT ["dtrt", "finetune"]

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     entry_points={
         "console_scripts": [
             "dtrt=deepthought.cli:main",
+            "dtrt-finetune=deepthought.cli.finetune:main",
         ]
     },
     description="DeepThought reThought - experimental AI framework",


### PR DESCRIPTION
## Summary
- provide `docker/Dockerfile.finetune` for CUDA fine‑tuning
- expose `dtrt-finetune` entry point
- document running the finetuning image
- build the image in CI on tags or PRs

## Testing
- `pre-commit run --files setup.py README.md .github/workflows/ci.yml docker/Dockerfile.finetune`

------
https://chatgpt.com/codex/tasks/task_e_686d13bc2d348326be21245099c945b9