### PR TITLE
Add OfflineSearch FTS5 compile options test

### DIFF
--- a/tests/unit/test_offline_search.py
+++ b/tests/unit/test_offline_search.py
@@ -83,3 +83,25 @@ def test_create_index_missing_fts5(monkeypatch, tmp_path):
 
     with pytest.raises(RuntimeError, match="FTS5"):
         OfflineSearch.create_index(str(path), [("t", "c")])
+
+
+def test_create_index_missing_fts5_compile_options(monkeypatch, tmp_path):
+    """Fail early when FTS5 support is absent in compile options."""
+    path = tmp_path / "nofts5_compile.db"
+
+    orig_connect = sqlite3.connect
+
+    class NoFTS5Conn(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            if sql.lower().startswith("pragma compile_options"):
+                return [("SOME_OPTION",)]
+            return super().execute(sql, *args, **kwargs)
+
+    def connect(*args, **kwargs):
+        kwargs["factory"] = NoFTS5Conn
+        return orig_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+
+    with pytest.raises(RuntimeError, match="FTS5"):
+        OfflineSearch.create_index(str(path), [("t", "c")])


### PR DESCRIPTION
## Summary
- verify index creation fails when compile options lack FTS5

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_offline_search.py::test_create_index_and_search tests/unit/test_offline_search.py::test_create_index_empty_docs tests/unit/test_offline_search.py::test_create_index_missing_fts5 tests/unit/test_offline_search.py::test_create_index_missing_fts5_compile_options -q`


------
https://chatgpt.com/codex/tasks/task_e_687d507ac2288326bbd1efb2a2d80ddc