### PR TITLE
Add CRUD graph memory demo

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -107,6 +107,24 @@ export DT_GRAPH_BACKEND=noop
 python examples/graph_memory_demo.py
 ```
 
+### CRUD Demo with Sample Data
+
+`graph_memory_demo.py` also demonstrates basic create, read, update and delete
+operations. It loads a tiny dataset of interactions from
+`examples/data/sample_graph_data.txt`:
+
+```text
+Alice met Bob
+Bob chatted with Carol
+Carol saw Dave
+```
+
+Running the script with either backend will insert these facts, update a sample
+node and then delete it before performing a context retrieval query.
+
+Install the testing dependencies with `pip install -r requirements-ci.txt`
+before running the demo or executing the test suite.
+
 ### Orchestrator Configuration
 
 Start the `knowledge_graph` service via the orchestrator by writing an

--- a/examples/data/sample_graph_data.txt
+++ b/examples/data/sample_graph_data.txt
@@ -1,0 +1,3 @@
+Alice met Bob
+Bob chatted with Carol
+Carol saw Dave

--- a/examples/graph_memory_demo.py
+++ b/examples/graph_memory_demo.py
@@ -7,6 +7,7 @@ import os
 import time
 
 from deepthought.graph import GraphConnector, GraphDAL, Neo4jConnector
+import uuid
 from deepthought.memory.hierarchical import HierarchicalMemory
 from deepthought.memory.vector_store import create_vector_store
 
@@ -37,11 +38,9 @@ def main() -> None:
     dal = _create_dal(backend_name)
     memory = HierarchicalMemory(store, dal)
 
-    facts = [
-        "Alice met Bob",
-        "Bob chatted with Carol",
-        "Carol saw Dave",
-    ]
+    data_path = os.path.join(os.path.dirname(__file__), "data", "sample_graph_data.txt")
+    with open(data_path, "r", encoding="utf-8") as f:
+        facts = [line.strip() for line in f if line.strip()]
 
     store.add_texts(facts)
     for fact in facts:
@@ -52,6 +51,26 @@ def main() -> None:
             dal.merge_next_edge(src, dst)
         except Exception:  # pragma: no cover - demo only
             logger.error("Failed to store %s", fact, exc_info=True)
+
+    # Basic CRUD example using GraphDAL helper methods
+    alice_id = str(uuid.uuid4())
+    dal.add_entity("Person", {"id": alice_id, "name": "Alice"})
+    row = dal.get_entity("Person", "id", alice_id)
+    logger.info("Created entity: %s", row)
+
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) SET n.name = 'Alice Cooper'",
+        {"id": alice_id},
+    )
+    row = dal.get_entity("Person", "id", alice_id)
+    logger.info("Updated entity: %s", row)
+
+    dal.query_subgraph(
+        "MATCH (n:Person {id: $id}) DETACH DELETE n",
+        {"id": alice_id},
+    )
+    row = dal.get_entity("Person", "id", alice_id)
+    logger.info("Deleted entity lookup returned: %s", row)
 
     start = time.perf_counter()
     ctx = memory.retrieve_context("Alice")


### PR DESCRIPTION
## Summary
- expand `graph_memory_demo` to load sample graph data from file
- document the sample graph data in `graphdal.md`
- add `examples/data/sample_graph_data.txt`
- add note about installing test dependencies

## Testing
- `flake8 src tests examples`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68804a54c2908326a138cb8b44e0ffd1