### PR TITLE
Handle LRU cleanup when vector delete fails

### DIFF
--- a/src/deepthought/memory/tiered.py
+++ b/src/deepthought/memory/tiered.py
@@ -56,11 +56,13 @@ class TieredMemory:
     # internal helpers
     def _evict_if_needed(self) -> None:
         while len(self._lru) > self._capacity:
-            text, doc_id = self._lru.popitem(last=False)
+            text, doc_id = next(iter(self._lru.items()))
             try:
                 self._store.collection.delete([doc_id])
             except Exception:  # pragma: no cover - defensive
                 logger.error("Failed to delete %s from vector store", doc_id, exc_info=True)
+            finally:
+                self._lru.pop(text, None)
 
     def _add_to_vector(self, text: str) -> None:
         if text in self._lru:

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -87,3 +87,20 @@ def test_graph_backend_accessor():
     mem = TieredMemory(vec, dal)
 
     assert mem.graph_backend is dal
+
+
+def test_eviction_cleanup_on_delete_failure(monkeypatch):
+    vec = DummyVector()
+    dal = DummyDAL()
+    mem = TieredMemory(vec, dal, capacity=1, top_k=1)
+
+    def fail_delete(self, ids):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(DummyVector.Collection, "delete", fail_delete)
+
+    mem.store_interaction("a")
+    mem.store_interaction("b")
+
+    assert list(mem._lru.keys()) == ["b"]
+    assert list(vec.docs.values()) == ["a", "b"]


### PR DESCRIPTION
## Summary
- ensure `_evict_if_needed` always pops entries from the LRU
- add unit test covering failed vector store deletion

## Testing
- `pre-commit run --files src/deepthought/memory/tiered.py tests/unit/test_tiered_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_6870400650648326a42fd54e26881174