### PR TITLE
Update bus service template with TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ NATS_TLS_KEY=/path/to/client-key.pem
 NATS_TLS_CA=/path/to/ca.pem
 ```
 
+See [docs/bus_template.md](docs/bus_template.md) for a quick guide on
+generating test certificates and running the container.
+
 ### DTRT Bus Template
 
 Quick start example for scaffolding a bus service:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,6 +125,8 @@ NATS_PASSWORD=secret
 
 These TLS variables are commented out in the generated `nats.env.example` file.
 Uncomment them and provide the paths to your certificates to enable mTLS.
+See [bus_template.md](bus_template.md) for instructions on creating test
+certificates and running the Docker image.
 
 The generated `subscriber.py` includes a simple `rate_limit` decorator. Apply
 it to your message handler to throttle processing, e.g. `@rate_limit(10, 1)`

--- a/docs/bus_template.md
+++ b/docs/bus_template.md
@@ -1,0 +1,36 @@
+# Bus Service Template
+
+This guide shows how to generate test certificates and run a container built from
+the `bus_service` template.
+
+## Generate Certificates
+
+Use `openssl` to create a simple CA and client certificate pair:
+
+```bash
+mkdir certs
+openssl req -x509 -newkey rsa:2048 -days 365 -nodes \
+    -subj "/CN=test-ca" \
+    -keyout certs/ca-key.pem -out certs/ca.pem
+
+openssl req -newkey rsa:2048 -nodes \
+    -subj "/CN=test-client" \
+    -keyout certs/client-key.pem -out certs/client.csr
+
+openssl x509 -req -days 365 \
+    -in certs/client.csr -CA certs/ca.pem -CAkey certs/ca-key.pem \
+    -CAcreateserial -out certs/client-cert.pem
+```
+
+## Build and Run
+
+Build the image and start the service using the provided `nats.env.example`:
+
+```bash
+docker build -t mysvc -f Dockerfile .
+docker run --env-file nats.env.example mysvc
+```
+
+The container copies certificates from the `certs/` directory and sets
+`NATS_TLS_CERT`, `NATS_TLS_KEY` and `NATS_TLS_CA` automatically. Ensure your NATS
+server is started with the same certificate files.

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -8,7 +8,11 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
-from ..config import get_settings
+# Imported lazily in ``connect`` to avoid mandatory dependencies
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +88,8 @@ async def connect(
     name: str = "dtrt_publisher",
 ) -> "Publisher":
     """Create a :class:`Publisher` connected to ``nats_url`` with optional TLS."""
+
+    from ..config import get_settings
 
     settings = get_settings()
     nats_url = nats_url or settings.nats_url

--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -10,7 +10,11 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..config import get_settings
+# Imported lazily in ``connect`` to avoid mandatory dependencies
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from ..config import get_settings
 
 logger = logging.getLogger(__name__)
 MessageHandlerType = Callable[[Msg], Awaitable[None]]
@@ -71,6 +75,8 @@ class Subscriber:
                 exc_info=True,
             )
             return False
+        except ValueError:
+            raise
         except Exception as e:
             logger.error(
                 f"Failed to subscribe to '{subject}' (JetStream={use_jetstream}): {e}",
@@ -118,6 +124,8 @@ async def connect(
     name: str = "dtrt_subscriber",
 ) -> "Subscriber":
     """Create a :class:`Subscriber` connected to ``nats_url`` with optional TLS."""
+
+    from ..config import get_settings
 
     settings = get_settings()
     nats_url = nats_url or settings.nats_url

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
 try:  # pragma: no cover - optional dependency
     from neo4j import GraphDatabase
@@ -15,6 +15,9 @@ try:  # pragma: no cover - optional dependency
     from pymemgraph import Memgraph
 except Exception:  # pragma: no cover - driver not installed
     Memgraph = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from ..config import get_settings
 
 
 class GraphConnector:
@@ -30,14 +33,11 @@ class GraphConnector:
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
-        from ..config import get_settings
-
-        settings = get_settings()
         self._params = {
-            "host": host or settings.mg_host,
-            "port": int(port or settings.mg_port),
-            "username": username or settings.mg_user,
-            "password": password or settings.mg_password,
+            "host": host or os.getenv("MG_HOST", "localhost"),
+            "port": int(port or os.getenv("MG_PORT", 7687)),
+            "username": username or os.getenv("MG_USER", "memgraph"),
+            "password": password or os.getenv("MG_PASSWORD", "memgraph"),
         }
         self._max_retries = max_retries
         self._retry_delay = retry_delay
@@ -113,13 +113,10 @@ class Neo4jConnector:
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
-        from ..config import get_settings
-
-        settings = get_settings()
-        host = host or settings.neo4j_host
-        port = int(port or settings.neo4j_port)
-        username = username or settings.neo4j_user
-        password = password or settings.neo4j_password
+        host = host or os.getenv("NEO4J_HOST", "localhost")
+        port = int(port or os.getenv("NEO4J_PORT", 7687))
+        username = username or os.getenv("NEO4J_USER", "neo4j")
+        password = password or os.getenv("NEO4J_PASSWORD", "neo4j")
         self._uri = f"bolt://{host}:{port}"
         self._auth = (username, password)
         self._max_retries = max_retries

--- a/src/deepthought/templates/bus_service/Dockerfile
+++ b/src/deepthought/templates/bus_service/Dockerfile
@@ -4,8 +4,10 @@ COPY . .
 RUN pip install -e ../../..
 # Example credentials file for NATS connection
 COPY nats.env.example /etc/nats.env
-# Uncomment and update these lines to enable mTLS inside the container
-# ENV NATS_TLS_CERT=/certs/client-cert.pem
-# ENV NATS_TLS_KEY=/certs/client-key.pem
-# ENV NATS_TLS_CA=/certs/ca.pem
+# Copy TLS certificates if present
+COPY certs/*.pem /certs/
+# Configure mTLS inside the container
+ENV NATS_TLS_CERT=/certs/client-cert.pem
+ENV NATS_TLS_KEY=/certs/client-key.pem
+ENV NATS_TLS_CA=/certs/ca.pem
 CMD ["python", "-m", "template_service"]


### PR DESCRIPTION
## Summary
- configure TLS certificates in `bus_service` Dockerfile
- document how to create test certs and run the service container
- reference the new bus template guide from CLI docs
- handle subscriber errors without requiring optional deps
- read graph connector defaults from environment variables

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e900434bc8326a16ac19d1d6368c5