### PR TITLE
Fix integration test memory backend

### DIFF
--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -11,12 +11,16 @@ import sys
 import tempfile
 
 import pytest
+
 pytest.importorskip("nats")
 from nats.aio.client import Client as NATS
 from nats.js import JetStreamContext
 from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
-from deepthought.services import FileGraphDAL, MemoryService
+from deepthought.memory.tiered import TieredMemory
+from deepthought.memory.vector_store import create_vector_store
+from deepthought.services import MemoryService
+from deepthought.services.file_graph_dal import FileGraphBackend
 from tests.helpers import nats_server_available
 
 pytestmark = pytest.mark.nats
@@ -34,7 +38,9 @@ from src.deepthought.modules import (
 )
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 
@@ -132,21 +138,30 @@ async def test_full_module_flow(monkeypatch):
 
         # --- Define output callback ---
         def output_callback(input_id, response):
-            logger.info(f"Output callback received response for input_id={input_id}: {response}")
+            logger.info(
+                f"Output callback received response for input_id={input_id}: {response}"
+            )
             responses[input_id] = response
             # Only set event if it matches the ID we sent for this test run
             if input_id == test_input_id:
-                logger.info(f"Correct final response received via callback for ID {input_id}. Setting event.")
+                logger.info(
+                    f"Correct final response received via callback for ID {input_id}. Setting event."
+                )
                 final_response_received_event.set()
             else:
-                logger.warning(f"Callback received response for unexpected ID {input_id}, expected {test_input_id}")
+                logger.warning(
+                    f"Callback received response for unexpected ID {input_id}, expected {test_input_id}"
+                )
 
         # --- Instantiate module stubs ---
         logger.info("Initializing modules...")
         memory_file = tempfile.NamedTemporaryFile(delete=False, suffix=".json").name
         if os.path.exists(memory_file):
             os.remove(memory_file)
-        memory_service = MemoryService(nc, js)
+        vec = create_vector_store()
+        backend = FileGraphBackend(memory_file)
+        tiered = TieredMemory(vec, backend)
+        memory_service = MemoryService(nc, js, memory=tiered)
         input_handler = InputHandler(nc, js)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:
@@ -199,14 +214,20 @@ async def test_full_module_flow(monkeypatch):
             pytest.fail("Timeout: Final response was not received within 20 seconds.")
 
         # --- Assertions ---
-        assert final_response_received_event.is_set(), "Final response signal was not received via callback"
-        assert test_input_id in responses, f"OutputHandler did not record response for input_id {test_input_id}"
+        assert (
+            final_response_received_event.is_set()
+        ), "Final response signal was not received via callback"
+        assert (
+            test_input_id in responses
+        ), f"OutputHandler did not record response for input_id {test_input_id}"
         assert responses[test_input_id] is not None, "Response content is None"
 
         logger.info("Full module flow test completed successfully.")
 
     except Exception as e:
-        logger.error(f"An unexpected error occurred during the test: {e}", exc_info=True)
+        logger.error(
+            f"An unexpected error occurred during the test: {e}", exc_info=True
+        )
         pytest.fail(f"Test failed due to unexpected error: {e}")
     finally:
         # --- Cleanup ---
@@ -227,7 +248,8 @@ async def test_full_module_flow(monkeypatch):
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
                     logger.error(
-                        f"Error during stub listener cleanup {i}: {result}", exc_info=False
+                        f"Error during stub listener cleanup {i}: {result}",
+                        exc_info=False,
                     )  # Avoid deep traceback in cleanup
         logger.info("Listeners stopped.")
 
@@ -289,7 +311,10 @@ async def test_full_module_flow_graph_memory(monkeypatch):
         logger.info("Initializing modules (GraphMemory)...")
         if os.path.exists(GRAPH_MEMORY_FILE):
             os.remove(GRAPH_MEMORY_FILE)
-        memory_service = MemoryService(nc, js, dal=FileGraphDAL(GRAPH_MEMORY_FILE))
+        vec = create_vector_store()
+        backend = FileGraphBackend(GRAPH_MEMORY_FILE)
+        tiered = TieredMemory(vec, backend)
+        memory_service = MemoryService(nc, js, memory=tiered)
         input_handler = InputHandler(nc, js)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:


### PR DESCRIPTION
## Summary
- use a real TieredMemory built with FileGraphBackend in integration tests
- format imports for consistency

## Testing
- `flake8 tests/test_module_integration.py`
- `pytest tests/test_module_integration.py::test_full_module_flow -q`
- `pytest tests/test_module_integration.py::test_full_module_flow_graph_memory -q`


------
https://chatgpt.com/codex/tasks/task_e_686f2328bd948326bea3ddad74e7e4e2