### PR TITLE
Add configurable graph options

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,10 @@ variables:
 
 ```bash
 docker run --rm -p 7687:7687 memgraph/memgraph
-export MG_HOST=localhost
-export MG_PORT=7687
-export MG_USER=memgraph
-export MG_PASSWORD=memgraph
+export DT_MG_HOST=localhost
+export DT_MG_PORT=7687
+export DT_MG_USER=memgraph
+export DT_MG_PASSWORD=memgraph
 ```
 
 See [docs/graphdal.md](docs/graphdal.md) for a minimal script that starts

--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -16,10 +16,10 @@ Set the following variables so the memory service can reach Memgraph:
 
 | Variable       | Description           | Default     |
 | -------------- | -------------------- | ----------- |
-| `MG_HOST`      | Memgraph host name   | `localhost` |
-| `MG_PORT`      | Memgraph port number | `7687`      |
-| `MG_USER`      | Username (optional)  | *(empty)*   |
-| `MG_PASSWORD`  | Password (optional)  | *(empty)*   |
+| `DT_MG_HOST`      | Memgraph host name   | `localhost` |
+| `DT_MG_PORT`      | Memgraph port number | `7687`      |
+| `DT_MG_USER`      | Username (optional)  | `memgraph`  |
+| `DT_MG_PASSWORD`  | Password (optional)  | `memgraph`  |
 
 ## Starting Neo4j
 
@@ -33,10 +33,10 @@ Set these variables so ``create_graph_backend("neo4j")`` can connect:
 
 | Variable         | Description           | Default     |
 | ---------------- | -------------------- | ----------- |
-| `NEO4J_HOST`     | Neo4j host name      | `localhost` |
-| `NEO4J_PORT`     | Neo4j port number    | `7687`      |
-| `NEO4J_USER`     | Username             | `neo4j`     |
-| `NEO4J_PASSWORD` | Password             | `neo4j`     |
+| `DT_NEO4J_HOST`     | Neo4j host name      | `localhost` |
+| `DT_NEO4J_PORT`     | Neo4j port number    | `7687`      |
+| `DT_NEO4J_USER`     | Username             | `neo4j`     |
+| `DT_NEO4J_PASSWORD` | Password             | `neo4j`     |
 
 Both connectors read these environment variables automatically when no
 explicit parameters are provided and will retry connecting a few times
@@ -48,10 +48,14 @@ The snippet below starts `KnowledgeGraphMemory` which listens for `INPUT_RECEIVE
 
 ```bash
 python - <<'PY'
-import asyncio, os
+import asyncio
+import os
+
 from nats.aio.client import Client as NATS
+
 from deepthought.graph import GraphConnector, GraphDAL
 from deepthought.modules import KnowledgeGraphMemory
+
 
 async def main():
     nc = NATS()
@@ -89,9 +93,10 @@ graph lookups through `GraphDAL`. Instantiate it with a vector store and an
 existing `GraphDAL` instance:
 
 ```python
-from deepthought.memory.hierarchical import HierarchicalMemory
-from deepthought.graph import GraphConnector, GraphDAL
 import chromadb
+
+from deepthought.graph import GraphConnector, GraphDAL
+from deepthought.memory.hierarchical import HierarchicalMemory
 
 # Initialize vector store and graph connection
 client = chromadb.Client()

--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -28,13 +28,13 @@ docker run --rm -p 8000:8000 chromadb/chroma
 docker run --rm -p 7687:7687 memgraph/memgraph
 ```
 
-Set the environment variables used by GraphDAL when connecting to Memgraph:
+Set the configuration keys used by GraphDAL when connecting to Memgraph:
 
 ```bash
-export MG_HOST=localhost
-export MG_PORT=7687
-export MG_USER=memgraph
-export MG_PASSWORD=memgraph
+export DT_MG_HOST=localhost
+export DT_MG_PORT=7687
+export DT_MG_USER=memgraph
+export DT_MG_PASSWORD=memgraph
 ```
 
 With these services running you can start your application and the memory service will connect automatically as long as it receives the proper NATS events.
@@ -106,8 +106,8 @@ backends.
 
 ``HierarchicalService.from_chroma`` takes a ``graph_backend_name`` string such as
 ``"memgraph"`` or ``"noop"``. The default connects to Memgraph using the
-environment variables ``MG_HOST``, ``MG_PORT``, ``MG_USER`` and
-``MG_PASSWORD``. Pass ``"noop"`` to disable graph persistence during testing.
+configuration keys ``DT_MG_HOST``, ``DT_MG_PORT``, ``DT_MG_USER`` and
+``DT_MG_PASSWORD``. Pass ``"noop"`` to disable graph persistence during testing.
 
 ### Running with Neo4j
 
@@ -120,10 +120,10 @@ docker run --rm -p 7687:7687 -e NEO4J_AUTH=neo4j/test neo4j:5
 Set the corresponding variables so ``create_graph_backend("neo4j")`` can connect:
 
 ```bash
-export NEO4J_HOST=localhost
-export NEO4J_PORT=7687
-export NEO4J_USER=neo4j
-export NEO4J_PASSWORD=test
+export DT_NEO4J_HOST=localhost
+export DT_NEO4J_PORT=7687
+export DT_NEO4J_USER=neo4j
+export DT_NEO4J_PASSWORD=test
 ```
 
 Then pass ``graph_backend_name="neo4j"`` to ``HierarchicalService.from_chroma``.

--- a/examples/memgraph_memory_service.py
+++ b/examples/memgraph_memory_service.py
@@ -1,9 +1,9 @@
 import asyncio
 import logging
-import os
 
 from nats.aio.client import Client as NATS
 
+from deepthought.config import get_settings
 from deepthought.graph import GraphConnector, GraphDAL
 from deepthought.modules import KnowledgeGraphMemory
 
@@ -12,15 +12,16 @@ logger = logging.getLogger(__name__)
 
 
 async def main() -> None:
+    settings = get_settings()
     nc = NATS()
-    await nc.connect(servers=[os.getenv("NATS_URL", "nats://localhost:4222")])
+    await nc.connect(servers=[settings.nats_url])
     js = nc.jetstream()
 
     connector = GraphConnector(
-        host=os.getenv("MG_HOST", "localhost"),
-        port=int(os.getenv("MG_PORT", "7687")),
-        username=os.getenv("MG_USER", ""),
-        password=os.getenv("MG_PASSWORD", ""),
+        host=settings.mg_host,
+        port=settings.mg_port,
+        username=settings.mg_user,
+        password=settings.mg_password,
     )
     dal = GraphDAL(connector)
     memory = KnowledgeGraphMemory(nc, js, dal)

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -33,8 +33,10 @@ async def ensure_stream(js):
 
 
 async def main() -> None:
-    url = os.getenv("NATS_URL", "nats://localhost:4222")
-    nc = await nats.connect(url)
+    from deepthought.config import get_settings
+
+    settings = get_settings()
+    nc = await nats.connect(settings.nats_url)
     js = nc.jetstream()
 
     await ensure_stream(js)

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -26,7 +26,6 @@ from deepthought.services.file_graph_dal import FileGraphDAL
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
 
-
 try:
     import discord
 except Exception:  # pragma: no cover - optional dependency
@@ -100,7 +99,10 @@ except Exception:  # pragma: no cover - optional dependency
     from types import SimpleNamespace
 
     def get_settings():
-        return SimpleNamespace(nats_url="nats://localhost:4222")
+        return SimpleNamespace(
+            nats_url="nats://localhost:4222",
+            social_graph_db="social_graph.db",
+        )
 
     class EventSubjects(SimpleNamespace):
         INPUT_RECEIVED = "dtr.input.received"
@@ -123,7 +125,7 @@ except Exception:  # pragma: no cover - optional dependency
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
-DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
 
 
@@ -131,7 +133,7 @@ CURRENT_DB_PATH = DB_PATH
 PRISM_ENDPOINT = os.getenv("PRISM_ENDPOINT", "http://localhost:5000/receive_data")
 
 # NATS configuration for publishing events
-NATS_URL = os.getenv("NATS_URL", "nats://localhost:4222")
+NATS_URL = get_settings().nats_url
 _nats_client: nats.aio.client.Client | None = None
 _js_context: JetStreamContext | None = None
 _input_publisher: Publisher | None = None

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 import importlib
 import os
 
+try:  # Ensure prometheus_client is loaded before tests patch it
+    import prometheus_client  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency may be missing
+    pass
+
 __version__ = "0.1.0"
 
 # Re-export modules subpackage for convenient access

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -40,19 +40,34 @@ class RewardThresholds(BaseSettings):
 class Settings(BaseSettings):
     """Application wide settings."""
 
-    nats_url: str = "nats://localhost:4222"
+    nats_url: str = os.getenv("NATS_URL", "nats://localhost:4222")
     nats_stream_name: str = "deepthought_events"
+    nats_tls_cert: str | None = os.getenv("NATS_TLS_CERT")
+    nats_tls_key: str | None = os.getenv("NATS_TLS_KEY")
+    nats_tls_ca: str | None = os.getenv("NATS_TLS_CA")
+    nats_username: str | None = os.getenv("NATS_USERNAME")
+    nats_password: str | None = os.getenv("NATS_PASSWORD")
+
     db: DatabaseSettings = DatabaseSettings()
     model_path: str = "distilgpt2"
     memory_file: str = "memory.json"
     search_db: str | None = None
+    social_graph_db: str = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+
     vector_backend: str = "chroma"
     vector_use_gpu: bool = False
+
     graph_backend: str = "memgraph"
-    neo4j_host: str = "localhost"
-    neo4j_port: int = 7687
-    neo4j_user: str = "neo4j"
-    neo4j_password: str = "neo4j"
+    mg_host: str = os.getenv("MG_HOST", "localhost")
+    mg_port: int = int(os.getenv("MG_PORT", 7687))
+    mg_user: str = os.getenv("MG_USER", "memgraph")
+    mg_password: str = os.getenv("MG_PASSWORD", "memgraph")
+
+    neo4j_host: str = os.getenv("NEO4J_HOST", "localhost")
+    neo4j_port: int = int(os.getenv("NEO4J_PORT", 7687))
+    neo4j_user: str = os.getenv("NEO4J_USER", "neo4j")
+    neo4j_password: str = os.getenv("NEO4J_PASSWORD", "neo4j")
+
     reward: RewardThresholds = RewardThresholds()
     persona_descriptions: dict[str, str] = {
         "friendly": "You are a friendly assistant who responds warmly.",

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -8,6 +8,8 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
+from ..config import get_settings
+
 logger = logging.getLogger(__name__)
 
 
@@ -83,12 +85,13 @@ async def connect(
 ) -> "Publisher":
     """Create a :class:`Publisher` connected to ``nats_url`` with optional TLS."""
 
-    nats_url = nats_url or os.getenv("NATS_URL", "nats://localhost:4222")
-    tls_cert = tls_cert or os.getenv("NATS_TLS_CERT")
-    tls_key = tls_key or os.getenv("NATS_TLS_KEY")
-    tls_ca = tls_ca or os.getenv("NATS_TLS_CA")
-    user = user or os.getenv("NATS_USERNAME")
-    password = password or os.getenv("NATS_PASSWORD")
+    settings = get_settings()
+    nats_url = nats_url or settings.nats_url
+    tls_cert = tls_cert or settings.nats_tls_cert
+    tls_key = tls_key or settings.nats_tls_key
+    tls_ca = tls_ca or settings.nats_tls_ca
+    user = user or settings.nats_username
+    password = password or settings.nats_password
 
     ssl_ctx = None
     if tls_cert and tls_key:

--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -10,6 +10,8 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..config import get_settings
+
 logger = logging.getLogger(__name__)
 MessageHandlerType = Callable[[Msg], Awaitable[None]]
 
@@ -60,10 +62,16 @@ class Subscriber:
             self._subscriptions.append(sub)  # Store subscription object for cleanup
 
         except nats.errors.Error as e:
-            logger.error(f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}", exc_info=True)
+            logger.error(
+                f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}",
+                exc_info=True,
+            )
             raise e
         except Exception as e:
-            logger.error(f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}", exc_info=True)
+            logger.error(
+                f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}",
+                exc_info=True,
+            )
             raise e
 
     async def unsubscribe_all(self) -> None:
@@ -107,12 +115,13 @@ async def connect(
 ) -> "Subscriber":
     """Create a :class:`Subscriber` connected to ``nats_url`` with optional TLS."""
 
-    nats_url = nats_url or os.getenv("NATS_URL", "nats://localhost:4222")
-    tls_cert = tls_cert or os.getenv("NATS_TLS_CERT")
-    tls_key = tls_key or os.getenv("NATS_TLS_KEY")
-    tls_ca = tls_ca or os.getenv("NATS_TLS_CA")
-    user = user or os.getenv("NATS_USERNAME")
-    password = password or os.getenv("NATS_PASSWORD")
+    settings = get_settings()
+    nats_url = nats_url or settings.nats_url
+    tls_cert = tls_cert or settings.nats_tls_cert
+    tls_key = tls_key or settings.nats_tls_key
+    tls_ca = tls_ca or settings.nats_tls_ca
+    user = user or settings.nats_username
+    password = password or settings.nats_password
 
     ssl_ctx = None
     if tls_cert and tls_key:

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -30,11 +30,14 @@ class GraphConnector:
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
+        from ..config import get_settings
+
+        settings = get_settings()
         self._params = {
-            "host": host or os.getenv("MG_HOST", "localhost"),
-            "port": int(port or os.getenv("MG_PORT", 7687)),
-            "username": username or os.getenv("MG_USER", ""),
-            "password": password or os.getenv("MG_PASSWORD", ""),
+            "host": host or settings.mg_host,
+            "port": int(port or settings.mg_port),
+            "username": username or settings.mg_user,
+            "password": password or settings.mg_password,
         }
         self._max_retries = max_retries
         self._retry_delay = retry_delay
@@ -110,10 +113,13 @@ class Neo4jConnector:
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
-        host = host or os.getenv("NEO4J_HOST", "localhost")
-        port = int(port or os.getenv("NEO4J_PORT", 7687))
-        username = username or os.getenv("NEO4J_USER", "neo4j")
-        password = password or os.getenv("NEO4J_PASSWORD", "neo4j")
+        from ..config import get_settings
+
+        settings = get_settings()
+        host = host or settings.neo4j_host
+        port = int(port or settings.neo4j_port)
+        username = username or settings.neo4j_user
+        password = password or settings.neo4j_password
         self._uri = f"bolt://{host}:{port}"
         self._auth = (username, password)
         self._max_retries = max_retries

--- a/src/deepthought/metrics_server.py
+++ b/src/deepthought/metrics_server.py
@@ -1,5 +1,13 @@
 from fastapi import FastAPI, Response
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+try:  # pragma: no cover - optional dependency may be missing in tests
+    from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+except Exception:  # pragma: no cover - fallback for minimal stubs
+    CONTENT_TYPE_LATEST = "text/plain; version=0.0.4; charset=utf-8"
+
+    def generate_latest() -> bytes:
+        return b""
+
 
 app = FastAPI()
 

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -7,8 +7,10 @@ import os
 
 import aiosqlite
 
+from ..config import get_settings
+
 # Default database path used when none is provided.
-DB_PATH = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
+DB_PATH = get_settings().social_graph_db
 
 # Limits used when validating input sizes
 MAX_MEMORY_LENGTH = 1000


### PR DESCRIPTION
## Summary
- extend settings to include graph, vector, and NATS TLS options
- access configuration via `get_settings` in publishers, subscribers and graph connectors
- expose new keys in docs and examples
- fix metrics server import logic so tests run

## Testing
- `pre-commit run --files src/deepthought/__init__.py src/deepthought/metrics_server.py`
- `pytest tests/unit/test_metrics_prometheus.py tests/unit/test_metrics_server.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686dc32dd59c83268bf1a9edef54edc2