### PR TITLE
Escape bus template values

### DIFF
--- a/src/deepthought/cli/template_helpers.py
+++ b/src/deepthought/cli/template_helpers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from importlib import resources
 from pathlib import Path
 
@@ -27,6 +28,11 @@ def apply_bus_substitutions(
     max_msgs: int | None = None,
 ) -> str:
     """Replace placeholders for bus service templates."""
+
+    def _quote(value: str) -> str:
+        """Return a Dockerfile/.env-safe quoted value."""
+        return json.dumps(value)
+
     if service_name is not None:
         text = text.replace("${SERVICE_NAME}", service_name)
         text = text.replace("template_service", service_name)
@@ -36,20 +42,25 @@ def apply_bus_substitutions(
         text = text.replace("deepthought_events", stream_name)
     if tls_cert is not None:
         text = text.replace("${TLS_CERT}", tls_cert)
-        text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={tls_cert}")
-        text = text.replace("ENV NATS_TLS_CERT=", f"ENV NATS_TLS_CERT={tls_cert}")
+        q_cert = _quote(tls_cert)
+        text = text.replace("NATS_TLS_CERT=", f"NATS_TLS_CERT={q_cert}")
+        text = text.replace("ENV NATS_TLS_CERT=", f"ENV NATS_TLS_CERT={q_cert}")
     if tls_key is not None:
         text = text.replace("${TLS_KEY}", tls_key)
-        text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={tls_key}")
-        text = text.replace("ENV NATS_TLS_KEY=", f"ENV NATS_TLS_KEY={tls_key}")
+        q_key = _quote(tls_key)
+        text = text.replace("NATS_TLS_KEY=", f"NATS_TLS_KEY={q_key}")
+        text = text.replace("ENV NATS_TLS_KEY=", f"ENV NATS_TLS_KEY={q_key}")
     if tls_ca is not None:
         text = text.replace("${TLS_CA}", tls_ca)
-        text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={tls_ca}")
-        text = text.replace("ENV NATS_TLS_CA=", f"ENV NATS_TLS_CA={tls_ca}")
+        q_ca = _quote(tls_ca)
+        text = text.replace("NATS_TLS_CA=", f"NATS_TLS_CA={q_ca}")
+        text = text.replace("ENV NATS_TLS_CA=", f"ENV NATS_TLS_CA={q_ca}")
     if js_storage is not None:
-        text = text.replace("NATS_JS_STORAGE=memory", f"NATS_JS_STORAGE={js_storage}")
-        text = text.replace("ENV NATS_JS_STORAGE=memory", f"ENV NATS_JS_STORAGE={js_storage}")
+        q_js = _quote(js_storage)
+        text = text.replace("NATS_JS_STORAGE=memory", f"NATS_JS_STORAGE={q_js}")
+        text = text.replace("ENV NATS_JS_STORAGE=memory", f"ENV NATS_JS_STORAGE={q_js}")
     if max_msgs is not None:
-        text = text.replace("NATS_MAX_MSGS=10000", f"NATS_MAX_MSGS={max_msgs}")
-        text = text.replace("ENV NATS_MAX_MSGS=10000", f"ENV NATS_MAX_MSGS={max_msgs}")
+        q_msgs = _quote(str(max_msgs))
+        text = text.replace("NATS_MAX_MSGS=10000", f"NATS_MAX_MSGS={q_msgs}")
+        text = text.replace("ENV NATS_MAX_MSGS=10000", f"ENV NATS_MAX_MSGS={q_msgs}")
     return text

--- a/tests/unit/test_cli_bus_init_project.py
+++ b/tests/unit/test_cli_bus_init_project.py
@@ -77,14 +77,14 @@ def test_bus_init_project_options(tmp_path: Path) -> None:
     service_dir = tmp_path / "opt" / "src" / "deepthought" / "services" / "opt"
     env_text = (service_dir / "nats.env.example").read_text(encoding="utf-8")
     assert "NATS_STREAM=custom" in env_text
-    assert "NATS_TLS_CERT=c.pem" in env_text
-    assert "NATS_JS_STORAGE=file" in env_text
-    assert "NATS_MAX_MSGS=42" in env_text
+    assert 'NATS_TLS_CERT="c.pem"' in env_text
+    assert 'NATS_JS_STORAGE="file"' in env_text
+    assert 'NATS_MAX_MSGS="42"' in env_text
     docker_text = (service_dir / "Dockerfile").read_text(encoding="utf-8")
     assert "pip install deepthought-rethought" in docker_text
-    assert "NATS_TLS_CERT=c.pem" in docker_text
-    assert "NATS_JS_STORAGE=file" in docker_text
-    assert "NATS_MAX_MSGS=42" in docker_text
+    assert 'NATS_TLS_CERT="c.pem"' in docker_text
+    assert 'NATS_JS_STORAGE="file"' in docker_text
+    assert 'NATS_MAX_MSGS="42"' in docker_text
 
     compose_text = (tmp_path / "opt" / "docker-compose.yml").read_text(encoding="utf-8")
     assert "custom" in compose_text

--- a/tests/unit/test_cli_bus_init_service.py
+++ b/tests/unit/test_cli_bus_init_service.py
@@ -70,10 +70,10 @@ def test_bus_init_service_options(tmp_path: Path) -> None:
     dest = tmp_path / "src" / "deepthought" / "services" / "opt"
     env_text = (dest / "nats.env.example").read_text(encoding="utf-8")
     assert "NATS_STREAM=custom" in env_text
-    assert "NATS_TLS_CERT=c.pem" in env_text
-    assert "NATS_JS_STORAGE=file" in env_text
-    assert "NATS_MAX_MSGS=42" in env_text
+    assert 'NATS_TLS_CERT="c.pem"' in env_text
+    assert 'NATS_JS_STORAGE="file"' in env_text
+    assert 'NATS_MAX_MSGS="42"' in env_text
     docker_text = (dest / "Dockerfile").read_text(encoding="utf-8")
-    assert "NATS_TLS_CERT=c.pem" in docker_text
-    assert "NATS_JS_STORAGE=file" in docker_text
-    assert "NATS_MAX_MSGS=42" in docker_text
+    assert 'NATS_TLS_CERT="c.pem"' in docker_text
+    assert 'NATS_JS_STORAGE="file"' in docker_text
+    assert 'NATS_MAX_MSGS="42"' in docker_text

--- a/tests/unit/test_template_helpers.py
+++ b/tests/unit/test_template_helpers.py
@@ -1,0 +1,21 @@
+import deepthought.cli.template_helpers as th
+
+
+def test_apply_bus_substitutions_escape() -> None:
+    template = "\n".join(
+        [
+            "NATS_TLS_CERT=",
+            "NATS_TLS_KEY=",
+            "ENV NATS_TLS_CERT=",
+            "ENV NATS_TLS_KEY=",
+        ]
+    )
+    result = th.apply_bus_substitutions(
+        template,
+        tls_cert="cert path.pem",
+        tls_key='key"path.pem',
+    )
+    assert 'NATS_TLS_CERT="cert path.pem"' in result
+    assert 'NATS_TLS_KEY="key\\"path.pem"' in result
+    assert 'ENV NATS_TLS_CERT="cert path.pem"' in result
+    assert 'ENV NATS_TLS_KEY="key\\"path.pem"' in result


### PR DESCRIPTION
## Summary
- properly quote injected values in Dockerfiles and `.env` files
- adjust tests to expect quoted values
- add unit test for escaping special characters

## Testing
- `pre-commit run --files src/deepthought/cli/template_helpers.py tests/unit/test_cli_bus_init_service.py tests/unit/test_cli_bus_init_project.py tests/unit/test_template_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68802112490483268be5c5a2ff381957