### PR TITLE
Add graph_backend property

### DIFF
--- a/src/deepthought/memory/tiered.py
+++ b/src/deepthought/memory/tiered.py
@@ -29,6 +29,11 @@ class TieredMemory:
         self._counter = 0
         self._lru: OrderedDict[str, str] = OrderedDict()
 
+    @property
+    def graph_backend(self) -> GraphBackend:
+        """Return the underlying graph backend."""
+        return self._graph
+
     @classmethod
     def from_chroma(
         cls,
@@ -55,9 +60,7 @@ class TieredMemory:
             try:
                 self._store.collection.delete([doc_id])
             except Exception:  # pragma: no cover - defensive
-                logger.error(
-                    "Failed to delete %s from vector store", doc_id, exc_info=True
-                )
+                logger.error("Failed to delete %s from vector store", doc_id, exc_info=True)
 
     def _add_to_vector(self, text: str) -> None:
         if text in self._lru:

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -209,7 +209,7 @@ class HierarchicalService:
         os.makedirs(path, exist_ok=True)
         dot_path = os.path.join(path, "graph.dot")
 
-        rows = self._memory._graph.query_subgraph(
+        rows = self._memory.graph_backend.query_subgraph(
             (
                 "MATCH (a)-[r]->(b) RETURN id(a) AS src_id, "
                 "coalesce(a.name, '') AS src, type(r) AS rel, "

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -6,8 +6,12 @@ from types import SimpleNamespace
 
 sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
 record_mod = types.ModuleType("record")
+
+
 class TraceEvent:
     pass
+
+
 record_mod.TraceEvent = TraceEvent
 sys.modules.setdefault("deepthought.harness.record", record_mod)
 sys.modules.setdefault("deepthought.learn", types.ModuleType("learn"))
@@ -51,6 +55,7 @@ sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 fake_prom = types.ModuleType("prometheus_client")
 
+
 class _Metric:
     def labels(self, **kwargs):
         return self
@@ -71,10 +76,10 @@ from typing import List
 import pytest
 
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.graph.backend import GraphDALBackend
 from deepthought.memory.tiered import TieredMemory
 from deepthought.search import OfflineSearch
 from deepthought.services.hierarchical_service import HierarchicalService
-from deepthought.graph.backend import GraphDALBackend
 
 
 class DummyNATS:
@@ -187,6 +192,10 @@ class DummyMemory:
     def __init__(self, backend):
         self._graph = backend
 
+    @property
+    def graph_backend(self):
+        return self._graph
+
 
 def test_dump_graph(tmp_path):
     dal = DummyGraphDAL()
@@ -233,6 +242,7 @@ def test_retrieve_context_from_config(monkeypatch, tmp_path):
     config._settings_cache = None
     monkeypatch.setattr(config, "get_settings", lambda: types.SimpleNamespace(search_db=str(db)))
     import deepthought.services.hierarchical_service as hs
+
     monkeypatch.setattr(hs, "get_settings", lambda: types.SimpleNamespace(search_db=str(db)))
     service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     ctx = service.retrieve_context("config")

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -79,3 +79,11 @@ def test_public_vector_and_graph_methods():
     assert mem.vector_matches("whatever") == ["v1"]
     assert mem.graph_facts() == ["g1"]
     assert mem.graph_facts(2) == ["g1", "g2"]
+
+
+def test_graph_backend_accessor():
+    vec = DummyVector()
+    dal = DummyDAL()
+    mem = TieredMemory(vec, dal)
+
+    assert mem.graph_backend is dal


### PR DESCRIPTION
## Summary
- expose graph backend in `TieredMemory`
- reference `graph_backend` in `HierarchicalService.dump_graph`
- adjust tests for new property
- add unit test for `graph_backend` accessor

## Testing
- `pre-commit run --files src/deepthought/memory/tiered.py src/deepthought/services/hierarchical_service.py tests/unit/services/test_hierarchical_service.py tests/unit/test_tiered_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_686d2fc9fe38832683423da1e1c80d07