### PR TITLE
Add safety checks and timeout for template execution

### DIFF
--- a/src/deepthought/services/code_generation_service.py
+++ b/src/deepthought/services/code_generation_service.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import json
 import logging
 import operator
@@ -61,15 +62,42 @@ class CodeGenerationService:
             return self._unary_ops[op_type](operand)
         raise ValueError("Disallowed expression")
 
-    def _safe_execute(self, code: str, variables: Dict[str, Any]) -> Any:
-        module = ast.parse(code, mode="exec")
-        if len(module.body) != 1 or not isinstance(module.body[0], ast.Assign):
-            raise ValueError("Code must be a single assignment to 'result'")
-        assign = module.body[0]
-        if len(assign.targets) != 1 or not isinstance(assign.targets[0], ast.Name) or assign.targets[0].id != "result":
-            raise ValueError("Code must assign to 'result'")
-        value = self._eval_expr(assign.value, variables)
-        return value
+    async def _safe_execute(self, code: str, variables: Dict[str, Any], timeout: float = 0.1) -> Any:
+        """Safely evaluate a simple assignment expression.
+
+        The code must consist of a single assignment to ``result`` and may only
+        contain arithmetic expressions built from constants or provided
+        variables. Loops and excessively large constants are rejected. The
+        evaluation runs in a separate thread and is cancelled if it exceeds the
+        given ``timeout`` seconds.
+        """
+
+        def check_ast(module: ast.Module) -> None:
+            for node in ast.walk(module):
+                if isinstance(node, (ast.For, ast.While, ast.AsyncFor, ast.AsyncWith, ast.With)):
+                    raise ValueError("Loops are not allowed")
+                if isinstance(node, ast.Constant):
+                    val = node.value
+                    if isinstance(val, (int, float)) and abs(val) > 1_000_000:
+                        raise ValueError("Constant too large")
+                    if isinstance(val, str) and len(val) > 1000:
+                        raise ValueError("Constant too large")
+
+        def eval_ast() -> Any:
+            module = ast.parse(code, mode="exec")
+            check_ast(module)
+            if len(module.body) != 1 or not isinstance(module.body[0], ast.Assign):
+                raise ValueError("Code must be a single assignment to 'result'")
+            assign = module.body[0]
+            if (
+                len(assign.targets) != 1
+                or not isinstance(assign.targets[0], ast.Name)
+                or assign.targets[0].id != "result"
+            ):
+                raise ValueError("Code must assign to 'result'")
+            return self._eval_expr(assign.value, variables)
+
+        return await asyncio.wait_for(asyncio.to_thread(eval_ast), timeout)
 
     async def _handle_template_request(self, msg: Msg) -> None:
         request_id = "unknown"
@@ -85,7 +113,7 @@ class CodeGenerationService:
             logger.info("CodeGenerationService received request ID %s", request_id)
 
             code = Template(template_text).safe_substitute(**variables)
-            result = self._safe_execute(code, variables)
+            result = await self._safe_execute(code, variables)
 
             payload = CodeGeneratedPayload(
                 code=code,

--- a/tests/unit/services/test_code_generation_service.py
+++ b/tests/unit/services/test_code_generation_service.py
@@ -1,9 +1,32 @@
 import json
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
 
 pytest.importorskip("nats")
+sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+import importlib.machinery
+
+fake_nx = types.ModuleType("networkx")
+setattr(fake_nx, "DiGraph", object)
+fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
+sys.modules.setdefault("networkx", fake_nx)
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+fake_pyd.Field = lambda default=None, **kwargs: default
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+fake_ps.BaseSettings = object
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+fake_prom = types.ModuleType("prometheus_client")
+fake_prom.Counter = lambda *a, **k: object()
+fake_prom.Histogram = lambda *a, **k: object()
+fake_prom.REGISTRY = SimpleNamespace(_names_to_collectors={})
+sys.modules.setdefault("prometheus_client", fake_prom)
 
 from deepthought.eda.events import CodeTemplatePayload, EventSubjects
 from deepthought.services.code_generation_service import CodeGenerationService
@@ -76,3 +99,53 @@ async def test_rejects_unsafe_code(monkeypatch):
     assert msg.acked
     pub = service._publisher
     assert not pub.published
+
+
+@pytest.mark.asyncio
+async def test_rejects_loops():
+    service = CodeGenerationService(DummyNATS(), DummyJS())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    template = "result = 0\nfor i in range(5):\n    result += i"
+    payload = CodeTemplatePayload(template=template, variables={}, input_id="c")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_template_request(msg)
+
+    assert msg.acked
+    assert not service._publisher.published
+
+
+@pytest.mark.asyncio
+async def test_rejects_large_constant():
+    service = CodeGenerationService(DummyNATS(), DummyJS())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = CodeTemplatePayload(template="result = 1000001", variables={}, input_id="d")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_template_request(msg)
+
+    assert msg.acked
+    assert not service._publisher.published
+
+
+@pytest.mark.asyncio
+async def test_execution_timeout(monkeypatch):
+    service = CodeGenerationService(DummyNATS(), DummyJS())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    def slow_eval(self, node, variables):
+        import time
+        time.sleep(0.2)
+        return 1
+
+    monkeypatch.setattr(CodeGenerationService, "_eval_expr", slow_eval)
+
+    payload = CodeTemplatePayload(template="result = 1", variables={}, input_id="e")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_template_request(msg)
+
+    assert msg.acked
+    assert not service._publisher.published


### PR DESCRIPTION
## Summary
- update `CodeGenerationService._safe_execute` to reject loops and large constants
- run evaluation in a background thread with a timeout
- adjust handler for async safe execution
- expand tests for new safety features and timeout handling

## Testing
- `flake8`
- `pytest tests/unit/services/test_code_generation_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68802111df3083269a41cdf9dd9c81dc