### PR TITLE
Expose run_training API

### DIFF
--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -121,9 +121,7 @@ def init_project(
         os.chdir(dest)
         init_service(
             name,
-            template_name=(
-                "bus_service" if language == "python" else f"bus_service_{language}"
-            ),
+            template_name=("bus_service" if language == "python" else f"bus_service_{language}"),
             stream_name=stream_name,
             tls_cert=tls_cert,
             tls_key=tls_key,
@@ -154,9 +152,7 @@ def _cmd_init_service(args: argparse.Namespace) -> None:
         init_service(
             args.name,
             template_name=(
-                template
-                if getattr(args, "language", "python") == "python"
-                else f"{template}_{args.language}"
+                template if getattr(args, "language", "python") == "python" else f"{template}_{args.language}"
             ),
             stream_name=getattr(args, "stream_name", None),
             tls_cert=getattr(args, "tls_cert", None),
@@ -169,37 +165,35 @@ def _cmd_init_service(args: argparse.Namespace) -> None:
 
 def _cmd_finetune(args: argparse.Namespace) -> int:
     training = import_module("deepthought.train")
-    argv = [
-        "--dataset-path",
-        args.dataset_path,
-        "--bits",
-        str(args.bits),
-        "--output-dir",
-        args.output_dir,
-        "--model-loader",
-        args.model_loader,
-        "--dataset-loader",
-        args.dataset_loader,
-        "--max-seq-length",
-        str(args.max_seq_length),
-        "--epochs",
-        str(args.epochs),
-        "--batch-size",
-        str(args.batch_size),
-        "--lr",
-        str(args.lr),
-    ]
-    if args.model_path:
-        argv[0:0] = ["--model-path", args.model_path]
-    if args.pack_sequences != "off":
-        argv.extend(["--pack-sequences", args.pack_sequences])
-    if args.estimate_only:
-        argv.append("--estimate-only")
-    elif args.estimate_vram:
-        argv.append("--estimate-vram")
-    if args.resume:
-        argv.append("--resume")
-    return training.main(argv)
+    cfg = training.TrainingConfig(
+        model_path=args.model_path,
+        dataset_path=args.dataset_path,
+        model_loader=args.model_loader,
+        dataset_loader=args.dataset_loader,
+        bits=args.bits,
+        output_dir=args.output_dir,
+        max_seq_length=args.max_seq_length,
+        pack_sequences=args.pack_sequences,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        resume=args.resume,
+    )
+
+    if args.estimate_vram or args.estimate_only:
+        model, _ = training.load_model(cfg.model_path, cfg.bits, loader=cfg.model_loader)
+        vram = training.estimate_vram(
+            model,
+            batch_size=cfg.batch_size,
+            seq_length=cfg.max_seq_length,
+            gradient_accumulation_steps=8,
+            bits=cfg.bits,
+        )
+        print(f"Estimated VRAM requirement: {vram:.2f} GB")
+        if args.estimate_only:
+            return 0
+
+    return training.run_training(cfg)
 
 
 def _cmd_orchestrate(args: argparse.Namespace) -> int:

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+from dataclasses import dataclass
 from importlib import metadata
 from typing import Callable, Tuple
 
 import torch
-from datasets import Dataset, load_dataset as hf_load_dataset
+from datasets import Dataset
+from datasets import load_dataset as hf_load_dataset
 from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
 from transformers import (
     AutoModelForCausalLM,
@@ -26,10 +28,12 @@ __all__ = [
     "_hf_model_loader",
     "_hf_dataset_loader",
     "create_trainer",
+    "run_training",
     "run",
     "estimate_vram",
     "parse_args",
     "main",
+    "TrainingConfig",
 ]
 
 
@@ -38,6 +42,24 @@ logger = logging.getLogger(__name__)
 
 _MODEL_GROUP = "dtrt.model_loaders"
 _DATASET_GROUP = "dtrt.dataset_loaders"
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration options for :func:`run_training`."""
+
+    model_path: str | None = None
+    dataset_path: str = "databricks/databricks-dolly-15k"
+    model_loader: str = "hf"
+    dataset_loader: str = "hf"
+    bits: int = 4
+    output_dir: str = "./results/lora-adapter"
+    max_seq_length: int = 2048
+    pack_sequences: str | bool = "off"
+    epochs: float = 1.0
+    batch_size: int = 2
+    lr: float = 2e-4
+    resume: bool = False
 
 
 def _resolve_plugin(group: str, name: str) -> Callable:
@@ -239,30 +261,49 @@ def estimate_vram(
     return (param_bytes + activation_bytes) / (1024**3)
 
 
-def run(args: argparse.Namespace) -> int:
-    """Execute training using high level helper functions."""
-    model, tokenizer = load_model(args.model_path, args.bits, loader=args.model_loader)
+def run_training(config: TrainingConfig) -> int:
+    """Execute training using :class:`TrainingConfig`."""
+    model, tokenizer = load_model(config.model_path, config.bits, loader=config.model_loader)
     train_ds, eval_ds = load_dataset(
-        args.dataset_path,
+        config.dataset_path,
         tokenizer,
-        max_seq_length=args.max_seq_length,
-        pack_sequences=args.pack_sequences,
-        loader=args.dataset_loader,
+        max_seq_length=config.max_seq_length,
+        pack_sequences=config.pack_sequences,
+        loader=config.dataset_loader,
     )
     trainer, _ = create_trainer(
         model,
         tokenizer,
         train_ds,
         eval_ds,
-        args.output_dir,
-        epochs=args.epochs,
-        batch_size=args.batch_size,
-        lr=args.lr,
+        config.output_dir,
+        epochs=config.epochs,
+        batch_size=config.batch_size,
+        lr=config.lr,
     )
-    trainer.train(resume_from_checkpoint=args.resume)
+    trainer.train(resume_from_checkpoint=config.resume)
     trainer.save_model()
     trainer.save_state()
     return 0
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute training using high level helper functions."""
+    cfg = TrainingConfig(
+        model_path=args.model_path,
+        dataset_path=args.dataset_path,
+        model_loader=args.model_loader,
+        dataset_loader=args.dataset_loader,
+        bits=args.bits,
+        output_dir=args.output_dir,
+        max_seq_length=args.max_seq_length,
+        pack_sequences=args.pack_sequences,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        resume=args.resume,
+    )
+    return run_training(cfg)
 
 
 def parse_args(args: list[str] | None = None) -> argparse.Namespace:
@@ -354,7 +395,21 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Estimated VRAM requirement: {vram:.2f} GB")
         if args.estimate_only:
             return 0
-    return run(args)
+    cfg = TrainingConfig(
+        model_path=args.model_path,
+        dataset_path=args.dataset_path,
+        model_loader=args.model_loader,
+        dataset_loader=args.dataset_loader,
+        bits=args.bits,
+        output_dir=args.output_dir,
+        max_seq_length=args.max_seq_length,
+        pack_sequences=args.pack_sequences,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        lr=args.lr,
+        resume=args.resume,
+    )
+    return run_training(cfg)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_finetune_cli.py
+++ b/tests/integration/test_finetune_cli.py
@@ -15,7 +15,7 @@ def test_finetune_estimate_only(tmp_path: Path, monkeypatch) -> None:
     cfg = GPT2Config(n_embd=4, n_layer=1, n_head=1, vocab_size=10)
     dummy_model = AutoModelForCausalLM.from_config(cfg)
     monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", lambda *a, **k: dummy_model)
-    monkeypatch.setattr(train, "run", lambda args: 0)
+    monkeypatch.setattr(train, "run_training", lambda cfg: 0)
 
     dataset = Path(__file__).resolve().parents[1] / "data" / "finetune_sample.jsonl"
     out_dir = tmp_path / "model"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -202,7 +202,7 @@ def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:
     cfg = GPT2Config(n_embd=4, n_layer=1, n_head=1, vocab_size=10)
     dummy_model = AutoModelForCausalLM.from_config(cfg)
     monkeypatch.setattr(AutoModelForCausalLM, "from_pretrained", lambda *a, **k: dummy_model)
-    monkeypatch.setattr(train, "run", lambda args: 0)
+    monkeypatch.setattr(train, "run_training", lambda cfg: 0)
 
     result = _run_dtrt(
         tmp_path,

--- a/tests/unit/test_train_main.py
+++ b/tests/unit/test_train_main.py
@@ -7,9 +7,9 @@ pytest.importorskip("torch")
 train = importlib.import_module("deepthought.train")
 
 
-def test_main_delegates_to_run(monkeypatch):
+def test_main_delegates_to_run_training(monkeypatch):
     dummy_run = mock.Mock(return_value=42)
-    monkeypatch.setattr(train, "run", dummy_run)
+    monkeypatch.setattr(train, "run_training", dummy_run)
     result = train.main(["--model-path", "mp", "--dataset-path", "ds"])
     dummy_run.assert_called_once()
     assert result == 42


### PR DESCRIPTION
## Summary
- add `TrainingConfig` dataclass and `run_training` function
- refactor existing CLI and `run` to use the new API
- update tests to patch `run_training`

## Testing
- `pre-commit run --files src/deepthought/train/__init__.py src/deepthought/cli/__init__.py tests/unit/test_train_main.py tests/integration/test_finetune_cli.py tests/unit/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68802ce7a4d88326bf9855f498aba8d7