### PR TITLE
Use edge server in multi-agent demo

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -143,7 +143,7 @@ Customize the generated files to implement your service logic.
 
 ## Multi-Agent Demo
 
-The repository includes a demonstration of three lightweight agents exchanging messages using the `MemoryService` and `LLMStub`. The agents are coordinated with a small LangGraph state machine and live in `examples/multi_agent_demo.py`.
+The repository includes a demonstration of three lightweight agents exchanging messages using the `MemoryService` and a small HTTP LLM module. The agents are coordinated with a LangGraph state machine and live in `examples/multi_agent_demo.py`.
 
 Start a local NATS server with `./scripts/start_nats.sh` and create the JetStream stream:
 
@@ -157,7 +157,7 @@ Install the optional dependency used by the demo:
 pip install langgraph
 ```
 
-Then launch the demo:
+Set `MODEL_PATH` to start the quantized edge model locally or set `LLM_ENDPOINT` to an existing `/generate` endpoint. Then launch the demo:
 
 ```bash
 python examples/multi_agent_demo.py
@@ -167,8 +167,8 @@ You should see log lines similar to the following as the message circulates betw
 
 ```text
 Agent 1 says: Hello from agent 1!
-Agent 2 says: Based on: ..., this is a stub response...
-Agent 3 says: Based on: ..., this is a stub response...
+Agent 2 says: <generated reply>
+Agent 3 says: <generated reply>
 ```
 
 Ensure a NATS server is running on `localhost:4222` or set the `NATS_URL` environment variable accordingly.

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -1,14 +1,18 @@
 import asyncio
 import logging
 import os
+import subprocess
+import sys
 import uuid
+from pathlib import Path
 from typing import TypedDict
 
 import nats
 from langgraph.graph import StateGraph
 from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
-from deepthought.modules import InputHandler, LLMStub, OutputHandler
+from deepthought.modules import InputHandler, OutputHandler
+from deepthought.modules.llm_remote import RemoteLLM
 from deepthought.services import MemoryService
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
@@ -41,8 +45,15 @@ async def main() -> None:
 
     await ensure_stream(js)
 
+    model_proc = None
+    if os.getenv("MODEL_PATH"):
+        script = Path(__file__).resolve().parents[1] / "tools" / "edge_server.py"
+        logger.info("Starting edge model from %s", script)
+        model_proc = await asyncio.create_subprocess_exec(sys.executable, str(script))
+        await asyncio.sleep(2.0)
+
     memory_service = MemoryService(nc, js)
-    llm = LLMStub(nc, js)
+    llm = RemoteLLM(nc, js)
 
     global input_handlers, output_handlers
     input_handlers = [InputHandler(nc, js) for _ in range(3)]
@@ -96,6 +107,9 @@ async def main() -> None:
     await llm.stop_listening()
     await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
     await nc.drain()
+    if model_proc:
+        model_proc.terminate()
+        await model_proc.wait()
 
 
 if __name__ == "__main__":

--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -24,6 +24,7 @@ except Exception as exc:  # pragma: no cover - optional dependency may be missin
             raise ImportError("KnowledgeGraphMemory requires optional dependency mgclient") from _missing_kg_err
 
 
+from .llm_remote import RemoteLLM
 from .llm_stub import LLMStub
 
 # ProductionLLM depends on additional optional packages (transformers, torch, peft)
@@ -66,4 +67,5 @@ __all__ = [
     "KnowledgeGraphMemory",
     "BasicLLM",
     "ProductionLLM",
+    "RemoteLLM",
 ]

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -1,0 +1,98 @@
+"""HTTP-based LLM module for the demo."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Optional
+
+import aiohttp
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects, ResponseGeneratedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteLLM:
+    """LLM module that calls a remote HTTP endpoint."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext, endpoint: Optional[str] = None) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._endpoint = endpoint or os.getenv("LLM_ENDPOINT", "http://localhost:8000/generate")
+        logger.info("RemoteLLM initialized with endpoint %s", self._endpoint)
+
+    async def _generate(self, prompt: str) -> str:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self._endpoint, json={"text": prompt}) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                text = data.get("text")
+                if not isinstance(text, str):
+                    raise ValueError("Invalid generate response")
+                return text
+
+    async def _handle_memory_event(self, msg: Msg) -> None:
+        input_id = "unknown"
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("MemoryRetrieved payload must be a dict")
+            input_id = data.get("input_id")
+            retrieved = data.get("retrieved_knowledge", {})
+            facts = retrieved.get("facts", [])
+            prompt = ", ".join(map(str, facts))
+            logger.info("RemoteLLM generating for %s", input_id)
+            response = await self._generate(prompt)
+            payload = ResponseGeneratedPayload(
+                final_response=response,
+                input_id=input_id,
+                timestamp=None,
+                confidence=0.9,
+            )
+            await self._publisher.publish(
+                EventSubjects.RESPONSE_GENERATED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            await msg.ack()
+        except Exception as exc:  # pragma: no cover - runtime network or parse errors
+            logger.error("RemoteLLM failed: %s", exc, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+
+    async def start_listening(self, durable_name: str = "remote_llm_listener") -> bool:
+        if not self._subscriber:
+            logger.error("Subscriber not initialized for RemoteLLM.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.MEMORY_RETRIEVED,
+                handler=self._handle_memory_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("RemoteLLM subscribed to %s", EventSubjects.MEMORY_RETRIEVED)
+            return True
+        except nats.errors.Error as e:
+            logger.error("RemoteLLM failed to subscribe: %s", e, exc_info=True)
+            return False
+        except Exception as e:
+            logger.error("RemoteLLM failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop_listening(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("RemoteLLM stopped listening.")


### PR DESCRIPTION
## Summary
- launch the quantized edge model automatically when `MODEL_PATH` is set
- call the HTTP LLM from the demo via new `RemoteLLM`
- export `RemoteLLM` in modules package
- document demo setup with `MODEL_PATH` and `LLM_ENDPOINT`

## Testing
- `pre-commit run --files examples/multi_agent_demo.py src/deepthought/modules/llm_remote.py src/deepthought/modules/__init__.py docs/architecture.md`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686f14721ac88326a00ed648fc6d0aaa