### PR TITLE
Add finetune hyperparameter CLI options

### DIFF
--- a/docs/finetune_cli.md
+++ b/docs/finetune_cli.md
@@ -43,3 +43,15 @@ The `auto` option samples up to 1000 records from the dataset and enables
 packing when the average tokenized length is below 70% of the configured
 maximum. These heuristics mirror the behaviour of Predibase's automatic
 packing logic and aim to reduce padding without manual tuning.
+
+Additional hyperparameters can be configured from the command line:
+
+```bash
+dtrt finetune \
+    --epochs 3 \
+    --batch-size 4 \
+    --lr 1e-4
+```
+
+These options map directly to `TrainingArguments.num_train_epochs`,
+`per_device_train_batch_size` and `learning_rate` respectively.

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -115,6 +115,12 @@ def _cmd_finetune(args: argparse.Namespace) -> int:
         args.output_dir,
         "--max-seq-length",
         str(args.max_seq_length),
+        "--epochs",
+        str(args.epochs),
+        "--batch-size",
+        str(args.batch_size),
+        "--lr",
+        str(args.lr),
     ]
     if args.model_path:
         argv[0:0] = ["--model-path", args.model_path]
@@ -163,6 +169,24 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=["on", "off", "auto"],
         default="off",
         help="Sequence packing mode. 'auto' uses heuristics to reduce padding",
+    )
+    finetune_p.add_argument(
+        "--epochs",
+        type=float,
+        default=1,
+        help="Number of training epochs",
+    )
+    finetune_p.add_argument(
+        "--batch-size",
+        type=int,
+        default=2,
+        help="Per-device training batch size",
+    )
+    finetune_p.add_argument(
+        "--lr",
+        type=float,
+        default=2e-4,
+        help="Learning rate",
     )
     finetune_p.add_argument(
         "--estimate-only",

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -137,6 +137,10 @@ def create_trainer(
     train_dataset,
     eval_dataset,
     output_dir: str,
+    *,
+    epochs: float = 1,
+    batch_size: int = 2,
+    lr: float = 2e-4,
 ) -> Tuple[Trainer, TrainingArguments]:
     """Create the Trainer instance used for fine-tuning."""
     os.makedirs(output_dir, exist_ok=True)
@@ -152,15 +156,15 @@ def create_trainer(
     model = get_peft_model(model, lora_config)
     training_args = TrainingArguments(
         output_dir=output_dir,
-        num_train_epochs=1,
-        per_device_train_batch_size=2,
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
         gradient_accumulation_steps=8,
-        per_device_eval_batch_size=2,
+        per_device_eval_batch_size=batch_size,
         logging_dir=f"{output_dir}/logs",
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
-        learning_rate=2e-4,
+        learning_rate=lr,
         weight_decay=0.01,
         warmup_steps=50,
         fp16=False,
@@ -201,7 +205,16 @@ def run(args: argparse.Namespace) -> int:
         max_seq_length=args.max_seq_length,
         pack_sequences=args.pack_sequences,
     )
-    trainer, _ = create_trainer(model, tokenizer, train_ds, eval_ds, args.output_dir)
+    trainer, _ = create_trainer(
+        model,
+        tokenizer,
+        train_ds,
+        eval_ds,
+        args.output_dir,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+    )
     trainer.train(resume_from_checkpoint=args.resume)
     trainer.save_model()
     trainer.save_state()
@@ -242,6 +255,24 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         help="Sequence packing mode. 'auto' uses heuristics to reduce padding",
     )
     parser.add_argument(
+        "--epochs",
+        type=float,
+        default=1,
+        help="Number of training epochs",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=2,
+        help="Per-device training batch size",
+    )
+    parser.add_argument(
+        "--lr",
+        type=float,
+        default=2e-4,
+        help="Learning rate",
+    )
+    parser.add_argument(
         "--estimate-only",
         action="store_true",
         help="Estimate VRAM and exit without loading the dataset",
@@ -261,7 +292,7 @@ def main(argv: list[str] | None = None) -> int:
         model, _ = load_model(args.model_path, args.bits)
         vram = estimate_vram(
             model,
-            batch_size=2,
+            batch_size=args.batch_size,
             seq_length=args.max_seq_length,
             gradient_accumulation_steps=8,
             bits=args.bits,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -127,6 +127,12 @@ def test_parse_finetune_args():
             "4096",
             "--pack-sequences",
             "auto",
+            "--epochs",
+            "2",
+            "--batch-size",
+            "4",
+            "--lr",
+            "0.001",
             "--estimate-vram",
         ]
     )
@@ -137,6 +143,9 @@ def test_parse_finetune_args():
     assert args.output_dir == "/tmp/out"
     assert args.max_seq_length == 4096
     assert args.pack_sequences == "auto"
+    assert args.epochs == 2
+    assert args.batch_size == 4
+    assert args.lr == 0.001
     assert args.estimate_vram
     assert args.func.__name__ == "_cmd_finetune"
 

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -18,3 +18,6 @@ def test_finetune_cli_help(tmp_path):
     assert "--estimate-vram" in result.stdout
     assert "--estimate-only" in result.stdout
     assert "--pack-sequences" in result.stdout
+    assert "--epochs" in result.stdout
+    assert "--batch-size" in result.stdout
+    assert "--lr" in result.stdout


### PR DESCRIPTION
## Summary
- expose more training options via CLI (`--epochs`, `--batch-size`, `--lr`)
- propagate these to `TrainingArguments`
- document new flags in `docs/finetune_cli.md`
- test new parser behaviour

## Testing
- `python -m flake8 src tests`
- `pytest tests/unit/test_cli.py::test_parse_finetune_args tests/unit/test_finetune_cli.py::test_finetune_cli_help -q`


------
https://chatgpt.com/codex/tasks/task_e_6870715f82b08326ad7ed66d55d486c7