### PR TITLE
Refactor connectors to use Settings

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -10,6 +10,25 @@ from typing import Optional
 from pydantic import AnyUrl, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
+def _apply_env_aliases() -> None:
+    """Map legacy environment variables to the expected ``DT_*`` names."""
+
+    mapping = {
+        "MG_HOST": "DT_MG_HOST",
+        "MG_PORT": "DT_MG_PORT",
+        "MG_USER": "DT_MG_USER",
+        "MG_PASSWORD": "DT_MG_PASSWORD",
+        "NEO4J_HOST": "DT_NEO4J_HOST",
+        "NEO4J_PORT": "DT_NEO4J_PORT",
+        "NEO4J_USER": "DT_NEO4J_USER",
+        "NEO4J_PASSWORD": "DT_NEO4J_PASSWORD",
+    }
+
+    for old, new in mapping.items():
+        if old in os.environ and new not in os.environ:
+            os.environ[new] = os.environ[old]
+
 try:  # YAML support is optional
     import yaml  # type: ignore
 except Exception:  # pragma: no cover - yaml may not be installed
@@ -87,6 +106,7 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
     Either the default ``DT_`` prefix or plain variable names are accepted
     for Memgraph options, e.g. ``DT_MG_HOST`` or ``MG_HOST``.
     """
+    _apply_env_aliases()
     file_path = config_file or os.getenv("DT_CONFIG_FILE")
     if file_path:
         path = Path(file_path)

--- a/src/deepthought/graph/backend.py
+++ b/src/deepthought/graph/backend.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, List
+from typing import Any, List, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    from ..config import Settings
 
 from .connector import GraphConnector, Neo4jConnector
 from .dal import GraphDAL
@@ -62,15 +65,21 @@ class NoOpGraphBackend(GraphBackend):
         pass
 
 
-def create_graph_backend(backend: str = "memgraph", **params: Any) -> GraphBackend:
+def create_graph_backend(
+    backend: str = "memgraph", *, settings: Settings | None = None, **params: Any
+) -> GraphBackend:
     """Return a :class:`GraphBackend` implementation for ``backend``."""
+    from ..config import get_settings, Settings
+
+    settings = settings or get_settings()
+
     lower = backend.lower()
     if lower == "memgraph":
-        connector = GraphConnector(**params)
+        connector = GraphConnector(settings=settings, **params)
         dal = GraphDAL(connector)
         return GraphDALBackend(dal)
     if lower == "neo4j":
-        connector = Neo4jConnector(**params)
+        connector = Neo4jConnector(settings=settings, **params)
         return Neo4jBackend(connector)
     if lower in {"none", "noop", "stub"}:
         return NoOpGraphBackend()

--- a/src/deepthought/graph/connector.py
+++ b/src/deepthought/graph/connector.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    from ..config import Settings
 
 try:  # pragma: no cover - optional dependency
     from neo4j import GraphDatabase
@@ -22,17 +25,18 @@ class GraphConnector:
 
     def __init__(
         self,
+        settings: Settings | None = None,
+        *,
         host: str | None = None,
         port: int | None = None,
         username: str | None = None,
         password: str | None = None,
-        *,
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
         from ..config import get_settings
 
-        settings = get_settings()
+        settings = settings or get_settings()
 
         host = settings.mg_host if host is None else host
         port = settings.mg_port if port is None else port
@@ -121,17 +125,18 @@ class Neo4jConnector:
 
     def __init__(
         self,
+        settings: Settings | None = None,
+        *,
         host: str | None = None,
         port: int | None = None,
         username: str | None = None,
         password: str | None = None,
-        *,
         max_retries: int = 3,
         retry_delay: float = 1.0,
     ) -> None:
         from ..config import get_settings
 
-        settings = get_settings()
+        settings = settings or get_settings()
 
         host = settings.neo4j_host if host is None else host
         port = settings.neo4j_port if port is None else port

--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -62,8 +62,8 @@ def create_memory_backend(
     top_k: int | None = None,
 ) -> TieredMemory:
     """Return :class:`TieredMemory` configured from the provided ``Settings``."""
-
-    settings = load_memory_settings(settings)
+    full_settings = settings or get_settings()
+    settings = load_memory_settings(full_settings)
 
     store = create_vector_store(
         backend=vector_backend or settings.vector_backend,
@@ -72,7 +72,9 @@ def create_memory_backend(
         use_gpu=use_gpu if use_gpu is not None else settings.vector_use_gpu,
     )
 
-    backend = create_graph_backend(graph_backend_name or settings.graph_backend)
+    backend = create_graph_backend(
+        graph_backend_name or settings.graph_backend, settings=full_settings
+    )
 
     return TieredMemory(
         store,

--- a/tests/unit/test_graph_connector.py
+++ b/tests/unit/test_graph_connector.py
@@ -90,6 +90,20 @@ def test_env_defaults(monkeypatch):
     }
 
 
+def test_settings_argument():
+    from deepthought.config import Settings
+
+    s = Settings(mg_host="h", mg_port=12, mg_user="u", mg_password="p")
+    connector = GraphConnector(settings=s)
+
+    assert connector._params == {
+        "host": "h",
+        "port": 12,
+        "username": "u",
+        "password": "p",
+    }
+
+
 def test_connect_retries(monkeypatch):
     calls = []
 

--- a/tests/unit/test_memory_factory.py
+++ b/tests/unit/test_memory_factory.py
@@ -35,8 +35,8 @@ def test_factory_uses_settings(monkeypatch):
         calls["vector"] = (backend, collection_name, persist_directory, use_gpu)
         return vec_obj
 
-    def fake_create_graph_backend(name):
-        calls["graph"] = name
+    def fake_create_graph_backend(name, *, settings=None):
+        calls["graph"] = (name, settings)
         return graph_obj
 
     class DummyTiered:
@@ -60,8 +60,8 @@ def test_factory_uses_settings(monkeypatch):
         ),
     )
 
-    memory.create_memory_backend(capacity=42, top_k=7)
+    memory.create_memory_backend(settings=fake_settings, capacity=42, top_k=7)
 
     assert calls["vector"] == ("faiss", "deepthought", None, True)
-    assert calls["graph"] == "noop"
+    assert calls["graph"] == ("noop", fake_settings)
     assert calls["tiered"] == (vec_obj, graph_obj, 42, 7)

--- a/tests/unit/test_neo4j_connector.py
+++ b/tests/unit/test_neo4j_connector.py
@@ -31,3 +31,13 @@ def test_connect_retries(monkeypatch):
     driver = connector.connect()
     assert driver == "driver"
     assert len(calls) == 2
+
+
+def test_settings_argument():
+    from deepthought.config import Settings
+
+    s = Settings(neo4j_host="h", neo4j_port=11, neo4j_user="u", neo4j_password="p")
+    c = Neo4jConnector(settings=s)
+
+    assert c._uri == "bolt://h:11"
+    assert c._auth == ("u", "p")


### PR DESCRIPTION
## Summary
- allow GraphConnector and Neo4jConnector to receive a Settings object
- add legacy environment variable handling in config
- pass Settings through create_graph_backend and memory.create_memory_backend
- update tests for new Settings parameter

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_graph_connector.py tests/unit/test_neo4j_connector.py tests/unit/graph/test_connector_validation.py tests/unit/test_memory_factory.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2ac991d483269306857e718248dc