### PR TITLE
Add bus project scaffolding and integration test

### DIFF
--- a/docs/bus_template.md
+++ b/docs/bus_template.md
@@ -128,3 +128,25 @@ docker compose up --build
 ```
 
 The command scaffolds a directory ``mybus`` with a ``docker-compose.yml`` and a service in ``src/deepthought/services/mybus``.
+
+The compose file defines NATS alongside the generated service:
+
+```yaml
+version: '3'
+services:
+  nats:
+    image: nats:latest
+    command: ['-js']
+    ports:
+      - '4222:4222'
+
+  mybus:
+    build: ./src/deepthought/services/mybus
+    env_file:
+      - ./src/deepthought/services/mybus/nats.env.example
+    environment:
+      - NATS_URL=nats://nats:4222
+      - STREAM_NAME=demo_events
+    depends_on:
+      - nats
+```

--- a/examples/bus_project-compose.yml
+++ b/examples/bus_project-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  nats:
+    image: nats:latest
+    command: ['-js']
+    ports:
+      - '4222:4222'
+
+  demo:
+    build: ./src/deepthought/services/demo
+    env_file:
+      - ./src/deepthought/services/demo/nats.env.example
+    environment:
+      - NATS_URL=nats://nats:4222
+      - STREAM_NAME=deepthought_events
+    depends_on:
+      - nats

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -105,6 +105,7 @@ def init_project(
         text = compose_file.read_text(encoding="utf-8")
         text = apply_bus_substitutions(
             text,
+            service_name=name,
             stream_name=stream_name,
             tls_cert=tls_cert,
             tls_key=tls_key,

--- a/src/deepthought/cli/template_helpers.py
+++ b/src/deepthought/cli/template_helpers.py
@@ -18,6 +18,7 @@ def find_template(template_name: str) -> Path:
 def apply_bus_substitutions(
     text: str,
     *,
+    service_name: str | None = None,
     stream_name: str | None = None,
     tls_cert: str | None = None,
     tls_key: str | None = None,
@@ -26,6 +27,9 @@ def apply_bus_substitutions(
     max_msgs: int | None = None,
 ) -> str:
     """Replace placeholders for bus service templates."""
+    if service_name is not None:
+        text = text.replace("${SERVICE_NAME}", service_name)
+        text = text.replace("template_service", service_name)
     if stream_name is not None:
         text = text.replace("${STREAM_NAME}", stream_name)
         text = text.replace("deepthought_events", stream_name)

--- a/src/deepthought/templates/bus_project/docker-compose.yml
+++ b/src/deepthought/templates/bus_project/docker-compose.yml
@@ -14,3 +14,13 @@ services:
       - "STREAM_NAME=${STREAM_NAME}"
     ports:
       - "4222:4222"
+
+  ${SERVICE_NAME}:
+    build: ./src/deepthought/services/${SERVICE_NAME}
+    env_file:
+      - ./src/deepthought/services/${SERVICE_NAME}/nats.env.example
+    environment:
+      - "NATS_URL=nats://nats:4222"
+      - "STREAM_NAME=${STREAM_NAME}"
+    depends_on:
+      - nats

--- a/tests/integration/test_bus_project.py
+++ b/tests/integration/test_bus_project.py
@@ -1,0 +1,90 @@
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("nats")
+from nats.aio.client import Client as NATS
+from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+
+from tests.helpers import nats_server_available
+
+pytestmark = pytest.mark.nats
+
+STREAM_NAME = "deepthought_events"
+
+
+async def ensure_stream_exists(js):
+    try:
+        await js.stream_info(STREAM_NAME)
+    except Exception:
+        cfg = StreamConfig(
+            name=STREAM_NAME,
+            subjects=["dtr.>"],
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.MEMORY,
+            max_msgs_per_subject=100,
+            discard=DiscardPolicy.OLD,
+        )
+        await js.add_stream(cfg)
+
+
+def _compose_cmd():
+    if shutil.which("docker-compose"):
+        return ["docker-compose"]
+    if shutil.which("docker"):
+        return ["docker", "compose"]
+    return None
+
+
+@pytest.mark.asyncio
+async def test_bus_project(tmp_path: Path):
+    compose = _compose_cmd()
+    if compose is None:
+        pytest.skip("Docker compose not available")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[2] / "src")
+    subprocess.run(
+        [sys.executable, "-m", "deepthought.cli", "bus", "init", "project", "demo"],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+        env=env,
+    )
+    compose_file = tmp_path / "demo" / "docker-compose.yml"
+
+    proc = subprocess.run(compose + ["-f", str(compose_file), "up", "-d"], capture_output=True, text=True)
+    if proc.returncode != 0:
+        pytest.skip(f"Could not start compose: {proc.stderr}")
+    try:
+        for _ in range(30):
+            if nats_server_available("localhost:4222"):
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError("NATS did not start")
+
+        nc = await NATS().connect(servers=["nats://localhost:4222"], connect_timeout=10)
+        js = nc.jetstream(timeout=10.0)
+        await ensure_stream_exists(js)
+
+        received = asyncio.Event()
+
+        async def handler(msg):
+            received.set()
+            await msg.ack()
+
+        sub = await js.subscribe("dtr.template.output", durable="sink", cb=handler, stream=STREAM_NAME)
+        await js.publish("dtr.template.input", b"test")
+        await asyncio.wait_for(received.wait(), timeout=20.0)
+        await sub.unsubscribe()
+        await nc.drain()
+    finally:
+        subprocess.run(compose + ["-f", str(compose_file), "down"], capture_output=True)

--- a/tests/unit/test_cli_bus_init_project.py
+++ b/tests/unit/test_cli_bus_init_project.py
@@ -25,7 +25,10 @@ def test_bus_init_project(tmp_path: Path) -> None:
     assert (service_dir / "subscriber.py").exists()
     assert (service_dir / "service.py").exists()
 
-    assert "deepthought_events" in docker_compose.read_text(encoding="utf-8")
+    compose_text = docker_compose.read_text(encoding="utf-8")
+    assert "deepthought_events" in compose_text
+    assert "demo:" in compose_text
+    assert "services/demo" in compose_text
 
     for py_file in service_dir.glob("*.py"):
         subprocess.run(
@@ -88,3 +91,4 @@ def test_bus_init_project_options(tmp_path: Path) -> None:
     assert "c.pem" in compose_text
     assert "k.pem" in compose_text
     assert "ca.pem" in compose_text
+    assert "opt:" in compose_text


### PR DESCRIPTION
## Summary
- generate Docker Compose with new service when initializing a bus project
- add `${SERVICE_NAME}` substitution handling
- document the project template usage and compose file example
- provide a ready-to-run compose example
- test project scaffolding and container startup

## Testing
- `pre-commit run --files docs/bus_template.md src/deepthought/cli/__init__.py src/deepthought/cli/template_helpers.py src/deepthought/templates/bus_project/docker-compose.yml tests/unit/test_cli_bus_init_project.py examples/bus_project-compose.yml tests/integration/test_bus_project.py`
- `pytest tests/unit/test_cli_bus_init_project.py tests/integration/test_bus_project.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d31333c0c83268671d80cb425a8bf