### PR TITLE
Refactor CLI template handling

### DIFF
--- a/docs/bus_template.md
+++ b/docs/bus_template.md
@@ -116,3 +116,15 @@ INPUT_LATENCY_SECONDS.labels(service="template_service").observe(duration)
 
 These metrics can be scraped from the metrics server to monitor throughput
 and latency of your service.
+
+## End-to-End Example
+
+Create a new project and start both NATS and the initial service using Docker Compose:
+
+```bash
+dtrt bus init project mybus --stream-name demo_events --js-storage file --max-msgs 5000
+cd mybus
+docker compose up --build
+```
+
+The command scaffolds a directory ``mybus`` with a ``docker-compose.yml`` and a service in ``src/deepthought/services/mybus``.

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -4,8 +4,10 @@ import argparse
 import asyncio
 import os
 import shutil
-from importlib import import_module, resources
+from importlib import import_module
 from pathlib import Path
+
+from .template_helpers import apply_bus_substitutions, find_template
 
 
 def _to_camel(name: str) -> str:
@@ -27,22 +29,7 @@ def init_service(
     if dest.exists():
         raise SystemExit(f"Service '{name}' already exists")
 
-    template = None
-    try:
-        templ_res = resources.files("deepthought.templates").joinpath(template_name)
-        with resources.as_file(templ_res) as path:
-            if path.exists():
-                template = Path(path)
-    except ModuleNotFoundError:
-        template = None
-    if template is None or not template.exists():
-        # templates live under ``templates/<template_name>`` during development
-        candidate = Path(__file__).resolve().parents[3] / "templates" / template_name
-        if candidate.exists():
-            template = candidate
-        else:
-            # fallback to package data when installed from a wheel
-            template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
+    template = find_template(template_name)
 
     shutil.copytree(template, dest)
     class_name = _to_camel(name) + "Service"
@@ -63,33 +50,28 @@ def init_service(
     env_file = dest / "nats.env.example"
     if env_file.exists():
         text = env_file.read_text(encoding="utf-8")
-        if stream_name:
-            text = text.replace("deepthought_events", stream_name)
-        if tls_cert is not None:
-            text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
-        if tls_key is not None:
-            text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
-        if tls_ca is not None:
-            text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
-        if js_storage is not None:
-            text = text.replace("NATS_JS_STORAGE=memory", f"NATS_JS_STORAGE={js_storage}")
-        if max_msgs is not None:
-            text = text.replace("NATS_MAX_MSGS=10000", f"NATS_MAX_MSGS={max_msgs}")
+        text = apply_bus_substitutions(
+            text,
+            stream_name=stream_name,
+            tls_cert=tls_cert,
+            tls_key=tls_key,
+            tls_ca=tls_ca,
+            js_storage=js_storage,
+            max_msgs=max_msgs,
+        )
         env_file.write_text(text, encoding="utf-8")
 
     docker_file = dest / "Dockerfile"
     if docker_file.exists():
         text = docker_file.read_text(encoding="utf-8")
-        if tls_cert is not None:
-            text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
-        if tls_key is not None:
-            text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
-        if tls_ca is not None:
-            text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
-        if js_storage is not None:
-            text = text.replace("NATS_JS_STORAGE=memory", f"NATS_JS_STORAGE={js_storage}")
-        if max_msgs is not None:
-            text = text.replace("NATS_MAX_MSGS=10000", f"NATS_MAX_MSGS={max_msgs}")
+        text = apply_bus_substitutions(
+            text,
+            tls_cert=tls_cert,
+            tls_key=tls_key,
+            tls_ca=tls_ca,
+            js_storage=js_storage,
+            max_msgs=max_msgs,
+        )
         docker_file.write_text(text, encoding="utf-8")
 
 
@@ -115,33 +97,19 @@ def init_project(
     if dest.exists():
         raise SystemExit(f"Project '{name}' already exists")
 
-    template = None
-    try:
-        templ_res = resources.files("deepthought.templates").joinpath(template_name)
-        with resources.as_file(templ_res) as path:
-            if path.exists():
-                template = Path(path)
-    except ModuleNotFoundError:
-        template = None
-    if template is None or not template.exists():
-        candidate = Path(__file__).resolve().parents[3] / "templates" / template_name
-        if candidate.exists():
-            template = candidate
-    if template is None or not template.exists():
-        raise SystemExit("Project template not found")
+    template = find_template(template_name)
 
     shutil.copytree(template, dest)
     compose_file = dest / "docker-compose.yml"
     if compose_file.exists():
         text = compose_file.read_text(encoding="utf-8")
-        if stream_name:
-            text = text.replace("${STREAM_NAME}", stream_name)
-        if tls_cert:
-            text = text.replace("${TLS_CERT}", tls_cert)
-        if tls_key:
-            text = text.replace("${TLS_KEY}", tls_key)
-        if tls_ca:
-            text = text.replace("${TLS_CA}", tls_ca)
+        text = apply_bus_substitutions(
+            text,
+            stream_name=stream_name,
+            tls_cert=tls_cert,
+            tls_key=tls_key,
+            tls_ca=tls_ca,
+        )
         compose_file.write_text(text, encoding="utf-8")
     cwd = Path.cwd()
     try:

--- a/src/deepthought/cli/bus.py
+++ b/src/deepthought/cli/bus.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
+import sys
+
 from . import main as cli_main
 
 
 def main(argv: list[str] | None = None) -> int:
-    return cli_main(argv)
+    args = list(argv) if argv is not None else sys.argv[1:]
+    if not args or args[0] != "bus":
+        args.insert(0, "bus")
+    return cli_main(args)
 
 
 if __name__ == "__main__":

--- a/src/deepthought/cli/template_helpers.py
+++ b/src/deepthought/cli/template_helpers.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+
+__all__ = ["find_template", "apply_bus_substitutions"]
+
+
+def find_template(template_name: str) -> Path:
+    """Return the path to a bundled template."""
+    template = None
+    try:
+        templ_res = resources.files("deepthought.templates").joinpath(template_name)
+        with resources.as_file(templ_res) as path:
+            if path.exists():
+                template = Path(path)
+    except ModuleNotFoundError:
+        template = None
+
+    if template is None or not template.exists():
+        candidate = Path(__file__).resolve().parents[3] / "templates" / template_name
+        if candidate.exists():
+            template = candidate
+        elif template_name == "service":
+            template = Path(__file__).resolve().parents[2] / "tools" / "template_service"
+
+    if template is None or not template.exists():
+        raise SystemExit("Template not found")
+
+    return template
+
+
+def apply_bus_substitutions(
+    text: str,
+    *,
+    stream_name: str | None = None,
+    tls_cert: str | None = None,
+    tls_key: str | None = None,
+    tls_ca: str | None = None,
+    js_storage: str | None = None,
+    max_msgs: int | None = None,
+) -> str:
+    """Replace placeholders for bus service templates."""
+    if stream_name is not None:
+        text = text.replace("${STREAM_NAME}", stream_name)
+        text = text.replace("deepthought_events", stream_name)
+    if tls_cert is not None:
+        text = text.replace("${TLS_CERT}", tls_cert)
+        text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
+        text = text.replace("ENV NATS_TLS_CERT=", f"ENV NATS_TLS_CERT={tls_cert}")
+    if tls_key is not None:
+        text = text.replace("${TLS_KEY}", tls_key)
+        text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
+        text = text.replace("ENV NATS_TLS_KEY=", f"ENV NATS_TLS_KEY={tls_key}")
+    if tls_ca is not None:
+        text = text.replace("${TLS_CA}", tls_ca)
+        text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
+        text = text.replace("ENV NATS_TLS_CA=", f"ENV NATS_TLS_CA={tls_ca}")
+    if js_storage is not None:
+        text = text.replace("NATS_JS_STORAGE=memory", f"NATS_JS_STORAGE={js_storage}")
+        text = text.replace("ENV NATS_JS_STORAGE=memory", f"ENV NATS_JS_STORAGE={js_storage}")
+    if max_msgs is not None:
+        text = text.replace("NATS_MAX_MSGS=10000", f"NATS_MAX_MSGS={max_msgs}")
+        text = text.replace("ENV NATS_MAX_MSGS=10000", f"ENV NATS_MAX_MSGS={max_msgs}")
+    return text

--- a/tests/unit/test_cli_bus.py
+++ b/tests/unit/test_cli_bus.py
@@ -9,7 +9,7 @@ def test_cli_bus_init_service(tmp_path: Path) -> None:
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
 
     subprocess.run(
-        [sys.executable, "-m", "deepthought.cli", "bus", "init", "service", "demo"],
+        [sys.executable, "-m", "deepthought.cli.bus", "init", "service", "demo"],
         cwd=tmp_path,
         stdout=subprocess.PIPE,
         text=True,


### PR DESCRIPTION
## Summary
- centralize bus template search and variable substitution in `template_helpers`
- apply shared substitution logic in `init_service` and `init_project`
- update bus CLI to prepend `bus` when run as module
- document an end-to-end example for bus projects
- adjust bus CLI test to use the module entrypoint

## Testing
- `pre-commit run --files docs/bus_template.md src/deepthought/cli/__init__.py src/deepthought/cli/template_helpers.py src/deepthought/cli/bus.py tests/unit/test_cli_bus.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab144a88483268628ff28e4d4743e