### PR TITLE
Add orchestrator end-to-end demo

### DIFF
--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -17,3 +17,16 @@ dtrt orchestrate orchestrator.yaml
 ```
 
 Publishing an `INPUT_RECEIVED` event will now flow through the `DemoService` and the `CodeGenerationService`, demonstrating end-to-end event handling.
+
+## End-to-End Demo
+
+The `examples/end_to_end_demo.py` script shows how to run multiple services via
+the orchestrator. It launches a local NATS server and starts the
+`MemoryService`, `RemoteLLM`, `OutputHandler` and `RewardManager` services. A
+sample message is then processed end-to-end.
+
+Run the demo with:
+
+```bash
+python examples/end_to_end_demo.py
+```

--- a/examples/end_to_end_demo.py
+++ b/examples/end_to_end_demo.py
@@ -1,0 +1,77 @@
+"""Run MemoryService, RemoteLLM, OutputHandler and RewardManager via the orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import nats
+
+from deepthought import orchestrator
+from deepthought.modules import InputHandler
+
+
+def _nats_available(url: str) -> bool:
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url if "://" in url else f"//{url}")
+    host = parsed.hostname
+    port = parsed.port or 4222
+    try:
+        with socket.create_connection((host, port), timeout=1):
+            return True
+    except Exception:
+        return False
+
+
+async def _start_nats(port: int) -> subprocess.Popen:
+    if shutil.which("nats-server") is None:
+        raise RuntimeError("nats-server executable not found")
+    proc = subprocess.Popen(["nats-server", "-js", "-p", str(port)])
+    for _ in range(20):
+        if _nats_available(f"nats://localhost:{port}"):
+            break
+        time.sleep(0.25)
+    else:
+        proc.terminate()
+        raise RuntimeError("nats-server failed to start")
+    return proc
+
+
+async def main() -> None:
+    port = 4222
+    nats_proc = await _start_nats(port)
+    cfg = Path(tempfile.gettempdir()) / "orchestrator.yaml"
+    cfg.write_text(
+        """services:\n  - memory\n  - remote_llm\n  - output_handler\n  - reward_manager\n""",
+        encoding="utf-8",
+    )
+    orch_task = asyncio.create_task(orchestrator.run(str(cfg)))
+    await asyncio.sleep(2.0)
+    nc = await nats.connect(f"nats://localhost:{port}")
+    js = nc.jetstream()
+    handler = InputHandler(nc, js)
+    await handler.process_input("Hello orchestrator")
+    await asyncio.sleep(2.0)
+    orch_task.cancel()
+    try:
+        await orch_task
+    except asyncio.CancelledError:
+        pass
+    if nc.is_connected:
+        await nc.drain()
+    nats_proc.terminate()
+    try:
+        nats_proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        nats_proc.kill()
+    print("End-to-end demo complete")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dtrt-finetune = "deepthought.train:main"
 demo = "deepthought.services.demo.service:DemoService"
 codegen = "deepthought.services.code_generation_service:CodeGenerationService"
 memory = "deepthought.services.memory_service:MemoryService"
+remote_llm = "deepthought.services.llm_remote_service:LLMRemoteService"
+output_handler = "deepthought.services.output_handler_service:OutputHandlerService"
+reward_manager = "deepthought.services.reward_manager_service:RewardManagerService"
 
 
 [tool.setuptools.package-data]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ markers =
     cli: command line interface tests
     hierarchical: hierarchical service tests
     vector_store: vector store implementation tests
+    slow: long running integration tests

--- a/src/deepthought/services/llm_remote_service.py
+++ b/src/deepthought/services/llm_remote_service.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import logging
+
+from nats.aio.client import Client as NATS
+from nats.js.client import JetStreamContext
+
+from ..modules.llm_remote import RemoteLLM
+
+logger = logging.getLogger(__name__)
+
+
+class LLMRemoteService:
+    """Service wrapper for :class:`RemoteLLM`."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._llm = RemoteLLM(nats_client, js_context)
+
+    async def start(self, durable_name: str = "llm_remote_service") -> bool:
+        return await self._llm.start_listening(durable_name=durable_name)
+
+    async def stop(self) -> None:
+        await self._llm.stop_listening()

--- a/src/deepthought/services/output_handler_service.py
+++ b/src/deepthought/services/output_handler_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from nats.aio.client import Client as NATS
+from nats.js.client import JetStreamContext
+
+from ..modules.output_handler import OutputHandler
+
+
+class OutputHandlerService:
+    """Service wrapper for :class:`OutputHandler`."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._handler = OutputHandler(nats_client, js_context)
+
+    async def start(self, durable_name: str = "output_handler_service") -> bool:
+        return await self._handler.start_listening(durable_name=durable_name)
+
+    async def stop(self) -> None:
+        await self._handler.stop_listening()

--- a/src/deepthought/services/reward_manager_service.py
+++ b/src/deepthought/services/reward_manager_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import os
+
+from nats.aio.client import Client as NATS
+from nats.js.client import JetStreamContext
+
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+from ..motivate import Ledger, RewardManager
+
+
+class RewardManagerService:
+    """Service wrapper for :class:`RewardManager`."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        subscriber = Subscriber(nats_client, js_context)
+        ledger = Ledger(nats_client, js_context)
+        publisher = Publisher(nats_client, js_context)
+        token = os.getenv("DISCORD_TOKEN", "")
+        self._manager = RewardManager(subscriber, ledger, publisher, token)
+
+    async def start(self, durable_name: str = "reward_manager_service") -> bool:
+        return await self._manager.start_listening(durable_name=durable_name)
+
+    async def stop(self) -> None:
+        await self._manager.stop_listening()

--- a/tests/integration/test_end_to_end_demo.py
+++ b/tests/integration/test_end_to_end_demo.py
@@ -1,0 +1,30 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.slow
+def test_end_to_end_demo_runs(tmp_path: Path) -> None:
+    if shutil.which("nats-server") is None:
+        pytest.skip("nats-server executable not found")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(Path(__file__).resolve().parents[1] / "src"),
+            str(Path(__file__).resolve().parents[1]),
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parents[1] / "examples" / "end_to_end_demo.py")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=True,
+        env=env,
+    )
+    assert "End-to-end demo complete" in result.stdout


### PR DESCRIPTION
## Summary
- implement LLMRemoteService, OutputHandlerService and RewardManagerService
- register new services as entry points
- add `examples/end_to_end_demo.py`
- document demo usage in orchestrator quickstart
- mark `slow` test running the demo in CI

## Testing
- `pre-commit run --files tests/integration/test_end_to_end_demo.py examples/end_to_end_demo.py src/deepthought/services/llm_remote_service.py src/deepthought/services/output_handler_service.py src/deepthought/services/reward_manager_service.py docs/orchestrator_quickstart.md pyproject.toml pytest.ini`

------
https://chatgpt.com/codex/tasks/task_e_687a9d83e97c8326a1110f8f539afbab