### PR TITLE
Add edge container support to demo

### DIFF
--- a/docker/Dockerfile.edge
+++ b/docker/Dockerfile.edge
@@ -3,6 +3,7 @@ FROM python:3.11-slim
 ENV MODEL_PATH=/model
 ARG MODEL_NAME=gpt2
 ENV MODEL_NAME=${MODEL_NAME}
+ENV PORT=8000
 
 RUN apt-get update && \
     apt-get install -y git gcc && \
@@ -20,5 +21,7 @@ tokenizer = AutoTokenizer.from_pretrained("$MODEL_NAME")
 model.save_pretrained("/model")
 tokenizer.save_pretrained("/model")
 PY
+
+EXPOSE 8000
 
 CMD ["uvicorn", "edge_server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docs/deployment_hardware.md
+++ b/docs/deployment_hardware.md
@@ -53,3 +53,18 @@ docker build --build-arg MODEL_NAME=tiiuae/falcon-7b-instruct -f docker/Dockerfi
 ```
 
 This image downloads the model during build and starts `tools/edge_server.py` on port `8000`.
+
+### Hardware Requirements
+
+* A GPU with **6\-8GB VRAM** is recommended for reasonable inference speed.
+* At least **4 CPU cores** and **16GB RAM** allow the container to run comfortably.
+
+### Launching via `multi_agent_demo.py`
+
+After building the image, set the `EDGE_IMAGE` environment variable so the demo will start the container automatically:
+
+```bash
+EDGE_IMAGE=dtrt-edge python examples/multi_agent_demo.py
+```
+
+The container runs `tools/edge_server.py` on port `8000` and is terminated when the demo exits.

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import subprocess
 import sys
 import uuid
 from pathlib import Path
@@ -46,7 +45,13 @@ async def main() -> None:
     await ensure_stream(js)
 
     model_proc = None
-    if os.getenv("MODEL_PATH"):
+    container_proc = None
+    edge_image = os.getenv("EDGE_IMAGE")
+    if edge_image:
+        logger.info("Starting edge model container %s", edge_image)
+        container_proc = await asyncio.create_subprocess_exec("docker", "run", "--rm", "-p", "8000:8000", edge_image)
+        await asyncio.sleep(5.0)
+    elif os.getenv("MODEL_PATH"):
         script = Path(__file__).resolve().parents[1] / "tools" / "edge_server.py"
         logger.info("Starting edge model from %s", script)
         model_proc = await asyncio.create_subprocess_exec(sys.executable, str(script))
@@ -107,7 +112,10 @@ async def main() -> None:
     await llm.stop_listening()
     await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
     await nc.drain()
-    if model_proc:
+    if container_proc:
+        container_proc.terminate()
+        await container_proc.wait()
+    elif model_proc:
         model_proc.terminate()
         await model_proc.wait()
 


### PR DESCRIPTION
## Summary
- expose port 8000 in `docker/Dockerfile.edge`
- allow `examples/multi_agent_demo.py` to start the edge container via `EDGE_IMAGE`
- document hardware requirements and how to launch the container

## Testing
- `pre-commit run --files docker/Dockerfile.edge examples/multi_agent_demo.py docs/deployment_hardware.md`

------
https://chatgpt.com/codex/tasks/task_e_687ab693e7588326a8dca49072b030ba