### PR TITLE
Standardize env vars for graph connectors

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -61,15 +61,15 @@ class Settings(BaseSettings):
     memory_top_k: int = 3
 
     graph_backend: str = "memgraph"
-    mg_host: str = os.getenv("MG_HOST", "localhost")
-    mg_port: int = int(os.getenv("MG_PORT", 7687))
-    mg_user: str = os.getenv("MG_USER", "memgraph")
-    mg_password: str = os.getenv("MG_PASSWORD", "memgraph")
+    mg_host: str = "localhost"
+    mg_port: int = 7687
+    mg_user: str = "memgraph"
+    mg_password: str = "memgraph"
 
-    neo4j_host: str = os.getenv("NEO4J_HOST", "localhost")
-    neo4j_port: int = int(os.getenv("NEO4J_PORT", 7687))
-    neo4j_user: str = os.getenv("NEO4J_USER", "neo4j")
-    neo4j_password: str = os.getenv("NEO4J_PASSWORD", "neo4j")
+    neo4j_host: str = "localhost"
+    neo4j_port: int = 7687
+    neo4j_user: str = "neo4j"
+    neo4j_password: str = "neo4j"
 
     reward: RewardThresholds = RewardThresholds()
     persona_descriptions: dict[str, str] = {

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -132,8 +131,12 @@ class Neo4jConnector:
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
-        host = os.getenv("NEO4J_HOST", "localhost") if host is None else host
-        port = os.getenv("NEO4J_PORT", 7687) if port is None else port
+        from ..config import get_settings
+
+        settings = get_settings()
+
+        host = settings.neo4j_host if host is None else host
+        port = settings.neo4j_port if port is None else port
 
         if not host:
             raise ValueError("Neo4j host is required")
@@ -145,8 +148,8 @@ class Neo4jConnector:
         if port_int <= 0:
             raise ValueError("Neo4j port must be positive")
 
-        username = username or os.getenv("NEO4J_USER", "neo4j")
-        password = password or os.getenv("NEO4J_PASSWORD", "neo4j")
+        username = username or settings.neo4j_user
+        password = password or settings.neo4j_password
         self._uri = f"bolt://{host}:{port_int}"
         self._auth = (username, password)
         self._max_retries = max_retries

--- a/tests/unit/graph/test_connector_validation.py
+++ b/tests/unit/graph/test_connector_validation.py
@@ -13,7 +13,39 @@ def test_graph_connector_requires_host_and_port(monkeypatch):
 
 
 def test_neo4j_connector_requires_host_and_port(monkeypatch):
-    monkeypatch.delenv("NEO4J_HOST", raising=False)
-    monkeypatch.delenv("NEO4J_PORT", raising=False)
+    monkeypatch.delenv("DT_NEO4J_HOST", raising=False)
+    monkeypatch.delenv("DT_NEO4J_PORT", raising=False)
     with pytest.raises(ValueError):
         Neo4jConnector(host="", port=0)
+
+
+def test_graph_connector_env_overrides(monkeypatch):
+    monkeypatch.setenv("DT_MG_HOST", "envhost")
+    monkeypatch.setenv("DT_MG_PORT", "9999")
+    monkeypatch.setenv("DT_MG_USER", "envuser")
+    monkeypatch.setenv("DT_MG_PASSWORD", "envpass")
+
+    import deepthought.config as cfg
+
+    monkeypatch.setattr(cfg, "_settings_cache", None)
+
+    connector = GraphConnector()
+    assert connector._params["host"] == "envhost"
+    assert connector._params["port"] == 9999
+    assert connector._params["username"] == "envuser"
+    assert connector._params["password"] == "envpass"
+
+
+def test_neo4j_connector_env_overrides(monkeypatch):
+    monkeypatch.setenv("DT_NEO4J_HOST", "neo4jhost")
+    monkeypatch.setenv("DT_NEO4J_PORT", "9998")
+    monkeypatch.setenv("DT_NEO4J_USER", "neo4juser")
+    monkeypatch.setenv("DT_NEO4J_PASSWORD", "neo4jpass")
+
+    import deepthought.config as cfg
+
+    monkeypatch.setattr(cfg, "_settings_cache", None)
+
+    connector = Neo4jConnector()
+    assert connector._uri == "bolt://neo4jhost:9998"
+    assert connector._auth == ("neo4juser", "neo4jpass")


### PR DESCRIPTION
## Summary
- rely on DT-prefixed variables in `Settings`
- look up Neo4j values using `Settings`
- test env var overrides for both connectors

## Testing
- `pre-commit run --files src/deepthought/config.py src/deepthought/graph/connector.py tests/unit/graph/test_connector_validation.py`
- `pytest -q tests/unit/graph/test_connector_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_687062d27eb08326a74f8f2af41c0e60