### PR TITLE
Refactor training loaders to plugin system

### DIFF
--- a/docs/finetune_cli.md
+++ b/docs/finetune_cli.md
@@ -58,3 +58,24 @@ dtrt finetune \
 
 These options map directly to `TrainingArguments.num_train_epochs`,
 `per_device_train_batch_size` and `learning_rate` respectively.
+
+## Registering custom loaders
+
+`deepthought.train` discovers model and dataset loaders through entry point
+plugins. To register your own loader, declare an entry point in your project's
+`pyproject.toml`:
+
+```toml
+[project.entry-points."dtrt.model_loaders"]
+my_loader = "my_package.loaders:load_model"
+
+[project.entry-points."dtrt.dataset_loaders"]
+my_dataset = "my_package.loaders:load_dataset"
+```
+
+After installing the package, select the loader with `--model-loader` or
+`--dataset-loader`:
+
+```bash
+dtrt finetune --model-loader my_loader --dataset-loader my_dataset
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dynamic = ["version", "dependencies"]
 dtrt = "deepthought.cli:main"
 dtrt-finetune = "deepthought.train:main"
 
+[project.entry-points."dtrt.model_loaders"]
+hf = "deepthought.train:_hf_model_loader"
+
+[project.entry-points."dtrt.dataset_loaders"]
+hf = "deepthought.train:_hf_dataset_loader"
+
 [tool.setuptools.package-data]
 "tools" = ["template_service/*"]
 "deepthought.templates" = ["bus_service/*"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,9 @@ setup(
         "console_scripts": [
             "dtrt=deepthought.cli:main",
             "dtrt-finetune=deepthought.train:main",
-        ]
+        ],
+        "dtrt.model_loaders": ["hf=deepthought.train:_hf_model_loader"],
+        "dtrt.dataset_loaders": ["hf=deepthought.train:_hf_dataset_loader"],
     },
     description="DeepThought reThought - experimental AI framework",
     license="MIT",

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -113,6 +113,10 @@ def _cmd_finetune(args: argparse.Namespace) -> int:
         str(args.bits),
         "--output-dir",
         args.output_dir,
+        "--model-loader",
+        args.model_loader,
+        "--dataset-loader",
+        args.dataset_loader,
         "--max-seq-length",
         str(args.max_seq_length),
         "--epochs",
@@ -145,6 +149,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--dataset-path",
         default="databricks/databricks-dolly-15k",
         help="Dataset path or HF dataset identifier",
+    )
+    finetune_p.add_argument(
+        "--model-loader",
+        default="hf",
+        help="Name of the model loader plugin to use",
+    )
+    finetune_p.add_argument(
+        "--dataset-loader",
+        default="hf",
+        help="Name of the dataset loader plugin to use",
     )
     finetune_p.add_argument(
         "--bits",

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-from typing import Tuple
+from importlib import metadata
+from typing import Callable, Tuple
 
 import torch
 from datasets import Dataset, load_dataset
@@ -22,6 +23,8 @@ from transformers import (
 __all__ = [
     "load_model",
     "load_dataset",
+    "_hf_model_loader",
+    "_hf_dataset_loader",
     "create_trainer",
     "run",
     "estimate_vram",
@@ -33,8 +36,25 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:
-    """Load a model and tokenizer with the given quantization bits."""
+_MODEL_GROUP = "dtrt.model_loaders"
+_DATASET_GROUP = "dtrt.dataset_loaders"
+
+
+def _resolve_plugin(group: str, name: str) -> Callable:
+    """Return a plugin callable from entry points."""
+    eps = metadata.entry_points()
+    for ep in eps.select(group=group):
+        if ep.name == name:
+            return ep.load()
+    if group == _MODEL_GROUP and name == "hf":
+        return _hf_model_loader
+    if group == _DATASET_GROUP and name == "hf":
+        return _hf_dataset_loader
+    raise KeyError(f"No plugin named '{name}' in group '{group}'")
+
+
+def _hf_model_loader(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:
+    """Default Hugging Face model loader."""
     base_model_id = model_path or "meta-llama/Llama-3.2-3B-Instruct"
     quantization_config = BitsAndBytesConfig(
         load_in_4bit=bits == 4,
@@ -60,13 +80,24 @@ def load_model(model_path: str | None, bits: int) -> Tuple[AutoModelForCausalLM,
     return model, tokenizer
 
 
-def load_dataset(
+def load_model(
+    model_path: str | None,
+    bits: int,
+    *,
+    loader: str = "hf",
+) -> Tuple[AutoModelForCausalLM, AutoTokenizer]:
+    """Load a model using the specified loader plugin."""
+    fn = _resolve_plugin(_MODEL_GROUP, loader)
+    return fn(model_path, bits)
+
+
+def _hf_dataset_loader(
     dataset_path: str,
     tokenizer: AutoTokenizer,
     max_seq_length: int = 2048,
     pack_sequences: str | bool = "off",
-):
-    """Load and tokenize the dataset used for fine-tuning."""
+) -> Tuple[Dataset, Dataset]:
+    """Default Hugging Face dataset loader."""
     raw_dataset = load_dataset(dataset_path)
 
     def format_prompt(example):
@@ -127,6 +158,19 @@ def load_dataset(
         train_ds, eval_ds = split_dataset["train"], split_dataset["test"]
 
     return train_ds, eval_ds
+
+
+def load_dataset(
+    dataset_path: str,
+    tokenizer: AutoTokenizer,
+    max_seq_length: int = 2048,
+    pack_sequences: str | bool = "off",
+    *,
+    loader: str = "hf",
+) -> Tuple[Dataset, Dataset]:
+    """Load datasets using the specified loader plugin."""
+    fn = _resolve_plugin(_DATASET_GROUP, loader)
+    return fn(dataset_path, tokenizer, max_seq_length=max_seq_length, pack_sequences=pack_sequences)
 
 
 def create_trainer(
@@ -196,12 +240,13 @@ def estimate_vram(
 
 def run(args: argparse.Namespace) -> int:
     """Execute training using high level helper functions."""
-    model, tokenizer = load_model(args.model_path, args.bits)
+    model, tokenizer = load_model(args.model_path, args.bits, loader=args.model_loader)
     train_ds, eval_ds = load_dataset(
         args.dataset_path,
         tokenizer,
         max_seq_length=args.max_seq_length,
         pack_sequences=args.pack_sequences,
+        loader=args.dataset_loader,
     )
     trainer, _ = create_trainer(
         model,
@@ -227,6 +272,16 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         "--dataset-path",
         default="databricks/databricks-dolly-15k",
         help="Dataset path or HF dataset identifier",
+    )
+    parser.add_argument(
+        "--model-loader",
+        default="hf",
+        help="Name of the model loader plugin to use",
+    )
+    parser.add_argument(
+        "--dataset-loader",
+        default="hf",
+        help="Name of the dataset loader plugin to use",
     )
     parser.add_argument(
         "--bits",
@@ -287,7 +342,7 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if args.estimate_vram or args.estimate_only:
-        model, _ = load_model(args.model_path, args.bits)
+        model, _ = load_model(args.model_path, args.bits, loader=args.model_loader)
         vram = estimate_vram(
             model,
             batch_size=args.batch_size,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -150,6 +150,8 @@ def test_parse_finetune_args():
     assert args.batch_size == 4
     assert args.lr == 0.001
     assert args.estimate_vram
+    assert args.model_loader == "hf"
+    assert args.dataset_loader == "hf"
     assert args.func.__name__ == "_cmd_finetune"
 
 

--- a/tests/unit/test_finetune_cli.py
+++ b/tests/unit/test_finetune_cli.py
@@ -21,3 +21,5 @@ def test_finetune_cli_help(tmp_path):
     assert "--epochs" in result.stdout
     assert "--batch-size" in result.stdout
     assert "--lr" in result.stdout
+    assert "--model-loader" in result.stdout
+    assert "--dataset-loader" in result.stdout

--- a/tests/unit/test_train_load_model.py
+++ b/tests/unit/test_train_load_model.py
@@ -58,6 +58,6 @@ def test_load_model_raises(monkeypatch, caplog):
     monkeypatch.setattr(train.AutoModelForCausalLM, "from_pretrained", mock.Mock(side_effect=exc))
     with caplog.at_level(logging.ERROR):
         with pytest.raises(RuntimeError) as info:
-            train.load_model("foo", 4)
+            train.load_model("foo", 4, loader="hf")
     assert info.value is exc
     assert any("Failed to load model" in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_train_plugins.py
+++ b/tests/unit/test_train_plugins.py
@@ -1,0 +1,24 @@
+import importlib
+import sys
+from importlib.metadata import EntryPoint, EntryPoints
+from types import ModuleType
+
+import deepthought.train as train
+
+
+def test_custom_model_loader(monkeypatch):
+    calls = {}
+
+    def loader(mp, bits):
+        calls["args"] = (mp, bits)
+        return "m", "t"
+
+    mod = ModuleType("dummy_mod")
+    mod.loader = loader
+    sys.modules["dummy_mod"] = mod
+    ep = EntryPoint(name="dummy", value="dummy_mod:loader", group="dtrt.model_loaders")
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda: EntryPoints([ep]))
+
+    model, tok = train.load_model("foo", 4, loader="dummy")
+    assert (model, tok) == ("m", "t")
+    assert calls["args"] == ("foo", 4)


### PR DESCRIPTION
## Summary
- refactor `deepthought.train` to load model and dataset via entry points
- add default `hf` loader implementations
- expose plugin options in CLI and parser
- document registering plugins in `finetune_cli.md`
- provide package entry points for built‑in loaders
- test plugin loader resolution

## Testing
- `pre-commit run --files docs/finetune_cli.md pyproject.toml setup.py src/deepthought/cli/__init__.py src/deepthought/train/__init__.py tests/unit/test_cli.py tests/unit/test_finetune_cli.py tests/unit/test_train_load_model.py tests/unit/test_train_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_6871db9f61ec8326acefc7f4bdfa56fb