### PR TITLE
Fix message ack/nak handling

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -123,18 +123,22 @@ class HierarchicalService:
                 timeout=10.0,
             )
             logger.info("HierarchicalService published memory event ID %s", input_id)
-            await msg.ack()
+            if hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except NatsError:
+                    logger.error("Failed to ack message", exc_info=True)
         except (json.JSONDecodeError, ValueError) as e:
             logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
-                except Exception:
+                except NatsError:
                     logger.error("Failed to NAK message", exc_info=True)
             elif hasattr(msg, "ack") and callable(msg.ack):
                 try:
                     await msg.ack()
-                except Exception:
+                except NatsError:
                     logger.error("Failed to ack message after error", exc_info=True)
 
         except Exception as e:  # pragma: no cover - defensive

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -68,18 +68,22 @@ class MemoryService:
 
             await self._publisher.publish(EventSubjects.MEMORY_RETRIEVED, payload, use_jetstream=True, timeout=10.0)
             logger.info("MemoryService published memory event ID %s", input_id)
-            await msg.ack()
+            if hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except nats.errors.Error:
+                    logger.error("Failed to ack message", exc_info=True)
         except (json.JSONDecodeError, ValueError) as e:
             logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
-                except Exception:
+                except nats.errors.Error:
                     logger.error("Failed to NAK message", exc_info=True)
             elif hasattr(msg, "ack") and callable(msg.ack):
                 try:
                     await msg.ack()
-                except Exception:
+                except nats.errors.Error:
                     logger.error("Failed to ack message after error", exc_info=True)
 
         except Exception as e:

--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -43,11 +43,13 @@ sys.modules.setdefault("nats.js", fake_nats.js)
 sys.modules.setdefault("nats.js.client", fake_js_client_mod)
 sys.modules.setdefault("nats.errors", fake_errors_mod)
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+import importlib.machinery
 import importlib.util
 
 if importlib.util.find_spec("networkx") is None:
     fake_nx = types.ModuleType("networkx")
     setattr(fake_nx, "DiGraph", object)
+    fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
     sys.modules.setdefault("networkx", fake_nx)
 fake_pyd = types.ModuleType("pydantic")
 fake_pyd.AnyUrl = str
@@ -346,3 +348,50 @@ async def test_stop_skips_drain_when_not_connected():
     await service.stop()
 
     assert not service._nc.drain_called
+
+
+class FailingAckMsg(DummyMsg):
+    async def ack(self):
+        raise fake_nats.errors.Error("boom")
+
+
+class FailingNakMsg(DummyMsg):
+    async def nak(self):
+        raise fake_nats.errors.Error("boom")
+
+
+class NoAckMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+
+
+@pytest.mark.asyncio
+async def test_handle_input_ack_error_suppressed():
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hi", input_id="i1")
+    msg = FailingAckMsg(payload.to_json())
+    await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_nak_error_suppressed():
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = FailingNakMsg('{"bad": "payload"}')
+    await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_without_ack_attribute():
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hey", input_id="i2")
+    msg = NoAckMsg(payload.to_json())
+    await service._handle_input(msg)

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -16,11 +16,13 @@ class TraceEvent:
 
 record_mod.TraceEvent = TraceEvent
 sys.modules.setdefault("deepthought.harness.record", record_mod)
+import importlib.machinery
 import importlib.util
 
 if importlib.util.find_spec("networkx") is None:
     fake_nx = types.ModuleType("networkx")
     setattr(fake_nx, "DiGraph", object)
+    fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
     sys.modules.setdefault("networkx", fake_nx)
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
 fake_pyd = types.ModuleType("pydantic")
@@ -83,6 +85,7 @@ class _Metric:
 
 fake_prom.Counter = lambda *a, **k: _Metric()
 fake_prom.Histogram = lambda *a, **k: _Metric()
+fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
 sys.modules.setdefault("prometheus_client", fake_prom)
 
 from deepthought.config import Settings
@@ -214,3 +217,50 @@ async def test_stop_skips_drain_when_not_connected():
     await service.stop()
 
     assert not service._nc.drain_called
+
+
+class FailingAckMsg(DummyMsg):
+    async def ack(self):
+        raise fake_nats.errors.Error("boom")
+
+
+class FailingNakMsg(DummyMsg):
+    async def nak(self):
+        raise fake_nats.errors.Error("boom")
+
+
+class NoAckMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+
+
+@pytest.mark.asyncio
+async def test_handle_input_ack_error_suppressed():
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hi", input_id="i1")
+    msg = FailingAckMsg(payload.to_json())
+    await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_nak_error_suppressed():
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = FailingNakMsg('{"bad": "payload"}')
+    await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_without_ack_attribute():
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hey", input_id="i2")
+    msg = NoAckMsg(payload.to_json())
+    await service._handle_input(msg)


### PR DESCRIPTION
## Summary
- add attribute checks and suppress NATS errors in memory and hierarchical services
- add regression tests for ack/nak failures

## Testing
- `pre-commit run --files src/deepthought/services/memory_service.py src/deepthought/services/hierarchical_service.py tests/unit/services/test_memory_service.py tests/unit/services/test_hierarchical_service.py`

------
https://chatgpt.com/codex/tasks/task_e_687142805140832689e4cd60cb7b5c4f