### PR TITLE
Add JetStream connection retries

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,6 +151,7 @@ Start a local NATS server with `./scripts/start_nats.sh` and create the JetStrea
 ```bash
 python -c "import asyncio, setup_jetstream; asyncio.run(setup_jetstream.setup_jetstream())"
 ```
+The helper now retries connecting to NATS up to three times before giving up.
 
 Install the optional dependency used by the demo:
 

--- a/setup_jetstream.py
+++ b/setup_jetstream.py
@@ -58,12 +58,29 @@ async def setup_jetstream() -> None:
         logger.error("Example command: 'nats-server -js'")
         raise JetStreamSetupError("NATS server unavailable")
 
-    # Connect to NATS
+    # Connect to NATS with retries
     nats_client = NATS()
     try:
-        logger.info("Attempting to connect to NATS server...")
-        await nats_client.connect(servers=[NATS_URL])
-        logger.info("Connected to NATS server")
+        last_exc: Exception | None = None
+        for attempt in range(1, 4):
+            try:
+                logger.info(
+                    "Attempting to connect to NATS server (attempt %s/3)...",
+                    attempt,
+                )
+                await nats_client.connect(servers=[NATS_URL])
+                logger.info("Connected to NATS server")
+                break
+            except Exception as exc:  # pragma: no cover - network dependent
+                last_exc = exc
+                logger.warning(
+                    "Connection attempt %s failed: %s", attempt, exc
+                )
+                if attempt < 3:
+                    await asyncio.sleep(1)
+        else:  # pragma: no cover - loop exhausted
+            assert last_exc is not None
+            raise last_exc
 
         # Create JetStream context
         js = nats_client.jetstream()


### PR DESCRIPTION
## Summary
- retry connecting to NATS in `setup_jetstream` up to three times
- note new retry behaviour in `docs/architecture.md`

## Testing
- `flake8 setup_jetstream.py`
- `pytest tests/unit/test_setup_jetstream.py tests/test_setup_jetstream.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d23dfe0e48326a115c1a64459017a