### PR TITLE
Fix TieredMemory delete check

### DIFF
--- a/src/deepthought/memory/tiered.py
+++ b/src/deepthought/memory/tiered.py
@@ -58,7 +58,8 @@ class TieredMemory:
         while len(self._lru) > self._capacity:
             text, doc_id = next(iter(self._lru.items()))
             try:
-                self._store.collection.delete([doc_id])
+                if hasattr(self._store.collection, "delete"):
+                    self._store.collection.delete([doc_id])
             except Exception:  # pragma: no cover - defensive
                 logger.error("Failed to delete %s from vector store", doc_id, exc_info=True)
             finally:

--- a/tests/unit/test_tiered_memory.py
+++ b/tests/unit/test_tiered_memory.py
@@ -119,6 +119,27 @@ def test_eviction_cleanup_on_delete_failure(monkeypatch):
     assert list(vec.docs.values()) == ["a", "b"]
 
 
+def test_eviction_when_delete_missing():
+    class NoDeleteVector(DummyVector):
+        class Collection:
+            def __init__(self, outer):
+                self.outer = outer
+
+        @property
+        def collection(self):
+            return NoDeleteVector.Collection(self)
+
+    vec = NoDeleteVector()
+    dal = DummyDAL()
+    mem = TieredMemory(vec, dal, capacity=1, top_k=1)
+
+    mem.store_interaction("a")
+    mem.store_interaction("b")
+
+    assert list(mem._lru.keys()) == ["b"]
+    assert list(vec.docs.values()) == ["a", "b"]
+
+
 def test_vector_match_logs_error(monkeypatch):
     vec = FailingVector()
     dal = DummyDAL()


### PR DESCRIPTION
## Summary
- avoid calling vector store delete if missing
- test missing delete for tiered memory eviction

## Testing
- `pre-commit run --files src/deepthought/memory/tiered.py tests/unit/test_tiered_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_687aae94fff4832690af991dc5d3fa39