### PR TITLE
Add EDA publisher/subscriber timeout tests

### DIFF
--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -35,8 +35,11 @@ class Subscriber:
         queue: str = "",
         use_jetstream: bool = False,  # Flag to control behavior
         durable: str = "",
-    ) -> None:
-        """Subscribe using basic NATS or JetStream."""
+    ) -> bool:
+        """Subscribe using basic NATS or JetStream.
+
+        Returns ``True`` on success and ``False`` if an error occurred.
+        """
         try:
             if use_jetstream:
                 if not self._js:
@@ -60,19 +63,20 @@ class Subscriber:
                 logger.info(f"Basic NATS subscription created for '{subject}'")
 
             self._subscriptions.append(sub)  # Store subscription object for cleanup
+            return True
 
         except nats.errors.Error as e:
             logger.error(
                 f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}",
                 exc_info=True,
             )
-            raise e
+            return False
         except Exception as e:
             logger.error(
                 f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}",
                 exc_info=True,
             )
-            raise e
+            return False
 
     async def unsubscribe_all(self) -> None:
         """Unsubscribe from all active subscriptions."""

--- a/tests/unit/eda/test_publisher.py
+++ b/tests/unit/eda/test_publisher.py
@@ -1,0 +1,33 @@
+import logging
+
+import nats
+import pytest
+
+from deepthought.eda.publisher import Publisher
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class TimeoutJS:
+    async def publish(self, subject, data, timeout=10.0):
+        raise nats.errors.TimeoutError("too slow")
+
+
+@pytest.mark.asyncio
+async def test_publish_timeout_message(caplog):
+    nc = DummyNATS()
+    js = TimeoutJS()
+    pub = Publisher(nc, js)
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(nats.errors.TimeoutError) as exc:
+            await pub.publish("topic", {"foo": "bar"})
+
+    msg = exc.value.args[0]
+    assert "Publish timeout" in msg
+    assert "topic" in msg
+    assert "foo" in msg
+    assert any("Publish timeout" in r.getMessage() for r in caplog.records)

--- a/tests/unit/eda/test_subscriber.py
+++ b/tests/unit/eda/test_subscriber.py
@@ -1,0 +1,55 @@
+import logging
+
+import nats
+import pytest
+
+from deepthought.eda.subscriber import Subscriber
+
+
+class DummyNATS:
+    def __init__(self, error=None):
+        self.is_connected = True
+        self.error = error
+
+    async def subscribe(self, *args, **kwargs):
+        if self.error:
+            raise self.error
+        return object()
+
+
+class DummyJS:
+    def __init__(self, error=None):
+        self.error = error
+
+    async def subscribe(self, *args, **kwargs):
+        if self.error:
+            raise self.error
+        return object()
+
+
+async def dummy_handler(msg):
+    return None
+
+
+@pytest.mark.asyncio
+async def test_subscribe_timeout_logs_and_returns_false(caplog):
+    nc = DummyNATS(error=nats.errors.TimeoutError("no sub"))
+    sub = Subscriber(nc, DummyJS())
+
+    with caplog.at_level(logging.ERROR):
+        result = await sub.subscribe("topic", dummy_handler)
+
+    assert result is False
+    assert any("Failed to subscribe" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_js_subscribe_error(caplog):
+    js = DummyJS(error=RuntimeError("boom"))
+    sub = Subscriber(DummyNATS(), js)
+
+    with caplog.at_level(logging.ERROR):
+        result = await sub.subscribe("topic", dummy_handler, use_jetstream=True, durable="d")
+
+    assert result is False
+    assert any("Failed to subscribe" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow Subscriber.subscribe to return bool instead of raising
- add publisher timeout test
- add subscriber failure tests

## Testing
- `pre-commit run --files src/deepthought/eda/subscriber.py tests/unit/eda/test_publisher.py tests/unit/eda/test_subscriber.py`
- `pytest tests/unit/eda/test_publisher.py tests/unit/eda/test_subscriber.py`

------
https://chatgpt.com/codex/tasks/task_e_686e7872f98083268426817df15530e6