### PR TITLE
Add memory backend factory and refactor services

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -1,13 +1,15 @@
 """Memory utilities."""
 
+from ..config import get_settings
+from ..graph import create_graph_backend
 from .faiss_vector_store import FaissVectorStore
 from .hierarchical import HierarchicalMemory
 from .tiered import TieredMemory
 from .vector_store import (
-    SimpleEmbeddingFunction,
-    VectorStore,
     ChromaVectorStore,
     FaissVectorStore,
+    SimpleEmbeddingFunction,
+    VectorStore,
     create_vector_store,
 )
 
@@ -15,9 +17,35 @@ __all__ = [
     "HierarchicalMemory",
     "VectorStore",
     "ChromaVectorStore",
-
     "FaissVectorStore",
     "create_vector_store",
     "SimpleEmbeddingFunction",
     "TieredMemory",
+    "create_memory_backend",
 ]
+
+
+def create_memory_backend(
+    *,
+    graph_backend_name: str | None = None,
+    collection_name: str = "deepthought",
+    persist_directory: str | None = None,
+    vector_backend: str | None = None,
+    use_gpu: bool | None = None,
+    capacity: int = 100,
+    top_k: int = 3,
+) -> TieredMemory:
+    """Return :class:`TieredMemory` configured from environment variables."""
+
+    settings = get_settings()
+
+    store = create_vector_store(
+        backend=vector_backend or settings.vector_backend,
+        collection_name=collection_name,
+        persist_directory=persist_directory,
+        use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
+    )
+
+    backend = create_graph_backend(graph_backend_name or settings.graph_backend)
+
+    return TieredMemory(store, backend, capacity=capacity, top_k=top_k)

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -14,8 +14,8 @@ from ..config import get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
-from ..memory.vector_store import create_vector_store
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..search import OfflineSearch
 
@@ -71,17 +71,15 @@ class HierarchicalService:
         search_db: Optional[str] = None,
     ) -> "HierarchicalService":
         """Instantiate with a new :class:`TieredMemory` using the chosen backend."""
-        store = create_vector_store(
-            backend=backend,
+        memory = create_memory_backend(
+            graph_backend_name=graph_backend_name,
             collection_name=collection_name,
             persist_directory=persist_directory,
+            vector_backend=backend,
             use_gpu=use_gpu,
+            capacity=capacity,
+            top_k=top_k,
         )
-        from ..graph import create_graph_backend
-
-        backend_obj = create_graph_backend(graph_backend_name)
-
-        memory = TieredMemory(store, backend_obj, capacity=capacity, top_k=top_k)
         db_path = search_db or get_settings().search_db
         if db_path:
             if not os.path.exists(db_path):

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -13,7 +13,7 @@ from ..config import get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
-from ..graph import create_graph_backend
+from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 
@@ -42,12 +42,11 @@ class MemoryService:
         self._nc = nats_client
         if memory is None:
             settings = get_settings()
-            backend_obj = create_graph_backend(graph_backend_name or settings.graph_backend)
-            memory = TieredMemory.from_chroma(
-                backend_obj,
+            memory = create_memory_backend(
+                graph_backend_name=graph_backend_name or settings.graph_backend,
                 collection_name=collection_name,
                 persist_directory=persist_directory,
-                backend=vector_backend or settings.vector_backend,
+                vector_backend=vector_backend or settings.vector_backend,
                 use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
                 capacity=capacity,
                 top_k=top_k,

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -8,8 +8,12 @@ import pytest
 
 sys.modules.setdefault("deepthought.harness", types.ModuleType("harness"))
 record_mod = types.ModuleType("record")
+
+
 class TraceEvent:
     pass
+
+
 record_mod.TraceEvent = TraceEvent
 sys.modules.setdefault("deepthought.harness.record", record_mod)
 fake_nx = types.ModuleType("networkx")
@@ -49,6 +53,7 @@ sys.modules.setdefault("nats.js", fake_nats.js)
 sys.modules.setdefault("nats.js.client", fake_js_client_mod)
 sys.modules.setdefault("nats.errors", fake_errors_mod)
 fake_prom = types.ModuleType("prometheus_client")
+
 
 class _Metric:
     def labels(self, **kwargs):
@@ -143,53 +148,27 @@ def test_init_from_settings(monkeypatch):
     calls = {}
     import deepthought.services.memory_service as ms
 
-    def fake_create_vector_store(backend, collection_name, persist_directory=None, use_gpu=False, embedding_function=None):
-        calls["vector"] = (backend, use_gpu)
+    def fake_create_memory_backend(**kwargs):
+        calls.update(kwargs)
         return object()
 
-    def fake_create_graph_backend(name):
-        calls["graph"] = name
-        return object()
-
-    class DummyTiered:
-        def __init__(self, store, backend, capacity=100, top_k=3):
-            calls["tiered"] = (store, backend, capacity, top_k)
-
-        @classmethod
-        def from_chroma(
-            cls,
-            graph_backend,
-            collection_name="deepthought",
-            persist_directory=None,
-            backend="faiss",
-            use_gpu=False,
-            capacity=100,
-            top_k=3,
-        ):
-            vs.create_vector_store(
-                backend=backend,
-                collection_name=collection_name,
-                persist_directory=persist_directory,
-                use_gpu=use_gpu,
-            )
-            return cls(object(), graph_backend, capacity=capacity, top_k=top_k)
-
-    import deepthought.memory.vector_store as vs
-    monkeypatch.setattr(vs, "create_vector_store", fake_create_vector_store)
-    monkeypatch.setattr(ms, "create_graph_backend", fake_create_graph_backend)
-    monkeypatch.setattr(ms, "TieredMemory", DummyTiered)
+    monkeypatch.setattr(ms, "create_memory_backend", fake_create_memory_backend)
 
     import deepthought.config as config
 
     config._settings_cache = None
-    fake_settings = SimpleNamespace(
-        vector_backend="faiss", vector_use_gpu=True, graph_backend="noop"
-    )
+    fake_settings = SimpleNamespace(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
     monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
     monkeypatch.setattr(ms, "get_settings", lambda: fake_settings)
 
     ms.MemoryService(DummyNATS(), DummyJS())
 
-    assert calls["vector"] == ("faiss", True)
-    assert calls["graph"] == "noop"
-    assert calls["tiered"][2:] == (100, 3)
+    assert calls == {
+        "graph_backend_name": "noop",
+        "collection_name": "deepthought",
+        "persist_directory": None,
+        "vector_backend": "faiss",
+        "use_gpu": True,
+        "capacity": 100,
+        "top_k": 3,
+    }

--- a/tests/unit/test_memory_factory.py
+++ b/tests/unit/test_memory_factory.py
@@ -1,0 +1,44 @@
+import types
+
+import deepthought.memory as memory
+
+
+def test_factory_uses_settings(monkeypatch):
+    calls = {}
+    vec_obj = object()
+    graph_obj = object()
+
+    def fake_create_vector_store(
+        backend, collection_name, persist_directory=None, use_gpu=False, embedding_function=None
+    ):
+        calls["vector"] = (backend, collection_name, persist_directory, use_gpu)
+        return vec_obj
+
+    def fake_create_graph_backend(name):
+        calls["graph"] = name
+        return graph_obj
+
+    class DummyTiered:
+        def __init__(self, store, backend, capacity=100, top_k=3):
+            calls["tiered"] = (store, backend, capacity, top_k)
+
+    monkeypatch.setattr(memory, "create_vector_store", fake_create_vector_store)
+    monkeypatch.setattr(memory, "create_graph_backend", fake_create_graph_backend)
+    monkeypatch.setattr(memory, "TieredMemory", DummyTiered)
+
+    import deepthought.config as config
+
+    config._settings_cache = None
+    fake_settings = types.SimpleNamespace(
+        vector_backend="faiss",
+        vector_use_gpu=True,
+        graph_backend="noop",
+    )
+    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
+    monkeypatch.setattr(memory, "get_settings", lambda: fake_settings)
+
+    memory.create_memory_backend(capacity=42, top_k=7)
+
+    assert calls["vector"] == ("faiss", "deepthought", None, True)
+    assert calls["graph"] == "noop"
+    assert calls["tiered"] == (vec_obj, graph_obj, 42, 7)


### PR DESCRIPTION
## Summary
- create `create_memory_backend` factory to build TieredMemory from env vars
- refactor MemoryService and HierarchicalService to use the factory
- add unit test for the factory
- adjust MemoryService tests for new factory

## Testing
- `pre-commit run --files src/deepthought/memory/__init__.py src/deepthought/services/hierarchical_service.py src/deepthought/services/memory_service.py tests/unit/services/test_memory_service.py tests/unit/test_memory_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_686e7d0af33c8326b9b15c08b6811a77