### PR TITLE
Add edge server and rate-limit tests

### DIFF
--- a/tests/unit/test_bus_service_subscriber.py
+++ b/tests/unit/test_bus_service_subscriber.py
@@ -1,0 +1,30 @@
+import pytest
+
+from deepthought.templates.bus_service import subscriber as bus_subscriber
+
+
+@pytest.mark.asyncio
+async def test_rate_limit(monkeypatch):
+    current = 0.0
+
+    def mono():
+        return current
+
+    async def fake_sleep(seconds):
+        nonlocal current
+        current += seconds
+
+    monkeypatch.setattr(bus_subscriber.time, "monotonic", mono)
+    monkeypatch.setattr(bus_subscriber.asyncio, "sleep", fake_sleep)
+
+    events = []
+
+    @bus_subscriber.rate_limit(2, 1)
+    async def handler(val):
+        events.append((val, current))
+
+    await handler(1)
+    await handler(2)
+    await handler(3)
+
+    assert events == [(1, 0.0), (2, 0.0), (3, 1.0)]

--- a/tests/unit/test_edge_server.py
+++ b/tests/unit/test_edge_server.py
@@ -66,3 +66,38 @@ def test_generate_endpoint(monkeypatch):
     data = response.json()
     assert isinstance(data["text"], str)
     assert data["text"]
+
+
+def test_generate_custom_model_path(monkeypatch, tmp_path):
+    tf = types.ModuleType("transformers")
+    tf.AutoTokenizer = DummyTokenizer
+    tf.AutoModelForCausalLM = DummyModel
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    monkeypatch.setitem(sys.modules, "transformers", tf)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    monkeypatch.setenv("MODEL_PATH", str(model_dir))
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+    import edge_server
+
+    importlib.reload(edge_server)
+
+    assert edge_server.MODEL_PATH == str(model_dir)
+    client = TestClient(edge_server.app)
+    resp = client.post("/generate", json={"text": "hi"})
+    assert resp.status_code == 200
+    assert resp.json()["text"]

--- a/tests/unit/test_graph_dal.py
+++ b/tests/unit/test_graph_dal.py
@@ -95,3 +95,22 @@ def test_query_subgraph():
 
     assert result == [{"id": 1}]
     assert connector.executed == [(q, {"limit": 1})]
+
+
+def test_add_entity_empty_props():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    dal.add_entity("Thing", {})
+    assert connector.executed == [("MERGE (n:`Thing`) SET n += $props", {"props": {}})]
+
+
+def test_add_relationship_empty_props():
+    connector = DummyConnector()
+    dal = GraphDAL(connector)
+    dal.add_relationship("A", "B", "REL", {})
+    assert connector.executed == [
+        (
+            "MATCH (a {id: $start_id}), (b {id: $end_id}) MERGE (a)-[r:REL]->(b) SET r += $props",
+            {"start_id": "A", "end_id": "B", "props": {}},
+        )
+    ]


### PR DESCRIPTION
## Summary
- add dummy model edge server test for custom model path
- test rate limiter in bus service subscriber
- cover empty property cases for GraphDAL

## Testing
- `pre-commit run --files tests/unit/test_edge_server.py tests/unit/test_graph_dal.py tests/unit/test_bus_service_subscriber.py`
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/test_edge_server.py tests/unit/test_graph_dal.py tests/unit/test_bus_service_subscriber.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687ab69728e083269230840b2608df8a