### PR TITLE
Enhance PyPI packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@ The project is hosted on GitHub: [https://github.com/d0tTino/DeepThought-ReThoug
 
 ## Installation
 
-Build a wheel and install it with pip:
+Install the package from PyPI:
+
+```bash
+pip install deepthought-rethought
+```
+
+This exposes the `dtrt` CLI (also available as `dtrt-finetune`).
+
+### Build from source
+
+Create a wheel and install it with pip:
 
 ```bash
 python -m build
@@ -19,6 +29,15 @@ After installation, the `dtrt` CLI is available. View its commands with:
 
 ```bash
 dtrt finetune --help
+```
+
+### Publishing to PyPI
+
+Create a wheel and upload it using `twine`:
+
+```bash
+python -m build --wheel
+twine upload dist/*
 ```
 
 ## Goals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deepthought-rethought"
+description = "DeepThought reThought - experimental AI framework"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [{name = "Tino Tonitini"}]
+urls = {Homepage = "https://github.com/d0tTino/DeepThought-ReThought"}
+dynamic = ["version", "dependencies"]
+
+[project.scripts]
+dtrt = "deepthought.cli:main"
+dtrt-finetune = "deepthought.train:main"
+
+[tool.setuptools.package-data]
+"tools" = ["template_service/*"]
+"deepthought.templates" = ["bus_service/*"]
+
+[tool.setuptools.dynamic]
+version = {attr = "deepthought.__init__.__version__"}
+dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
## Summary
- clarify installation steps using `pip install deepthought-rethought`
- restructure instructions for building and publishing wheels
- include detailed project metadata in `pyproject.toml`

## Testing
- `pre-commit run --files README.md pyproject.toml`
- `pytest tests/test_basic.py`


------
https://chatgpt.com/codex/tasks/task_e_686f2f2f193c832697f2a6aca5ee2ca4