### PR TITLE
Add UI app and edge server tests

### DIFF
--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -1,8 +1,11 @@
 import importlib
 import sys
+import types
 from pathlib import Path
 
 import pytest
+
+from tests.unit.test_edge_server import DummyModel, DummyTokenizer
 
 pytest.importorskip("fastapi")
 import requests
@@ -39,3 +42,38 @@ def test_generate_with_distilgpt2(monkeypatch):
         data = resp.json()
         assert isinstance(data.get("text"), str)
         assert data["text"]
+
+
+def test_generate_unreachable(monkeypatch):
+    """Edge server returns 500 when model inference fails."""
+    tf = types.ModuleType("transformers")
+    tf.AutoTokenizer = DummyTokenizer
+    tf.AutoModelForCausalLM = DummyModel
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    monkeypatch.setitem(sys.modules, "transformers", tf)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+    import edge_server
+
+    importlib.reload(edge_server)
+
+    def fail_generate(**_kwargs):
+        raise requests.ConnectionError
+
+    monkeypatch.setattr(edge_server.model, "generate", fail_generate)
+
+    with TestClient(edge_server.app, raise_server_exceptions=False) as client:
+        resp = client.post("/generate", json={"text": "Hello"})
+        assert resp.status_code == 500

--- a/tests/unit/test_ui_app.py
+++ b/tests/unit/test_ui_app.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -11,3 +12,38 @@ def test_ui_app_load(monkeypatch):
     sys.modules.pop("ui.app", None)
     pytest.importorskip("streamlit")
     importlib.import_module("ui.app")
+
+
+def test_ui_app_search(monkeypatch):
+    """Interact with the Streamlit app and verify requests are made."""
+    testing = pytest.importorskip("streamlit.testing.v1")
+    import requests
+
+    responses = []
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return self._data
+
+    def fake_post(url, json):
+        responses.append((url, json))
+        return DummyResp({"answer": "42"})
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    monkeypatch.setenv("MEMORY_API_URL", "http://api")
+
+    app_path = Path(__file__).resolve().parents[2] / "ui" / "app.py"
+    at = testing.AppTest.from_file(app_path)
+    at.run()
+    at.text_input[0].input("hello")
+    at.button[0].click()
+    at.run()
+
+    assert responses == [("http://api/memory/query", {"query": "hello"})]
+    assert at.subheader[0].value == "Retrieved Facts"


### PR DESCRIPTION
## Summary
- add Streamlit-based UI unit tests for request handling
- extend edge server integration tests with unreachable endpoint case
- minor cleanup in test file

## Testing
- `pre-commit run --files tests/unit/test_ui_app.py tests/integration/test_edge_server_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_687a9d86c29c8326b287c2230218f090