### PR TITLE
Add persistent aiohttp session and tests

### DIFF
--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -27,17 +27,17 @@ class RemoteLLM:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._endpoint = endpoint or os.getenv("LLM_ENDPOINT", "http://localhost:8000/generate")
+        self._session = aiohttp.ClientSession()
         logger.info("RemoteLLM initialized with endpoint %s", self._endpoint)
 
     async def _generate(self, prompt: str) -> str:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(self._endpoint, json={"text": prompt}) as resp:
-                resp.raise_for_status()
-                data = await resp.json()
-                text = data.get("text")
-                if not isinstance(text, str):
-                    raise ValueError("Invalid generate response")
-                return text
+        async with self._session.post(self._endpoint, json={"text": prompt}) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+            text = data.get("text")
+            if not isinstance(text, str):
+                raise ValueError("Invalid generate response")
+            return text
 
     async def _handle_memory_event(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -95,4 +95,6 @@ class RemoteLLM:
     async def stop_listening(self) -> None:
         if self._subscriber:
             await self._subscriber.unsubscribe_all()
-            logger.info("RemoteLLM stopped listening.")
+        if not self._session.closed:
+            await self._session.close()
+        logger.info("RemoteLLM stopped listening.")

--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -77,3 +77,58 @@ def test_generate_unreachable(monkeypatch):
     with TestClient(edge_server.app, raise_server_exceptions=False) as client:
         resp = client.post("/generate", json={"text": "Hello"})
         assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_llm_session_closed(monkeypatch):
+    pytest.importorskip("aiohttp")
+    from deepthought.modules import llm_remote as llm_mod
+
+    class DummyNATS:
+        pass
+
+    class DummyJS:
+        pass
+
+    class DummyPublisher:
+        async def publish(self, *a, **k):
+            pass
+
+    class DummySubscriber:
+        async def unsubscribe_all(self):
+            pass
+
+    class DummyResp:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def raise_for_status(self):
+            pass
+
+        async def json(self):
+            return {"text": "ok"}
+
+    class DummySession:
+        def __init__(self):
+            self.closed = False
+
+        def post(self, *_args, **_kwargs):
+            return DummyResp()
+
+        async def close(self):
+            self.closed = True
+
+    session = DummySession()
+    monkeypatch.setattr(llm_mod, "Publisher", lambda *a, **k: DummyPublisher())
+    monkeypatch.setattr(llm_mod, "Subscriber", lambda *a, **k: DummySubscriber())
+    monkeypatch.setattr(llm_mod.aiohttp, "ClientSession", lambda: session)
+
+    llm = llm_mod.RemoteLLM(DummyNATS(), DummyJS(), endpoint="http://api")
+
+    await llm._generate("hi")
+    await llm.stop_listening()
+
+    assert session.closed


### PR DESCRIPTION
## Summary
- keep an `aiohttp.ClientSession` on `RemoteLLM`
- close the session when stopping
- test session closure in `test_edge_server_integration`

## Testing
- `pre-commit run --files src/deepthought/modules/llm_remote.py tests/integration/test_edge_server_integration.py`
- `PYTHONPATH=src pytest tests/integration/test_edge_server_integration.py::test_llm_session_closed -q`

------
https://chatgpt.com/codex/tasks/task_e_687d23e0abe48326977c96b4bf533840