### PR TITLE
Add host and port validation to GraphConnector

### DIFF
--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -33,9 +33,25 @@ class GraphConnector:
         from ..config import get_settings
 
         settings = get_settings()
+
+        host = host or settings.mg_host
+        port = port or settings.mg_port
+
+        if not host:
+            raise ValueError("Memgraph host is required")
+        if port in (None, ""):
+            raise ValueError("Memgraph port is required")
+
+        try:
+            port_int = int(port)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Memgraph port must be an integer") from exc
+        if port_int <= 0:
+            raise ValueError("Memgraph port must be positive")
+
         self._params = {
-            "host": host or settings.mg_host,
-            "port": int(port or settings.mg_port),
+            "host": host,
+            "port": port_int,
             "username": username or settings.mg_user,
             "password": password or settings.mg_password,
         }

--- a/tests/integration/test_memgraph_integration.py
+++ b/tests/integration/test_memgraph_integration.py
@@ -94,3 +94,63 @@ def test_graphdal_live(memgraph_server):
         assert row[0] == "Alice" and row[1] == "Bob"
     else:
         assert row.get("src") == "Alice" and row.get("dst") == "Bob"
+
+
+def test_connector_requires_host(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(
+        mg_host="",
+        mg_port=MG_PORT,
+        mg_user=MG_USER,
+        mg_password=MG_PASSWORD,
+    )
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="host"):
+        GraphConnector()
+
+
+def test_connector_requires_port(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(
+        mg_host=MG_HOST,
+        mg_port=0,
+        mg_user=MG_USER,
+        mg_password=MG_PASSWORD,
+    )
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="port"):
+        GraphConnector()
+
+
+def test_connector_port_must_be_positive(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(
+        mg_host=MG_HOST,
+        mg_port=-1,
+        mg_user=MG_USER,
+        mg_password=MG_PASSWORD,
+    )
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="positive"):
+        GraphConnector()
+
+
+def test_connector_port_must_be_int(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(
+        mg_host=MG_HOST,
+        mg_port="abc",
+        mg_user=MG_USER,
+        mg_password=MG_PASSWORD,
+    )
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="integer"):
+        GraphConnector()

--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -71,10 +71,16 @@ def test_execute_direct_execute_commits(monkeypatch):
 
 
 def test_env_defaults(monkeypatch):
-    monkeypatch.setenv("MG_HOST", "envhost")
-    monkeypatch.setenv("MG_PORT", "9999")
-    monkeypatch.setenv("MG_USER", "user")
-    monkeypatch.setenv("MG_PASSWORD", "pass")
+    import types
+
+    fake = types.SimpleNamespace(
+        mg_host="envhost",
+        mg_port=9999,
+        mg_user="user",
+        mg_password="pass",
+    )
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: fake)
+
     connector = GraphConnector()
     assert connector._params == {
         "host": "envhost",
@@ -99,3 +105,43 @@ def test_connect_retries(monkeypatch):
     conn = connector.connect()
     assert isinstance(conn, FailOnce)
     assert len(calls) == 2
+
+
+def test_init_requires_host(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(mg_host="", mg_port=7687, mg_user="u", mg_password="p")
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="host"):
+        GraphConnector()
+
+
+def test_init_requires_port(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(mg_host="h", mg_port=0, mg_user="u", mg_password="p")
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="port"):
+        GraphConnector()
+
+
+def test_init_port_must_be_positive(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(mg_host="h", mg_port=-1, mg_user="u", mg_password="p")
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="positive"):
+        GraphConnector()
+
+
+def test_init_port_must_be_int(monkeypatch):
+    import types
+
+    ns = types.SimpleNamespace(mg_host="h", mg_port="abc", mg_user="u", mg_password="p")
+    monkeypatch.setattr("deepthought.config.get_settings", lambda: ns)
+
+    with pytest.raises(ValueError, match="integer"):
+        GraphConnector()


### PR DESCRIPTION
## Summary
- validate host and port in GraphConnector's `__init__`
- raise clear errors when port is non-integer or not positive
- update unit and integration tests with new scenarios

## Testing
- `flake8 src/deepthought/graph/connector.py tests/integration/test_memgraph_integration.py tests/unit/test_graph_connector.py`
- `PYTHONPATH=src pytest tests/unit/test_graph_connector.py tests/integration/test_memgraph_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed38510688326a0d8e0f813fa3c11