### PR TITLE
Add OfflineSearch search limit test

### DIFF
--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -31,3 +31,24 @@ def test_create_index_existing_db(tmp_path):
     results = search.search("foo OR bar", limit=5)
     assert "foo" in results
     assert "bar" in results
+
+
+def test_search_expected_hits_and_limit(tmp_path):
+    """Create an index and ensure search respects the limit."""
+    path = tmp_path / "limit_hits.db"
+    docs = [
+        ("d1", "lorem ipsum"),
+        ("d2", "ipsum lorem"),
+        ("d3", "ipsum dolor"),
+    ]
+    search = OfflineSearch.create_index(str(path), docs)
+
+    # limit should restrict the number of returned documents
+    assert search.search("ipsum", limit=2) == ["lorem ipsum", "ipsum lorem"]
+
+    # requesting more results should return all matching documents
+    assert search.search("ipsum", limit=5) == [
+        "lorem ipsum",
+        "ipsum lorem",
+        "ipsum dolor",
+    ]


### PR DESCRIPTION
## Summary
- add a test ensuring OfflineSearch.search returns correct hits
- verify that the limit parameter truncates results

## Testing
- `pre-commit run --files tests/unit/test_offline_search.py`

------
https://chatgpt.com/codex/tasks/task_e_686e900cb288832680f91ed48d9916e5