### PR TITLE
Mention MG_HOST and update docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ variables:
 
 ```bash
 docker run --rm -p 7687:7687 memgraph/memgraph
-export DT_MG_HOST=localhost
+export DT_MG_HOST=localhost  # MG_HOST also accepted
 export DT_MG_PORT=7687
 export DT_MG_USER=memgraph
 export DT_MG_PASSWORD=memgraph

--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -22,7 +22,7 @@ Set the following variables so the memory service can reach Memgraph:
 
 | Variable       | Description           | Default     |
 | -------------- | -------------------- | ----------- |
-| `DT_MG_HOST`      | Memgraph host name   | `localhost` |
+| `DT_MG_HOST` / `MG_HOST` | Memgraph host name | `localhost` |
 | `DT_MG_PORT`      | Memgraph port number | `7687`      |
 | `DT_MG_USER`      | Username (optional)  | `memgraph`  |
 | `DT_MG_PASSWORD`  | Password (optional)  | `memgraph`  |

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -82,7 +82,11 @@ class Settings(BaseSettings):
 
 
 def load_settings(config_file: Optional[str] = None) -> Settings:
-    """Load settings from environment variables or a config file."""
+    """Load settings from environment variables or a config file.
+
+    Either the default ``DT_`` prefix or plain variable names are accepted
+    for Memgraph options, e.g. ``DT_MG_HOST`` or ``MG_HOST``.
+    """
     file_path = config_file or os.getenv("DT_CONFIG_FILE")
     if file_path:
         path = Path(file_path)


### PR DESCRIPTION
## Summary
- document MG_HOST as an accepted alternative to DT_MG_HOST
- clarify load_settings() docstring on prefix handling

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_6873277b3da8832692f19a927cbeaddc