### PR TITLE
Add rate limiter metrics

### DIFF
--- a/docs/bus_template.md
+++ b/docs/bus_template.md
@@ -101,3 +101,18 @@ async def _handle(self, msg):
 The first argument is the bucket capacity and the second is the refill interval
 in seconds. When the bucket is empty, the wrapper waits until enough tokens are
 available before calling the original handler.
+
+### Prometheus Metrics
+
+The generated `subscriber.py` records simple Prometheus metrics for each
+message that is handled. After acknowledging a message it increments the
+`inputs_total` counter and observes the processing latency:
+
+```python
+duration = time.perf_counter() - start
+INPUTS_TOTAL.labels(service="template_service").inc()
+INPUT_LATENCY_SECONDS.labels(service="template_service").observe(duration)
+```
+
+These metrics can be scraped from the metrics server to monitor throughput
+and latency of your service.

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -34,7 +34,10 @@ try:  # pragma: no cover - optional dependency may be missing
     from . import motivate  # type: ignore  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
     motivate = None  # type: ignore
-from . import orchestrator  # noqa: F401
+try:  # pragma: no cover - optional dependency may be missing
+    from . import orchestrator  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - optional dependency may be missing
+    orchestrator = None  # type: ignore
 from . import persona  # noqa: F401
 
 # neuromorphic uses optional nengo dependency

--- a/src/deepthought/templates/bus_service/subscriber.py
+++ b/src/deepthought/templates/bus_service/subscriber.py
@@ -2,6 +2,8 @@ import asyncio
 import time
 from typing import Any, Awaitable, Callable
 
+from deepthought.metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+
 
 def rate_limit(
     capacity: int, refill_interval: float
@@ -50,4 +52,8 @@ class TemplateServiceSubscriber:
 
     @rate_limit(10, 1)  # 10 messages per second
     async def _handle(self, msg):
+        start = time.perf_counter()
         await msg.ack()
+        duration = time.perf_counter() - start
+        INPUTS_TOTAL.labels(service="template_service").inc()
+        INPUT_LATENCY_SECONDS.labels(service="template_service").observe(duration)

--- a/tests/unit/test_cli_bus.py
+++ b/tests/unit/test_cli_bus.py
@@ -29,6 +29,8 @@ def test_cli_bus_init_service(tmp_path: Path) -> None:
     sub_text = (dest / "subscriber.py").read_text(encoding="utf-8")
     assert f"{class_name}Publisher" in pub_text
     assert f"{class_name}Subscriber" in sub_text
+    assert "INPUTS_TOTAL" in sub_text
+    assert 'service="demo"' in sub_text
 
     for py_file in dest.glob("*.py"):
         subprocess.run(


### PR DESCRIPTION
## Summary
- collect Prometheus counters in bus service subscriber
- document new counters in the bus template guide
- assert placeholders for metrics in generated subscriber
- skip orchestrator import if dependencies are missing

## Testing
- `pre-commit run --files src/deepthought/__init__.py docs/bus_template.md src/deepthought/templates/bus_service/subscriber.py tests/unit/test_cli_bus.py`
- `PYTHONPATH=src pytest tests/unit/test_cli_bus.py::test_cli_bus_init_service -q`
- `PYTHONPATH=src pytest tests/unit/test_cli_wheel.py::test_dtrt_init_service_from_wheel -q`


------
https://chatgpt.com/codex/tasks/task_e_687307da522c8326a16a35488f7186ff