### PR TITLE
Update graph env vars

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -61,15 +61,15 @@ class Settings(BaseSettings):
     memory_top_k: int = 3
 
     graph_backend: str = Field("memgraph", env="DT_GRAPH_BACKEND")
-    mg_host: str = os.getenv("MG_HOST", "localhost")
-    mg_port: int = int(os.getenv("MG_PORT", 7687))
-    mg_user: str = os.getenv("MG_USER", "memgraph")
-    mg_password: str = os.getenv("MG_PASSWORD", "memgraph")
+    mg_host: str = Field("localhost", env="DT_MG_HOST")
+    mg_port: int = Field(7687, env="DT_MG_PORT")
+    mg_user: str = Field("memgraph", env="DT_MG_USER")
+    mg_password: str = Field("memgraph", env="DT_MG_PASSWORD")
 
-    neo4j_host: str = Field(default_factory=lambda: os.getenv("NEO4J_HOST", "localhost"))
-    neo4j_port: int = Field(default_factory=lambda: int(os.getenv("NEO4J_PORT", 7687)))
-    neo4j_user: str = Field(default_factory=lambda: os.getenv("NEO4J_USER", "neo4j"))
-    neo4j_password: str = Field(default_factory=lambda: os.getenv("NEO4J_PASSWORD", "neo4j"))
+    neo4j_host: str = Field("localhost", env="DT_NEO4J_HOST")
+    neo4j_port: int = Field(7687, env="DT_NEO4J_PORT")
+    neo4j_user: str = Field("neo4j", env="DT_NEO4J_USER")
+    neo4j_password: str = Field("neo4j", env="DT_NEO4J_PASSWORD")
 
     reward: RewardThresholds = RewardThresholds()
     persona_descriptions: dict[str, str] = {

--- a/tests/integration/test_graph_backend_factory.py
+++ b/tests/integration/test_graph_backend_factory.py
@@ -28,10 +28,10 @@ def test_factory_memgraph_live(memgraph_server, monkeypatch):
     if not memgraph_available(MG_HOST, MG_PORT):
         pytest.skip("Memgraph not reachable")
 
-    monkeypatch.setenv("MG_HOST", MG_HOST)
-    monkeypatch.setenv("MG_PORT", str(MG_PORT))
-    monkeypatch.setenv("MG_USER", MG_USER)
-    monkeypatch.setenv("MG_PASSWORD", MG_PASSWORD)
+    monkeypatch.setenv("DT_MG_HOST", MG_HOST)
+    monkeypatch.setenv("DT_MG_PORT", str(MG_PORT))
+    monkeypatch.setenv("DT_MG_USER", MG_USER)
+    monkeypatch.setenv("DT_MG_PASSWORD", MG_PASSWORD)
 
     backend = create_graph_backend("memgraph")
     assert isinstance(backend, GraphDALBackend)
@@ -50,10 +50,10 @@ def test_factory_neo4j_live(neo4j_server, monkeypatch):
     if not neo4j_available(NEO4J_HOST, NEO4J_PORT):
         pytest.skip("Neo4j not reachable")
 
-    monkeypatch.setenv("NEO4J_HOST", NEO4J_HOST)
-    monkeypatch.setenv("NEO4J_PORT", str(NEO4J_PORT))
-    monkeypatch.setenv("NEO4J_USER", NEO4J_USER)
-    monkeypatch.setenv("NEO4J_PASSWORD", NEO4J_PASSWORD)
+    monkeypatch.setenv("DT_NEO4J_HOST", NEO4J_HOST)
+    monkeypatch.setenv("DT_NEO4J_PORT", str(NEO4J_PORT))
+    monkeypatch.setenv("DT_NEO4J_USER", NEO4J_USER)
+    monkeypatch.setenv("DT_NEO4J_PASSWORD", NEO4J_PASSWORD)
 
     backend = create_graph_backend("neo4j")
     assert isinstance(backend, Neo4jBackend)

--- a/tests/unit/test_neo4j_connector.py
+++ b/tests/unit/test_neo4j_connector.py
@@ -5,10 +5,10 @@ from deepthought.graph.connector import Neo4jConnector
 
 
 def test_env_defaults(monkeypatch):
-    monkeypatch.setenv("NEO4J_HOST", "h")
-    monkeypatch.setenv("NEO4J_PORT", "7777")
-    monkeypatch.setenv("NEO4J_USER", "u")
-    monkeypatch.setenv("NEO4J_PASSWORD", "p")
+    monkeypatch.setenv("DT_NEO4J_HOST", "h")
+    monkeypatch.setenv("DT_NEO4J_PORT", "7777")
+    monkeypatch.setenv("DT_NEO4J_USER", "u")
+    monkeypatch.setenv("DT_NEO4J_PASSWORD", "p")
     monkeypatch.setattr(cfg, "_settings_cache", None)
     c = Neo4jConnector()
     assert c._uri == "bolt://h:7777"


### PR DESCRIPTION
## Summary
- replace Memgraph and Neo4j defaults with DT-prefixed environment variables
- fix tests for new DT_ variable names

## Testing
- `pre-commit run --files src/deepthought/config.py tests/unit/test_neo4j_connector.py tests/integration/test_graph_backend_factory.py`
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/test_graph_connector.py tests/unit/test_neo4j_connector.py tests/integration/test_graph_backend_factory.py -m "not nats"`


------
https://chatgpt.com/codex/tasks/task_e_6873277c47dc8326ac9d0ff4cd1305ec