### PR TITLE
Ensure connectors close in service stop

### DIFF
--- a/src/deepthought/services/hierarchical_service.py
+++ b/src/deepthought/services/hierarchical_service.py
@@ -197,6 +197,17 @@ class HierarchicalService:
             logger.info("HierarchicalService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
+        try:
+            backend = getattr(self._memory, "graph_backend", None)
+            connector = None
+            if hasattr(backend, "_dal"):
+                connector = getattr(getattr(backend, "_dal", None), "_connector", None)
+            elif backend is not None:
+                connector = getattr(backend, "_connector", None)
+            if connector and hasattr(connector, "close"):
+                connector.close()
+        except Exception:
+            logger.error("Failed to close graph connector", exc_info=True)
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
 

--- a/src/deepthought/services/knowledge_graph_service.py
+++ b/src/deepthought/services/knowledge_graph_service.py
@@ -142,6 +142,17 @@ class KnowledgeGraphService:
             logger.info("KnowledgeGraphService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
+        try:
+            backend = getattr(self._memory, "graph_backend", None)
+            connector = None
+            if hasattr(backend, "_dal"):
+                connector = getattr(getattr(backend, "_dal", None), "_connector", None)
+            elif backend is not None:
+                connector = getattr(backend, "_connector", None)
+            if connector and hasattr(connector, "close"):
+                connector.close()
+        except Exception:
+            logger.error("Failed to close graph connector", exc_info=True)
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
 

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -129,6 +129,17 @@ class MemoryService:
             logger.info("MemoryService stopped listening.")
         else:
             logger.warning("Cannot stop listening - no subscriber available.")
+        try:
+            backend = getattr(self._memory, "graph_backend", None)
+            connector = None
+            if hasattr(backend, "_dal"):
+                connector = getattr(getattr(backend, "_dal", None), "_connector", None)
+            elif backend is not None:
+                connector = getattr(backend, "_connector", None)
+            if connector and hasattr(connector, "close"):
+                connector.close()
+        except Exception:
+            logger.error("Failed to close graph connector", exc_info=True)
         if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
             await self._nc.drain()
 

--- a/tests/unit/services/test_connector_close.py
+++ b/tests/unit/services/test_connector_close.py
@@ -1,0 +1,80 @@
+import types
+
+import pytest
+
+# Import memory_service tests for dummy modules and classes
+import tests.unit.services.test_memory_service as tm
+from deepthought.config import Settings
+from deepthought.services.hierarchical_service import HierarchicalService
+from deepthought.services.knowledge_graph_service import KnowledgeGraphService
+from deepthought.services.memory_service import MemoryService
+
+
+class DummyConnector:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class DummyMemory:
+    def __init__(self, connector):
+        backend = types.SimpleNamespace(_dal=types.SimpleNamespace(_connector=connector))
+        self.graph_backend = backend
+
+    def store_interaction(self, text):
+        pass
+
+    def retrieve_context(self, prompt):
+        return []
+
+
+class DummyNATS(tm.DummyNATS):
+    async def drain(self):
+        pass
+
+
+class DummyJS(tm.DummyJS):
+    pass
+
+
+class DummySubscriber(tm.DummySubscriber):
+    pass
+
+
+class DummyPublisher(tm.DummyPublisher):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_knowledge_graph_service_stop_closes_connector():
+    connector = DummyConnector()
+    memory = DummyMemory(connector)
+    service = KnowledgeGraphService(DummyNATS(), DummyJS(), Settings(), memory)
+    service._subscriber = DummySubscriber()
+    service._publisher = DummyPublisher()
+    await service.stop()
+    assert connector.closed
+
+
+@pytest.mark.asyncio
+async def test_memory_service_stop_closes_connector():
+    connector = DummyConnector()
+    memory = DummyMemory(connector)
+    service = MemoryService(DummyNATS(), DummyJS(), Settings(), memory)
+    service._subscriber = DummySubscriber()
+    service._publisher = DummyPublisher()
+    await service.stop()
+    assert connector.closed
+
+
+@pytest.mark.asyncio
+async def test_hierarchical_service_stop_closes_connector():
+    connector = DummyConnector()
+    memory = DummyMemory(connector)
+    service = HierarchicalService(DummyNATS(), DummyJS(), Settings(), memory)
+    service._subscriber = DummySubscriber()
+    service._publisher = DummyPublisher()
+    await service.stop()
+    assert connector.closed


### PR DESCRIPTION
## Summary
- call `close()` on graph connectors when stopping KnowledgeGraphService, MemoryService and HierarchicalService
- add unit tests checking connectors are closed on stop

## Testing
- `pre-commit run --files src/deepthought/services/knowledge_graph_service.py src/deepthought/services/memory_service.py src/deepthought/services/hierarchical_service.py tests/unit/services/test_connector_close.py`

------
https://chatgpt.com/codex/tasks/task_e_68802111da00832680a5463a9ecf0491