### PR TITLE
Add mocked multi-agent demo test

### DIFF
--- a/tests/test_multi_agent_demo_mocked.py
+++ b/tests/test_multi_agent_demo_mocked.py
@@ -1,0 +1,148 @@
+import asyncio
+import importlib
+import types
+import sys
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+
+class DummyMsg:
+    def __init__(self, subject: str, data: bytes):
+        self.subject = subject
+        self.data = data
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+class DummyBus:
+    def __init__(self):
+        self.subscribers: dict[str, list] = {}
+
+    def subscribe(self, subject: str, cb):
+        self.subscribers.setdefault(subject, []).append(cb)
+        return DummySubscription(self, subject, cb)
+
+    def unsubscribe(self, subject: str, cb):
+        if subject in self.subscribers:
+            self.subscribers[subject].remove(cb)
+
+    async def publish(self, subject: str, data: bytes):
+        for cb in list(self.subscribers.get(subject, [])):
+            await cb(DummyMsg(subject, data))
+
+
+class DummySubscription:
+    def __init__(self, bus: DummyBus, subject: str, cb):
+        self._bus = bus
+        self._subject = subject
+        self._cb = cb
+
+    async def unsubscribe(self):
+        self._bus.unsubscribe(self._subject, self._cb)
+
+
+class DummyJS:
+    def __init__(self, bus: DummyBus):
+        self._bus = bus
+
+    async def publish(self, subject, data, timeout=10.0):
+        await self._bus.publish(subject, data)
+        return types.SimpleNamespace(seq=1, stream="s")
+
+    async def subscribe(self, subject, *, queue="", durable="", cb=None, manual_ack=False):
+        return self._bus.subscribe(subject, cb)
+
+    async def add_stream(self, config):
+        return None
+
+    async def stream_info(self, name):
+        raise Exception("missing")
+
+
+class DummyNATS:
+    def __init__(self, bus: DummyBus):
+        self.is_connected = True
+        self._bus = bus
+
+    def jetstream(self):
+        return DummyJS(self._bus)
+
+    async def drain(self):
+        return None
+
+
+bus = DummyBus()
+
+
+async def dummy_connect(*args, **kwargs):
+    return DummyNATS(bus)
+
+
+# Create fake nats module hierarchy
+fake_nats = types.ModuleType("nats")
+fake_nats.__spec__ = importlib.machinery.ModuleSpec("nats", loader=None)
+fake_nats.connect = dummy_connect
+fake_nats.errors = types.SimpleNamespace(Error=Exception, TimeoutError=Exception)
+fake_nats.aio = types.ModuleType("aio")
+fake_nats.aio.client = types.ModuleType("client")
+fake_nats.aio.client.Client = object
+fake_nats.aio.msg = types.ModuleType("msg")
+fake_nats.aio.msg.Msg = object
+fake_nats.js = types.ModuleType("js")
+fake_nats.js.client = types.ModuleType("client")
+fake_nats.js.client.JetStreamContext = object
+fake_nats.js.api = types.ModuleType("api")
+
+class DiscardPolicy:
+    OLD = "old"
+
+class RetentionPolicy:
+    LIMITS = "limits"
+
+class StorageType:
+    MEMORY = "memory"
+
+class StreamConfig:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+fake_nats.js.api.DiscardPolicy = DiscardPolicy
+fake_nats.js.api.RetentionPolicy = RetentionPolicy
+fake_nats.js.api.StorageType = StorageType
+fake_nats.js.api.StreamConfig = StreamConfig
+
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_nats.aio.client)
+sys.modules.setdefault("nats.aio.msg", fake_nats.aio.msg)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_nats.js.client)
+sys.modules.setdefault("nats.js.api", fake_nats.js.api)
+sys.modules.setdefault("nats.errors", fake_nats.errors)
+
+
+import examples.multi_agent_demo as demo
+
+
+@pytest.mark.asyncio
+async def test_multi_agent_demo_main(monkeypatch):
+    async def fake_generate(self, prompt: str) -> str:
+        return f"echo: {prompt}"
+
+    monkeypatch.setattr(demo, "nats", fake_nats)
+    monkeypatch.setattr(demo.RemoteLLM, "_generate", fake_generate)
+    monkeypatch.setattr(demo.asyncio, "sleep", lambda *a, **k: asyncio.sleep(0))
+
+    await demo.main()
+
+    for handler in demo.output_handlers:
+        assert handler.get_all_responses(), "handler received no messages"
+


### PR DESCRIPTION
## Summary
- mock NATS and the LLM endpoint for `multi_agent_demo`
- run the example's `main()` coroutine with the mocked services
- verify each agent received a response when langgraph is available

## Testing
- `flake8 tests/test_multi_agent_demo_mocked.py`
- `pytest tests/test_multi_agent_demo_mocked.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732aca8f8483269ea912ef51719b8b