### PR TITLE
Add malformed input tests and logging checks

### DIFF
--- a/tests/unit/services/test_hierarchical_service.py
+++ b/tests/unit/services/test_hierarchical_service.py
@@ -365,6 +365,15 @@ class NoAckMsg:
         self.data = data.encode()
 
 
+class AckNakMsg(DummyMsg):
+    def __init__(self, data):
+        super().__init__(data)
+        self.nacked = False
+
+    async def nak(self):
+        self.nacked = True
+
+
 @pytest.mark.asyncio
 async def test_handle_input_ack_error_suppressed():
     service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
@@ -395,3 +404,29 @@ async def test_handle_input_without_ack_attribute():
     payload = InputReceivedPayload(user_input="hey", input_id="i2")
     msg = NoAckMsg(payload.to_json())
     await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_invalid_payload():
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = AckNakMsg("not json")
+    await service._handle_input(msg)
+
+    assert msg.nacked
+    assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_input_missing_fields():
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = AckNakMsg(json.dumps({"user_input": "hi"}))
+    await service._handle_input(msg)
+
+    assert msg.nacked
+    assert not msg.acked

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -234,6 +234,15 @@ class NoAckMsg:
         self.data = data.encode()
 
 
+class AckNakMsg(DummyMsg):
+    def __init__(self, data):
+        super().__init__(data)
+        self.nacked = False
+
+    async def nak(self):
+        self.nacked = True
+
+
 @pytest.mark.asyncio
 async def test_handle_input_ack_error_suppressed():
     service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
@@ -264,3 +273,29 @@ async def test_handle_input_without_ack_attribute():
     payload = InputReceivedPayload(user_input="hey", input_id="i2")
     msg = NoAckMsg(payload.to_json())
     await service._handle_input(msg)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_invalid_payload():
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = AckNakMsg("not json")
+    await service._handle_input(msg)
+
+    assert msg.nacked
+    assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_handle_input_missing_fields():
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = AckNakMsg(json.dumps({"input_id": "x"}))
+    await service._handle_input(msg)
+
+    assert msg.nacked
+    assert not msg.acked

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -8,6 +8,9 @@ sys.modules.setdefault("deepthought.motivate", types.ModuleType("motivate"))
 sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 
+import pytest
+
+import deepthought.memory.tiered as tiered
 from deepthought.memory.tiered import TieredMemory
 
 
@@ -48,6 +51,16 @@ class DummyDAL:
 
     def merge_entity(self, name):
         self.merged.append(name)
+
+
+class FailingVector(DummyVector):
+    def query(self, query_texts, n_results=3):
+        raise RuntimeError("vector fail")
+
+
+class FailingDAL(DummyDAL):
+    def query_subgraph(self, query, params):
+        raise RuntimeError("graph fail")
 
 
 def test_eviction_lru():
@@ -104,3 +117,29 @@ def test_eviction_cleanup_on_delete_failure(monkeypatch):
 
     assert list(mem._lru.keys()) == ["b"]
     assert list(vec.docs.values()) == ["a", "b"]
+
+
+def test_vector_match_logs_error(monkeypatch):
+    vec = FailingVector()
+    dal = DummyDAL()
+    mem = TieredMemory(vec, dal)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("log")
+
+    monkeypatch.setattr(tiered.logger, "error", boom)
+    with pytest.raises(RuntimeError, match="log"):
+        mem.vector_matches("hi")
+
+
+def test_graph_facts_logs_error(monkeypatch):
+    vec = DummyVector()
+    dal = FailingDAL()
+    mem = TieredMemory(vec, dal)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("log")
+
+    monkeypatch.setattr(tiered.logger, "error", boom)
+    with pytest.raises(RuntimeError, match="log"):
+        mem.graph_facts()


### PR DESCRIPTION
## Summary
- test invalid data handling for memory and hierarchical services
- ensure TieredMemory logs errors when backends fail

## Testing
- `pre-commit run --files tests/unit/services/test_memory_service.py tests/unit/services/test_hierarchical_service.py tests/unit/test_tiered_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_687307dc7fe0832682389c673960a4de