### PR TITLE
Add estimate-only and auto token packing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,21 @@ You can also estimate the VRAM requirement before launching training:
 dtrt finetune --estimate-vram
 ```
 
+Estimate VRAM without loading the dataset:
+
+```bash
+dtrt finetune --estimate-only
+```
+
 Enable sequence packing to reduce padding:
 
 ```bash
-dtrt finetune --pack-sequences --max-seq-length 2048
+dtrt finetune --pack-sequences auto --max-seq-length 2048
 ```
+
+The `auto` mode samples a small portion of the dataset and enables packing when
+the average sequence length is under 70% of the maximum, mirroring the
+heuristics used by Predibase.
 
 Run ``dtrt finetune --help`` to see all available options.
 

--- a/docs/finetune_cli.md
+++ b/docs/finetune_cli.md
@@ -20,3 +20,20 @@ You can estimate the required VRAM before starting:
 ```bash
 dtrt finetune --estimate-vram
 ```
+
+To only calculate the estimate without loading the dataset, use:
+
+```bash
+dtrt finetune --estimate-only
+```
+
+Sequence packing can be controlled automatically using heuristics:
+
+```bash
+dtrt finetune --pack-sequences auto --max-seq-length 2048
+```
+
+The `auto` option samples up to 1000 records from the dataset and enables
+packing when the average tokenized length is below 70% of the configured
+maximum. These heuristics mirror the behaviour of Predibase's automatic
+packing logic and aim to reduce padding without manual tuning.

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -59,9 +59,11 @@ def _cmd_finetune(args: argparse.Namespace) -> int:
     ]
     if args.model_path:
         argv[0:0] = ["--model-path", args.model_path]
-    if args.pack_sequences:
-        argv.append("--pack-sequences")
-    if args.estimate_vram:
+    if args.pack_sequences != "off":
+        argv.extend(["--pack-sequences", args.pack_sequences])
+    if args.estimate_only:
+        argv.append("--estimate-only")
+    elif args.estimate_vram:
         argv.append("--estimate-vram")
     if args.resume:
         argv.append("--resume")
@@ -99,13 +101,19 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     finetune_p.add_argument(
         "--pack-sequences",
+        choices=["on", "off", "auto"],
+        default="off",
+        help="Sequence packing mode. 'auto' uses heuristics to reduce padding",
+    )
+    finetune_p.add_argument(
+        "--estimate-only",
         action="store_true",
-        help="Pack multiple sequences to reduce padding",
+        help="Estimate VRAM and exit without loading the dataset",
     )
     finetune_p.add_argument(
         "--estimate-vram",
         action="store_true",
-        help="Estimate VRAM requirements and exit",
+        help="Print VRAM estimate before training",
     )
     finetune_p.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
     finetune_p.set_defaults(func=_cmd_finetune)

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -66,7 +66,7 @@ def load_dataset(
     dataset_path: str,
     tokenizer: AutoTokenizer,
     max_seq_length: int = 2048,
-    pack_sequences: bool = False,
+    pack_sequences: str | bool = "off",
 ):
     """Load and tokenize the dataset used for fine-tuning."""
     raw_dataset = load_dataset(dataset_path)
@@ -89,6 +89,14 @@ def load_dataset(
         return {"text": prompt}
 
     formatted_dataset = raw_dataset["train"].map(format_prompt)
+
+    if pack_sequences == "auto":
+        sample = formatted_dataset.select(range(min(1000, len(formatted_dataset))))
+        tokenized = tokenizer(sample["text"])
+        avg_len = sum(len(ids) for ids in tokenized["input_ids"]) / len(tokenized["input_ids"])
+        pack_sequences = avg_len < 0.7 * max_seq_length
+    elif isinstance(pack_sequences, str):
+        pack_sequences = pack_sequences == "on"
 
     def tokenize_function(examples):
         return tokenizer(
@@ -231,13 +239,19 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--pack-sequences",
+        choices=["on", "off", "auto"],
+        default="off",
+        help="Sequence packing mode. 'auto' uses heuristics to reduce padding",
+    )
+    parser.add_argument(
+        "--estimate-only",
         action="store_true",
-        help="Pack multiple sequences to reduce padding",
+        help="Estimate VRAM and exit without loading the dataset",
     )
     parser.add_argument(
         "--estimate-vram",
         action="store_true",
-        help="Estimate VRAM requirements and exit",
+        help="Print VRAM estimate before training",
     )
     parser.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
     return parser.parse_args(args)
@@ -245,7 +259,7 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    if args.estimate_vram:
+    if args.estimate_vram or args.estimate_only:
         model, _ = load_model(args.model_path, args.bits)
         vram = estimate_vram(
             model,
@@ -255,7 +269,8 @@ def main(argv: list[str] | None = None) -> int:
             bits=args.bits,
         )
         print(f"Estimated VRAM requirement: {vram:.2f} GB")
-        return 0
+        if args.estimate_only:
+            return 0
     return run(args)
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -101,6 +101,7 @@ def test_parse_finetune_args():
             "--max-seq-length",
             "4096",
             "--pack-sequences",
+            "auto",
             "--estimate-vram",
         ]
     )
@@ -110,7 +111,7 @@ def test_parse_finetune_args():
     assert args.bits == 8
     assert args.output_dir == "/tmp/out"
     assert args.max_seq_length == 4096
-    assert args.pack_sequences
+    assert args.pack_sequences == "auto"
     assert args.estimate_vram
     assert args.func.__name__ == "_cmd_finetune"
 

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -16,4 +16,5 @@ def test_finetune_cli_help(tmp_path):
     )
     assert "usage" in result.stdout.lower()
     assert "--estimate-vram" in result.stdout
+    assert "--estimate-only" in result.stdout
     assert "--pack-sequences" in result.stdout


### PR DESCRIPTION
## Summary
- support `--estimate-only` mode for VRAM estimation
- add automatic token packing heuristics
- document new CLI features and clarify heuristics

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_cli.py tests/unit/test_finetune_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e9003fbe4832689b257c878a1c04e