### PR TITLE
Add hierarchical memory fallback tests

### DIFF
--- a/tests/unit/test_hierarchical_memory.py
+++ b/tests/unit/test_hierarchical_memory.py
@@ -39,3 +39,25 @@ def test_retrieve_context_failures():
     mem = HierarchicalMemory(FailingVector(), FailingDAL())
     ctx = mem.retrieve_context("x")
     assert ctx == []
+
+
+def test_retrieve_context_deduplicates_vector_and_graph():
+    vector = DummyVector(["d", "dup", "v"])
+    dal = DummyDAL([{"fact": "dup"}, {"fact": "g"}])
+    mem = HierarchicalMemory(vector, dal, top_k=3)
+    ctx = mem.retrieve_context("mix")
+    assert ctx == ["d", "dup", "v", "g"]
+
+
+def test_retrieve_context_graph_when_vector_fails():
+    dal = DummyDAL([{"fact": "g1"}, {"fact": "g2"}])
+    mem = HierarchicalMemory(FailingVector(), dal, top_k=2)
+    ctx = mem.retrieve_context("prompt")
+    assert ctx == ["g1", "g2"]
+
+
+def test_retrieve_context_vector_when_graph_fails():
+    vector = DummyVector(["v1", "v2"])
+    mem = HierarchicalMemory(vector, FailingDAL(), top_k=2)
+    ctx = mem.retrieve_context("prompt")
+    assert ctx == ["v1", "v2"]


### PR DESCRIPTION
## Summary
- test mixing graph and vector results in hierarchical memory
- ensure fallback returns results when one backend fails

## Testing
- `pre-commit run --files tests/unit/test_hierarchical_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68804a5993c08326a3137eacc489078e