### PR TITLE
Add from_config convenience to MemoryService

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -44,27 +44,26 @@ before failing.
 
 ## Example Memory Service
 
-The snippet below starts `KnowledgeGraphMemory` which listens for `INPUT_RECEIVED` events and stores them in Memgraph via GraphDAL:
+Start the unified `MemoryService` which configures its backends from environment variables:
 
 ```bash
 python - <<'PY'
 import asyncio
-import os
 
 from nats.aio.client import Client as NATS
 
-from deepthought.graph import GraphConnector, GraphDAL
-from deepthought.modules import KnowledgeGraphMemory
+from deepthought.config import get_settings
+from deepthought.services import MemoryService
 
 
 async def main():
+    settings = get_settings()
     nc = NATS()
-    await nc.connect(servers=[os.getenv("NATS_URL", "nats://localhost:4222")])
+    await nc.connect(servers=[settings.nats_url])
     js = nc.jetstream()
-    connector = GraphConnector()  # reads MG_* variables by default
-    dal = GraphDAL(connector)
-    memory = KnowledgeGraphMemory(nc, js, dal)
-    await memory.start_listening()
+
+    service = MemoryService.from_config(nc, js)
+    await service.start()
     await asyncio.Event().wait()
 
 asyncio.run(main())

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -51,6 +51,13 @@ class MemoryService:
             )
         self._memory = memory
 
+    @classmethod
+    def from_config(cls, nats_client: NATS, js_context: JetStreamContext) -> "MemoryService":
+        """Return a service with backends configured from environment variables."""
+
+        memory = create_memory_backend()
+        return cls(nats_client, js_context, memory)
+
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
         start = time.perf_counter()

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -172,6 +172,21 @@ def test_init_from_settings(monkeypatch):
     }
 
 
+def test_from_config(monkeypatch):
+    import deepthought.services.memory_service as ms
+
+    dummy = object()
+
+    def fake_create_memory_backend():
+        return dummy
+
+    monkeypatch.setattr(ms, "create_memory_backend", fake_create_memory_backend)
+
+    service = ms.MemoryService.from_config(DummyNATS(), DummyJS())
+
+    assert service._memory is dummy
+
+
 class ClosedNATS(DummyNATS):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Summary
- add `MemoryService.from_config` helper
- document using the new helper
- test from_config creation

## Testing
- `python -m flake8 src tests examples scripts ui`
- `pytest tests/unit/services/test_memory_service.py::test_from_config -q`

------
https://chatgpt.com/codex/tasks/task_e_686f2a36b8508326a4a370c054e53540