### PR TITLE
Add orchestrator with entrypoint discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ the template and environment configuration.
 dtrt bus init service mysvc
 ```
 
+### Orchestrator Quick Start
+
+See [docs/orchestrator_quickstart.md](docs/orchestrator_quickstart.md) for running multiple services together:
+
+```bash
+dtrt orchestrate orchestrator.yaml
+```
+
 ## Current Status
 
 * The foundational EDA using NATS/JetStream is implemented and tested with the `BasicMemory` and `BasicLLM` reference modules.

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -1,0 +1,19 @@
+# Orchestrator Quick Start
+
+The orchestrator starts multiple services with a single NATS connection. Each service is registered via an entry point in the `deepthought.services` group.
+
+Create a configuration file listing the services to launch:
+
+```yaml
+services:
+  - demo
+  - codegen
+```
+
+Start a local NATS server with JetStream enabled then run:
+
+```bash
+dtrt orchestrate orchestrator.yaml
+```
+
+Publishing an `INPUT_RECEIVED` event will now flow through the `DemoService` and the `CodeGenerationService`, demonstrating end-to-end event handling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,11 @@ dynamic = ["version", "dependencies"]
 dtrt = "deepthought.cli:main"
 dtrt-finetune = "deepthought.train:main"
 
+[project.entry-points."deepthought.services"]
+demo = "deepthought.services.demo.service:DemoService"
+codegen = "deepthought.services.code_generation_service:CodeGenerationService"
+memory = "deepthought.services.memory_service:MemoryService"
+
 [tool.setuptools.package-data]
 "tools" = ["template_service/*"]
 "deepthought.templates" = ["bus_service/*"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,12 @@ setup(
         "console_scripts": [
             "dtrt=deepthought.cli:main",
             "dtrt-finetune=deepthought.train:main",
-        ]
+        ],
+        "deepthought.services": [
+            "demo=deepthought.services.demo.service:DemoService",
+            "codegen=deepthought.services.code_generation_service:CodeGenerationService",
+            "memory=deepthought.services.memory_service:MemoryService",
+        ],
     },
     description="DeepThought reThought - experimental AI framework",
     license="MIT",

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -34,6 +34,7 @@ try:  # pragma: no cover - optional dependency may be missing
     from . import motivate  # type: ignore  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
     motivate = None  # type: ignore
+from . import orchestrator  # noqa: F401
 from . import persona  # noqa: F401
 
 # neuromorphic uses optional nengo dependency

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import shutil
 from importlib import import_module, resources
 from pathlib import Path
@@ -135,6 +136,13 @@ def _cmd_finetune(args: argparse.Namespace) -> int:
     return training.main(argv)
 
 
+def _cmd_orchestrate(args: argparse.Namespace) -> int:
+    from .. import orchestrator
+
+    asyncio.run(orchestrator.run(args.config))
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="dtrt")
     sub = parser.add_subparsers(dest="command")
@@ -200,6 +208,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     finetune_p.add_argument("--resume", action="store_true", help="Resume training from the last checkpoint")
     finetune_p.set_defaults(func=_cmd_finetune)
+
+    orchestrate_p = sub.add_parser(
+        "orchestrate",
+        description="Launch multiple services from a config file",
+    )
+    orchestrate_p.add_argument("config", help="Path to YAML or JSON config")
+    orchestrate_p.set_defaults(func=_cmd_orchestrate)
 
     init_p = sub.add_parser("init")
     init_sub = init_p.add_subparsers(dest="target")

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import ssl
+from importlib import metadata
+from pathlib import Path
+from typing import Any, Iterable
+
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def discover_services(names: Iterable[str] | None = None) -> list[type]:
+    """Return service classes registered under ``deepthought.services``."""
+    try:
+        eps = metadata.entry_points().select(group="deepthought.services")
+    except Exception:
+        eps = []
+    selected = []
+    if names is None:
+        selected = eps
+    else:
+        wanted = set(names)
+        for ep in eps:
+            if ep.name in wanted:
+                selected.append(ep)
+    services = []
+    for ep in selected:
+        try:
+            services.append(ep.load())
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to load service %s: %s", ep.name, exc, exc_info=True)
+    return services
+
+
+def _load_config(path: str) -> dict[str, Any]:
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix in {".yaml", ".yml"}:
+        try:
+            import yaml
+        except Exception as exc:  # pragma: no cover - optional dep
+            raise RuntimeError("PyYAML required for YAML config") from exc
+        return yaml.safe_load(text) or {}
+    return json.loads(text)
+
+
+async def _connect_nats():
+    from nats.aio.client import Client as NATS
+
+    settings = get_settings()
+    ssl_ctx = None
+    if settings.nats_tls_cert and settings.nats_tls_key:
+        ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        if settings.nats_tls_ca:
+            ssl_ctx.load_verify_locations(settings.nats_tls_ca)
+        ssl_ctx.load_cert_chain(settings.nats_tls_cert, settings.nats_tls_key)
+    nc = NATS()
+    await nc.connect(
+        servers=[settings.nats_url],
+        tls=ssl_ctx,
+        user=settings.nats_username,
+        password=settings.nats_password,
+        name="dtrt_orchestrator",
+    )
+    js = nc.jetstream()
+    return nc, js
+
+
+async def run(config_path: str) -> None:
+    """Start services defined in ``config_path``."""
+    cfg = _load_config(config_path)
+    names = cfg.get("services", [])
+    service_classes = discover_services(names)
+    if not service_classes:
+        logger.warning("No services found for names %s", names)
+        return
+    nc, js = await _connect_nats()
+    instances = [cls(nc, js) for cls in service_classes]
+    for inst in instances:
+        await inst.start()
+    logger.info("Started %d services", len(instances))
+    try:
+        await asyncio.Event().wait()
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        pass
+    finally:
+        for inst in instances:
+            try:
+                await inst.stop()
+            except Exception:  # pragma: no cover - defensive
+                logger.error("Failed to stop service %s", inst, exc_info=True)
+        if nc.is_connected:
+            await nc.drain()

--- a/tests/unit/test_cli_orchestrate.py
+++ b/tests/unit/test_cli_orchestrate.py
@@ -1,0 +1,9 @@
+from deepthought.cli import _build_parser
+
+
+def test_parse_orchestrate_args():
+    parser = _build_parser()
+    args = parser.parse_args(["orchestrate", "cfg.yml"])
+    assert args.command == "orchestrate"
+    assert args.config == "cfg.yml"
+    assert args.func.__name__ == "_cmd_orchestrate"

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,0 +1,51 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought import orchestrator
+
+
+class DummyService:
+    def __init__(self, nc, js):
+        self.started = False
+        self.stopped = False
+
+    async def start(self, durable_name: str = "d") -> bool:
+        self.started = True
+        return True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_run(monkeypatch, tmp_path):
+    ep = SimpleNamespace(name="dummy", load=lambda: DummyService)
+    monkeypatch.setattr(
+        orchestrator.metadata,
+        "entry_points",
+        lambda: SimpleNamespace(select=lambda **k: [ep]),
+    )
+
+    class DummyNATS:
+        def __init__(self) -> None:
+            self.is_connected = True
+
+        async def drain(self):
+            pass
+
+    class DummyJS:
+        pass
+
+    async def fake_connect():
+        return DummyNATS(), DummyJS()
+
+    monkeypatch.setattr(orchestrator, "_connect_nats", fake_connect)
+
+    monkeypatch.setattr(asyncio.Event, "wait", lambda self: asyncio.sleep(0))
+
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text('{"services": ["dummy"]}', encoding="utf-8")
+
+    await orchestrator.run(str(cfg))


### PR DESCRIPTION
## Summary
- implement `deepthought.orchestrator` for launching services discovered via entry points
- add `dtrt orchestrate` CLI command
- document orchestrator quick start
- provide entry points for built-in services
- test orchestrator and CLI parser

## Testing
- `pytest tests/unit/test_cli_orchestrate.py tests/unit/test_orchestrator.py -q`
- `pre-commit run --files src/deepthought/orchestrator.py src/deepthought/cli/__init__.py src/deepthought/__init__.py pyproject.toml setup.py README.md docs/orchestrator_quickstart.md tests/unit/test_orchestrator.py tests/unit/test_cli_orchestrate.py`

------
https://chatgpt.com/codex/tasks/task_e_6871dba04a448326b22d8ab750a6497a