### PR TITLE
Expose env vars for vector and graph backends

### DIFF
--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -97,6 +97,10 @@ search_db: wiki.db
 Set ``DT_VECTOR_BACKEND`` to ``faiss`` to use the in-memory FAISS store instead of Chroma.
 When using FAISS, ``DT_VECTOR_USE_GPU`` enables GPU acceleration if available.
 
+These environment variables correspond to the ``vector_backend``, ``vector_use_gpu``
+and ``graph_backend`` fields of ``deepthought.config.Settings``. They may also be
+set in a configuration file.
+
 ``DT_GRAPH_BACKEND`` selects the knowledge graph backend. Supported values include
 ``memgraph``, ``neo4j`` and ``noop``. These variables are read by both
 ``HierarchicalService.from_chroma`` and ``MemoryService`` when initializing the

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from pydantic import AnyUrl, ValidationError
+from pydantic import AnyUrl, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 try:  # YAML support is optional
@@ -54,13 +54,13 @@ class Settings(BaseSettings):
     search_db: str | None = None
     social_graph_db: str = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")
 
-    vector_backend: str = "chroma"
-    vector_use_gpu: bool = False
+    vector_backend: str = Field("chroma", env="DT_VECTOR_BACKEND")
+    vector_use_gpu: bool = Field(False, env="DT_VECTOR_USE_GPU")
 
     memory_capacity: int = 100
     memory_top_k: int = 3
 
-    graph_backend: str = "memgraph"
+    graph_backend: str = Field("memgraph", env="DT_GRAPH_BACKEND")
     mg_host: str = os.getenv("MG_HOST", "localhost")
     mg_port: int = int(os.getenv("MG_PORT", 7687))
     mg_user: str = os.getenv("MG_USER", "memgraph")
@@ -141,4 +141,6 @@ def load_bot_env() -> BotEnv:
         return BotEnv()
     except ValidationError as exc:  # pragma: no cover - runtime validation
         missing = ", ".join(err["loc"][0] for err in exc.errors())
-        raise SystemExit(f"Missing or invalid environment variables: {missing}") from exc
+        raise SystemExit(
+            f"Missing or invalid environment variables: {missing}"
+        ) from exc

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -5,12 +5,8 @@ import pytest
 pytest.importorskip("yaml")
 import yaml
 
-from deepthought.config import (
-    BotEnv,
-    get_settings,
-    load_bot_env,
-    load_settings,
-)
+from deepthought.config import (BotEnv, get_settings, load_bot_env,
+                                load_settings)
 
 
 def test_env_overrides(monkeypatch):
@@ -146,6 +142,20 @@ def test_load_settings_missing_yaml_module(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError):
         load_settings(str(cfg))
+
+
+def test_get_settings_env(monkeypatch):
+    import deepthought.config as config
+
+    config._settings_cache = None
+    monkeypatch.setenv("DT_VECTOR_BACKEND", "faiss")
+    monkeypatch.setenv("DT_VECTOR_USE_GPU", "true")
+    monkeypatch.setenv("DT_GRAPH_BACKEND", "neo4j")
+
+    settings = config.get_settings()
+    assert settings.vector_backend == "faiss"
+    assert settings.vector_use_gpu is True
+    assert settings.graph_backend == "neo4j"
 
 
 def test_load_bot_env_success(monkeypatch):


### PR DESCRIPTION
## Summary
- allow env overrides for vector backend, GPU usage, and graph backend
- mention these environment variables in the memory service docs
- test that `get_settings()` reads DT_VECTOR_BACKEND, DT_VECTOR_USE_GPU and DT_GRAPH_BACKEND

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_config.py::test_get_settings_env -q`


------
https://chatgpt.com/codex/tasks/task_e_687062e7bf048326bf7543635c4501b4