### PR TITLE
Add knowledge_graph service using GraphDAL backend

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -96,6 +96,34 @@ Another demo using a Neo4j backend is available:
 python examples/graph_memory_demo.py
 ```
 
+### Orchestrator Configuration
+
+Start the `knowledge_graph` service via the orchestrator by writing an
+`orchestrator.yml` file:
+
+```yaml
+services:
+  - knowledge_graph
+```
+
+Choose the backend with `DT_GRAPH_BACKEND` and set the connection variables.
+For Neo4j:
+
+```bash
+export DT_GRAPH_BACKEND=neo4j
+export DT_NEO4J_HOST=localhost
+export DT_NEO4J_PORT=7687
+export DT_NEO4J_USER=neo4j
+export DT_NEO4J_PASSWORD=test
+```
+
+For Memgraph simply set `DT_GRAPH_BACKEND=memgraph` and optionally the
+`DT_MG_*` variables. Then run:
+
+```bash
+dtrt orchestrate orchestrator.yml
+```
+
 
 ## Hierarchical Memory Wrapper
 

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -8,7 +8,12 @@ Create a configuration file listing the services to launch:
 services:
   - demo
   - codegen
+  - knowledge_graph
 ```
+
+Set `DT_GRAPH_BACKEND` to either `memgraph` or `neo4j` and export the matching
+connection variables (see `docs/graphdal.md`) so the service can reach your
+database.
 
 Start a local NATS server with JetStream enabled then run:
 

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -1,0 +1,2 @@
+services:
+  - knowledge_graph

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ demo = "deepthought.services.demo.service:DemoService"
 codegen = "deepthought.services.code_generation_service:CodeGenerationService"
 memory = "deepthought.services.memory_service:MemoryService"
 reward_manager = "deepthought.motivate.reward_manager:RewardManager"
+knowledge_graph = "deepthought.services.knowledge_graph_service:KnowledgeGraphService"
 
 
 

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -3,6 +3,7 @@
 from .db_manager import DBManager
 from .file_graph_dal import FileGraphDAL
 from .hierarchical_service import HierarchicalService
+from .knowledge_graph_service import KnowledgeGraphService
 from .memory_service import MemoryService
 from .persona_manager import PersonaManager
 from .social_graph_service import SocialGraphService
@@ -11,6 +12,7 @@ __all__ = [
     "FileGraphDAL",
     "MemoryService",
     "HierarchicalService",
+    "KnowledgeGraphService",
     "PersonaManager",
     "SocialGraphService",
     "DBManager",

--- a/src/deepthought/services/knowledge_graph_service.py
+++ b/src/deepthought/services/knowledge_graph_service.py
@@ -1,0 +1,146 @@
+import json
+import logging
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..config import Settings, get_settings
+from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+from ..graph import GraphConnector, GraphDAL, GraphDALBackend, Neo4jConnector
+from ..memory.tiered import TieredMemory
+from ..memory.vector_store import create_vector_store
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeGraphService:
+    """Service persisting interactions in a graph database via GraphDAL."""
+
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        settings: Settings | None = None,
+        memory: Optional[TieredMemory] = None,
+    ) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._nc = nats_client
+        self._settings = settings or get_settings()
+        if memory is None:
+            store = create_vector_store(
+                backend=self._settings.vector_backend,
+                use_gpu=self._settings.vector_use_gpu,
+            )
+            if self._settings.graph_backend.lower() == "neo4j":
+                connector = Neo4jConnector(
+                    host=self._settings.neo4j_host,
+                    port=self._settings.neo4j_port,
+                    username=self._settings.neo4j_user,
+                    password=self._settings.neo4j_password,
+                )
+            else:
+                connector = GraphConnector(
+                    host=self._settings.mg_host,
+                    port=self._settings.mg_port,
+                    username=self._settings.mg_user,
+                    password=self._settings.mg_password,
+                )
+            backend = GraphDALBackend(GraphDAL(connector))
+            memory = TieredMemory(
+                store,
+                backend,
+                capacity=self._settings.memory_capacity,
+                top_k=self._settings.memory_top_k,
+            )
+        self._memory = memory
+
+    async def _handle_input(self, msg: Msg) -> None:
+        input_id = "unknown"
+        start = time.perf_counter()
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("InputReceived payload must be a dict")
+            input_id = data.get("input_id")
+            user_input = data.get("user_input")
+            if not isinstance(input_id, str) or not isinstance(user_input, str):
+                raise ValueError("Invalid input payload fields")
+            logger.info("KnowledgeGraphService received input %s", input_id)
+
+            self._memory.store_interaction(user_input)
+            facts = self._memory.retrieve_context(user_input)
+            payload = MemoryRetrievedPayload(
+                retrieved_knowledge={"facts": facts, "source": "knowledge_graph"},
+                input_id=input_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            logger.info("KnowledgeGraphService published memory event %s", input_id)
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error("Error in KnowledgeGraphService: %s", e, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+        finally:
+            duration = time.perf_counter() - start
+            logger.info("KnowledgeGraphService processed input in %.3fs", duration)
+
+    async def start(self, durable_name: str = "knowledge_graph_listener") -> bool:
+        if self._subscriber is None:
+            logger.error("Subscriber not initialized for KnowledgeGraphService.")
+            return False
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            logger.info("KnowledgeGraphService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            return True
+        except Exception as e:  # pragma: no cover - network failure
+            logger.error("KnowledgeGraphService failed to subscribe: %s", e, exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+            logger.info("KnowledgeGraphService stopped listening.")
+        else:
+            logger.warning("Cannot stop listening - no subscriber available.")
+        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
+            await self._nc.drain()

--- a/tests/integration/test_knowledge_graph_backend.py
+++ b/tests/integration/test_knowledge_graph_backend.py
@@ -1,0 +1,92 @@
+import os
+import sys
+import types
+import uuid
+
+import pytest
+
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+fake_pyd.Field = lambda default=None, **kwargs: default
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+
+from deepthought.graph import GraphConnector, GraphDAL, Neo4jConnector
+from deepthought.graph.backend import GraphDALBackend
+from deepthought.memory.tiered import TieredMemory
+from deepthought.memory.vector_store import create_vector_store
+from tests.helpers import memgraph_available, neo4j_available
+from tests.integration.test_memgraph_integration import memgraph_server
+from tests.integration.test_neo4j_integration import neo4j_server
+
+MG_HOST = os.getenv("MG_HOST", "localhost")
+MG_PORT = int(os.getenv("MG_PORT", 7687))
+MG_USER = os.getenv("MG_USER", "memgraph")
+MG_PASSWORD = os.getenv("MG_PASSWORD", "memgraph")
+
+NEO4J_HOST = os.getenv("NEO4J_HOST", "localhost")
+NEO4J_PORT = int(os.getenv("NEO4J_PORT", 7687))
+NEO4J_USER = os.getenv("NEO4J_USER", "neo4j")
+NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "test")
+
+
+@pytest.mark.memgraph
+def test_retrieve_from_memgraph(memgraph_server):
+    if not memgraph_available(MG_HOST, MG_PORT):
+        pytest.skip("Memgraph not reachable")
+
+    connector = GraphConnector(
+        host=MG_HOST,
+        port=MG_PORT,
+        username=MG_USER,
+        password=MG_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+    backend = GraphDALBackend(dal)
+
+    store = create_vector_store("chroma", collection_name=f"kg-{uuid.uuid4()}")
+    memory = TieredMemory(store, backend, capacity=0, top_k=2)
+
+    memory.store_interaction("Alice loves Bob")
+    memory.store_interaction("Bob loves Carol")
+
+    ctx = memory.retrieve_context("test")
+    assert "Alice loves Bob" in ctx and "Bob loves Carol" in ctx
+
+
+@pytest.mark.neo4j
+def test_retrieve_from_neo4j(neo4j_server):
+    if not neo4j_available(NEO4J_HOST, NEO4J_PORT):
+        pytest.skip("Neo4j not reachable")
+
+    connector = Neo4jConnector(
+        host=NEO4J_HOST,
+        port=NEO4J_PORT,
+        username=NEO4J_USER,
+        password=NEO4J_PASSWORD,
+    )
+    dal = GraphDAL(connector)
+    backend = GraphDALBackend(dal)
+
+    store = create_vector_store("chroma", collection_name=f"kg-{uuid.uuid4()}")
+    memory = TieredMemory(store, backend, capacity=0, top_k=2)
+
+    memory.store_interaction("X meets Y")
+    memory.store_interaction("Y meets Z")
+
+    ctx = memory.retrieve_context("test")
+    assert "X meets Y" in ctx and "Y meets Z" in ctx


### PR DESCRIPTION
## Summary
- create `KnowledgeGraphService` wrapping `TieredMemory` with `GraphDALBackend`
- expose the service via entry points and exports
- document enabling Neo4j or Memgraph through the orchestrator
- add example `orchestrator.yml`
- add integration tests ensuring retrieval from live graph backends

## Testing
- `pre-commit run --files src/deepthought/services/knowledge_graph_service.py src/deepthought/services/__init__.py pyproject.toml docs/graphdal.md docs/orchestrator_quickstart.md examples/orchestrator.yml tests/integration/test_knowledge_graph_backend.py`

------
https://chatgpt.com/codex/tasks/task_e_687ab1457058832681d13b653c6a4e1b