### PR TITLE
Fix service shutdown when NATS client closed

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -197,7 +197,7 @@ class HierarchicalService:
             logger.info("HierarchicalService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
-        if getattr(self, "_nc", None) and self._nc.is_connected:
+        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
 
     def dump_graph(self, path: str) -> str:

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -132,5 +132,5 @@ class MemoryService:
             logger.info("MemoryService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
-        if getattr(self, "_nc", None) and self._nc.is_connected:
+        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -72,8 +72,8 @@ fake_prom.Histogram = lambda *a, **k: _Metric()
 fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
 sys.modules.setdefault("prometheus_client", fake_prom)
 
-from typing import List
 from pathlib import Path
+from typing import List
 
 import pytest
 
@@ -252,12 +252,7 @@ def test_retrieve_context_from_config(monkeypatch, tmp_path):
 
 
 def test_retrieve_context_with_example_corpus(tmp_path):
-    data_path = (
-        Path(__file__).resolve().parents[3]
-        / "examples"
-        / "data"
-        / "sample_docs.json"
-    )
+    data_path = Path(__file__).resolve().parents[3] / "examples" / "data" / "sample_docs.json"
     docs = json.loads(data_path.read_text())
     search = OfflineSearch.create_index(
         str(tmp_path / "example.db"),
@@ -311,3 +306,25 @@ def test_retrieve_context_merges_search_results():
     mem.retrieve_context.assert_called_once_with("question")
     search.search.assert_called_once_with("question", limit=2)
     assert ctx == ["m1", "dup", "s2"]
+
+
+class ClosedNATS(DummyNATS):
+    def __init__(self):
+        super().__init__()
+        self.is_connected = False
+        self.drain_called = False
+
+    async def drain(self):
+        self.drain_called = True
+
+
+@pytest.mark.asyncio
+async def test_stop_skips_drain_when_not_connected():
+    service = HierarchicalService(DummyNATS(), DummyJS(), None)
+    service._subscriber = DummySubscriber()
+    service._publisher = DummyPublisher()
+    service._nc = ClosedNATS()
+
+    await service.stop()
+
+    assert not service._nc.drain_called

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -156,6 +156,7 @@ def test_init_from_settings(monkeypatch):
 
     fake_settings = SimpleNamespace(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
     import deepthought.memory as memory
+
     monkeypatch.setattr(memory, "load_memory_settings", lambda: fake_settings)
 
     ms.MemoryService(DummyNATS(), DummyJS())
@@ -169,3 +170,25 @@ def test_init_from_settings(monkeypatch):
         "capacity": 100,
         "top_k": 3,
     }
+
+
+class ClosedNATS(DummyNATS):
+    def __init__(self):
+        super().__init__()
+        self.is_connected = False
+        self.drain_called = False
+
+    async def drain(self):
+        self.drain_called = True
+
+
+@pytest.mark.asyncio
+async def test_stop_skips_drain_when_not_connected():
+    service = MemoryService(DummyNATS(), DummyJS(), DummyMemory())
+    service._subscriber = DummySubscriber()
+    service._publisher = DummyPublisher()
+    service._nc = ClosedNATS()
+
+    await service.stop()
+
+    assert not service._nc.drain_called


### PR DESCRIPTION
## Summary
- only call `drain()` on HierarchicalService and MemoryService when the NATS client is connected
- test that shutdown skips draining on an already closed client

## Testing
- `pre-commit run --files src/deepthought/services/hierarchical_service.py src/deepthought/services/memory_service.py tests/unit/services/test_hierarchical_service.py tests/unit/services/test_memory_service.py`

------
https://chatgpt.com/codex/tasks/task_e_686f23294b948326ade673569647a440