### PR TITLE
Add finetune estimate-only integration test

### DIFF
--- a/tests/data/finetune_sample.jsonl
+++ b/tests/data/finetune_sample.jsonl
@@ -1,0 +1,2 @@
+{"instruction": "Say hello", "context": "", "response": "Hello"}
+{"instruction": "Say goodbye", "context": "", "response": "Goodbye"}

--- a/tests/integration/test_finetune_cli.py
+++ b/tests/integration/test_finetune_cli.py
@@ -1,0 +1,33 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+from deepthought.cli import main
+
+
+def test_finetune_estimate_only(tmp_path: Path, monkeypatch) -> None:
+    pytest.importorskip("torch")
+    pytest.importorskip("bitsandbytes")
+    from transformers import AutoModelForCausalLM, GPT2Config
+
+    train = importlib.import_module("deepthought.train")
+    cfg = GPT2Config(n_embd=4, n_layer=1, n_head=1, vocab_size=10)
+    dummy_model = AutoModelForCausalLM.from_config(cfg)
+    monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", lambda *a, **k: dummy_model)
+    monkeypatch.setattr(train, "run", lambda args: 0)
+
+    dataset = Path(__file__).resolve().parents[1] / "data" / "finetune_sample.jsonl"
+    out_dir = tmp_path / "model"
+    rc = main(
+        [
+            "finetune",
+            "--dataset-path",
+            str(dataset),
+            "--output-dir",
+            str(out_dir),
+            "--estimate-only",
+        ]
+    )
+    assert rc == 0
+    assert out_dir.is_dir()


### PR DESCRIPTION
## Summary
- include a tiny dataset for finetuning tests
- add integration test for `dtrt finetune --estimate-only`

## Testing
- `pre-commit run --files tests/integration/test_finetune_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_687307dc43e08326b283ab0b353cb207