### PR TITLE
Update memory config loading

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -1,5 +1,7 @@
 """Memory utilities."""
 
+from dataclasses import dataclass
+
 from ..config import get_settings
 from ..graph import create_graph_backend
 from .faiss_vector_store import FaissVectorStore
@@ -22,7 +24,28 @@ __all__ = [
     "SimpleEmbeddingFunction",
     "TieredMemory",
     "create_memory_backend",
+    "load_memory_settings",
 ]
+
+
+@dataclass
+class MemorySettings:
+    """Subset of configuration relevant for memory backends."""
+
+    vector_backend: str
+    vector_use_gpu: bool
+    graph_backend: str
+
+
+def load_memory_settings() -> MemorySettings:
+    """Return memory backend configuration from the environment."""
+
+    settings = get_settings()
+    return MemorySettings(
+        vector_backend=settings.vector_backend,
+        vector_use_gpu=settings.vector_use_gpu,
+        graph_backend=settings.graph_backend,
+    )
 
 
 def create_memory_backend(
@@ -37,7 +60,7 @@ def create_memory_backend(
 ) -> TieredMemory:
     """Return :class:`TieredMemory` configured from environment variables."""
 
-    settings = get_settings()
+    settings = load_memory_settings()
 
     store = create_vector_store(
         backend=vector_backend or settings.vector_backend,

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -9,7 +9,6 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..config import get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -41,13 +40,12 @@ class MemoryService:
         self._subscriber = Subscriber(nats_client, js_context)
         self._nc = nats_client
         if memory is None:
-            settings = get_settings()
             memory = create_memory_backend(
-                graph_backend_name=graph_backend_name or settings.graph_backend,
+                graph_backend_name=graph_backend_name,
                 collection_name=collection_name,
                 persist_directory=persist_directory,
-                vector_backend=vector_backend or settings.vector_backend,
-                use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
+                vector_backend=vector_backend,
+                use_gpu=use_gpu,
                 capacity=capacity,
                 top_k=top_k,
             )

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -154,21 +154,18 @@ def test_init_from_settings(monkeypatch):
 
     monkeypatch.setattr(ms, "create_memory_backend", fake_create_memory_backend)
 
-    import deepthought.config as config
-
-    config._settings_cache = None
     fake_settings = SimpleNamespace(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
-    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
-    monkeypatch.setattr(ms, "get_settings", lambda: fake_settings)
+    import deepthought.memory as memory
+    monkeypatch.setattr(memory, "load_memory_settings", lambda: fake_settings)
 
     ms.MemoryService(DummyNATS(), DummyJS())
 
     assert calls == {
-        "graph_backend_name": "noop",
+        "graph_backend_name": None,
         "collection_name": "deepthought",
         "persist_directory": None,
-        "vector_backend": "faiss",
-        "use_gpu": True,
+        "vector_backend": None,
+        "use_gpu": None,
         "capacity": 100,
         "top_k": 3,
     }

--- a/tests/unit/test_memory_factory.py
+++ b/tests/unit/test_memory_factory.py
@@ -26,16 +26,12 @@ def test_factory_uses_settings(monkeypatch):
     monkeypatch.setattr(memory, "create_graph_backend", fake_create_graph_backend)
     monkeypatch.setattr(memory, "TieredMemory", DummyTiered)
 
-    import deepthought.config as config
-
-    config._settings_cache = None
     fake_settings = types.SimpleNamespace(
         vector_backend="faiss",
         vector_use_gpu=True,
         graph_backend="noop",
     )
-    monkeypatch.setattr(config, "get_settings", lambda: fake_settings)
-    monkeypatch.setattr(memory, "get_settings", lambda: fake_settings)
+    monkeypatch.setattr(memory, "load_memory_settings", lambda: fake_settings)
 
     memory.create_memory_backend(capacity=42, top_k=7)
 


### PR DESCRIPTION
## Summary
- add `load_memory_settings` helper for memory configuration
- use helper in `create_memory_backend`
- simplify `MemoryService` initialization
- adjust tests for new defaults

## Testing
- `flake8 src/deepthought/memory/__init__.py src/deepthought/services/memory_service.py tests/unit/services/test_memory_service.py tests/unit/test_memory_factory.py`
- `pytest tests/unit/test_memory_factory.py tests/unit/services/test_memory_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686f0e01049483268a31f595e67cd82e