### PR TITLE
Refactor memory modules around TieredMemory

### DIFF
--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -4,11 +4,13 @@ This document outlines the design of the experimental hierarchical memory system
 
 ## Memory Layers
 
-1. **BasicMemory** – stores recent messages in a JSON file on disk.
-2. **VectorMemory** – persists embeddings in a Chroma database for semantic search.
+1. **BasicMemory** – thin wrapper over `TieredMemory` using an in-memory vector store.
+2. **GraphMemory** – wraps `TieredMemory` with a file-backed graph database.
 3. **KnowledgeGraphMemory** – persists structured facts in Memgraph using the GraphDAL layer.
 
-The `MemoryService` coordinates these layers. When an `INPUT_RECEIVED` event arrives the service updates each layer and aggregates their retrieved facts into a single `MEMORY_RETRIEVED` event.
+The `MemoryService` coordinates these layers through a single `TieredMemory` instance.
+When an `INPUT_RECEIVED` event arrives the service stores the text and publishes a
+`MEMORY_RETRIEVED` event with the combined context.
 
 ## Running the Service
 

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -1,15 +1,21 @@
-from prometheus_client import Counter, Histogram
+from prometheus_client import Counter, Histogram, REGISTRY
 
-INPUTS_TOTAL = Counter(
-    "inputs_total",
-    "Total number of input events processed",
-    labelnames=["service"],
-)
+if "inputs_total" not in REGISTRY._names_to_collectors:
+    INPUTS_TOTAL = Counter(
+        "inputs_total",
+        "Total number of input events processed",
+        labelnames=["service"],
+    )
+else:  # pragma: no cover - already registered in another module
+    INPUTS_TOTAL = REGISTRY._names_to_collectors["inputs_total"]  # type: ignore
 
-INPUT_LATENCY_SECONDS = Histogram(
-    "input_latency_seconds",
-    "Latency for processing input events",
-    labelnames=["service"],
-)
+if "input_latency_seconds" not in REGISTRY._names_to_collectors:
+    INPUT_LATENCY_SECONDS = Histogram(
+        "input_latency_seconds",
+        "Latency for processing input events",
+        labelnames=["service"],
+    )
+else:  # pragma: no cover - already registered
+    INPUT_LATENCY_SECONDS = REGISTRY._names_to_collectors["input_latency_seconds"]  # type: ignore
 
 __all__ = ["INPUTS_TOTAL", "INPUT_LATENCY_SECONDS"]

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -1,66 +1,42 @@
 import json
 import logging
-import os
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Optional
 
 import nats
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..config import get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..memory.tiered import TieredMemory
+from ..memory.vector_store import create_vector_store
+from ..graph import NoOpGraphBackend
 
 logger = logging.getLogger(__name__)
 
 
 class BasicMemory:
-    """File-backed memory module storing past inputs."""
+    """Simple memory module backed by :class:`TieredMemory`."""
 
     def __init__(
         self,
         nats_client: NATS,
         js_context: JetStreamContext,
-        memory_file: Optional[str] = None,
+        memory: Optional[TieredMemory] = None,
+        *,
+        capacity: int = 100,
+        top_k: int = 3,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._memory_file = memory_file or get_settings().memory_file
-
-        dir_path = os.path.dirname(self._memory_file)
-        if dir_path:
-            os.makedirs(dir_path, exist_ok=True)
-
-        if not os.path.exists(self._memory_file):
-            try:
-                with open(self._memory_file, "w", encoding="utf-8") as f:
-                    json.dump([], f)
-            except Exception as e:
-                logger.error("Failed to initialize memory file %s: %s", self._memory_file, e, exc_info=True)
-                raise
-        logger.info("BasicMemory initialized with file %s", self._memory_file)
-
-    def _read_memory(self) -> List[Dict[str, Any]]:
-        try:
-            with open(self._memory_file, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except (FileNotFoundError, PermissionError, OSError, json.JSONDecodeError) as e:
-            logger.error("Failed to read memory file: %s", e)
-            return []
-        except Exception as e:  # fallback
-            logger.error("Unexpected error reading memory file: %s", e, exc_info=True)
-            return []
-
-    def _write_memory(self, data: List[Dict[str, Any]]) -> None:
-        try:
-            with open(self._memory_file, "w", encoding="utf-8") as f:
-                json.dump(data, f)
-        except Exception as e:
-            logger.error("Failed to write memory file %s: %s", self._memory_file, e, exc_info=True)
-            raise
+        if memory is None:
+            store = create_vector_store()
+            memory = TieredMemory(store, NoOpGraphBackend(), capacity=capacity, top_k=top_k)
+        self._memory = memory
+        logger.info("BasicMemory initialized using TieredMemory")
 
     async def _handle_input_event(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -74,19 +50,20 @@ class BasicMemory:
                 raise ValueError("Invalid input payload fields")
             logger.info("BasicMemory received input event ID %s", input_id)
 
-            history = self._read_memory()
-            history.append({"timestamp": datetime.now(timezone.utc).isoformat(), "user_input": user_input})
-            self._write_memory(history)
-
-            last_entries = history[-3:]
-            facts = [entry["user_input"] for entry in last_entries]
+            self._memory.store_interaction(user_input)
+            facts = self._memory.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "basic_memory"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 
-            await self._publisher.publish(EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0)
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
             logger.info("BasicMemory published memory event ID %s", input_id)
             await msg.ack()
         except (json.JSONDecodeError, ValueError) as e:

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -1,11 +1,9 @@
 import json
 import logging
-import os
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Optional
 
 import nats
-import networkx as nx
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
@@ -13,85 +11,34 @@ from nats.js.client import JetStreamContext
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..memory.tiered import TieredMemory
+from ..memory.vector_store import create_vector_store
+from ..services.file_graph_dal import FileGraphBackend
 
 logger = logging.getLogger(__name__)
 
 
 class GraphMemory:
-    """Graph-based memory using NetworkX persisted to a JSON file."""
+    """File-based graph memory backed by :class:`TieredMemory`."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, graph_file: str = "graph_memory.json"):
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        *,
+        memory: Optional[TieredMemory] = None,
+        graph_file: str = "graph_memory.json",
+        capacity: int = 100,
+        top_k: int = 3,
+    ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._graph_file = graph_file
-        self.repaired = False
-        self._last_read_error: Optional[Exception] = None
-
-        dir_path = os.path.dirname(self._graph_file)
-        if dir_path:
-            os.makedirs(dir_path, exist_ok=True)
-
-        if os.path.exists(self._graph_file):
-            self._graph, valid = self._read_graph()
-            if not valid:
-                self.repaired = True
-                try:
-                    self._write_graph()
-                except Exception:
-                    # _write_graph already logs the error
-                    raise
-
-        else:
-            self._graph = nx.DiGraph()
-            try:
-                self._write_graph()
-            except Exception:
-                # _write_graph already logs the error
-                raise
-        logger.info("GraphMemory initialized with file %s", self._graph_file)
-
-    def _read_graph(self) -> tuple[nx.DiGraph, bool]:
-
-        try:
-            with open(self._graph_file, "r", encoding="utf-8") as f:
-                data = json.load(f)
-            self._last_read_error = None
-            return nx.readwrite.json_graph.node_link_graph(data), True
-        except (FileNotFoundError, PermissionError, OSError, json.JSONDecodeError) as e:
-            self._last_read_error = e
-            logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
-            return nx.DiGraph(), False
-
-        except Exception as e:  # fallback
-            self._last_read_error = e
-            logger.error("Unexpected error reading graph file %s: %s", self._graph_file, e, exc_info=True)
-            return nx.DiGraph(), False
-
-    def _write_graph(self) -> None:
-        data = nx.readwrite.json_graph.node_link_data(self._graph)
-        try:
-            with open(self._graph_file, "w", encoding="utf-8") as f:
-                json.dump(data, f)
-        except Exception as e:
-            logger.error("Failed to write graph file %s: %s", self._graph_file, e, exc_info=True)
-            raise
-
-    def _add_interaction(self, user_input: str) -> str:
-        timestamp = datetime.now(timezone.utc).isoformat()
-        node_id = timestamp
-        self._graph.add_node(node_id, user_input=user_input, timestamp=timestamp)
-        # Link to previous node if any
-        nodes = list(self._graph.nodes(data=True))
-        if len(nodes) > 1:
-            prev_id = nodes[-2][0]
-            self._graph.add_edge(prev_id, node_id, relation="next")
-        self._write_graph()
-        return node_id
-
-    def _get_recent_facts(self, count: int = 3) -> List[str]:
-        nodes = sorted(self._graph.nodes(data=True), key=lambda n: n[1].get("timestamp", ""))
-        recent = nodes[-count:]
-        return [n[1].get("user_input", "") for n in recent]
+        if memory is None:
+            store = create_vector_store()
+            backend = FileGraphBackend(graph_file)
+            memory = TieredMemory(store, backend, capacity=capacity, top_k=top_k)
+        self._memory = memory
+        logger.info("GraphMemory initialized using TieredMemory with %s", graph_file)
 
     async def _handle_input_event(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -105,15 +52,20 @@ class GraphMemory:
                 raise ValueError("Invalid input payload fields")
             logger.info("GraphMemory received input event ID %s", input_id)
 
-            self._add_interaction(user_input)
-            facts = self._get_recent_facts()
+            self._memory.store_interaction(user_input)
+            facts = self._memory.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "graph_memory"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 
-            await self._publisher.publish(EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0)
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
             logger.info("GraphMemory published memory event ID %s", input_id)
             await msg.ack()
         except (json.JSONDecodeError, ValueError) as e:
@@ -168,8 +120,3 @@ class GraphMemory:
             logger.info("GraphMemory stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
-
-    @property
-    def last_read_error(self) -> Optional[Exception]:
-        """Return the exception from the last failed graph read, if any."""
-        return self._last_read_error

--- a/src/deepthought/services/file_graph_dal.py
+++ b/src/deepthought/services/file_graph_dal.py
@@ -4,6 +4,8 @@ import os
 from datetime import datetime, timezone
 from typing import List
 
+from ..graph import GraphBackend
+
 import networkx as nx
 
 logger = logging.getLogger(__name__)
@@ -53,3 +55,18 @@ class FileGraphDAL:
         nodes = sorted(self._graph.nodes(data=True), key=lambda n: n[1].get("timestamp", ""))
         recent = nodes[-count:]
         return [n[1].get("user_input", "") for n in recent]
+
+
+class FileGraphBackend(GraphBackend):
+    """Adapter exposing :class:`FileGraphDAL` via the :class:`GraphBackend` interface."""
+
+    def __init__(self, graph_file: str = "graph_memory.json") -> None:
+        self._dal = FileGraphDAL(graph_file)
+
+    def query_subgraph(self, query: str, params: dict) -> List[dict]:
+        limit = int(params.get("limit", 3))
+        facts = self._dal.get_recent_facts(limit)
+        return [{"fact": f} for f in facts]
+
+    def merge_entity(self, name: str) -> None:
+        self._dal.add_interaction(name)

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -14,7 +14,6 @@ from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..memory.tiered import TieredMemory
-from ..memory.vector_store import create_vector_store
 from ..graph import create_graph_backend
 from ..config import get_settings
 
@@ -42,16 +41,18 @@ class MemoryService:
         self._subscriber = Subscriber(nats_client, js_context)
         if memory is None:
             settings = get_settings()
-            store = create_vector_store(
-                backend=vector_backend or settings.vector_backend,
-                collection_name=collection_name,
-                persist_directory=persist_directory,
-                use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
-            )
             backend_obj = create_graph_backend(
                 graph_backend_name or settings.graph_backend
             )
-            memory = TieredMemory(store, backend_obj, capacity=capacity, top_k=top_k)
+            memory = TieredMemory.from_chroma(
+                backend_obj,
+                collection_name=collection_name,
+                persist_directory=persist_directory,
+                backend=vector_backend or settings.vector_backend,
+                use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
+                capacity=capacity,
+                top_k=top_k,
+            )
         self._memory = memory
 
     async def _handle_input(self, msg: Msg) -> None:

--- a/tests/unit/modules/test_memory_basic.py
+++ b/tests/unit/modules/test_memory_basic.py
@@ -1,7 +1,5 @@
-import builtins
 import json
 import logging
-from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -30,10 +28,7 @@ class DummyPublisher:
 
 class FailingPublisher(DummyPublisher):
     async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
-        summary = str(payload)
-        if len(summary) > 50:
-            summary = summary[:47] + "..."
-        raise RuntimeError(f"Failed to publish to '{subject}' with payload {summary}")
+        raise RuntimeError("boom")
 
 
 class DummySubscriber:
@@ -60,16 +55,30 @@ class DummyMsg:
         self.nacked = True
 
 
-def create_memory(monkeypatch, memory_file, publisher_cls=DummyPublisher):
+class DummyMemory:
+    def __init__(self):
+        self.stored = []
+        self.prompts = []
+
+    def store_interaction(self, text):
+        self.stored.append(text)
+
+    def retrieve_context(self, prompt):
+        self.prompts.append(prompt)
+        return [prompt]
+
+
+def create_memory(monkeypatch, memory=None, publisher_cls=DummyPublisher):
     monkeypatch.setattr(memory_basic, "Publisher", publisher_cls)
     monkeypatch.setattr(memory_basic, "Subscriber", DummySubscriber)
-    return memory_basic.BasicMemory(DummyNATS(), DummyJS(), memory_file=memory_file)
+    mem = memory_basic.BasicMemory(DummyNATS(), DummyJS(), memory=memory)
+    return mem
 
 
 @pytest.mark.asyncio
-async def test_handle_input_success(tmp_path, monkeypatch):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file)
+async def test_handle_input_success(monkeypatch):
+    dummy = DummyMemory()
+    mem = create_memory(monkeypatch, dummy)
     payload = InputReceivedPayload(user_input="hello", input_id="42")
     msg = DummyMsg(payload.to_json())
     await mem._handle_input_event(msg)
@@ -80,17 +89,14 @@ async def test_handle_input_success(tmp_path, monkeypatch):
     subject, sent_payload = pub.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "42"
-    with open(mem_file, "r", encoding="utf-8") as f:
-        history = json.load(f)
-    assert history[-1]["user_input"] == "hello"
-    ts = sent_payload.timestamp
-    assert datetime.fromisoformat(ts).tzinfo == timezone.utc
+    assert dummy.stored == ["hello"]
+    assert dummy.prompts == ["hello"]
 
 
 @pytest.mark.asyncio
-async def test_handle_input_error(tmp_path, monkeypatch, caplog):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file, FailingPublisher)
+async def test_handle_input_error(monkeypatch, caplog):
+    dummy = DummyMemory()
+    mem = create_memory(monkeypatch, dummy, FailingPublisher)
     payload = InputReceivedPayload(user_input="boom", input_id="99")
     msg = DummyMsg(payload.to_json())
     with caplog.at_level(logging.ERROR):
@@ -98,17 +104,12 @@ async def test_handle_input_error(tmp_path, monkeypatch, caplog):
 
     assert msg.nacked
     assert not msg.acked
-    assert mem._publisher.published == []
-    with open(mem_file, "r", encoding="utf-8") as f:
-        history = json.load(f)
-    assert history[-1]["user_input"] == "boom"
-    assert any("Failed to publish to 'dtr.memory.retrieved'" in r.getMessage() for r in caplog.records)
+    assert dummy.stored == ["boom"]
 
 
 @pytest.mark.asyncio
-async def test_handle_input_invalid_payload(tmp_path, monkeypatch):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file)
+async def test_handle_input_invalid_payload(monkeypatch):
+    mem = create_memory(monkeypatch, DummyMemory())
     msg = DummyMsg("not json")
     await mem._handle_input_event(msg)
 
@@ -117,9 +118,8 @@ async def test_handle_input_invalid_payload(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_input_missing_fields(tmp_path, monkeypatch):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file)
+async def test_handle_input_missing_fields(monkeypatch):
+    mem = create_memory(monkeypatch, DummyMemory())
     msg = DummyMsg(json.dumps({"input_id": "1"}))
     await mem._handle_input_event(msg)
 
@@ -127,58 +127,9 @@ async def test_handle_input_missing_fields(tmp_path, monkeypatch):
     assert not msg.acked
 
 
-def test_read_memory_invalid_json_logs_error(tmp_path, monkeypatch, caplog):
-    mem_file = tmp_path / "mem.json"
-    mem_file.write_text("{ invalid json")
-    mem = create_memory(monkeypatch, mem_file)
-
-    with caplog.at_level(logging.ERROR):
-        data = mem._read_memory()
-
-    assert data == []
-    assert any("Failed to read memory file" in record.getMessage() for record in caplog.records)
-
-
-def test_init_creates_directory(tmp_path, monkeypatch):
-    mem_file = tmp_path / "newdir" / "mem.json"
-    create_memory(monkeypatch, mem_file)
-    assert mem_file.parent.is_dir()
-    assert mem_file.exists()
-    with open(mem_file, "r", encoding="utf-8") as f:
-        assert json.load(f) == []
-
-
-def test_write_memory_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file)
-
-    def fail_open(*args, **kwargs):
-        raise IOError("fail")
-
-    monkeypatch.setattr(builtins, "open", fail_open)
-    with caplog.at_level(logging.ERROR), pytest.raises(IOError):
-        mem._write_memory([{"test": 1}])
-
-    assert any("Failed to write memory file" in r.getMessage() for r in caplog.records)
-
-
-def test_init_write_failure_logs_and_raises(tmp_path, monkeypatch, caplog):
-    mem_file = tmp_path / "mem.json"
-
-    def fail_open(*args, **kwargs):
-        raise IOError("fail")
-
-    monkeypatch.setattr(builtins, "open", fail_open)
-    with caplog.at_level(logging.ERROR), pytest.raises(IOError):
-        memory_basic.BasicMemory(DummyNATS(), DummyJS(), memory_file=mem_file)
-
-    assert any("Failed to initialize memory file" in r.getMessage() for r in caplog.records)
-
-
 @pytest.mark.asyncio
-async def test_start_listening_no_subscriber(tmp_path, monkeypatch, caplog):
-    mem_file = tmp_path / "mem.json"
-    mem = create_memory(monkeypatch, mem_file)
+async def test_start_listening_no_subscriber(monkeypatch, caplog):
+    mem = create_memory(monkeypatch, DummyMemory())
     mem._subscriber = None
     with caplog.at_level(logging.ERROR):
         result = await mem.start_listening()

--- a/tests/unit/modules/test_memory_graph.py
+++ b/tests/unit/modules/test_memory_graph.py
@@ -1,12 +1,11 @@
-import builtins
 import json
 import logging
 from types import SimpleNamespace
 
-import networkx as nx
 import pytest
 
 import deepthought.modules.memory_graph as memory_graph
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
 
 
 class DummyNATS:
@@ -51,94 +50,48 @@ class DummyMsg:
         self.nacked = True
 
 
-def create_memory(monkeypatch, graph_file):
+class DummyMemory:
+    def __init__(self):
+        self.stored = []
+        self.prompts = []
+
+    def store_interaction(self, text):
+        self.stored.append(text)
+
+    def retrieve_context(self, prompt):
+        self.prompts.append(prompt)
+        return [prompt]
+
+
+def create_memory(monkeypatch, memory=None):
     monkeypatch.setattr(memory_graph, "Publisher", DummyPublisher)
     monkeypatch.setattr(memory_graph, "Subscriber", DummySubscriber)
-    return memory_graph.GraphMemory(DummyNATS(), DummyJS(), graph_file=graph_file)
-
-
-def test_read_graph_invalid_json(tmp_path, monkeypatch, caplog):
-    graph_file = tmp_path / "graph.json"
-    graph_file.write_text("{ invalid json")
-
-    caplog.set_level(logging.ERROR)
-    mem = create_memory(monkeypatch, graph_file)
-
-    assert isinstance(mem._graph, nx.DiGraph)
-    assert len(mem._graph.nodes) == 0
-    assert mem.repaired
-    assert isinstance(mem.last_read_error, Exception)
-    error_logs = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert any("Failed to read graph file" in r.getMessage() for r in error_logs)
-
-
-def test_invalid_json_rewritten_and_readable(tmp_path, monkeypatch, caplog):
-    graph_file = tmp_path / "graph.json"
-    graph_file.write_text("{ invalid json")
-
-    caplog.set_level(logging.ERROR)
-    mem = create_memory(monkeypatch, graph_file)
-    first_mtime = graph_file.stat().st_mtime
-    assert mem.repaired
-    assert mem.last_read_error is not None
-
-    error_logs = [r for r in caplog.records if "Failed to read graph file" in r.getMessage()]
-    assert len(error_logs) == 1
-
-    with open(graph_file, "r", encoding="utf-8") as f:
-        data = json.load(f)
-    assert data == nx.readwrite.json_graph.node_link_data(nx.DiGraph())
-
-    caplog.clear()
-    mem2 = create_memory(monkeypatch, graph_file)
-    second_mtime = graph_file.stat().st_mtime
-
-    assert not mem2.repaired
-    assert mem2.last_read_error is None
-    assert first_mtime == second_mtime
-    assert not any("Failed to read graph file" in r.getMessage() for r in caplog.records)
-
-
-def test_init_creates_directory(tmp_path, monkeypatch):
-    graph_file = tmp_path / "newdir" / "graph.json"
-    mem = create_memory(monkeypatch, graph_file)
-    assert graph_file.parent.is_dir()
-    assert graph_file.exists()
-    assert isinstance(mem._graph, nx.DiGraph)
-    assert mem.last_read_error is None
-    with open(graph_file, "r", encoding="utf-8") as f:
-        assert isinstance(json.load(f), dict)
+    return memory_graph.GraphMemory(DummyNATS(), DummyJS(), memory=memory)
 
 
 @pytest.mark.asyncio
-async def test_handle_input_invalid_payload(tmp_path, monkeypatch):
-    graph_file = tmp_path / "graph.json"
-    mem = create_memory(monkeypatch, graph_file)
+async def test_handle_input_invalid_payload(monkeypatch):
+    mem = create_memory(monkeypatch, DummyMemory())
     msg = DummyMsg("not json")
     await mem._handle_input_event(msg)
-
     assert msg.nacked
     assert not msg.acked
 
 
 @pytest.mark.asyncio
-async def test_handle_input_missing_fields(tmp_path, monkeypatch):
-    graph_file = tmp_path / "graph.json"
-    mem = create_memory(monkeypatch, graph_file)
+async def test_handle_input_missing_fields(monkeypatch):
+    mem = create_memory(monkeypatch, DummyMemory())
     msg = DummyMsg(json.dumps({"user_input": "hi"}))
     await mem._handle_input_event(msg)
-
     assert msg.nacked
     assert not msg.acked
 
 
 @pytest.mark.asyncio
-async def test_start_listening_no_subscriber(tmp_path, monkeypatch, caplog):
-    graph_file = tmp_path / "graph.json"
-    mem = create_memory(monkeypatch, graph_file)
+async def test_start_listening_no_subscriber(monkeypatch, caplog):
+    mem = create_memory(monkeypatch, DummyMemory())
     mem._subscriber = None
     with caplog.at_level(logging.ERROR):
         result = await mem.start_listening()
-
     assert result is False
     assert any("Subscriber not initialized for GraphMemory." in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- rely on `TieredMemory` for `BasicMemory` and `GraphMemory`
- add a file-based graph backend for tiered memory
- instantiate tiered memory inside `MemoryService` when not provided
- avoid Prometheus collector duplication
- update docs for new memory design
- adapt unit tests for the refactored API

## Testing
- `flake8 src tests`
- `TRANSFORMERS_OFFLINE=1 HF_DATASETS_OFFLINE=1 PYTHONPATH=src pytest -m "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_686da01864c88326b54e6b6142922c08