### PR TITLE
Add CLI VRAM estimate test

### DIFF
--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -3,6 +3,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def _run_dtrt(tmp_path: Path, *args: str) -> subprocess.CompletedProcess:
     env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[2] / "src"))
@@ -38,6 +40,29 @@ def test_init_service_demo_start_stop(tmp_path: Path) -> None:
     svc_file = service_dir / "service.py"
 
     import importlib.util
+    import sys
+    import types
+
+    fake_nats = types.ModuleType("nats")
+    fake_aio = types.ModuleType("aio")
+    fake_client = types.ModuleType("client")
+    setattr(fake_client, "Client", object)
+    fake_msg_mod = types.ModuleType("msg")
+    setattr(fake_msg_mod, "Msg", object)
+    fake_aio.client = fake_client
+    fake_aio.msg = fake_msg_mod
+    fake_js = types.ModuleType("js")
+    fake_js_client = types.ModuleType("client")
+    setattr(fake_js_client, "JetStreamContext", object)
+    fake_js.client = fake_js_client
+    fake_nats.aio = fake_aio
+    fake_nats.js = fake_js
+    sys.modules.setdefault("nats", fake_nats)
+    sys.modules.setdefault("nats.aio", fake_aio)
+    sys.modules.setdefault("nats.aio.client", fake_client)
+    sys.modules.setdefault("nats.aio.msg", fake_msg_mod)
+    sys.modules.setdefault("nats.js", fake_js)
+    sys.modules.setdefault("nats.js.client", fake_js_client)
 
     if svc_file.exists():
         spec = importlib.util.spec_from_file_location("demo.service", svc_file)
@@ -125,3 +150,25 @@ def test_parse_bus_init_service():
     assert args.name == "foo"
     assert args.template == "bus_service"
     assert args.func.__name__ == "_cmd_init_service"
+
+
+def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("torch")
+    import importlib
+
+    from transformers import AutoModelForCausalLM, GPT2Config
+
+    train = importlib.import_module("deepthought.train")
+    cfg = GPT2Config(n_embd=4, n_layer=1, n_head=1, vocab_size=10)
+    dummy_model = AutoModelForCausalLM.from_config(cfg)
+    monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", lambda *a, **k: dummy_model)
+    monkeypatch.setattr(train, "run", lambda args: 0)
+
+    result = _run_dtrt(
+        tmp_path,
+        "finetune",
+        "--dataset-path",
+        "ds",
+        "--estimate-vram",
+    )
+    assert "Estimated VRAM" in result.stdout


### PR DESCRIPTION
## Summary
- test `dtrt finetune --estimate-vram` output
- stub `nats` modules for service start-stop test
- mock `AutoModelForCausalLM.from_pretrained` to avoid model downloads

## Testing
- `pre-commit run --files tests/unit/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_686f1474e3208326b039ee93871deaa2