### PR TITLE
Update bus project init to interpolate compose placeholders

### DIFF
--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -104,6 +104,13 @@ def init_project(
     max_msgs: int | None = None,
     template_name: str = "bus_project",
 ) -> None:
+    """Create a new bus project with a default service.
+
+    The function copies the ``bus_project`` template to ``name`` and then calls
+    :func:`init_service` to scaffold the initial service within that directory.
+    Any provided stream name or TLS file paths are substituted into the copied
+    ``docker-compose.yml`` file.
+    """
     dest = Path(name)
     if dest.exists():
         raise SystemExit(f"Project '{name}' already exists")
@@ -124,6 +131,18 @@ def init_project(
         raise SystemExit("Project template not found")
 
     shutil.copytree(template, dest)
+    compose_file = dest / "docker-compose.yml"
+    if compose_file.exists():
+        text = compose_file.read_text(encoding="utf-8")
+        if stream_name:
+            text = text.replace("${STREAM_NAME}", stream_name)
+        if tls_cert:
+            text = text.replace("${TLS_CERT}", tls_cert)
+        if tls_key:
+            text = text.replace("${TLS_KEY}", tls_key)
+        if tls_ca:
+            text = text.replace("${TLS_CA}", tls_ca)
+        compose_file.write_text(text, encoding="utf-8")
     cwd = Path.cwd()
     try:
         os.chdir(dest)

--- a/src/deepthought/templates/bus_project/docker-compose.yml
+++ b/src/deepthought/templates/bus_project/docker-compose.yml
@@ -2,6 +2,15 @@ version: '3'
 services:
   nats:
     image: nats:latest
-    command: ["-js"]
+    command:
+      - "-js"
+      - "--tlscert"
+      - "${TLS_CERT}"
+      - "--tlskey"
+      - "${TLS_KEY}"
+      - "--tlscacert"
+      - "${TLS_CA}"
+    environment:
+      - "STREAM_NAME=${STREAM_NAME}"
     ports:
       - "4222:4222"

--- a/tests/unit/test_cli_bus_init_project.py
+++ b/tests/unit/test_cli_bus_init_project.py
@@ -18,11 +18,14 @@ def test_bus_init_project(tmp_path: Path) -> None:
     dest = tmp_path / "demo"
     service_dir = dest / "src" / "deepthought" / "services" / "demo"
     assert dest.is_dir()
-    assert (dest / "docker-compose.yml").exists()
+    docker_compose = dest / "docker-compose.yml"
+    assert docker_compose.exists()
     assert service_dir.is_dir()
     assert (service_dir / "publisher.py").exists()
     assert (service_dir / "subscriber.py").exists()
     assert (service_dir / "service.py").exists()
+
+    assert "deepthought_events" in docker_compose.read_text(encoding="utf-8")
 
     for py_file in service_dir.glob("*.py"):
         subprocess.run([
@@ -74,3 +77,9 @@ def test_bus_init_project_options(tmp_path: Path) -> None:
     assert "NATS_TLS_CERT=c.pem" in docker_text
     assert "NATS_JS_STORAGE=file" in docker_text
     assert "NATS_MAX_MSGS=42" in docker_text
+
+    compose_text = (tmp_path / "opt" / "docker-compose.yml").read_text(encoding="utf-8")
+    assert "custom" in compose_text
+    assert "c.pem" in compose_text
+    assert "k.pem" in compose_text
+    assert "ca.pem" in compose_text


### PR DESCRIPTION
## Summary
- inject stream and TLS values into docker-compose when initializing a bus project
- make `bus_project` docker-compose template use `${STREAM_NAME}` and TLS placeholders
- extend bus project init tests to verify compose interpolation
- document `init_project` behavior

## Testing
- `flake8`
- `pytest tests/unit/test_cli_bus_init_project.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6877fb62a540832680561cd24587d2fe