### PR TITLE
Add finetune publish script and packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This installs the ``dtrt`` and ``dtrt-finetune`` entry points for the CLI.
 
 ### Build from source
 
-Build the project and install the wheel with pip:
+Build the project using [build](https://pypi.org/project/build/) then install the wheel:
 
 ```bash
 python -m build
@@ -31,14 +31,8 @@ After installation, the `dtrt` CLI is available. View its commands with:
 dtrt finetune --help
 ```
 
-### Publishing to PyPI
-
-Build the project and upload it using `twine`:
-
-```bash
-python -m build
-twine upload dist/*
-```
+See [docs/packaging.md](docs/packaging.md) for detailed instructions on publishing
+both the core package and the standalone `dtrt-finetune` helper.
 
 
 ## DTRT FineTune v0.1

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,37 @@
+# Packaging and Publishing
+
+This project consists of two Python distributions: the main `deepthought-rethought` package and a standalone `dtrt-finetune` training helper. Both are published to PyPI using [build](https://pypi.org/project/build/) and [twine](https://pypi.org/project/twine/).
+
+## Build the Core Package
+
+From the repository root run:
+
+```bash
+python -m build
+```
+
+The wheel will be created in `dist/`. Install it locally with:
+
+```bash
+pip install dist/*.whl
+```
+
+## Publish the Core Package
+
+To upload the wheel to PyPI execute:
+
+```bash
+twine upload dist/*
+```
+
+Authentication is handled via the `PYPI_API_TOKEN` environment variable.
+
+## Build and Publish `dtrt-finetune`
+
+The training helper is defined by `train/pyproject.toml`. Use the helper script to build and upload it:
+
+```bash
+python tools/publish_finetune.py
+```
+
+The script builds the wheel under `train/dist/` and then runs `twine upload` on that file. Set `PYPI_API_TOKEN` in your environment to authenticate.

--- a/tools/publish_finetune.py
+++ b/tools/publish_finetune.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Build and upload the dtrt-finetune package to PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def build(project_dir: Path) -> Path:
+    """Build the wheel for the project located in ``project_dir``."""
+    subprocess.run(["python", "-m", "build", "--wheel", str(project_dir)], check=True)
+    dist_dir = project_dir / "dist"
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if not wheels:
+        raise RuntimeError(f"No wheel found in {dist_dir}")
+    return wheels[-1]
+
+
+def upload(wheel: Path, repository: str, skip_existing: bool) -> None:
+    """Upload ``wheel`` to the given repository using twine."""
+    cmd = ["twine", "upload", "--repository", repository]
+    if skip_existing:
+        cmd.append("--skip-existing")
+    cmd.append(str(wheel))
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish dtrt-finetune to PyPI")
+    parser.add_argument(
+        "--repository",
+        default="pypi",
+        help="Twine repository name (default: pypi)",
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Ignore existing files on the repository",
+    )
+    args = parser.parse_args()
+
+    project_dir = Path(__file__).resolve().parent.parent / "train"
+    wheel = build(project_dir)
+    upload(wheel, args.repository, args.skip_existing)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual script
+    main()


### PR DESCRIPTION
## Summary
- consolidate packaging instructions in a new doc
- reference that doc from the README
- add a helper script to build and upload `train/pyproject.toml`

## Testing
- `pre-commit run --files tools/publish_finetune.py`
- `flake8 tools/publish_finetune.py`
- `black --line-length=120 tools/publish_finetune.py`
- `isort --profile=black --line-length=120 tools/publish_finetune.py`
- `PYTHONPATH=src pytest -q tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_687fb07067cc8326ab4282ad39f566d4