### PR TITLE
Wrap heavy imports in integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,9 +11,10 @@ A few integration tests require additional optional dependencies. These tests ar
 - `chromadb` for `test_chroma_service.py` (requires a running Chroma service)
 - `pymemgraph` for `test_memgraph_service.py` (requires a Memgraph instance)
 - `deepthought.motivate` for `test_motivation.py` and `test_reward_manager.py`
+- `torch` and `transformers` for `test_edge_server_integration.py` (for language model integration)
 
 Install these extras if you want to run the entire suite:
 
 ```bash
-pip install chromadb pymemgraph deepthought-motivate
+pip install chromadb pymemgraph deepthought-motivate torch transformers
 ```

--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -8,13 +8,8 @@ from fastapi.testclient import TestClient
 
 @pytest.mark.slow
 def test_generate_with_distilgpt2(monkeypatch):
-    try:
-        import torch  # noqa: F401
-        import transformers  # noqa: F401
-    except Exception:
-        pytest.skip("transformers or torch not installed")
-
-    import transformers as _tf
+    pytest.importorskip("torch")
+    _tf = pytest.importorskip("transformers")
 
     real_load = _tf.AutoModelForCausalLM.from_pretrained
 


### PR DESCRIPTION
## Summary
- skip integration test when torch or transformers aren't installed
- document optional torch/transformers dependencies for tests
- use bare importorskip statement for torch import

## Testing
- `pre-commit run --files tests/integration/test_edge_server_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_686d89e3fda08326993f992ab0ceb529