### PR TITLE
Add TemplateService to bus template

### DIFF
--- a/src/deepthought/templates/bus_service/service.py
+++ b/src/deepthought/templates/bus_service/service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from deepthought.eda import Publisher, Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TemplateService:
+    """Skeleton service using Publisher and Subscriber."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+
+    async def _handle_input(self, msg: Msg) -> None:
+        logger.info("Handling message %s", msg.subject)
+        try:
+            await self._publisher.publish("dtr.template.output", msg.data, use_jetstream=True)
+        finally:
+            await msg.ack()
+
+    async def start(self, durable_name: str = "template_service_listener") -> bool:
+        await self._subscriber.subscribe(
+            subject="dtr.template.input",
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        return True
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()

--- a/tests/unit/test_cli_bus_init_service.py
+++ b/tests/unit/test_cli_bus_init_service.py
@@ -20,12 +20,17 @@ def test_bus_init_service(tmp_path: Path) -> None:
     assert (dest / "__init__.py").exists()
     assert (dest / "publisher.py").exists()
     assert (dest / "subscriber.py").exists()
+    assert (dest / "service.py").exists()
     assert (dest / "Dockerfile").exists()
 
     for py_file in dest.glob("*.py"):
-        subprocess.run([
-            sys.executable,
-            "-m",
-            "py_compile",
-            str(py_file),
-        ], check=True, env=env)
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "py_compile",
+                str(py_file),
+            ],
+            check=True,
+            env=env,
+        )


### PR DESCRIPTION
## Summary
- add `service.py` to `bus_service` template using the existing template service skeleton
- update bus init service test for the new file

## Testing
- `pre-commit run --files src/deepthought/templates/bus_service/service.py tests/unit/test_cli_bus_init_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686ed3847f188326825b73df5f4cae28