### PR TITLE
Fix plugin discovery for Python 3.10+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "deepthought-rethought"
 description = "DeepThought reThought - experimental AI framework"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [{name = "Tino Tonitini"}]
 urls = {Homepage = "https://github.com/d0tTino/DeepThought-ReThought"}

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -15,10 +15,11 @@ logger = logging.getLogger(__name__)
 
 def discover_services(names: Iterable[str] | None = None) -> list[type]:
     """Return service classes registered under ``deepthought.services``."""
-    try:
-        eps = metadata.entry_points().select(group="deepthought.services")
-    except Exception:
-        eps = []
+    eps_obj = metadata.entry_points()
+    if hasattr(eps_obj, "select"):
+        eps = eps_obj.select(group="deepthought.services")
+    else:  # pragma: no cover - Python < 3.10
+        eps = eps_obj.get("deepthought.services", [])
     selected = []
     if names is None:
         selected = eps

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -43,7 +43,8 @@ _DATASET_GROUP = "dtrt.dataset_loaders"
 def _resolve_plugin(group: str, name: str) -> Callable:
     """Return a plugin callable from entry points."""
     eps = metadata.entry_points()
-    for ep in eps.select(group=group):
+    ep_iter = eps.select(group=group) if hasattr(eps, "select") else eps.get(group, [])
+    for ep in ep_iter:
         if ep.name == name:
             return ep.load()
     if group == _MODEL_GROUP and name == "hf":

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -1,9 +1,39 @@
 import asyncio
-from types import SimpleNamespace
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
-import deepthought.orchestrator as orchestrator
+
+def _load_orchestrator_module():
+    if "pydantic" not in sys.modules:
+        pydantic_mod = ModuleType("pydantic")
+
+        class AnyUrl(str):
+            pass
+
+        def Field(default=None, **k):
+            return default
+
+        class ValidationError(Exception):
+            pass
+
+        pydantic_mod.AnyUrl = AnyUrl
+        pydantic_mod.Field = Field
+        pydantic_mod.ValidationError = ValidationError
+        sys.modules["pydantic"] = pydantic_mod
+
+    if "pydantic_settings" not in sys.modules:
+        ps_mod = ModuleType("pydantic_settings")
+
+        class BaseSettings:
+            model_config: dict = {}
+
+        ps_mod.BaseSettings = BaseSettings
+        ps_mod.SettingsConfigDict = dict
+        sys.modules["pydantic_settings"] = ps_mod
+    return importlib.import_module("deepthought.orchestrator")
 
 
 class DummyService:
@@ -21,6 +51,7 @@ class DummyService:
 
 @pytest.mark.asyncio
 async def test_run(monkeypatch, tmp_path):
+    orchestrator = _load_orchestrator_module()
     created: dict[str, DummyService] = {}
 
     orig_init = DummyService.__init__
@@ -64,3 +95,16 @@ async def test_run(monkeypatch, tmp_path):
     assert service is not None, "DummyService instance was not created"
     assert service.started is True
     assert service.stopped is True
+
+
+def test_discover_services_fallback(monkeypatch):
+    orchestrator = _load_orchestrator_module()
+    ep = SimpleNamespace(name="dummy", load=lambda: DummyService)
+
+    def dummy_entry_points():
+        return {"deepthought.services": [ep]}
+
+    monkeypatch.setattr(orchestrator.metadata, "entry_points", dummy_entry_points)
+
+    services = orchestrator.discover_services(["dummy"])
+    assert services == [DummyService]

--- a/tests/unit/test_train_plugins.py
+++ b/tests/unit/test_train_plugins.py
@@ -3,7 +3,34 @@ import sys
 from importlib.metadata import EntryPoint, EntryPoints
 from types import ModuleType
 
-import deepthought.train as train
+
+def _load_train_module():
+    sys.modules.setdefault("torch", ModuleType("torch"))
+
+    datasets_mod = ModuleType("datasets")
+    datasets_mod.Dataset = object
+    datasets_mod.load_dataset = lambda *a, **k: None
+    sys.modules["datasets"] = datasets_mod
+
+    peft_mod = ModuleType("peft")
+    peft_mod.LoraConfig = object
+    peft_mod.get_peft_model = lambda *a, **k: None
+    peft_mod.prepare_model_for_kbit_training = lambda *a, **k: None
+    sys.modules["peft"] = peft_mod
+
+    transformers_mod = ModuleType("transformers")
+    for cls in [
+        "AutoModelForCausalLM",
+        "AutoTokenizer",
+        "BitsAndBytesConfig",
+        "DataCollatorForLanguageModeling",
+        "Trainer",
+        "TrainingArguments",
+    ]:
+        setattr(transformers_mod, cls, type(cls, (), {}))
+    sys.modules["transformers"] = transformers_mod
+
+    return importlib.import_module("deepthought.train")
 
 
 def test_custom_model_loader(monkeypatch):
@@ -19,6 +46,23 @@ def test_custom_model_loader(monkeypatch):
     ep = EntryPoint(name="dummy", value="dummy_mod:loader", group="dtrt.model_loaders")
     monkeypatch.setattr(importlib.metadata, "entry_points", lambda: EntryPoints([ep]))
 
+    train = _load_train_module()
     model, tok = train.load_model("foo", 4, loader="dummy")
     assert (model, tok) == ("m", "t")
     assert calls["args"] == ("foo", 4)
+
+
+def test_plugin_fallback(monkeypatch):
+    ep = EntryPoint(name="dummy", value="dummy_mod:loader", group="dtrt.model_loaders")
+
+    def dummy_entry_points():
+        return {"dtrt.model_loaders": [ep]}
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", dummy_entry_points)
+    mod = ModuleType("dummy_mod")
+    mod.loader = lambda *a, **k: ("m", "t")
+    sys.modules["dummy_mod"] = mod
+
+    train = _load_train_module()
+    model, tok = train.load_model("foo", 4, loader="dummy")
+    assert (model, tok) == ("m", "t")


### PR DESCRIPTION
## Summary
- bump required Python version to 3.10
- add fallback when importlib metadata entry_points lacks `.select`
- provide lightweight stubs in tests

## Testing
- `pre-commit run --files pyproject.toml src/deepthought/orchestrator.py src/deepthought/train/__init__.py tests/unit/test_train_plugins.py tests/unit/test_orchestrator.py`

------
https://chatgpt.com/codex/tasks/task_e_687aae9495bc83268770e7e476790483