### PR TITLE
Add FTS5 support check

### DIFF
--- a/src/deepthought/search/offline_search.py
+++ b/src/deepthought/search/offline_search.py
@@ -13,7 +13,17 @@ class OfflineSearch:
     def create_index(cls, db_path: str, docs: Iterable[Tuple[str, str]]) -> "OfflineSearch":
         """Create or reuse an FTS5 index at ``db_path``."""
         conn = sqlite3.connect(db_path)
-        conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS documents USING FTS5(title, content)")
+        compile_options = {row[0] for row in conn.execute("pragma compile_options")}
+        if not any("FTS5" in opt for opt in compile_options):
+            conn.close()
+            raise RuntimeError("SQLite library is not compiled with FTS5 support")
+
+        try:
+            conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS documents USING FTS5(title, content)")
+        except sqlite3.OperationalError as exc:  # pragma: no cover - environment dependent
+            conn.close()
+            raise RuntimeError("SQLite library is not compiled with FTS5 support") from exc
+
         conn.executemany("INSERT INTO documents(title, content) VALUES (?, ?)", list(docs))
         conn.commit()
         conn.close()

--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -1,3 +1,7 @@
+import sqlite3
+
+import pytest
+
 from deepthought.search.offline_search import OfflineSearch
 
 
@@ -52,3 +56,24 @@ def test_search_expected_hits_and_limit(tmp_path):
         "ipsum lorem",
         "ipsum dolor",
     ]
+
+
+def test_create_index_missing_fts5(monkeypatch, tmp_path):
+    path = tmp_path / "nofts5.db"
+
+    orig_connect = sqlite3.connect
+
+    class FailingConn(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if "CREATE VIRTUAL TABLE" in sql:
+                raise sqlite3.OperationalError("no such module: fts5")
+            return super().execute(sql, *args, **kwargs)
+
+    def connect(*args, **kwargs):
+        kwargs["factory"] = FailingConn
+        return orig_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+
+    with pytest.raises(RuntimeError, match="FTS5"):
+        OfflineSearch.create_index(str(path), [])


### PR DESCRIPTION
## Summary
- ensure SQLite FTS5 support before creating the search index
- raise a RuntimeError if FTS5 support is missing
- test OperationalError conversion to RuntimeError when FTS5 is absent

## Testing
- `pre-commit run --files src/deepthought/search/offline_search.py tests/unit/test_offline_search.py`
- `pytest tests/unit/test_offline_search.py::test_create_index_missing_fts5 -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d30ea9048326af50f54388445eaa