### PR TITLE
Handle empty docs for OfflineSearch

### DIFF
--- a/src/deepthought/search/offline_search.py
+++ b/src/deepthought/search/offline_search.py
@@ -12,6 +12,10 @@ class OfflineSearch:
     @classmethod
     def create_index(cls, db_path: str, docs: Iterable[Tuple[str, str]]) -> "OfflineSearch":
         """Create or reuse an FTS5 index at ``db_path``."""
+        docs = list(docs)
+        if not docs:
+            raise ValueError("No documents provided to create_index")
+
         conn = sqlite3.connect(db_path)
         compile_options = {row[0] for row in conn.execute("pragma compile_options")}
         if not any("FTS5" in opt for opt in compile_options):

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -69,7 +69,11 @@ class HierarchicalService:
         db_path = settings.search_db
         if db_path:
             if not os.path.exists(db_path):
-                search = OfflineSearch.create_index(db_path, [])
+                try:
+                    search = OfflineSearch.create_index(db_path, [])
+                except ValueError:
+                    logger.warning("No documents available for search index; disabling offline search")
+                    search = None
             else:
                 search = OfflineSearch(db_path)
         else:

--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -58,6 +58,12 @@ def test_search_expected_hits_and_limit(tmp_path):
     ]
 
 
+def test_create_index_empty_docs(tmp_path):
+    path = tmp_path / "empty.db"
+    with pytest.raises(ValueError):
+        OfflineSearch.create_index(str(path), [])
+
+
 def test_create_index_missing_fts5(monkeypatch, tmp_path):
     path = tmp_path / "nofts5.db"
 
@@ -76,4 +82,4 @@ def test_create_index_missing_fts5(monkeypatch, tmp_path):
     monkeypatch.setattr(sqlite3, "connect", connect)
 
     with pytest.raises(RuntimeError, match="FTS5"):
-        OfflineSearch.create_index(str(path), [])
+        OfflineSearch.create_index(str(path), [("t", "c")])


### PR DESCRIPTION
## Summary
- raise `ValueError` when `OfflineSearch.create_index` is called with no documents
- log a warning in `HierarchicalService.from_chroma` when index creation fails due to empty docs
- add regression test for empty docs and update FTS5 test

## Testing
- `pre-commit run --files src/deepthought/search/offline_search.py src/deepthought/services/hierarchical_service.py tests/unit/test_offline_search.py`

------
https://chatgpt.com/codex/tasks/task_e_687d23e0160c8326bbc20cc0c09b37fd