### PR TITLE
Add graph memory demo and docs

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -90,9 +90,20 @@ Alternatively, run the example script directly:
 python examples/memgraph_memory_service.py
 ```
 
-Another demo using a Neo4j backend is available:
+You can try a standalone graph memory demo once either Memgraph or Neo4j is
+running. Choose the backend via ``DT_GRAPH_BACKEND`` before executing the
+script. A ``noop`` backend is also available for quick testing without any
+database:
 
 ```bash
+# For Memgraph
+export DT_GRAPH_BACKEND=memgraph
+python examples/graph_memory_demo.py
+# For Neo4j
+export DT_GRAPH_BACKEND=neo4j
+python examples/graph_memory_demo.py
+# Or to quickly run it with no database
+export DT_GRAPH_BACKEND=noop
 python examples/graph_memory_demo.py
 ```
 

--- a/examples/graph_memory_demo.py
+++ b/examples/graph_memory_demo.py
@@ -1,27 +1,63 @@
-import logging
+"""Small demo storing graph facts and retrieving them."""
 
-from deepthought.graph import create_graph_backend
-from deepthought.memory.tiered import TieredMemory
+from __future__ import annotations
+
+import logging
+import os
+import time
+
+from deepthought.graph import GraphConnector, GraphDAL, Neo4jConnector
+from deepthought.memory.hierarchical import HierarchicalMemory
 from deepthought.memory.vector_store import create_vector_store
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
-def main() -> None:
-    store = create_vector_store("faiss", collection_name="graph_demo")
-    backend = create_graph_backend("neo4j")
-    memory = TieredMemory(store, backend, capacity=3, top_k=2)
+class _NoOpConnector:
+    def execute(self, query: str, params: dict | None = None) -> list:
+        return []
 
-    for fact in [
+
+def _create_dal(backend: str) -> GraphDAL:
+    backend = backend.lower()
+    if backend == "neo4j":
+        connector = Neo4jConnector()
+    elif backend == "memgraph":
+        connector = GraphConnector()
+    elif backend in {"noop", "none"}:
+        connector = _NoOpConnector()
+    else:
+        raise ValueError(f"Unknown backend: {backend}")
+    return GraphDAL(connector)
+
+def main() -> None:
+    backend_name = os.getenv("DT_GRAPH_BACKEND", "memgraph")
+    store = create_vector_store("faiss", collection_name="graph_demo")
+    dal = _create_dal(backend_name)
+    memory = HierarchicalMemory(store, dal)
+
+    facts = [
         "Alice met Bob",
         "Bob chatted with Carol",
         "Carol saw Dave",
-    ]:
-        memory.store_interaction(fact)
+    ]
 
+    store.add_texts(facts)
+    for fact in facts:
+        try:
+            src, dst = fact.split()[0], fact.split()[-1]
+            dal.merge_entity(src)
+            dal.merge_entity(dst)
+            dal.merge_next_edge(src, dst)
+        except Exception:  # pragma: no cover - demo only
+            logger.error("Failed to store %s", fact, exc_info=True)
+
+    start = time.perf_counter()
     ctx = memory.retrieve_context("Alice")
+    latency = time.perf_counter() - start
     logger.info("Retrieved context: %s", ctx)
+    logger.info("Retrieval latency: %.3f seconds", latency)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_graph_memory_demo.py
+++ b/tests/unit/test_graph_memory_demo.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 import types
 
@@ -30,29 +31,16 @@ class DummyStore:
         return DummyStore.Collection(self)
 
 
-class DummyBackend:
-    def __init__(self):
-        self.entities = []
-
-    def query_subgraph(self, query, params):
-        return [{"fact": "g1"}]
-
-    def merge_entity(self, name):
-        self.entities.append(name)
-
-
-def test_main(monkeypatch):
+def test_main_noop(monkeypatch):
     store = DummyStore()
-    backend = DummyBackend()
+    monkeypatch.setenv("DT_GRAPH_BACKEND", "noop")
     importlib.reload(demo)
     monkeypatch.setattr(demo, "create_vector_store", lambda *a, **k: store)
-    monkeypatch.setattr(demo, "create_graph_backend", lambda *a, **k: backend)
 
-    captured = {}
-    monkeypatch.setattr(demo.logger, "info", lambda msg, ctx: captured.setdefault("ctx", ctx))
+    logs = []
+    monkeypatch.setattr(demo.logger, "info", lambda msg, *a: logs.append(msg))
 
     demo.main()
 
     assert store.added
-    assert backend.entities
-    assert captured.get("ctx")
+    assert any("Retrieval latency" in m for m in logs)


### PR DESCRIPTION
## Summary
- implement `graph_memory_demo.py` using `HierarchicalMemory`
- document running the demo with Memgraph or Neo4j
- mention `noop` backend option
- test running the demo with the `noop` backend

## Testing
- `flake8`
- `pytest -q tests/unit/test_graph_memory_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_687d5074141483268219d3efaef22450