### PR TITLE
Fix metrics server startup conditions

### DIFF
--- a/docs/deployment_hardware.md
+++ b/docs/deployment_hardware.md
@@ -69,6 +69,8 @@ EDGE_IMAGE=dtrt-edge python examples/multi_agent_demo.py
 
 The container runs `tools/edge_server.py` on port `8000` and is terminated when the demo exits.
 
+Set `METRICS_PORT` to a positive integer to expose Prometheus metrics. If `METRICS_PORT` is `0` or unset, the metrics server is not started.
+
 ### Low-Resource Docker Compose Demo
 
 Use `docker-compose.edge.yml` to start NATS, the edge model and three agents with a single command:

--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -43,7 +43,8 @@ async def main() -> None:
 
     settings = get_settings()
     metrics_port = int(os.getenv("METRICS_PORT", "0"))
-    start_http_server(metrics_port)
+    if metrics_port > 0:
+        start_http_server(metrics_port)
     nc = await nats.connect(settings.nats_url)
     js = nc.jetstream()
 

--- a/tests/test_multi_agent_demo_mocked.py
+++ b/tests/test_multi_agent_demo_mocked.py
@@ -215,3 +215,23 @@ async def test_multi_agent_demo_main(monkeypatch):
 
     for handler in demo.output_handlers:
         assert handler.get_all_responses(), "handler received no messages"
+
+
+@pytest.mark.asyncio
+async def test_no_metrics_server_when_port_zero(monkeypatch):
+    calls: list[int] = []
+
+    async def fake_generate(self, prompt: str) -> str:
+        return f"echo: {prompt}"
+
+    monkeypatch.setattr(demo, "nats", fake_nats)
+    monkeypatch.setattr(demo.RemoteLLM, "_generate", fake_generate)
+    monkeypatch.setattr(demo, "start_http_server", lambda port: calls.append(port))
+    orig_sleep = asyncio.sleep
+    monkeypatch.setattr(demo.asyncio, "sleep", lambda *a, **k: orig_sleep(0))
+    monkeypatch.setenv("LANGGRAPH_RECURSION_LIMIT", "1000")
+    monkeypatch.setenv("METRICS_PORT", "0")
+
+    await demo.main()
+
+    assert not calls, "start_http_server should not be called when METRICS_PORT=0"


### PR DESCRIPTION
## Summary
- only start metrics server in demo when `METRICS_PORT` is positive
- document how to enable/disable metrics server
- test that demo skips server startup when `METRICS_PORT=0`

## Testing
- `pre-commit run --files examples/multi_agent_demo.py docs/deployment_hardware.md tests/test_multi_agent_demo_mocked.py`

------
https://chatgpt.com/codex/tasks/task_e_687d3ff6619483269918804978b34331