### PR TITLE
Add stream and TLS options to bus init

### DIFF
--- a/docs/bus_template.md
+++ b/docs/bus_template.md
@@ -3,6 +3,9 @@
 This guide shows how to generate test certificates and run a container built from
 the `bus_service` template.
 
+`dtrt bus init service` can optionally set the JetStream stream name and TLS
+paths when creating a new service.
+
 ## Generate Certificates
 
 Use `openssl` to create a simple CA and client certificate pair:
@@ -35,6 +38,20 @@ The container copies certificates from the `certs/` directory and sets
 `NATS_TLS_CERT`, `NATS_TLS_KEY` and `NATS_TLS_CA` automatically. Ensure your NATS
 server is started with the same certificate files.
 
+### CLI Options
+
+`dtrt bus init service` accepts extra flags to customise the generated files:
+
+```bash
+dtrt bus init service mysvc \
+  --stream-name deepthought_events \
+  --tls-cert certs/client-cert.pem \
+  --tls-key certs/client-key.pem \
+  --tls-ca certs/ca.pem
+```
+
+The values supplied are interpolated into `nats.env.example` and the Dockerfile.
+
 ## Generated Files
 
 Running `dtrt bus init service <name>` creates a service directory with several
@@ -59,6 +76,7 @@ both the publisher and subscriber helpers:
 | `NATS_URL` | URL of the NATS server | `nats://localhost:4222` |
 | `NATS_USERNAME` | Username for authentication | `example` |
 | `NATS_PASSWORD` | Password for authentication | `secret` |
+| `NATS_STREAM` | JetStream stream name | `deepthought_events` |
 | `NATS_TLS_CERT` | Path to the client certificate (optional) | *(unset)* |
 | `NATS_TLS_KEY` | Path to the client key (optional) | *(unset)* |
 | `NATS_TLS_CA` | Path to the CA certificate (optional) | *(unset)* |

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -10,7 +10,15 @@ def _to_camel(name: str) -> str:
     return "".join(part.capitalize() for part in name.split("_"))
 
 
-def init_service(name: str, *, template_name: str = "service") -> None:
+def init_service(
+    name: str,
+    *,
+    template_name: str = "service",
+    stream_name: str | None = None,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
+) -> None:
     dest = Path("src/deepthought/services") / name
     if dest.exists():
         raise SystemExit(f"Service '{name}' already exists")
@@ -38,11 +46,50 @@ def init_service(name: str, *, template_name: str = "service") -> None:
         text = path.read_text(encoding="utf-8")
         text = text.replace("TemplateService", class_name)
         text = text.replace("template_service", name)
+        if stream_name:
+            text = text.replace("template_stream", stream_name)
+        if tls_cert:
+            text = text.replace("template_tls_cert", tls_cert)
+        if tls_key:
+            text = text.replace("template_tls_key", tls_key)
+        if tls_ca:
+            text = text.replace("template_tls_ca", tls_ca)
         path.write_text(text, encoding="utf-8")
+
+    env_file = dest / "nats.env.example"
+    if env_file.exists():
+        text = env_file.read_text(encoding="utf-8")
+        if stream_name:
+            text = text.replace("deepthought_events", stream_name)
+        if tls_cert is not None:
+            text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
+        if tls_key is not None:
+            text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
+        if tls_ca is not None:
+            text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
+        env_file.write_text(text, encoding="utf-8")
+
+    docker_file = dest / "Dockerfile"
+    if docker_file.exists():
+        text = docker_file.read_text(encoding="utf-8")
+        if tls_cert is not None:
+            text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
+        if tls_key is not None:
+            text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
+        if tls_ca is not None:
+            text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
+        docker_file.write_text(text, encoding="utf-8")
 
 
 def _cmd_init_service(args: argparse.Namespace) -> None:
-    init_service(args.name, template_name=args.template)
+    init_service(
+        args.name,
+        template_name=args.template,
+        stream_name=getattr(args, "stream_name", None),
+        tls_cert=getattr(args, "tls_cert", None),
+        tls_key=getattr(args, "tls_key", None),
+        tls_ca=getattr(args, "tls_ca", None),
+    )
 
 
 def _cmd_finetune(args: argparse.Namespace) -> int:
@@ -133,6 +180,14 @@ def _build_parser() -> argparse.ArgumentParser:
 
     bus_svc = bus_init_sub.add_parser("service")
     bus_svc.add_argument("name")
+    bus_svc.add_argument(
+        "--stream-name",
+        default="deepthought_events",
+        help="JetStream stream name to use",
+    )
+    bus_svc.add_argument("--tls-cert", default="", help="Path to the client certificate")
+    bus_svc.add_argument("--tls-key", default="", help="Path to the client key")
+    bus_svc.add_argument("--tls-ca", default="", help="Path to the CA certificate")
     bus_svc.set_defaults(func=_cmd_init_service, template="bus_service")
 
     return parser

--- a/src/deepthought/templates/bus_service/Dockerfile
+++ b/src/deepthought/templates/bus_service/Dockerfile
@@ -6,8 +6,8 @@ RUN pip install -e ../../..
 COPY nats.env.example /etc/nats.env
 # Copy TLS certificates if present
 COPY certs/*.pem /certs/
-# Configure mTLS inside the container
-ENV NATS_TLS_CERT=/certs/client-cert.pem
-ENV NATS_TLS_KEY=/certs/client-key.pem
-ENV NATS_TLS_CA=/certs/ca.pem
+# Configure mTLS inside the container if certificates are provided
+ENV NATS_TLS_CERT=
+ENV NATS_TLS_KEY=
+ENV NATS_TLS_CA=
 CMD ["python", "-m", "template_service"]

--- a/src/deepthought/templates/bus_service/nats.env.example
+++ b/src/deepthought/templates/bus_service/nats.env.example
@@ -3,7 +3,7 @@
 NATS_URL=nats://localhost:4222
 NATS_USERNAME=example
 NATS_PASSWORD=secret
-# Uncomment and set paths to enable mTLS
-# NATS_TLS_CERT=/path/to/client-cert.pem
-# NATS_TLS_KEY=/path/to/client-key.pem
-# NATS_TLS_CA=/path/to/ca.pem
+NATS_STREAM=deepthought_events
+NATS_TLS_CERT=
+NATS_TLS_KEY=
+NATS_TLS_CA=

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -143,13 +143,32 @@ def test_parse_finetune_args():
 
 def test_parse_bus_init_service():
     parser = _build_parser()
-    args = parser.parse_args(["bus", "init", "service", "foo"])
+    args = parser.parse_args(
+        [
+            "bus",
+            "init",
+            "service",
+            "foo",
+            "--stream-name",
+            "bar",
+            "--tls-cert",
+            "c.pem",
+            "--tls-key",
+            "k.pem",
+            "--tls-ca",
+            "ca.pem",
+        ]
+    )
     assert args.command == "bus"
     assert args.bus_cmd == "init"
     assert args.target == "service"
     assert args.name == "foo"
     assert args.template == "bus_service"
     assert args.func.__name__ == "_cmd_init_service"
+    assert args.stream_name == "bar"
+    assert args.tls_cert == "c.pem"
+    assert args.tls_key == "k.pem"
+    assert args.tls_ca == "ca.pem"
 
 
 def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- allow `init_service` to inject stream name and TLS settings
- expose these parameters via `dtrt bus init service`
- update bus service template files for new placeholders
- document the optional command flags
- adjust CLI unit test

## Testing
- `pre-commit run --files docs/bus_template.md src/deepthought/cli/__init__.py src/deepthought/templates/bus_service/Dockerfile src/deepthought/templates/bus_service/nats.env.example tests/unit/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_686f2f2fd0d08326a2e77b2550e300c4