### PR TITLE
Add CRUD integration tests for graph databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,13 @@ services:
     ports:
       - "7687:7687"
 
+  neo4j:
+    image: neo4j:5
+    ports:
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/test
+
   chroma:
     image: chromadb/chroma
     ports:

--- a/tests/integration/test_memgraph_integration.py
+++ b/tests/integration/test_memgraph_integration.py
@@ -27,42 +27,35 @@ def memgraph_server():
     """Start a Memgraph Docker container if needed and yield when ready."""
     if pymemgraph is None:
         pytest.skip("pymemgraph not installed")
-    if shutil.which("docker") is None:
-        pytest.skip("Docker not available")
+    compose = None
+    if shutil.which("docker-compose"):
+        compose = ["docker-compose"]
+    elif shutil.which("docker"):
+        compose = ["docker", "compose"]
+    if compose is None:
+        pytest.skip("Docker compose not available")
 
     already_running = memgraph_available(MG_HOST, MG_PORT)
-    container_name = None
 
     if not already_running:
-        container_name = f"pytest-memgraph-{uuid.uuid4().hex[:8]}"
-        cmd = [
-            "docker",
-            "run",
-            "-d",
-            "--rm",
-            "-p",
-            f"{MG_PORT}:7687",
-            "--name",
-            container_name,
-            "memgraph/memgraph",
-        ]
+        cmd = compose + ["-f", "docker-compose.yml", "up", "-d", "memgraph"]
         proc = subprocess.run(cmd, capture_output=True, text=True)
         if proc.returncode != 0:
-            pytest.skip(f"Could not start memgraph container: {proc.stderr}")
+            pytest.skip(f"Could not start memgraph service: {proc.stderr}")
 
         for _ in range(30):
             if memgraph_available(MG_HOST, MG_PORT):
                 break
             time.sleep(1)
         else:
-            subprocess.run(["docker", "stop", container_name], capture_output=True)
+            subprocess.run(compose + ["-f", "docker-compose.yml", "down"], capture_output=True)
             pytest.skip("Memgraph container did not start")
 
     try:
         yield
     finally:
-        if container_name:
-            subprocess.run(["docker", "stop", container_name], capture_output=True)
+        if not already_running:
+            subprocess.run(compose + ["-f", "docker-compose.yml", "down"], capture_output=True)
 
 
 def test_graphdal_live(memgraph_server):
@@ -94,6 +87,59 @@ def test_graphdal_live(memgraph_server):
         assert row[0] == "Alice" and row[1] == "Bob"
     else:
         assert row.get("src") == "Alice" and row.get("dst") == "Bob"
+
+
+def test_graphdal_crud(memgraph_server):
+    """Verify basic CRUD operations against Memgraph."""
+    if not memgraph_available(MG_HOST, MG_PORT):
+        pytest.skip("Memgraph not reachable")
+
+    connector = GraphConnector(
+        host=MG_HOST,
+        port=MG_PORT,
+        username=MG_USER,
+        password=MG_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+
+    entity_id = str(uuid.uuid4())
+
+    # Create
+    dal.add_entity("Person", {"id": entity_id, "name": "Charlie"})
+
+    # Read
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n.name AS name",
+        {"id": entity_id},
+    )
+    assert rows
+    row = rows[0]
+    name = row[0] if isinstance(row, tuple) else row.get("name")
+    assert name == "Charlie"
+
+    # Update
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) SET n.name = $name",
+        {"id": entity_id, "name": "Dave"},
+    )
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n.name AS name",
+        {"id": entity_id},
+    )
+    row = rows[0]
+    name = row[0] if isinstance(row, tuple) else row.get("name")
+    assert name == "Dave"
+
+    # Delete
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) DETACH DELETE n",
+        {"id": entity_id},
+    )
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n",
+        {"id": entity_id},
+    )
+    assert not rows
 
 
 def test_connector_requires_host(monkeypatch):

--- a/tests/integration/test_neo4j_integration.py
+++ b/tests/integration/test_neo4j_integration.py
@@ -6,7 +6,7 @@ import uuid
 
 import pytest
 
-from deepthought.graph import Neo4jConnector, GraphDAL
+from deepthought.graph import GraphDAL, Neo4jConnector
 from tests.helpers import neo4j_available
 
 try:  # optional dependency
@@ -27,44 +27,35 @@ def neo4j_server():
     """Start a Neo4j Docker container if needed and yield when ready."""
     if neo4j is None:
         pytest.skip("neo4j-driver not installed")
-    if shutil.which("docker") is None:
-        pytest.skip("Docker not available")
+    compose = None
+    if shutil.which("docker-compose"):
+        compose = ["docker-compose"]
+    elif shutil.which("docker"):
+        compose = ["docker", "compose"]
+    if compose is None:
+        pytest.skip("Docker compose not available")
 
     already_running = neo4j_available(NEO4J_HOST, NEO4J_PORT)
-    container_name = None
 
     if not already_running:
-        container_name = f"pytest-neo4j-{uuid.uuid4().hex[:8]}"
-        cmd = [
-            "docker",
-            "run",
-            "-d",
-            "--rm",
-            "-p",
-            f"{NEO4J_PORT}:7687",
-            "-e",
-            f"NEO4J_AUTH={NEO4J_USER}/{NEO4J_PASSWORD}",
-            "--name",
-            container_name,
-            "neo4j:5",
-        ]
+        cmd = compose + ["-f", "docker-compose.yml", "up", "-d", "neo4j"]
         proc = subprocess.run(cmd, capture_output=True, text=True)
         if proc.returncode != 0:
-            pytest.skip(f"Could not start neo4j container: {proc.stderr}")
+            pytest.skip(f"Could not start neo4j service: {proc.stderr}")
 
         for _ in range(30):
             if neo4j_available(NEO4J_HOST, NEO4J_PORT):
                 break
             time.sleep(1)
         else:
-            subprocess.run(["docker", "stop", container_name], capture_output=True)
+            subprocess.run(compose + ["-f", "docker-compose.yml", "down"], capture_output=True)
             pytest.skip("Neo4j container did not start")
 
     try:
         yield
     finally:
-        if container_name:
-            subprocess.run(["docker", "stop", container_name], capture_output=True)
+        if not already_running:
+            subprocess.run(compose + ["-f", "docker-compose.yml", "down"], capture_output=True)
 
 
 def test_graphdal_live(neo4j_server):
@@ -98,3 +89,56 @@ def test_graphdal_live(neo4j_server):
         src = row["src"] if isinstance(row, dict) else row.get("src")
         dst = row["dst"] if isinstance(row, dict) else row.get("dst")
         assert src == "Alice" and dst == "Bob"
+
+
+def test_graphdal_crud(neo4j_server):
+    """Verify basic CRUD operations against Neo4j."""
+    if not neo4j_available(NEO4J_HOST, NEO4J_PORT):
+        pytest.skip("Neo4j not reachable")
+
+    connector = Neo4jConnector(
+        host=NEO4J_HOST,
+        port=NEO4J_PORT,
+        username=NEO4J_USER,
+        password=NEO4J_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+
+    entity_id = str(uuid.uuid4())
+
+    # Create
+    dal.add_entity("Person", {"id": entity_id, "name": "Charlie"})
+
+    # Read
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n.name AS name",
+        {"id": entity_id},
+    )
+    assert rows
+    row = rows[0]
+    name = row[0] if isinstance(row, tuple) else row.get("name")
+    assert name == "Charlie"
+
+    # Update
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) SET n.name = $name",
+        {"id": entity_id, "name": "Dave"},
+    )
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n.name AS name",
+        {"id": entity_id},
+    )
+    row = rows[0]
+    name = row[0] if isinstance(row, tuple) else row.get("name")
+    assert name == "Dave"
+
+    # Delete
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) DETACH DELETE n",
+        {"id": entity_id},
+    )
+    rows = dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) RETURN n",
+        {"id": entity_id},
+    )
+    assert not rows


### PR DESCRIPTION
## Summary
- spin up Neo4j and Memgraph via docker-compose
- add CRUD tests for the graph databases
- extend docker-compose with a Neo4j service

## Testing
- `pre-commit run --files docker-compose.yml tests/integration/test_neo4j_integration.py tests/integration/test_memgraph_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_687051ce5aa4832698e8fa5c4e660f95