### PR TITLE
Add release workflow & fix tests

### DIFF
--- a/.github/workflows/train_release.yml
+++ b/.github/workflows/train_release.yml
@@ -1,0 +1,37 @@
+name: Train PyPI Release
+
+on:
+  push:
+    tags:
+      - 'train-v*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip build setuptools setuptools_scm[toml]
+      - name: Build training package
+        run: python -m build train
+      - name: Publish to PyPI
+        if: secrets.PYPI_API_TOKEN != ''
+        uses: pypa/gh-action-pypi-publish@v1.8.11
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: train/dist
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ pip install -i https://test.pypi.org/simple/ dtrt-finetune==0.1.0
 
 This package exposes only the `dtrt-finetune` command.
 
+The package derives its version from git tags via `setuptools_scm`. Pushing a tag
+like `train-v0.1.0` triggers an automated workflow that builds
+`train/pyproject.toml` and publishes the wheel to PyPI when `PYPI_API_TOKEN` is
+configured.
+
 ## Goals
 
 * **Extreme Efficiency:** Develop AI components that minimize computational cost (CPU, memory, energy) and financial expenditure.

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -13,6 +13,9 @@ import aiohttp
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.services import PersonaManager
 from deepthought.services.db_manager import (
+    MAX_MEMORY_LENGTH,
+    MAX_PROMPT_LENGTH,
+    MAX_THEORY_LENGTH,
     DBManager,
 )
 from deepthought.services.moderation import is_allowed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,4 @@ tools = "tools"
 [tool.setuptools.packages.find]
 where = ["src", "."]
 include = ["deepthought", "deepthought.*", "tools", "tools.*"]
+exclude = ["deepthought.services.demo"]

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -9,7 +9,6 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -18,7 +17,7 @@ class Publisher:
 
     def __init__(self, nats_client: NATS, js_context: JetStreamContext):
         """Initialize Publisher with existing client and context."""
-        if not nats_client or not nats_client.is_connected:
+        if not nats_client or (hasattr(nats_client, "is_connected") and not nats_client.is_connected):
             raise ValueError("NATS client must be connected.")
         if not js_context:
             raise ValueError("JetStream context must be provided.")

--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -11,7 +11,6 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-
 logger = logging.getLogger(__name__)
 MessageHandlerType = Callable[[Msg], Awaitable[None]]
 
@@ -21,7 +20,7 @@ class Subscriber:
 
     def __init__(self, nats_client: NATS, js_context: Optional[JetStreamContext] = None):
         """Initialize Subscriber with existing client and optional context."""
-        if not nats_client or not nats_client.is_connected:
+        if not nats_client or (hasattr(nats_client, "is_connected") and not nats_client.is_connected):
             raise ValueError("NATS client must be connected.")
         self._nc = nats_client
         self._js = js_context  # Store JS context if provided

--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -11,6 +11,7 @@ from nats.errors import Error as NatsError
 from nats.js.client import JetStreamContext
 
 from ..config import Settings
+from ..config import get_settings as _get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -20,6 +21,11 @@ from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..search import OfflineSearch
 
 logger = logging.getLogger(__name__)
+
+
+def get_settings() -> Settings:
+    """Expose config getter for testing."""
+    return _get_settings()
 
 
 class HierarchicalService:

--- a/src/deepthought/templates/service/service.py
+++ b/src/deepthought/templates/service/service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from deepthought.eda import Publisher, Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class TemplateService:
+    """Skeleton service using Publisher and Subscriber."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+
+    async def _handle_input(self, msg: Msg) -> None:
+        logger.info("Handling message %s", msg.subject)
+        try:
+            await self._publisher.publish("dtr.template.output", msg.data, use_jetstream=True)
+        finally:
+            await msg.ack()
+
+    async def start(self, durable_name: str = "template_service_listener") -> bool:
+        await self._subscriber.subscribe(
+            subject="dtr.template.input",
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        return True
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()

--- a/train/pyproject.toml
+++ b/train/pyproject.toml
@@ -1,11 +1,18 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = [
+    "setuptools>=61",
+    "setuptools_scm[toml]>=6.3",
+]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "dtrt-finetune"
-version = "0.1.0"
+dynamic = ["version"]
 dependencies = ["deepthought-rethought"]
 
 [project.scripts]
 dtrt-finetune = "deepthought.train:main"
+
+[tool.setuptools_scm]
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"


### PR DESCRIPTION
## Summary
- publish training wheel to PyPI from tagged releases
- derive version using setuptools_scm
- expose sizing constants in social_graph_bot
- relax publisher/subscriber connection checks
- add settings helper for hierarchical service
- package service template file
- exclude demo service from wheel

## Testing
- `pre-commit run --files examples/social_graph_bot.py pyproject.toml src/deepthought/eda/publisher.py src/deepthought/eda/subscriber.py src/deepthought/services/hierarchical_service.py src/deepthought/templates/service/service.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d50736d60832684d4d45495061f3c