### PR TITLE
Add env-driven graph connectors with retries

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -21,6 +21,27 @@ Set the following variables so the memory service can reach Memgraph:
 | `MG_USER`      | Username (optional)  | *(empty)*   |
 | `MG_PASSWORD`  | Password (optional)  | *(empty)*   |
 
+## Starting Neo4j
+
+Run a local Neo4j instance with Docker:
+
+```bash
+docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/test neo4j:5
+```
+
+Set these variables so ``create_graph_backend("neo4j")`` can connect:
+
+| Variable         | Description           | Default     |
+| ---------------- | -------------------- | ----------- |
+| `NEO4J_HOST`     | Neo4j host name      | `localhost` |
+| `NEO4J_PORT`     | Neo4j port number    | `7687`      |
+| `NEO4J_USER`     | Username             | `neo4j`     |
+| `NEO4J_PASSWORD` | Password             | `neo4j`     |
+
+Both connectors read these environment variables automatically when no
+explicit parameters are provided and will retry connecting a few times
+before failing.
+
 ## Example Memory Service
 
 The snippet below starts `KnowledgeGraphMemory` which listens for `INPUT_RECEIVED` events and stores them in Memgraph via GraphDAL:
@@ -36,12 +57,7 @@ async def main():
     nc = NATS()
     await nc.connect(servers=[os.getenv("NATS_URL", "nats://localhost:4222")])
     js = nc.jetstream()
-    connector = GraphConnector(
-        host=os.getenv("MG_HOST", "localhost"),
-        port=int(os.getenv("MG_PORT", "7687")),
-        username=os.getenv("MG_USER", ""),
-        password=os.getenv("MG_PASSWORD", ""),
-    )
+    connector = GraphConnector()  # reads MG_* variables by default
     dal = GraphDAL(connector)
     memory = KnowledgeGraphMemory(nc, js, dal)
     await memory.start_listening()

--- a/src/deepthought/graph/backend.py
+++ b/src/deepthought/graph/backend.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 """Graph backend strategy interfaces."""
 
-import os
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, List
@@ -63,24 +62,16 @@ class NoOpGraphBackend(GraphBackend):
         pass
 
 
-def create_graph_backend(name: str = "memgraph", **params: Any) -> GraphBackend:
-    """Return a :class:`GraphBackend` implementation based on ``name``."""
-    lower = name.lower()
+def create_graph_backend(backend: str = "memgraph", **params: Any) -> GraphBackend:
+    """Return a :class:`GraphBackend` implementation for ``backend``."""
+    lower = backend.lower()
     if lower == "memgraph":
-        host = params.get("host", os.getenv("MG_HOST", "localhost"))
-        port = int(params.get("port", os.getenv("MG_PORT", 7687)))
-        username = params.get("username", os.getenv("MG_USER", ""))
-        password = params.get("password", os.getenv("MG_PASSWORD", ""))
-        connector = GraphConnector(host=host, port=port, username=username, password=password)
+        connector = GraphConnector(**params)
         dal = GraphDAL(connector)
         return GraphDALBackend(dal)
     if lower == "neo4j":
-        host = params.get("host", os.getenv("NEO4J_HOST", "localhost"))
-        port = int(params.get("port", os.getenv("NEO4J_PORT", 7687)))
-        username = params.get("username", os.getenv("NEO4J_USER", "neo4j"))
-        password = params.get("password", os.getenv("NEO4J_PASSWORD", "neo4j"))
-        connector = Neo4jConnector(host=host, port=port, username=username, password=password)
+        connector = Neo4jConnector(**params)
         return Neo4jBackend(connector)
     if lower in {"none", "noop", "stub"}:
         return NoOpGraphBackend()
-    raise ValueError(f"Unknown graph backend: {name}")
+    raise ValueError(f"Unknown graph backend: {backend}")

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import time
 from typing import Any, Dict, Optional
 
 try:  # pragma: no cover - optional dependency
@@ -20,17 +22,22 @@ class GraphConnector:
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 7687,
-        username: str = "",
-        password: str = "",
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
     ) -> None:
         self._params = {
-            "host": host,
-            "port": port,
-            "username": username,
-            "password": password,
+            "host": host or os.getenv("MG_HOST", "localhost"),
+            "port": int(port or os.getenv("MG_PORT", 7687)),
+            "username": username or os.getenv("MG_USER", ""),
+            "password": password or os.getenv("MG_PASSWORD", ""),
         }
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
         self._connection: Optional[Any] = None
 
     def connect(self) -> Any:
@@ -38,7 +45,16 @@ class GraphConnector:
         if not self._connection:
             if Memgraph is None:
                 raise ImportError("pymemgraph is not installed")
-            self._connection = Memgraph(**self._params)
+            last_error: Exception | None = None
+            for _ in range(max(1, self._max_retries)):
+                try:
+                    self._connection = Memgraph(**self._params)
+                    break
+                except Exception as exc:  # pragma: no cover - defensive
+                    last_error = exc
+                    time.sleep(self._retry_delay)
+            if self._connection is None and last_error is not None:
+                raise last_error
         return self._connection
 
     def close(self) -> None:
@@ -86,20 +102,38 @@ class Neo4jConnector:
 
     def __init__(
         self,
-        host: str = "localhost",
-        port: int = 7687,
-        username: str = "neo4j",
-        password: str = "neo4j",
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        *,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
     ) -> None:
+        host = host or os.getenv("NEO4J_HOST", "localhost")
+        port = int(port or os.getenv("NEO4J_PORT", 7687))
+        username = username or os.getenv("NEO4J_USER", "neo4j")
+        password = password or os.getenv("NEO4J_PASSWORD", "neo4j")
         self._uri = f"bolt://{host}:{port}"
         self._auth = (username, password)
+        self._max_retries = max_retries
+        self._retry_delay = retry_delay
         self._driver: Optional[Any] = None
 
     def connect(self) -> Any:
         if not self._driver:
             if GraphDatabase is None:
                 raise ImportError("neo4j-driver is not installed")
-            self._driver = GraphDatabase.driver(self._uri, auth=self._auth)
+            last_error: Exception | None = None
+            for _ in range(max(1, self._max_retries)):
+                try:
+                    self._driver = GraphDatabase.driver(self._uri, auth=self._auth)
+                    break
+                except Exception as exc:  # pragma: no cover - defensive
+                    last_error = exc
+                    time.sleep(self._retry_delay)
+            if self._driver is None and last_error is not None:
+                raise last_error
         return self._driver
 
     def close(self) -> None:

--- a/tests/integration/test_graph_backend_factory.py
+++ b/tests/integration/test_graph_backend_factory.py
@@ -1,0 +1,67 @@
+import os
+import uuid
+
+import pytest
+
+from deepthought.graph import create_graph_backend
+from deepthought.graph.backend import GraphDALBackend, Neo4jBackend
+from tests.helpers import memgraph_available, neo4j_available
+from tests.integration.test_memgraph_integration import memgraph_server
+from tests.integration.test_neo4j_integration import neo4j_server
+
+# Environment defaults reused from other integration tests
+MG_HOST = os.getenv("MG_HOST", "localhost")
+MG_PORT = int(os.getenv("MG_PORT", 7687))
+MG_USER = os.getenv("MG_USER", "memgraph")
+MG_PASSWORD = os.getenv("MG_PASSWORD", "memgraph")
+
+NEO4J_HOST = os.getenv("NEO4J_HOST", "localhost")
+NEO4J_PORT = int(os.getenv("NEO4J_PORT", 7687))
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "test")
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.memgraph
+def test_factory_memgraph_live(memgraph_server, monkeypatch):
+    if not memgraph_available(MG_HOST, MG_PORT):
+        pytest.skip("Memgraph not reachable")
+
+    monkeypatch.setenv("MG_HOST", MG_HOST)
+    monkeypatch.setenv("MG_PORT", str(MG_PORT))
+    monkeypatch.setenv("MG_USER", MG_USER)
+    monkeypatch.setenv("MG_PASSWORD", MG_PASSWORD)
+
+    backend = create_graph_backend("memgraph")
+    assert isinstance(backend, GraphDALBackend)
+
+    name = f"Alice-{uuid.uuid4()}"
+    backend.merge_entity(name)
+    rows = backend.query_subgraph(
+        "MATCH (e:Entity {name: $name}) RETURN e.name AS name",
+        {"name": name},
+    )
+    assert rows
+
+
+@pytest.mark.neo4j
+def test_factory_neo4j_live(neo4j_server, monkeypatch):
+    if not neo4j_available(NEO4J_HOST, NEO4J_PORT):
+        pytest.skip("Neo4j not reachable")
+
+    monkeypatch.setenv("NEO4J_HOST", NEO4J_HOST)
+    monkeypatch.setenv("NEO4J_PORT", str(NEO4J_PORT))
+    monkeypatch.setenv("NEO4J_USER", NEO4J_USER)
+    monkeypatch.setenv("NEO4J_PASSWORD", NEO4J_PASSWORD)
+
+    backend = create_graph_backend("neo4j")
+    assert isinstance(backend, Neo4jBackend)
+
+    name = f"Bob-{uuid.uuid4()}"
+    backend.merge_entity(name)
+    rows = backend.query_subgraph(
+        "MATCH (e:Entity {name: $name}) RETURN e.name AS name",
+        {"name": name},
+    )
+    assert rows

--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -68,3 +68,34 @@ def test_execute_direct_execute_commits(monkeypatch):
     assert result == [1]
     assert conn.commit_called
     assert conn.executed == [("SELECT 1", {})]
+
+
+def test_env_defaults(monkeypatch):
+    monkeypatch.setenv("MG_HOST", "envhost")
+    monkeypatch.setenv("MG_PORT", "9999")
+    monkeypatch.setenv("MG_USER", "user")
+    monkeypatch.setenv("MG_PASSWORD", "pass")
+    connector = GraphConnector()
+    assert connector._params == {
+        "host": "envhost",
+        "port": 9999,
+        "username": "user",
+        "password": "pass",
+    }
+
+
+def test_connect_retries(monkeypatch):
+    calls = []
+
+    class FailOnce:
+        def __init__(self, **_):
+            calls.append("called")
+            if len(calls) == 1:
+                raise RuntimeError("fail")
+
+    monkeypatch.setattr("deepthought.graph.connector.Memgraph", FailOnce)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    connector = GraphConnector(max_retries=2, retry_delay=0)
+    conn = connector.connect()
+    assert isinstance(conn, FailOnce)
+    assert len(calls) == 2

--- a/tests/unit/test_neo4j_connector.py
+++ b/tests/unit/test_neo4j_connector.py
@@ -1,0 +1,31 @@
+import pytest
+
+from deepthought.graph.connector import Neo4jConnector
+
+
+def test_env_defaults(monkeypatch):
+    monkeypatch.setenv("NEO4J_HOST", "h")
+    monkeypatch.setenv("NEO4J_PORT", "7777")
+    monkeypatch.setenv("NEO4J_USER", "u")
+    monkeypatch.setenv("NEO4J_PASSWORD", "p")
+    c = Neo4jConnector()
+    assert c._uri == "bolt://h:7777"
+    assert c._auth == ("u", "p")
+
+
+def test_connect_retries(monkeypatch):
+    calls = []
+
+    class DummyDB:
+        def driver(self, uri, auth):
+            calls.append((uri, auth))
+            if len(calls) == 1:
+                raise RuntimeError("fail")
+            return "driver"
+
+    monkeypatch.setattr("deepthought.graph.connector.GraphDatabase", DummyDB())
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+    connector = Neo4jConnector(max_retries=2, retry_delay=0)
+    driver = connector.connect()
+    assert driver == "driver"
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary
- add environment variable defaults and connection retry logic to graph connectors
- simplify `create_graph_backend` factory
- document configuration examples for Neo4j and Memgraph
- test connectors and new backend factory

## Testing
- `pre-commit run --files src/deepthought/graph/connector.py src/deepthought/graph/backend.py tests/unit/test_graph_connector.py tests/integration/test_graph_backend_factory.py tests/unit/test_neo4j_connector.py`

------
https://chatgpt.com/codex/tasks/task_e_686dab2e3c088326951d7b05acd5ab14