### PR TITLE
Add configurable vector/graph backend options

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ export DT_VECTOR_BACKEND=faiss
 export DT_VECTOR_USE_GPU=true
 ```
 
+Configure the knowledge graph backend with `DT_GRAPH_BACKEND` (`memgraph`,
+`neo4j` or `noop`):
+
+```bash
+export DT_GRAPH_BACKEND=memgraph
+```
+
 `SchedulerService` runs periodic summarization and reminder tasks. Adjust the interval
 between summaries with `DT_SCHEDULER_INTERVAL` (seconds):
 

--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -95,6 +95,11 @@ search_db: wiki.db
 Set ``DT_VECTOR_BACKEND`` to ``faiss`` to use the in-memory FAISS store instead of Chroma.
 When using FAISS, ``DT_VECTOR_USE_GPU`` enables GPU acceleration if available.
 
+``DT_GRAPH_BACKEND`` selects the knowledge graph backend. Supported values include
+``memgraph``, ``neo4j`` and ``noop``. These variables are read by both
+``HierarchicalService.from_chroma`` and ``MemoryService`` when initializing the
+backends.
+
 ### Graph Backend
 
 ``HierarchicalService.from_chroma`` takes a ``graph_backend_name`` string such as

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
     search_db: str | None = None
     vector_backend: str = "chroma"
     vector_use_gpu: bool = False
+    graph_backend: str = "memgraph"
     neo4j_host: str = "localhost"
     neo4j_port: int = 7687
     neo4j_user: str = "neo4j"

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -16,6 +16,7 @@ from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..memory.tiered import TieredMemory
 from ..memory.vector_store import create_vector_store
 from ..graph import create_graph_backend
+from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -29,24 +30,27 @@ class MemoryService:
         js_context: JetStreamContext,
         memory: Optional[TieredMemory] = None,
         *,
-        graph_backend_name: str = "memgraph",
+        graph_backend_name: str | None = None,
         collection_name: str = "deepthought",
         persist_directory: str | None = None,
-        vector_backend: str = "chroma",
-        use_gpu: bool = False,
+        vector_backend: str | None = None,
+        use_gpu: bool | None = None,
         capacity: int = 100,
         top_k: int = 3,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         if memory is None:
+            settings = get_settings()
             store = create_vector_store(
-                backend=vector_backend,
+                backend=vector_backend or settings.vector_backend,
                 collection_name=collection_name,
                 persist_directory=persist_directory,
-                use_gpu=use_gpu,
+                use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
             )
-            backend_obj = create_graph_backend(graph_backend_name)
+            backend_obj = create_graph_backend(
+                graph_backend_name or settings.graph_backend
+            )
             memory = TieredMemory(store, backend_obj, capacity=capacity, top_k=top_k)
         self._memory = memory
 

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -137,3 +137,39 @@ async def test_handle_input_updates_graph_and_publishes(monkeypatch):
     assert "hello" in sent_payload.retrieved_knowledge["facts"]
     ts = sent_payload.timestamp
     assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+
+
+def test_init_from_settings(monkeypatch):
+    calls = {}
+    import deepthought.services.memory_service as ms
+
+    def fake_create_vector_store(backend, collection_name, persist_directory=None, use_gpu=False, embedding_function=None):
+        calls["vector"] = (backend, use_gpu)
+        return object()
+
+    def fake_create_graph_backend(name):
+        calls["graph"] = name
+        return object()
+
+    class DummyTiered:
+        def __init__(self, store, backend, capacity=100, top_k=3):
+            calls["tiered"] = (store, backend, capacity, top_k)
+
+    monkeypatch.setattr(ms, "create_vector_store", fake_create_vector_store)
+    monkeypatch.setattr(ms, "create_graph_backend", fake_create_graph_backend)
+    monkeypatch.setattr(ms, "TieredMemory", DummyTiered)
+
+    import deepthought.config as config
+
+    config._settings_cache = None
+    fake_settings = SimpleNamespace(
+        vector_backend="faiss", vector_use_gpu=True, graph_backend="noop"
+    )
+    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
+    monkeypatch.setattr(ms, "get_settings", lambda: fake_settings)
+
+    ms.MemoryService(DummyNATS(), DummyJS())
+
+    assert calls["vector"] == ("faiss", True)
+    assert calls["graph"] == "noop"
+    assert calls["tiered"][2:] == (100, 3)


### PR DESCRIPTION
## Summary
- add `graph_backend` to settings
- automatically create memory backends from settings in `MemoryService`
- document new config variables
- test `MemoryService` initialization with custom config
- mention `DT_GRAPH_BACKEND` in README

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/services/test_memory_service.py::test_init_from_settings -q`


------
https://chatgpt.com/codex/tasks/task_e_686d13badaf4832695fcf605c266cb1e