### PR TITLE
Add bus project scaffold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ memory = "deepthought.services.memory_service:MemoryService"
 
 [tool.setuptools.package-data]
 "tools" = ["template_service/*"]
-"deepthought.templates" = ["bus_service/*"]
+"deepthought.templates" = ["bus_service/*", "bus_project/*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "deepthought.__init__.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_dir={"": "src", "tools": "tools"},
     package_data={
         "tools": ["template_service/*"],
-        "deepthought.templates": ["bus_service/*"],
+        "deepthought.templates": ["bus_service/*", "bus_project/*"],
     },
     include_package_data=True,
     install_requires=requirements,

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import shutil
 from importlib import import_module, resources
 from pathlib import Path
@@ -92,17 +93,76 @@ def init_service(
         docker_file.write_text(text, encoding="utf-8")
 
 
+def init_project(
+    name: str,
+    *,
+    stream_name: str | None = None,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
+    js_storage: str | None = None,
+    max_msgs: int | None = None,
+    template_name: str = "bus_project",
+) -> None:
+    dest = Path(name)
+    if dest.exists():
+        raise SystemExit(f"Project '{name}' already exists")
+
+    template = None
+    try:
+        templ_res = resources.files("deepthought.templates").joinpath(template_name)
+        with resources.as_file(templ_res) as path:
+            if path.exists():
+                template = Path(path)
+    except ModuleNotFoundError:
+        template = None
+    if template is None or not template.exists():
+        candidate = Path(__file__).resolve().parents[3] / "templates" / template_name
+        if candidate.exists():
+            template = candidate
+    if template is None or not template.exists():
+        raise SystemExit("Project template not found")
+
+    shutil.copytree(template, dest)
+    cwd = Path.cwd()
+    try:
+        os.chdir(dest)
+        init_service(
+            name,
+            template_name="bus_service",
+            stream_name=stream_name,
+            tls_cert=tls_cert,
+            tls_key=tls_key,
+            tls_ca=tls_ca,
+            js_storage=js_storage,
+            max_msgs=max_msgs,
+        )
+    finally:
+        os.chdir(cwd)
+
+
 def _cmd_init_service(args: argparse.Namespace) -> None:
-    init_service(
-        args.name,
-        template_name=args.template,
-        stream_name=getattr(args, "stream_name", None),
-        tls_cert=getattr(args, "tls_cert", None),
-        tls_key=getattr(args, "tls_key", None),
-        tls_ca=getattr(args, "tls_ca", None),
-        js_storage=getattr(args, "js_storage", None),
-        max_msgs=getattr(args, "max_msgs", None),
-    )
+    if args.template == "bus_project":
+        init_project(
+            args.name,
+            stream_name=getattr(args, "stream_name", None),
+            tls_cert=getattr(args, "tls_cert", None),
+            tls_key=getattr(args, "tls_key", None),
+            tls_ca=getattr(args, "tls_ca", None),
+            js_storage=getattr(args, "js_storage", None),
+            max_msgs=getattr(args, "max_msgs", None),
+        )
+    else:
+        init_service(
+            args.name,
+            template_name=args.template,
+            stream_name=getattr(args, "stream_name", None),
+            tls_cert=getattr(args, "tls_cert", None),
+            tls_key=getattr(args, "tls_key", None),
+            tls_ca=getattr(args, "tls_ca", None),
+            js_storage=getattr(args, "js_storage", None),
+            max_msgs=getattr(args, "max_msgs", None),
+        )
 
 
 def _cmd_finetune(args: argparse.Namespace) -> int:
@@ -266,6 +326,30 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Maximum messages per subject",
     )
     bus_svc.set_defaults(func=_cmd_init_service, template="bus_service")
+
+    bus_proj = bus_init_sub.add_parser("project")
+    bus_proj.add_argument("name")
+    bus_proj.add_argument(
+        "--stream-name",
+        default="deepthought_events",
+        help="JetStream stream name to use",
+    )
+    bus_proj.add_argument("--tls-cert", default="", help="Path to the client certificate")
+    bus_proj.add_argument("--tls-key", default="", help="Path to the client key")
+    bus_proj.add_argument("--tls-ca", default="", help="Path to the CA certificate")
+    bus_proj.add_argument(
+        "--js-storage",
+        choices=["memory", "file"],
+        default="memory",
+        help="JetStream storage backend",
+    )
+    bus_proj.add_argument(
+        "--max-msgs",
+        type=int,
+        default=10000,
+        help="Maximum messages per subject",
+    )
+    bus_proj.set_defaults(func=_cmd_init_service, template="bus_project")
 
     return parser
 

--- a/src/deepthought/templates/bus_project/docker-compose.yml
+++ b/src/deepthought/templates/bus_project/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  nats:
+    image: nats:latest
+    command: ["-js"]
+    ports:
+      - "4222:4222"

--- a/tests/unit/test_cli_bus_init_project.py
+++ b/tests/unit/test_cli_bus_init_project.py
@@ -1,0 +1,76 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_bus_init_project(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    subprocess.run(
+        [sys.executable, "-m", "deepthought.cli", "bus", "init", "project", "demo"],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    dest = tmp_path / "demo"
+    service_dir = dest / "src" / "deepthought" / "services" / "demo"
+    assert dest.is_dir()
+    assert (dest / "docker-compose.yml").exists()
+    assert service_dir.is_dir()
+    assert (service_dir / "publisher.py").exists()
+    assert (service_dir / "subscriber.py").exists()
+    assert (service_dir / "service.py").exists()
+
+    for py_file in service_dir.glob("*.py"):
+        subprocess.run([
+            sys.executable,
+            "-m",
+            "py_compile",
+            str(py_file),
+        ], check=True, env=env)
+
+
+def test_bus_init_project_options(tmp_path: Path) -> None:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "deepthought.cli",
+            "bus",
+            "init",
+            "project",
+            "opt",
+            "--stream-name",
+            "custom",
+            "--tls-cert",
+            "c.pem",
+            "--tls-key",
+            "k.pem",
+            "--tls-ca",
+            "ca.pem",
+            "--js-storage",
+            "file",
+            "--max-msgs",
+            "42",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    service_dir = tmp_path / "opt" / "src" / "deepthought" / "services" / "opt"
+    env_text = (service_dir / "nats.env.example").read_text(encoding="utf-8")
+    assert "NATS_STREAM=custom" in env_text
+    assert "NATS_TLS_CERT=c.pem" in env_text
+    assert "NATS_JS_STORAGE=file" in env_text
+    assert "NATS_MAX_MSGS=42" in env_text
+    docker_text = (service_dir / "Dockerfile").read_text(encoding="utf-8")
+    assert "NATS_TLS_CERT=c.pem" in docker_text
+    assert "NATS_JS_STORAGE=file" in docker_text
+    assert "NATS_MAX_MSGS=42" in docker_text


### PR DESCRIPTION
## Summary
- add new `bus_project` template with minimal Docker Compose
- implement `init_project` function
- extend CLI to support `bus init project`
- include template files in packaging
- test project initialization

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/test_cli_bus_init_service.py tests/unit/test_cli_bus_init_project.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68732ac962b88326880d4458ac9a9e9b