### PR TITLE
Refactor service settings

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -57,6 +57,9 @@ class Settings(BaseSettings):
     vector_backend: str = "chroma"
     vector_use_gpu: bool = False
 
+    memory_capacity: int = 100
+    memory_top_k: int = 3
+
     graph_backend: str = "memgraph"
     mg_host: str = os.getenv("MG_HOST", "localhost")
     mg_port: int = int(os.getenv("MG_PORT", 7687))

--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from ..config import get_settings
+from ..config import Settings, get_settings
 from ..graph import create_graph_backend
 from .faiss_vector_store import FaissVectorStore
 from .hierarchical import HierarchicalMemory
@@ -24,7 +24,6 @@ __all__ = [
     "SimpleEmbeddingFunction",
     "TieredMemory",
     "create_memory_backend",
-    "load_memory_settings",
 ]
 
 
@@ -35,32 +34,37 @@ class MemorySettings:
     vector_backend: str
     vector_use_gpu: bool
     graph_backend: str
+    memory_capacity: int
+    memory_top_k: int
 
 
-def load_memory_settings() -> MemorySettings:
-    """Return memory backend configuration from the environment."""
+def load_memory_settings(settings: Settings | None = None) -> MemorySettings:
+    """Return memory backend configuration from the given ``Settings``."""
 
-    settings = get_settings()
+    s = settings or get_settings()
     return MemorySettings(
-        vector_backend=settings.vector_backend,
-        vector_use_gpu=settings.vector_use_gpu,
-        graph_backend=settings.graph_backend,
+        vector_backend=s.vector_backend,
+        vector_use_gpu=s.vector_use_gpu,
+        graph_backend=s.graph_backend,
+        memory_capacity=s.memory_capacity,
+        memory_top_k=s.memory_top_k,
     )
 
 
 def create_memory_backend(
+    settings: Settings | None = None,
     *,
     graph_backend_name: str | None = None,
     collection_name: str = "deepthought",
     persist_directory: str | None = None,
     vector_backend: str | None = None,
     use_gpu: bool | None = None,
-    capacity: int = 100,
-    top_k: int = 3,
+    capacity: int | None = None,
+    top_k: int | None = None,
 ) -> TieredMemory:
-    """Return :class:`TieredMemory` configured from environment variables."""
+    """Return :class:`TieredMemory` configured from the provided ``Settings``."""
 
-    settings = load_memory_settings()
+    settings = load_memory_settings(settings)
 
     store = create_vector_store(
         backend=vector_backend or settings.vector_backend,
@@ -71,4 +75,9 @@ def create_memory_backend(
 
     backend = create_graph_backend(graph_backend_name or settings.graph_backend)
 
-    return TieredMemory(store, backend, capacity=capacity, top_k=top_k)
+    return TieredMemory(
+        store,
+        backend,
+        capacity=capacity if capacity is not None else settings.memory_capacity,
+        top_k=top_k if top_k is not None else settings.memory_top_k,
+    )

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -10,7 +10,7 @@ from nats.aio.msg import Msg
 from nats.errors import Error as NatsError
 from nats.js.client import JetStreamContext
 
-from ..config import get_settings
+from ..config import Settings, get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -29,16 +29,17 @@ class HierarchicalService:
         self,
         nats_client: NATS,
         js_context: JetStreamContext,
-        memory: TieredMemory | None,
+        settings: Settings,
+        memory: TieredMemory | None = None,
         search: OfflineSearch | None = None,
-        top_k: int = 3,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._nc = nats_client
         self._memory = memory
+        if self._memory is None:
+            self._memory = create_memory_backend(settings=settings)
         if search is None:
-            settings = get_settings()
             db_path = settings.search_db
             if db_path:
                 if not os.path.exists(db_path):
@@ -46,7 +47,7 @@ class HierarchicalService:
                 else:
                     search = OfflineSearch(db_path)
         self._search = search
-        self._top_k = top_k
+        self._top_k = settings.memory_top_k
 
     def _vector_matches(self, prompt: str) -> List[str]:
         """Return vector matches using the underlying memory store."""
@@ -61,26 +62,11 @@ class HierarchicalService:
         cls,
         nats_client: NATS,
         js_context: JetStreamContext,
-        graph_backend_name: str = "memgraph",
-        collection_name: str = "deepthought",
-        persist_directory: Optional[str] = None,
-        backend: str = "chroma",
-        use_gpu: bool = False,
-        capacity: int = 100,
-        top_k: int = 3,
-        search_db: Optional[str] = None,
+        settings: Settings,
     ) -> "HierarchicalService":
-        """Instantiate with a new :class:`TieredMemory` using the chosen backend."""
-        memory = create_memory_backend(
-            graph_backend_name=graph_backend_name,
-            collection_name=collection_name,
-            persist_directory=persist_directory,
-            vector_backend=backend,
-            use_gpu=use_gpu,
-            capacity=capacity,
-            top_k=top_k,
-        )
-        db_path = search_db or get_settings().search_db
+        """Instantiate with a new :class:`TieredMemory` using Chroma."""
+        memory = create_memory_backend(settings=settings)
+        db_path = settings.search_db
         if db_path:
             if not os.path.exists(db_path):
                 search = OfflineSearch.create_index(db_path, [])
@@ -88,7 +74,7 @@ class HierarchicalService:
                 search = OfflineSearch(db_path)
         else:
             search = None
-        return cls(nats_client, js_context, memory, search=search, top_k=top_k)
+        return cls(nats_client, js_context, settings, memory, search=search)
 
     def retrieve_context(self, prompt: str) -> List[str]:
         """Return retrieved facts using :class:`TieredMemory` and optional search."""

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -9,6 +9,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..config import Settings, get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -26,37 +27,22 @@ class MemoryService:
         self,
         nats_client: NATS,
         js_context: JetStreamContext,
+        settings: Settings,
         memory: Optional[TieredMemory] = None,
-        *,
-        graph_backend_name: str | None = None,
-        collection_name: str = "deepthought",
-        persist_directory: str | None = None,
-        vector_backend: str | None = None,
-        use_gpu: bool | None = None,
-        capacity: int = 100,
-        top_k: int = 3,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._nc = nats_client
         if memory is None:
-            memory = create_memory_backend(
-                graph_backend_name=graph_backend_name,
-                collection_name=collection_name,
-                persist_directory=persist_directory,
-                vector_backend=vector_backend,
-                use_gpu=use_gpu,
-                capacity=capacity,
-                top_k=top_k,
-            )
+            memory = create_memory_backend(settings=settings)
         self._memory = memory
 
     @classmethod
     def from_config(cls, nats_client: NATS, js_context: JetStreamContext) -> "MemoryService":
         """Return a service with backends configured from environment variables."""
 
-        memory = create_memory_backend()
-        return cls(nats_client, js_context, memory)
+        settings = get_settings()
+        return cls(nats_client, js_context, settings)
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"

--- a/tests/integration/test_service_stop.py
+++ b/tests/integration/test_service_stop.py
@@ -14,7 +14,15 @@ fake_pyd.AnyUrl = str
 fake_pyd.ValidationError = Exception
 sys.modules.setdefault("pydantic", fake_pyd)
 fake_ps = types.ModuleType("pydantic_settings")
-fake_ps.BaseSettings = object
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 fake_prom = types.ModuleType("prometheus_client")
@@ -37,10 +45,12 @@ fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
 sys.modules.setdefault("prometheus_client", fake_prom)
 
 import pytest
+
 pytest.importorskip("nats")
 from nats.aio.client import Client as NATS
 from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
+from deepthought.config import Settings
 from deepthought.modules.memory_graph import GraphMemory
 from deepthought.services.hierarchical_service import HierarchicalService
 from deepthought.services.memory_service import MemoryService
@@ -92,7 +102,7 @@ async def test_memory_service_stop_closes_nats():
     js = nc.jetstream(timeout=10.0)
     await ensure_stream_exists(js)
 
-    service = MemoryService(nc, js, memory=DummyMemory())
+    service = MemoryService(nc, js, Settings(), memory=DummyMemory())
     await service.start(durable_name="stop_mem_listener")
     await service.stop()
 
@@ -107,7 +117,7 @@ async def test_hierarchical_service_stop_closes_nats():
     js = nc.jetstream(timeout=10.0)
     await ensure_stream_exists(js)
 
-    service = HierarchicalService(nc, js, DummyMemory())
+    service = HierarchicalService(nc, js, Settings(), DummyMemory())
     await service.start(durable_name="stop_hier_listener")
     await service.stop()
 

--- a/tests/test_module_integration.py
+++ b/tests/test_module_integration.py
@@ -17,6 +17,7 @@ from nats.aio.client import Client as NATS
 from nats.js import JetStreamContext
 from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
 
+from deepthought.config import Settings
 from deepthought.memory.tiered import TieredMemory
 from deepthought.memory.vector_store import create_vector_store
 from deepthought.services import MemoryService
@@ -38,9 +39,7 @@ from src.deepthought.modules import (
 )
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
@@ -138,20 +137,14 @@ async def test_full_module_flow(monkeypatch):
 
         # --- Define output callback ---
         def output_callback(input_id, response):
-            logger.info(
-                f"Output callback received response for input_id={input_id}: {response}"
-            )
+            logger.info(f"Output callback received response for input_id={input_id}: {response}")
             responses[input_id] = response
             # Only set event if it matches the ID we sent for this test run
             if input_id == test_input_id:
-                logger.info(
-                    f"Correct final response received via callback for ID {input_id}. Setting event."
-                )
+                logger.info(f"Correct final response received via callback for ID {input_id}. Setting event.")
                 final_response_received_event.set()
             else:
-                logger.warning(
-                    f"Callback received response for unexpected ID {input_id}, expected {test_input_id}"
-                )
+                logger.warning(f"Callback received response for unexpected ID {input_id}, expected {test_input_id}")
 
         # --- Instantiate module stubs ---
         logger.info("Initializing modules...")
@@ -161,7 +154,7 @@ async def test_full_module_flow(monkeypatch):
         vec = create_vector_store()
         backend = FileGraphBackend(memory_file)
         tiered = TieredMemory(vec, backend)
-        memory_service = MemoryService(nc, js, memory=tiered)
+        memory_service = MemoryService(nc, js, Settings(), memory=tiered)
         input_handler = InputHandler(nc, js)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:
@@ -214,20 +207,14 @@ async def test_full_module_flow(monkeypatch):
             pytest.fail("Timeout: Final response was not received within 20 seconds.")
 
         # --- Assertions ---
-        assert (
-            final_response_received_event.is_set()
-        ), "Final response signal was not received via callback"
-        assert (
-            test_input_id in responses
-        ), f"OutputHandler did not record response for input_id {test_input_id}"
+        assert final_response_received_event.is_set(), "Final response signal was not received via callback"
+        assert test_input_id in responses, f"OutputHandler did not record response for input_id {test_input_id}"
         assert responses[test_input_id] is not None, "Response content is None"
 
         logger.info("Full module flow test completed successfully.")
 
     except Exception as e:
-        logger.error(
-            f"An unexpected error occurred during the test: {e}", exc_info=True
-        )
+        logger.error(f"An unexpected error occurred during the test: {e}", exc_info=True)
         pytest.fail(f"Test failed due to unexpected error: {e}")
     finally:
         # --- Cleanup ---
@@ -314,7 +301,7 @@ async def test_full_module_flow_graph_memory(monkeypatch):
         vec = create_vector_store()
         backend = FileGraphBackend(GRAPH_MEMORY_FILE)
         tiered = TieredMemory(vec, backend)
-        memory_service = MemoryService(nc, js, memory=tiered)
+        memory_service = MemoryService(nc, js, Settings(), memory=tiered)
         input_handler = InputHandler(nc, js)
         llm_cls = ProductionLLM if os.path.isdir("./results/lora-adapter") else BasicLLM
         try:

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -48,7 +48,15 @@ fake_pyd.AnyUrl = str
 fake_pyd.ValidationError = Exception
 sys.modules.setdefault("pydantic", fake_pyd)
 fake_ps = types.ModuleType("pydantic_settings")
-fake_ps.BaseSettings = object
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 sys.modules.setdefault("faiss", types.ModuleType("faiss"))
@@ -77,6 +85,7 @@ from typing import List
 
 import pytest
 
+from deepthought.config import Settings
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
 from deepthought.graph.backend import GraphDALBackend
 from deepthought.memory.tiered import TieredMemory
@@ -147,7 +156,7 @@ async def test_handle_input_publishes_combined_context(monkeypatch):
     vec = DummyVector()
     dal = DummyDAL()
     memory = TieredMemory(vec, GraphDALBackend(dal), top_k=3)
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory)
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
@@ -170,14 +179,14 @@ def test_retrieve_context_merges():
     vec = DummyVector()
     dal = DummyDAL()
     memory = TieredMemory(vec, GraphDALBackend(dal), top_k=3)
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory)
     ctx = service.retrieve_context("hi")
     assert ctx == ["vec1", "vec2", "graph1"]
 
 
 def test_retrieve_context_failures():
     memory = TieredMemory(FailingVector(), GraphDALBackend(FailingDAL()), top_k=3)
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory)
     ctx = service.retrieve_context("x")
     assert ctx == []
 
@@ -203,7 +212,7 @@ def test_dump_graph(tmp_path):
     dal = DummyGraphDAL()
     memory = DummyMemory(GraphDALBackend(dal))
 
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory)
 
     dot_file = service.dump_graph(str(tmp_path))
 
@@ -214,7 +223,7 @@ def test_dump_graph(tmp_path):
 
 
 def test_dump_graph_no_memory(tmp_path):
-    service = HierarchicalService(DummyNATS(), DummyJS(), None)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
     with pytest.raises(ValueError):
         service.dump_graph(str(tmp_path))
 
@@ -227,7 +236,7 @@ def test_retrieve_context_with_search(tmp_path):
         str(tmp_path / "index.db"),
         [("t1", "search result 1"), ("t2", "search result 2")],
     )
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory, search=search)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory, search=search)
     ctx = service.retrieve_context("result")
     assert "search result 1" in ctx and "search result 2" in ctx
 
@@ -242,11 +251,11 @@ def test_retrieve_context_from_config(monkeypatch, tmp_path):
     import deepthought.config as config
 
     config._settings_cache = None
-    monkeypatch.setattr(config, "get_settings", lambda: types.SimpleNamespace(search_db=str(db)))
+    monkeypatch.setattr(config, "get_settings", lambda: Settings(search_db=str(db)))
     import deepthought.services.hierarchical_service as hs
 
-    monkeypatch.setattr(hs, "get_settings", lambda: types.SimpleNamespace(search_db=str(db)))
-    service = HierarchicalService(DummyNATS(), DummyJS(), memory)
+    monkeypatch.setattr(hs, "get_settings", lambda: Settings(search_db=str(db)))
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(search_db=str(db)), memory)
     ctx = service.retrieve_context("config")
     assert "via config" in ctx
 
@@ -258,7 +267,7 @@ def test_retrieve_context_with_example_corpus(tmp_path):
         str(tmp_path / "example.db"),
         [(d["title"], d["content"]) for d in docs],
     )
-    service = HierarchicalService(DummyNATS(), DummyJS(), None, search=search)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None, search=search)
     ctx = service.retrieve_context("web")
     assert any("web development" in c for c in ctx)
 
@@ -277,7 +286,7 @@ def test_service_uses_public_memory_interface():
             return ["g"]
 
     mem = SpyMemory()
-    service = HierarchicalService(DummyNATS(), DummyJS(), mem)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), mem)
 
     assert service._vector_matches("hi") == ["v"]
     assert service._graph_facts() == ["g"]
@@ -290,7 +299,7 @@ from unittest import mock
 def test_retrieve_context_delegates_to_memory():
     mem = mock.MagicMock()
     mem.retrieve_context.return_value = ["m1", "m2"]
-    service = HierarchicalService(DummyNATS(), DummyJS(), mem)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), mem)
     ctx = service.retrieve_context("hello")
     mem.retrieve_context.assert_called_once_with("hello")
     assert ctx == ["m1", "m2"]
@@ -301,7 +310,7 @@ def test_retrieve_context_merges_search_results():
     mem.retrieve_context.return_value = ["m1", "dup"]
     search = mock.MagicMock()
     search.search.return_value = ["dup", "s2"]
-    service = HierarchicalService(DummyNATS(), DummyJS(), mem, search=search, top_k=2)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(memory_top_k=2), mem, search=search)
     ctx = service.retrieve_context("question")
     mem.retrieve_context.assert_called_once_with("question")
     search.search.assert_called_once_with("question", limit=2)
@@ -320,7 +329,7 @@ class ClosedNATS(DummyNATS):
 
 @pytest.mark.asyncio
 async def test_stop_skips_drain_when_not_connected():
-    service = HierarchicalService(DummyNATS(), DummyJS(), None)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
     service._subscriber = DummySubscriber()
     service._publisher = DummyPublisher()
     service._nc = ClosedNATS()

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -25,7 +25,15 @@ fake_pyd.AnyUrl = str
 fake_pyd.ValidationError = Exception
 sys.modules.setdefault("pydantic", fake_pyd)
 fake_ps = types.ModuleType("pydantic_settings")
-fake_ps.BaseSettings = object
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 sys.modules.setdefault("faiss", types.ModuleType("faiss"))
@@ -70,6 +78,7 @@ fake_prom.Counter = lambda *a, **k: _Metric()
 fake_prom.Histogram = lambda *a, **k: _Metric()
 sys.modules.setdefault("prometheus_client", fake_prom)
 
+from deepthought.config import Settings
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
 from deepthought.services.memory_service import MemoryService
 
@@ -125,7 +134,8 @@ async def test_handle_input_updates_graph_and_publishes(monkeypatch):
     memory = DummyMemory()
     monkeypatch.setattr(MemoryService, "_publisher", DummyPublisher(DummyNATS(), DummyJS()), raising=False)
     monkeypatch.setattr(MemoryService, "_subscriber", DummySubscriber(), raising=False)
-    service = MemoryService(DummyNATS(), DummyJS(), memory)
+    settings = Settings()
+    service = MemoryService(DummyNATS(), DummyJS(), settings, memory)
     # replace publisher and subscriber with dummies
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
@@ -148,28 +158,17 @@ def test_init_from_settings(monkeypatch):
     calls = {}
     import deepthought.services.memory_service as ms
 
-    def fake_create_memory_backend(**kwargs):
-        calls.update(kwargs)
+    def fake_create_memory_backend(*, settings):
+        calls["settings"] = settings
         return object()
 
     monkeypatch.setattr(ms, "create_memory_backend", fake_create_memory_backend)
 
-    fake_settings = SimpleNamespace(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
-    import deepthought.memory as memory
+    fake_settings = Settings(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
 
-    monkeypatch.setattr(memory, "load_memory_settings", lambda: fake_settings)
+    ms.MemoryService(DummyNATS(), DummyJS(), fake_settings)
 
-    ms.MemoryService(DummyNATS(), DummyJS())
-
-    assert calls == {
-        "graph_backend_name": None,
-        "collection_name": "deepthought",
-        "persist_directory": None,
-        "vector_backend": None,
-        "use_gpu": None,
-        "capacity": 100,
-        "top_k": 3,
-    }
+    assert calls["settings"] is fake_settings
 
 
 def test_from_config(monkeypatch):
@@ -177,10 +176,11 @@ def test_from_config(monkeypatch):
 
     dummy = object()
 
-    def fake_create_memory_backend():
+    def fake_create_memory_backend(*, settings):
         return dummy
 
     monkeypatch.setattr(ms, "create_memory_backend", fake_create_memory_backend)
+    monkeypatch.setattr(ms, "get_settings", lambda: Settings())
 
     service = ms.MemoryService.from_config(DummyNATS(), DummyJS())
 
@@ -199,7 +199,7 @@ class ClosedNATS(DummyNATS):
 
 @pytest.mark.asyncio
 async def test_stop_skips_drain_when_not_connected():
-    service = MemoryService(DummyNATS(), DummyJS(), DummyMemory())
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
     service._subscriber = DummySubscriber()
     service._publisher = DummyPublisher()
     service._nc = ClosedNATS()

--- a/tests/unit/test_memory_factory.py
+++ b/tests/unit/test_memory_factory.py
@@ -1,6 +1,27 @@
+import sys
 import types
 
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
 import deepthought.memory as memory
+from deepthought.config import Settings
 
 
 def test_factory_uses_settings(monkeypatch):
@@ -26,12 +47,18 @@ def test_factory_uses_settings(monkeypatch):
     monkeypatch.setattr(memory, "create_graph_backend", fake_create_graph_backend)
     monkeypatch.setattr(memory, "TieredMemory", DummyTiered)
 
-    fake_settings = types.SimpleNamespace(
-        vector_backend="faiss",
-        vector_use_gpu=True,
-        graph_backend="noop",
+    fake_settings = Settings(vector_backend="faiss", vector_use_gpu=True, graph_backend="noop")
+    monkeypatch.setattr(
+        memory,
+        "load_memory_settings",
+        lambda settings=None: memory.MemorySettings(
+            vector_backend=fake_settings.vector_backend,
+            vector_use_gpu=fake_settings.vector_use_gpu,
+            graph_backend=fake_settings.graph_backend,
+            memory_capacity=fake_settings.memory_capacity,
+            memory_top_k=fake_settings.memory_top_k,
+        ),
     )
-    monkeypatch.setattr(memory, "load_memory_settings", lambda: fake_settings)
 
     memory.create_memory_backend(capacity=42, top_k=7)
 


### PR DESCRIPTION
## Summary
- centralize memory/graph options in a single Settings loader
- refactor services to accept Settings instead of many parameters
- adjust tests to build Settings objects
- fix patched BaseSettings in service stop test

## Testing
- `pre-commit run --files tests/integration/test_service_stop.py`


------
https://chatgpt.com/codex/tasks/task_e_687048445e248326ba770da0ca4bee54