### PR TITLE
Add conda packaging recipe and workflow

### DIFF
--- a/.github/workflows/conda_package.yml
+++ b/.github/workflows/conda_package.yml
@@ -1,0 +1,27 @@
+name: Conda Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: '3.10'
+          auto-update-conda: true
+      - name: Install conda-build and anaconda-client
+        shell: bash -l {0}
+        run: conda install -y conda-build anaconda-client
+      - name: Build package
+        shell: bash -l {0}
+        run: conda-build conda
+      - name: Upload package
+        if: secrets.ANACONDA_TOKEN != ''
+        shell: bash -l {0}
+        run: |
+          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload $(conda-build conda --output) --user ${{ secrets.ANACONDA_USER }} --label main

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Install the package from PyPI:
 
 ```bash
 pip install deepthought-rethought
+conda install deepthought-rethought
 ```
 
 This exposes the `dtrt` CLI (also available as `dtrt-finetune`).

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,61 @@
+package:
+  name: deepthought-rethought
+  version: {{ GIT_DESCRIBE_TAG }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: {{ PYTHON }} -m pip install . -vv
+  entry_points:
+    - dtrt = deepthought.cli:main
+    - dtrt-finetune = deepthought.train:main
+
+requirements:
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - torch >=2.0.0
+    - transformers >=4.34.0
+    - datasets >=2.14.0
+    - peft >=0.5.0
+    - trl >=0.7.2
+    - accelerate >=0.21.0
+    - bitsandbytes >=0.41.0
+    - sentencepiece
+    - protobuf
+    - scipy
+    - evaluate
+    - nats-py
+    - pytest-asyncio
+    - aiosqlite
+    - aiohttp
+    - fastapi
+    - discord.py
+    - textblob
+    - networkx
+    - pydantic-settings
+    - pydantic
+    - vaderSentiment
+    - sentence-transformers
+    - uvicorn
+    - pyyaml
+    - faiss-cpu
+    - prometheus-client
+
+test:
+  commands:
+    - dtrt --help
+    - dtrt-finetune --help
+
+about:
+  home: https://github.com/d0tTino/DeepThought-ReThought
+  license: MIT
+  summary: DeepThought reThought - experimental AI framework
+
+extra:
+  recipe-maintainers:
+    - d0ttino

--- a/docs/finetune_cli.md
+++ b/docs/finetune_cli.md
@@ -1,5 +1,11 @@
 # Finetune CLI Quickstart
 
+Install the package with:
+
+```bash
+conda install deepthought-rethought
+```
+
 Build the training image and launch finetuning:
 
 ```bash

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -7,7 +7,7 @@ pytest-xdist==3.7.0
 pytest-asyncio==0.21.1
 flake8==6.1.0
 pydantic-settings==2.2.1
-pydantic
+pydantic>=2.7
 aiohttp==3.12.3
 fastapi==0.111.0
 discord.py==2.5.2
@@ -21,3 +21,5 @@ faiss-cpu
 prometheus-client
 setuptools
 streamlit
+datasets>=2.14.0
+peft>=0.5.0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -179,6 +179,7 @@ def test_parse_bus_init_service():
 
 def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:
     pytest.importorskip("torch")
+    pytest.importorskip("bitsandbytes")
     import importlib
 
     from transformers import AutoModelForCausalLM, GPT2Config
@@ -196,4 +197,4 @@ def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:
         "ds",
         "--estimate-vram",
     )
-    assert "Estimated VRAM" in result.stdout
+    assert "Estimated VRAM requirement" in result.stdout


### PR DESCRIPTION
## Summary
- add Conda packaging recipe with runtime dependencies and entry points
- document installing via `conda install deepthought-rethought`
- add workflow to build and publish Conda package
- fix failing CLI test by skipping if bitsandbytes is missing and updating expected output
- update CI dependencies for pydantic, datasets and peft

## Testing
- `flake8`
- `pytest -k "not integration" -q`


------
https://chatgpt.com/codex/tasks/task_e_687051cae5d8832691ed1dda8ef1ee27