### PR TITLE
Add example commands doc and CI test

### DIFF
--- a/.github/workflows/example_commands.yml
+++ b/.github/workflows/example_commands.yml
@@ -1,0 +1,27 @@
+name: Example Commands
+
+on:
+  pull_request:
+    paths:
+      - 'docs/example_commands.md'
+      - '.github/workflows/example_commands.yml'
+      - 'scripts/run_example_commands.sh'
+  push:
+    branches: ['**']
+    paths:
+      - 'docs/example_commands.md'
+      - '.github/workflows/example_commands.yml'
+      - 'scripts/run_example_commands.sh'
+
+jobs:
+  run-snippets:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build tools
+        run: apt-get update && apt-get install -y python3-pip build-essential
+      - name: Run example commands
+        run: |
+          bash scripts/run_example_commands.sh

--- a/docs/example_commands.md
+++ b/docs/example_commands.md
@@ -1,0 +1,16 @@
+# Example Commands
+
+These shell snippets demonstrate common tasks when working with DeepThought-ReThought.
+
+## Build and Install
+
+```bash
+python -m build
+pip install dist/*.whl
+```
+
+## Display CLI Help
+
+```bash
+dtrt finetune --help
+```

--- a/scripts/run_example_commands.sh
+++ b/scripts/run_example_commands.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all bash snippets from the example documentation.
+# The docs file path is resolved relative to this script so it works when
+# executed from any directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOC_FILE="${SCRIPT_DIR}/../docs/example_commands.md"
+
+# Extract bash code blocks and execute them one by one.
+awk '/^```bash/{flag=1;next}/^```/{flag=0}flag' "$DOC_FILE" | bash


### PR DESCRIPTION
## Summary
- add `docs/example_commands.md` with shell snippet docs
- create script to run shell snippets from docs
- add CI workflow to run example commands inside container
- improve snippet runner to resolve path relative to script

## Testing
- `pre-commit run --files scripts/run_example_commands.sh docs/example_commands.md`

------
https://chatgpt.com/codex/tasks/task_e_687ab698b7788326b9aebd92d89cd26b