### PR TITLE
Validate remote LLM endpoint

### DIFF
--- a/docker-compose.edge.yml
+++ b/docker-compose.edge.yml
@@ -19,6 +19,7 @@ services:
     working_dir: /app
     environment:
       - NATS_URL=nats://nats:4222
+      # LLM_ENDPOINT must point to the running /generate endpoint
       - LLM_ENDPOINT=http://edge:8000/generate
       - PYTHONPATH=/app/src:/app
       - EDGE_IMAGE=dtrt-edge
@@ -31,6 +32,7 @@ services:
     working_dir: /app
     environment:
       - NATS_URL=nats://nats:4222
+      # LLM_ENDPOINT must point to the running /generate endpoint
       - LLM_ENDPOINT=http://edge:8000/generate
       - PYTHONPATH=/app/src:/app
       - EDGE_IMAGE=dtrt-edge
@@ -43,6 +45,7 @@ services:
     working_dir: /app
     environment:
       - NATS_URL=nats://nats:4222
+      # LLM_ENDPOINT must point to the running /generate endpoint
       - LLM_ENDPOINT=http://edge:8000/generate
       - PYTHONPATH=/app/src:/app
       - EDGE_IMAGE=dtrt-edge

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -35,3 +35,6 @@ Run the demo with:
 ```bash
 python examples/end_to_end_demo.py
 ```
+
+RemoteLLM requires the `LLM_ENDPOINT` environment variable to point to a
+running `/generate` endpoint when not using the built-in edge server.

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -27,6 +27,8 @@ class RemoteLLM:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._endpoint = endpoint or os.getenv("LLM_ENDPOINT", "http://localhost:8000/generate")
+        if not self._endpoint:
+            raise ValueError("LLM_ENDPOINT environment variable must be set or passed to RemoteLLM")
         self._session = aiohttp.ClientSession()
         logger.info("RemoteLLM initialized with endpoint %s", self._endpoint)
 

--- a/tests/integration/test_edge_server_integration.py
+++ b/tests/integration/test_edge_server_integration.py
@@ -132,3 +132,22 @@ async def test_llm_session_closed(monkeypatch):
     await llm.stop_listening()
 
     assert session.closed
+
+
+@pytest.mark.asyncio
+async def test_llm_requires_endpoint(monkeypatch):
+    pytest.importorskip("aiohttp")
+    from deepthought.modules import llm_remote as llm_mod
+
+    class DummyNATS:
+        pass
+
+    class DummyJS:
+        pass
+
+    monkeypatch.setenv("LLM_ENDPOINT", "")
+    with pytest.raises(ValueError):
+        llm_mod.RemoteLLM(DummyNATS(), DummyJS())
+
+    with pytest.raises(ValueError):
+        llm_mod.RemoteLLM(DummyNATS(), DummyJS(), endpoint="")


### PR DESCRIPTION
## Summary
- fail fast if `LLM_ENDPOINT` is empty when using `RemoteLLM`
- document the required `LLM_ENDPOINT` variable
- clarify compose file with comments
- test endpoint configuration in integration tests

## Testing
- `pre-commit run --files docker-compose.edge.yml docs/orchestrator_quickstart.md src/deepthought/modules/llm_remote.py tests/integration/test_edge_server_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_687d3ff6ff8483269db7ecd2fe27ebbb