### PR TITLE
Skip edge server integration when offline

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,9 +11,10 @@ A few integration tests require additional optional dependencies. These tests ar
 - `chromadb` for `test_chroma_service.py` (requires a running Chroma service)
 - `pymemgraph` for `test_memgraph_service.py` (requires a Memgraph instance)
 - `deepthought.motivate` for `test_motivation.py` and `test_reward_manager.py`
+- `torch` and `transformers` for `integration/test_edge_server_integration.py` (needs access to `huggingface.co`)
 
 Install these extras if you want to run the entire suite:
 
 ```bash
-pip install chromadb pymemgraph deepthought-motivate
+pip install chromadb pymemgraph deepthought-motivate torch transformers
 ```

--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -8,11 +8,15 @@ from fastapi.testclient import TestClient
 
 @pytest.mark.slow
 def test_generate_with_distilgpt2(monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+
+    import socket
+
     try:
-        import torch  # noqa: F401
-        import transformers  # noqa: F401
-    except Exception:
-        pytest.skip("transformers or torch not installed")
+        socket.create_connection(("huggingface.co", 443), timeout=3)
+    except OSError:
+        pytest.skip("huggingface.co unreachable")
 
     import transformers as _tf
 


### PR DESCRIPTION
## Summary
- skip edge server integration when huggingface is unreachable
- document network requirement for the test

## Testing
- `pre-commit run --files tests/integration/test_edge_server_integration.py`
- `pytest tests/integration/test_edge_server_integration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686d2fcafe448326b286c88cdbce4928