### PR TITLE
Enable async context manager support for services

### DIFF
--- a/examples/multi_agent_demo.py
+++ b/examples/multi_agent_demo.py
@@ -70,64 +70,66 @@ async def main() -> None:
     input_handlers = [InputHandler(nc, js) for _ in range(3)]
     output_handlers = [OutputHandler(nc, js) for _ in range(3)]
 
-    await asyncio.gather(
-        memory_service.start(),
-        llm.start_listening(durable_name=f"llm_demo_{uuid.uuid4()}"),
-        *(oh.start_listening(durable_name=f"out_demo_{i}_{uuid.uuid4()}") for i, oh in enumerate(output_handlers)),
-    )
+    async with memory_service:
+        await asyncio.gather(
+            llm.start_listening(durable_name=f"llm_demo_{uuid.uuid4()}"),
+            *(
+                oh.start_listening(durable_name=f"out_demo_{i}_{uuid.uuid4()}")
+                for i, oh in enumerate(output_handlers)
+            ),
+        )
 
-    await asyncio.sleep(1.0)
+        await asyncio.sleep(1.0)
 
-    class AgentState(TypedDict):
-        text: str
-        idx: int
-        count: int
+        class AgentState(TypedDict):
+            text: str
+            idx: int
+            count: int
 
-    async def send_receive(state: AgentState) -> AgentState:
-        idx = state["idx"]
-        event = asyncio.Event()
-        start = time.perf_counter()
+        async def send_receive(state: AgentState) -> AgentState:
+            idx = state["idx"]
+            event = asyncio.Event()
+            start = time.perf_counter()
 
-        def cb(_id: str, text: str) -> None:
-            logger.info("Agent %s says: %s", idx + 1, text)
-            state["text"] = text
-            event.set()
+            def cb(_id: str, text: str) -> None:
+                logger.info("Agent %s says: %s", idx + 1, text)
+                state["text"] = text
+                event.set()
 
-        output_handlers[idx]._output_callback = cb
-        await input_handlers[idx].process_input(state["text"])
-        await event.wait()
-        duration = time.perf_counter() - start
-        INPUTS_TOTAL.labels(service="multi_agent_demo").inc()
-        INPUT_LATENCY_SECONDS.labels(service="multi_agent_demo").observe(duration)
-        state["count"] += 1
-        return state
+            output_handlers[idx]._output_callback = cb
+            await input_handlers[idx].process_input(state["text"])
+            await event.wait()
+            duration = time.perf_counter() - start
+            INPUTS_TOTAL.labels(service="multi_agent_demo").inc()
+            INPUT_LATENCY_SECONDS.labels(service="multi_agent_demo").observe(duration)
+            state["count"] += 1
+            return state
 
-    def rotate(state: AgentState) -> AgentState:
-        state["idx"] = (state["idx"] + 1) % 3
-        return state
+        def rotate(state: AgentState) -> AgentState:
+            state["idx"] = (state["idx"] + 1) % 3
+            return state
 
-    graph = StateGraph(AgentState)
-    graph.add_node("talk", send_receive)
-    graph.add_node("next", rotate)
-    graph.set_entry_point("talk")
-    graph.add_edge("talk", "next")
-    graph.add_edge("next", "talk")
-    compiled = graph.compile()
+        graph = StateGraph(AgentState)
+        graph.add_node("talk", send_receive)
+        graph.add_node("next", rotate)
+        graph.set_entry_point("talk")
+        graph.add_edge("talk", "next")
+        graph.add_edge("next", "talk")
+        compiled = graph.compile()
 
-    state: AgentState = {"text": "Hello from agent 1!", "idx": 0, "count": 0}
-    while state["count"] < 3:
-        state = await compiled.ainvoke(state)
+        state: AgentState = {"text": "Hello from agent 1!", "idx": 0, "count": 0}
+        while state["count"] < 3:
+            state = await compiled.ainvoke(state)
 
-    await memory_service.stop()
-    await llm.stop_listening()
-    await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
-    await nc.drain()
-    if container_proc:
-        container_proc.terminate()
-        await container_proc.wait()
-    elif model_proc:
-        model_proc.terminate()
-        await model_proc.wait()
+        await llm.stop_listening()
+        await asyncio.gather(*(oh.stop_listening() for oh in output_handlers))
+        await nc.drain()
+        if container_proc:
+            container_proc.terminate()
+            await container_proc.wait()
+        elif model_proc:
+            model_proc.terminate()
+            await model_proc.wait()
 
 
 if __name__ == "__main__":

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import AsyncExitStack
 import json
 import logging
 import ssl
@@ -80,19 +81,16 @@ async def run(config_path: str) -> None:
         logger.warning("No services found for names %s", names)
         return
     nc, js = await _connect_nats()
-    instances = [cls(nc, js) for cls in service_classes]
-    for inst in instances:
-        await inst.start()
-    logger.info("Started %d services", len(instances))
-    try:
-        await asyncio.Event().wait()
-    except (asyncio.CancelledError, KeyboardInterrupt):
-        pass
-    finally:
-        for inst in instances:
-            try:
-                await inst.stop()
-            except Exception:  # pragma: no cover - defensive
-                logger.error("Failed to stop service %s", inst, exc_info=True)
+    async with AsyncExitStack() as stack:
         if nc.is_connected:
-            await nc.drain()
+            stack.push_async_callback(nc.drain)
+        instances = []
+        for cls in service_classes:
+            inst = cls(nc, js)
+            await stack.enter_async_context(inst)
+            instances.append(inst)
+        logger.info("Started %d services", len(instances))
+        try:
+            await asyncio.Event().wait()
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            pass

--- a/src/deepthought/services/code_generation_service.py
+++ b/src/deepthought/services/code_generation_service.py
@@ -109,3 +109,10 @@ class CodeGenerationService:
             logger.info("CodeGenerationService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
+
+    async def __aenter__(self) -> "CodeGenerationService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -194,6 +194,13 @@ class HierarchicalService:
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
 
+    async def __aenter__(self) -> "HierarchicalService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()
+
     def dump_graph(self, path: str) -> str:
         """Write the underlying graph to ``path`` in DOT format."""
         import os

--- a/src/deepthought/services/knowledge_graph_service.py
+++ b/src/deepthought/services/knowledge_graph_service.py
@@ -144,3 +144,10 @@ class KnowledgeGraphService:
             logger.warning("Cannot stop listening - no subscriber available.")
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
+
+    async def __aenter__(self) -> "KnowledgeGraphService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/llm_remote_service.py
+++ b/src/deepthought/services/llm_remote_service.py
@@ -21,3 +21,10 @@ class LLMRemoteService:
 
     async def stop(self) -> None:
         await self._llm.stop_listening()
+
+    async def __aenter__(self) -> "LLMRemoteService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -131,3 +131,10 @@ class MemoryService:
             logger.warning("Cannot stop listening - no subscriber available.")
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
+
+    async def __aenter__(self) -> "MemoryService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/output_handler_service.py
+++ b/src/deepthought/services/output_handler_service.py
@@ -17,3 +17,10 @@ class OutputHandlerService:
 
     async def stop(self) -> None:
         await self._handler.stop_listening()
+
+    async def __aenter__(self) -> "OutputHandlerService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/reward_manager_service.py
+++ b/src/deepthought/services/reward_manager_service.py
@@ -25,3 +25,10 @@ class RewardManagerService:
 
     async def stop(self) -> None:
         await self._manager.stop_listening()
+
+    async def __aenter__(self) -> "RewardManagerService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -91,6 +91,13 @@ class SchedulerService:
             except asyncio.CancelledError:
                 pass
 
+    async def __aenter__(self) -> "SchedulerService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()
+
     async def _summary_loop(self) -> None:
         while self._running:
             await self._sleep(self._summary_interval)

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -106,3 +106,10 @@ class SocialGraphService:
             logger.info("SocialGraphService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
+
+    async def __aenter__(self) -> "SocialGraphService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -299,3 +299,25 @@ async def test_handle_input_missing_fields():
 
     assert msg.nacked
     assert not msg.acked
+
+
+@pytest.mark.asyncio
+async def test_context_manager_calls_start_stop(monkeypatch):
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), DummyMemory())
+
+    called = {"start": 0, "stop": 0}
+
+    async def fake_start(self, durable_name: str = "memory_service_listener"):
+        called["start"] += 1
+        return True
+
+    async def fake_stop(self):
+        called["stop"] += 1
+
+    monkeypatch.setattr(MemoryService, "start", fake_start)
+    monkeypatch.setattr(MemoryService, "stop", fake_stop)
+
+    async with service:
+        pass
+
+    assert called == {"start": 1, "stop": 1}

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -48,6 +48,13 @@ class DummyService:
     async def stop(self) -> None:
         self.stopped = True
 
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.stop()
+
 
 @pytest.mark.asyncio
 async def test_run(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- add `__aenter__` and `__aexit__` to all core service classes
- update orchestrator to manage services using an `AsyncExitStack`
- revise multi-agent demo to use `async with MemoryService`
- test context manager integration

## Testing
- `flake8 src/deepthought tests/unit/test_orchestrator.py tests/unit/services/test_memory_service.py examples/multi_agent_demo.py src/deepthought/services/*.py src/deepthought/orchestrator.py`
- `pytest tests/unit/test_orchestrator.py tests/unit/services/test_memory_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d4a6b263c8326a206c04f002ab776