### PR TITLE
Add BaseService for NATS subscriptions

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,10 +1,11 @@
 nats-py==2.6.0
 networkx==3.1
+numpy
 aiosqlite==0.19.0
 pytest==7.4.2
 pytest-cov==4.1.0
 pytest-xdist==3.7.0
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.6
 flake8==6.1.0
 pydantic-settings==2.2.1
 pydantic>=2.7

--- a/src/deepthought/services/base.py
+++ b/src/deepthought/services/base.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Awaitable, Callable, List, Tuple
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+MessageHandler = Callable[[Msg], Awaitable[None]]
+
+
+class BaseService:
+    """Base class providing subscription registration and lifecycle helpers.
+
+    Subclasses call :meth:`add_subscription` to register NATS subjects and then
+    use :meth:`start` and :meth:`stop` to manage them.
+    """
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._nc = nats_client
+        self._subscriptions: List[Tuple[str, MessageHandler, str, str, bool]] = []
+
+    def add_subscription(
+        self,
+        subject: str,
+        handler: MessageHandler,
+        *,
+        durable: str = "",
+        queue: str = "",
+        use_jetstream: bool = False,
+    ) -> None:
+        """Register a subscription to be created on :meth:`start`."""
+        self._subscriptions.append((subject, handler, durable, queue, use_jetstream))
+
+    async def start(self) -> bool:
+        """Create all registered subscriptions."""
+        if self._subscriber is None:
+            logger.error("Subscriber not initialized for %s.", self.__class__.__name__)
+            return False
+        success = True
+        for subject, handler, durable, queue, use_js in self._subscriptions:
+            res = await self._subscriber.subscribe(
+                subject=subject,
+                handler=handler,
+                durable=durable,
+                queue=queue,
+                use_jetstream=use_js,
+            )
+            success = success and res
+        return success
+
+    async def stop(self) -> None:
+        """Unsubscribe from all subjects and drain the NATS connection."""
+        if self._subscriber:
+            await self._subscriber.unsubscribe_all()
+        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
+            await self._nc.drain()
+
+    async def __aenter__(self) -> "BaseService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/src/deepthought/services/code_generation_service.py
+++ b/src/deepthought/services/code_generation_service.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from string import Template
 from typing import Any, Dict
 
-import nats
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
@@ -16,18 +15,16 @@ from ..eda.events import (
     CodeGeneratedPayload,
     EventSubjects,
 )
-from ..eda.publisher import Publisher
-from ..eda.subscriber import Subscriber
+from .base import BaseService
 
 logger = logging.getLogger(__name__)
 
 
-class CodeGenerationService:
+class CodeGenerationService(BaseService):
     """Simple template-based code generation service."""
 
     def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
-        self._publisher = Publisher(nats_client, js_context)
-        self._subscriber = Subscriber(nats_client, js_context)
+        super().__init__(nats_client, js_context)
 
     _bin_ops = {
         ast.Add: operator.add,
@@ -155,31 +152,20 @@ class CodeGenerationService:
                     logger.error("Failed to ack message after error", exc_info=True)
 
     async def start(self, durable_name: str = "codegen_listener") -> bool:
-        if self._subscriber is None:
-            logger.error("Subscriber not initialized for CodeGenerationService.")
-            return False
-        try:
-            await self._subscriber.subscribe(
-                subject=EventSubjects.CODE_TEMPLATE_REQUEST,
-                handler=self._handle_template_request,
-                use_jetstream=True,
-                durable=durable_name,
-            )
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.CODE_TEMPLATE_REQUEST,
+            handler=self._handle_template_request,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        started = await super().start()
+        if started:
             logger.info("CodeGenerationService subscribed to %s", EventSubjects.CODE_TEMPLATE_REQUEST)
-            return True
-        except nats.errors.Error as e:
-            logger.error("CodeGenerationService failed to subscribe: %s", e, exc_info=True)
-            return False
-        except Exception as e:
-            logger.error("CodeGenerationService failed to subscribe: %s", e, exc_info=True)
-            return False
+        return started
 
     async def stop(self) -> None:
-        if self._subscriber:
-            await self._subscriber.unsubscribe_all()
-            logger.info("CodeGenerationService stopped listening.")
-        else:
-            logger.warning("Cannot stop listening - no subscriber available.")
+        await super().stop()
 
     async def __aenter__(self) -> "CodeGenerationService":
         await self.start()

--- a/src/deepthought/services/knowledge_graph_service.py
+++ b/src/deepthought/services/knowledge_graph_service.py
@@ -10,16 +10,15 @@ from nats.js.client import JetStreamContext
 
 from ..config import Settings, get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
-from ..eda.publisher import Publisher
-from ..eda.subscriber import Subscriber
 from ..graph import GraphConnector, GraphDAL, GraphDALBackend, Neo4jConnector
 from ..memory.tiered import TieredMemory
 from ..memory.vector_store import create_vector_store
+from .base import BaseService
 
 logger = logging.getLogger(__name__)
 
 
-class KnowledgeGraphService:
+class KnowledgeGraphService(BaseService):
     """Service persisting interactions in a graph database via GraphDAL."""
 
     def __init__(
@@ -29,9 +28,7 @@ class KnowledgeGraphService:
         settings: Settings | None = None,
         memory: Optional[TieredMemory] = None,
     ) -> None:
-        self._publisher = Publisher(nats_client, js_context)
-        self._subscriber = Subscriber(nats_client, js_context)
-        self._nc = nats_client
+        super().__init__(nats_client, js_context)
         self._settings = settings or get_settings()
         if memory is None:
             store = create_vector_store(
@@ -120,28 +117,19 @@ class KnowledgeGraphService:
             logger.info("KnowledgeGraphService processed input in %.3fs", duration)
 
     async def start(self, durable_name: str = "knowledge_graph_listener") -> bool:
-        if self._subscriber is None:
-            logger.error("Subscriber not initialized for KnowledgeGraphService.")
-            return False
-        try:
-            await self._subscriber.subscribe(
-                subject=EventSubjects.INPUT_RECEIVED,
-                handler=self._handle_input,
-                use_jetstream=True,
-                durable=durable_name,
-            )
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.INPUT_RECEIVED,
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        started = await super().start()
+        if started:
             logger.info("KnowledgeGraphService subscribed to %s", EventSubjects.INPUT_RECEIVED)
-            return True
-        except Exception as e:  # pragma: no cover - network failure
-            logger.error("KnowledgeGraphService failed to subscribe: %s", e, exc_info=True)
-            return False
+        return started
 
     async def stop(self) -> None:
-        if self._subscriber:
-            await self._subscriber.unsubscribe_all()
-            logger.info("KnowledgeGraphService stopped listening.")
-        else:
-            logger.warning("Cannot stop listening - no subscriber available.")
         try:
             backend = getattr(self._memory, "graph_backend", None)
             connector = None
@@ -153,8 +141,7 @@ class KnowledgeGraphService:
                 connector.close()
         except Exception:
             logger.error("Failed to close graph connector", exc_info=True)
-        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
-            await self._nc.drain()
+        await super().stop()
 
     async def __aenter__(self) -> "KnowledgeGraphService":
         await self.start()

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -4,15 +4,12 @@ import time
 from datetime import datetime, timezone
 from typing import Optional
 
-import nats
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from ..config import Settings, get_settings
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
-from ..eda.publisher import Publisher
-from ..eda.subscriber import Subscriber
 from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
@@ -20,7 +17,10 @@ from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 logger = logging.getLogger(__name__)
 
 
-class MemoryService:
+from .base import BaseService
+
+
+class MemoryService(BaseService):
     """Service that stores and retrieves interactions using :class:`TieredMemory`."""
 
     def __init__(
@@ -30,9 +30,7 @@ class MemoryService:
         settings: Settings,
         memory: Optional[TieredMemory] = None,
     ) -> None:
-        self._publisher = Publisher(nats_client, js_context)
-        self._subscriber = Subscriber(nats_client, js_context)
-        self._nc = nats_client
+        super().__init__(nats_client, js_context)
         if memory is None:
             memory = create_memory_backend(settings=settings)
         self._memory = memory
@@ -104,31 +102,19 @@ class MemoryService:
             INPUT_LATENCY_SECONDS.labels(service="memory_service").observe(duration)
 
     async def start(self, durable_name: str = "memory_service_listener") -> bool:
-        if self._subscriber is None:
-            logger.error("Subscriber not initialized for MemoryService.")
-            return False
-        try:
-            await self._subscriber.subscribe(
-                subject=EventSubjects.INPUT_RECEIVED,
-                handler=self._handle_input,
-                use_jetstream=True,
-                durable=durable_name,
-            )
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.INPUT_RECEIVED,
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        started = await super().start()
+        if started:
             logger.info("MemoryService subscribed to %s", EventSubjects.INPUT_RECEIVED)
-            return True
-        except nats.errors.Error as e:
-            logger.error("MemoryService failed to subscribe: %s", e, exc_info=True)
-            return False
-        except Exception as e:
-            logger.error("MemoryService failed to subscribe: %s", e, exc_info=True)
-            return False
+        return started
 
     async def stop(self) -> None:
-        if self._subscriber:
-            await self._subscriber.unsubscribe_all()
-            logger.info("MemoryService stopped listening.")
-        else:
-            logger.warning("Cannot stop listening - no subscriber available.")
         try:
             backend = getattr(self._memory, "graph_backend", None)
             connector = None
@@ -140,8 +126,7 @@ class MemoryService:
                 connector.close()
         except Exception:
             logger.error("Failed to close graph connector", exc_info=True)
-        if getattr(self, "_nc", None) and getattr(self._nc, "is_connected", False):
-            await self._nc.drain()
+        await super().stop()
 
     async def __aenter__(self) -> "MemoryService":
         await self.start()

--- a/src/deepthought/services/reward_manager_service.py
+++ b/src/deepthought/services/reward_manager_service.py
@@ -5,26 +5,25 @@ import os
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
-from ..eda.publisher import Publisher
-from ..eda.subscriber import Subscriber
 from ..motivate import Ledger, RewardManager
+from .base import BaseService
 
 
-class RewardManagerService:
+class RewardManagerService(BaseService):
     """Service wrapper for :class:`RewardManager`."""
 
     def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
-        subscriber = Subscriber(nats_client, js_context)
+        super().__init__(nats_client, js_context)
         ledger = Ledger(nats_client, js_context)
-        publisher = Publisher(nats_client, js_context)
         token = os.getenv("DISCORD_TOKEN", "")
-        self._manager = RewardManager(subscriber, ledger, publisher, token)
+        self._manager = RewardManager(self._subscriber, ledger, self._publisher, token)
 
     async def start(self, durable_name: str = "reward_manager_service") -> bool:
         return await self._manager.start_listening(durable_name=durable_name)
 
     async def stop(self) -> None:
         await self._manager.stop_listening()
+        await super().stop()
 
     async def __aenter__(self) -> "RewardManagerService":
         await self.start()


### PR DESCRIPTION
## Summary
- introduce `BaseService` with reusable start/stop helpers
- refactor MemoryService, KnowledgeGraphService, CodeGenerationService and RewardManagerService to inherit from BaseService
- update CI requirements for compatibility

## Testing
- `pre-commit run --files src/deepthought/services/base.py src/deepthought/services/memory_service.py src/deepthought/services/knowledge_graph_service.py src/deepthought/services/code_generation_service.py src/deepthought/services/reward_manager_service.py`
- `pre-commit run --files requirements-ci.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68802ce6d5308326b0055070294cd015