### PR TITLE
Add offline search demo

### DIFF
--- a/examples/data/sample_docs.json
+++ b/examples/data/sample_docs.json
@@ -1,0 +1,5 @@
+[
+    {"title": "Python", "content": "Python is a programming language."},
+    {"title": "JavaScript", "content": "JavaScript is often used for web development."},
+    {"title": "SQLite", "content": "SQLite provides a lightweight database."}
+]

--- a/examples/offline_search_demo.py
+++ b/examples/offline_search_demo.py
@@ -1,0 +1,34 @@
+import json
+import logging
+from pathlib import Path
+
+from deepthought.search import OfflineSearch
+from deepthought.services import HierarchicalService
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+class DummyNATS:
+    pass
+
+
+class DummyJS:
+    pass
+
+
+def main() -> None:
+    data_file = Path(__file__).parent / "data" / "sample_docs.json"
+    docs = json.loads(data_file.read_text())
+    pairs = [(d["title"], d["content"]) for d in docs]
+
+    index_path = Path("offline_demo.db")
+    search = OfflineSearch.create_index(str(index_path), pairs)
+
+    service = HierarchicalService(DummyNATS(), DummyJS(), None, search=search)
+    results = service.retrieve_context("database")
+    logger.info("Results: %s", results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -73,6 +73,7 @@ fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
 sys.modules.setdefault("prometheus_client", fake_prom)
 
 from typing import List
+from pathlib import Path
 
 import pytest
 
@@ -248,6 +249,23 @@ def test_retrieve_context_from_config(monkeypatch, tmp_path):
     service = HierarchicalService(DummyNATS(), DummyJS(), memory)
     ctx = service.retrieve_context("config")
     assert "via config" in ctx
+
+
+def test_retrieve_context_with_example_corpus(tmp_path):
+    data_path = (
+        Path(__file__).resolve().parents[3]
+        / "examples"
+        / "data"
+        / "sample_docs.json"
+    )
+    docs = json.loads(data_path.read_text())
+    search = OfflineSearch.create_index(
+        str(tmp_path / "example.db"),
+        [(d["title"], d["content"]) for d in docs],
+    )
+    service = HierarchicalService(DummyNATS(), DummyJS(), None, search=search)
+    ctx = service.retrieve_context("web")
+    assert any("web development" in c for c in ctx)
 
 
 def test_service_uses_public_memory_interface():


### PR DESCRIPTION
## Summary
- provide a small example corpus
- add `offline_search_demo.py` showing how to build and query an FTS5 index
- test `HierarchicalService` retrieval using the example corpus

## Testing
- `flake8 src tests examples scripts ui`
- `pytest -q tests/unit/services/test_hierarchical_service.py::test_retrieve_context_with_example_corpus`
- `pytest -q tests/unit/services/test_hierarchical_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686f1471001083269ffc3be856eb21c8