### PR TITLE
Improve load_model error handling

### DIFF
--- a/docs/finetune_cli.md
+++ b/docs/finetune_cli.md
@@ -19,6 +19,9 @@ docker run --gpus all dtrt-finetune \
     --dataset-path <path> --model-path <model-id>
 ```
 
+If the specified model cannot be loaded, the CLI logs the underlying
+exception and exits instead of falling back to a different model.
+
 If you only have CPU resources, try the [Colab notebook](https://colab.research.google.com/github/d0tTino/DeepThought-ReThought/blob/main/docs/Finetune_CPU.ipynb).
 
 You can estimate the required VRAM before starting:

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Training utilities for fine-tuning language models."""
 
 import argparse
+import logging
 import os
 from typing import Tuple
 
@@ -29,6 +30,9 @@ __all__ = [
 ]
 
 
+logger = logging.getLogger(__name__)
+
+
 def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:
     """Load a model and tokenizer with the given quantization bits."""
     base_model_id = model_path or "meta-llama/Llama-3.2-3B-Instruct"
@@ -47,15 +51,9 @@ def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM,
             trust_remote_code=True,
         )
         tokenizer = AutoTokenizer.from_pretrained(base_model_id, trust_remote_code=True)
-    except Exception:
-        base_model_id = "HuggingFaceH4/zephyr-7b-beta"
-        model = AutoModelForCausalLM.from_pretrained(
-            base_model_id,
-            quantization_config=quantization_config,
-            device_map="auto",
-            trust_remote_code=True,
-        )
-        tokenizer = AutoTokenizer.from_pretrained(base_model_id, trust_remote_code=True)
+    except Exception as exc:
+        logger.exception("Failed to load model %s: %s", base_model_id, exc)
+        raise
 
     if tokenizer.pad_token is None:
         tokenizer.pad_token = tokenizer.eos_token

--- a/tests/unit/test_train_load_model.py
+++ b/tests/unit/test_train_load_model.py
@@ -1,0 +1,63 @@
+import importlib
+import logging
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+# Provide minimal stubs when optional deps are missing
+if "torch" not in sys.modules:
+    torch_stub = types.ModuleType("torch")
+    torch_stub.bfloat16 = "bf16"
+    sys.modules["torch"] = torch_stub
+
+if "datasets" not in sys.modules:
+    ds_stub = types.ModuleType("datasets")
+    ds_stub.Dataset = object
+    ds_stub.load_dataset = lambda *a, **k: None
+    sys.modules["datasets"] = ds_stub
+
+if "peft" not in sys.modules:
+    peft_stub = types.ModuleType("peft")
+    peft_stub.LoraConfig = object
+    peft_stub.get_peft_model = lambda *a, **k: None
+    peft_stub.prepare_model_for_kbit_training = lambda m: m
+    sys.modules["peft"] = peft_stub
+
+if "transformers" not in sys.modules:
+    tf_stub = types.ModuleType("transformers")
+
+    class DummyAutoModel:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            raise RuntimeError("boom")
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, *a, **k):
+            return cls()
+
+    class DummyBitsAndBytesConfig:
+        def __init__(self, **_kwargs):
+            pass
+
+    tf_stub.AutoModelForCausalLM = DummyAutoModel
+    tf_stub.AutoTokenizer = DummyTokenizer
+    tf_stub.BitsAndBytesConfig = DummyBitsAndBytesConfig
+    tf_stub.DataCollatorForLanguageModeling = object
+    tf_stub.Trainer = object
+    tf_stub.TrainingArguments = object
+    sys.modules["transformers"] = tf_stub
+
+train = importlib.import_module("deepthought.train")
+
+
+def test_load_model_raises(monkeypatch, caplog):
+    exc = RuntimeError("failed")
+    monkeypatch.setattr(train.AutoModelForCausalLM, "from_pretrained", mock.Mock(side_effect=exc))
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(RuntimeError) as info:
+            train.load_model("foo", 4)
+    assert info.value is exc
+    assert any("Failed to load model" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- raise error if `from_pretrained` fails and log the exception
- add a regression test for `load_model`
- document CLI failure behavior

## Testing
- `pre-commit run --files src/deepthought/train/__init__.py tests/unit/test_train_load_model.py docs/finetune_cli.md`

------
https://chatgpt.com/codex/tasks/task_e_6871c356ae2883268d6715fc7f3e158c