### PR TITLE
Add LangGraph multi-agent demo

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,11 +141,18 @@ Customize the generated files to implement your service logic.
 
 ## Multi-Agent Demo
 
-A simple demonstration of multiple agents communicating over NATS is provided in `examples/multi_agent_demo.py`.
-Start a local NATS server with `./scripts/start_nats.sh` and then run `setup_jetstream.py` to create the required JetStream stream:
+The repository includes a demonstration of three lightweight agents exchanging messages using the `MemoryService` and `LLMStub`. The agents are coordinated with a small LangGraph state machine and live in `examples/multi_agent_demo.py`.
+
+Start a local NATS server with `./scripts/start_nats.sh` and create the JetStream stream:
 
 ```bash
 python -c "import asyncio, setup_jetstream; asyncio.run(setup_jetstream.setup_jetstream())"
+```
+
+Install the optional dependency used by the demo:
+
+```bash
+pip install langgraph
 ```
 
 Then launch the demo:
@@ -154,5 +161,12 @@ Then launch the demo:
 python examples/multi_agent_demo.py
 ```
 
-This script spins up three agents that forward responses to each other in a round-robin fashion using the existing `InputHandler`, `BasicMemory`, `BasicLLM` (or `LLMStub`), and `OutputHandler` modules.
+You should see log lines similar to the following as the message circulates between agents:
+
+```text
+Agent 1 says: Hello from agent 1!
+Agent 2 says: Based on: ..., this is a stub response...
+Agent 3 says: Based on: ..., this is a stub response...
+```
+
 Ensure a NATS server is running on `localhost:4222` or set the `NATS_URL` environment variable accordingly.

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -2,17 +2,14 @@ import asyncio
 import logging
 import os
 import uuid
+from typing import TypedDict
 
 import nats
+from langgraph.graph import StateGraph
 from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
-from deepthought.modules import (
-    BasicLLM,
-    BasicMemory,
-    InputHandler,
-    LLMStub,
-    OutputHandler,
-)
+from deepthought.modules import InputHandler, LLMStub, OutputHandler
+from deepthought.services import MemoryService
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -42,44 +39,58 @@ async def main() -> None:
 
     await ensure_stream(js)
 
-    memory = BasicMemory(nc, js)
-    try:
-        llm = BasicLLM(nc, js)
-    except ImportError:
-        logger.warning("BasicLLM dependencies missing; falling back to LLMStub")
-        llm = LLMStub(nc, js)
+    memory_service = MemoryService(nc, js)
+    llm = LLMStub(nc, js)
 
+    global input_handlers, output_handlers
     input_handlers = [InputHandler(nc, js) for _ in range(3)]
-    done = asyncio.Event()
-    msg_count = 0
-
-    def make_callback(idx: int):
-        def cb(input_id: str, text: str) -> None:
-            nonlocal msg_count
-            logger.info("Agent %s says: %s", idx + 1, text)
-            msg_count += 1
-            next_idx = (idx + 1) % 3
-            if msg_count >= 3:
-                done.set()
-            else:
-                asyncio.create_task(input_handlers[next_idx].process_input(text))
-
-        return cb
-
-    output_handlers = [OutputHandler(nc, js, output_callback=make_callback(i)) for i in range(3)]
+    output_handlers = [OutputHandler(nc, js) for _ in range(3)]
 
     await asyncio.gather(
-        memory.start_listening(durable_name=f"mem_demo_{uuid.uuid4()}"),
+        memory_service.start(),
         llm.start_listening(durable_name=f"llm_demo_{uuid.uuid4()}"),
         *(oh.start_listening(durable_name=f"out_demo_{i}_{uuid.uuid4()}") for i, oh in enumerate(output_handlers)),
     )
 
     await asyncio.sleep(1.0)
-    await input_handlers[0].process_input("Hello from agent 1!")
 
-    await done.wait()
+    class AgentState(TypedDict):
+        text: str
+        idx: int
+        count: int
 
-    await memory.stop_listening()
+    async def send_receive(state: AgentState) -> AgentState:
+        idx = state["idx"]
+        event = asyncio.Event()
+
+        def cb(_id: str, text: str) -> None:
+            logger.info("Agent %s says: %s", idx + 1, text)
+            state["text"] = text
+            event.set()
+
+        output_handlers[idx]._output_callback = cb
+        await input_handlers[idx].process_input(state["text"])
+        await event.wait()
+        state["count"] += 1
+        return state
+
+    def rotate(state: AgentState) -> AgentState:
+        state["idx"] = (state["idx"] + 1) % 3
+        return state
+
+    graph = StateGraph(AgentState)
+    graph.add_node("talk", send_receive)
+    graph.add_node("next", rotate)
+    graph.set_entry_point("talk")
+    graph.add_edge("talk", "next")
+    graph.add_edge("next", "talk")
+    compiled = graph.compile()
+
+    state: AgentState = {"text": "Hello from agent 1!", "idx": 0, "count": 0}
+    while state["count"] < 3:
+        state = await compiled.ainvoke(state)
+
+    await memory_service.stop()
     await llm.stop_listening()
     await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
     await nc.drain()

--- a/tests/test_multi_agent_demo.py
+++ b/tests/test_multi_agent_demo.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.helpers import nats_server_available
+
+
+@pytest.mark.nats
+def test_multi_agent_demo_runs(tmp_path: Path) -> None:
+    """The demo script should run and emit at least one agent message."""
+    if not nats_server_available():
+        pytest.skip("NATS server not available")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[1] / "src"),
+            str(Path(__file__).resolve().parents[1]),
+        ]
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parents[1] / "examples" / "multi_agent_demo.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+        env=env,
+    )
+
+    assert "Agent 1 says" in result.stdout


### PR DESCRIPTION
## Summary
- implement a new `examples/multi_agent_demo.py` using `MemoryService` and `LLMStub`
- coordinate message passing with `LangGraph`
- document setup and expected output
- add regression test running the demo

## Testing
- `pre-commit run --files examples/multi_agent_demo.py tests/test_multi_agent_demo.py`
- `pytest -q tests/test_multi_agent_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_686dab2ecc1483268ba4de5fb801a2a5