### PR TITLE
Add Prometheus and Grafana setup docs

### DIFF
--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,22 @@
+version: '3.8'
+services:
+  metrics:
+    image: python:3.11-slim
+    command: python -m deepthought.metrics_server
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "8000:8000"
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,6 +91,7 @@ Execution traces from bots or training runs can be replayed and analyzed.
   ```
 
 The generated `dashboard.png` illustrates BLEU, ROUGE‑L and average latency over time.
+For a Prometheus and Grafana setup see [prometheus_grafana.md](prometheus_grafana.md).
 
 ## Service Template
 

--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -1,0 +1,47 @@
+# Prometheus and Grafana
+
+This snippet runs the metrics server described in [architecture.md](architecture.md) alongside Prometheus and Grafana.
+
+```yaml
+version: '3.8'
+services:
+  metrics:
+    image: python:3.11-slim
+    command: python -m deepthought.metrics_server
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "8000:8000"
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+  grafana:
+    image: grafana/grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    ports:
+      - "3000:3000"
+```
+
+Prometheus scrapes `metrics:8000` using the configuration below:
+
+```yaml
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'deepthought'
+    static_configs:
+      - targets: ['metrics:8000']
+```
+
+Import `grafana/deepthought_metrics.json` to view two panels:
+
+- **Inputs Total per Service** - rate of `inputs_total` events.
+- **Average Latency Seconds** - calculated from `input_latency_seconds`.
+
+These dashboards let you track throughput and latency for each service.

--- a/grafana/deepthought_metrics.json
+++ b/grafana/deepthought_metrics.json
@@ -1,0 +1,24 @@
+{
+  "title": "DeepThought Metrics",
+  "uid": "deepthought-metrics",
+  "schemaVersion": 36,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Inputs Total per Service",
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "rate(inputs_total[1m])", "legendFormat": "{{service}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Average Latency Seconds",
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8},
+      "targets": [
+        {"expr": "rate(input_latency_seconds_sum[1m]) / rate(input_latency_seconds_count[1m])", "legendFormat": "{{service}}"}
+      ]
+    }
+  ]
+}

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'deepthought'
+    static_configs:
+      - targets: ['metrics:8000']


### PR DESCRIPTION
## Summary
- document how to run Prometheus and Grafana
- provide a docker-compose snippet and Prometheus config
- supply an example Grafana dashboard
- cross-link the new guide from `docs/architecture.md`

## Testing
- `git show --stat -1`

------
https://chatgpt.com/codex/tasks/task_e_687ab693e4e48326a03f37566e8a28a5