### PR TITLE
Add NATS connection retries with failure handling

### DIFF
--- a/src/deepthought/services/base.py
+++ b/src/deepthought/services/base.py
@@ -1,5 +1,6 @@
+import asyncio
 import logging
-from typing import Awaitable, Callable, List, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
@@ -20,10 +21,27 @@ class BaseService:
     use :meth:`start` and :meth:`stop` to manage them.
     """
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
-        self._publisher = Publisher(nats_client, js_context)
-        self._subscriber = Subscriber(nats_client, js_context)
-        self._nc = nats_client
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        self._nats_url = nats_url
+        self._connect_retries = max(connect_retries, 1)
+        self._connect_timeout = connect_timeout
+        self._nc = nats_client or NATS()
+        self._js = js_context
+        self._publisher: Optional[Publisher] = None
+        self._subscriber: Optional[Subscriber] = None
+        if self._nc and getattr(self._nc, "is_connected", False) and self._js is None:
+            self._js = self._nc.jetstream()
+        if self._nc and getattr(self._nc, "is_connected", False) and self._js:
+            self._publisher = Publisher(self._nc, self._js)
+            self._subscriber = Subscriber(self._nc, self._js)
         self._subscriptions: List[Tuple[str, MessageHandler, str, str, bool]] = []
 
     def add_subscription(
@@ -38,10 +56,32 @@ class BaseService:
         """Register a subscription to be created on :meth:`start`."""
         self._subscriptions.append((subject, handler, durable, queue, use_jetstream))
 
+    async def _ensure_connected(self) -> bool:
+        if getattr(self._nc, "is_connected", False):
+            return True
+        if not hasattr(self._nc, "connect") or not self._nats_url:
+            logger.error("NATS connection unavailable for %s", self.__class__.__name__)
+            return False
+        for attempt in range(1, self._connect_retries + 1):
+            try:
+                await self._nc.connect(servers=[self._nats_url], connect_timeout=self._connect_timeout)
+                self._js = self._nc.jetstream()
+                self._publisher = Publisher(self._nc, self._js)
+                self._subscriber = Subscriber(self._nc, self._js)
+                return True
+            except Exception as exc:
+                if attempt >= self._connect_retries:
+                    logger.error(
+                        "Failed to connect to NATS after %d attempts: %s", self._connect_retries, exc
+                    )
+                    return False
+                logger.warning("NATS connect attempt %d failed: %s", attempt, exc)
+                await asyncio.sleep(0.5)
+        return False
+
     async def start(self) -> bool:
         """Create all registered subscriptions."""
-        if self._subscriber is None:
-            logger.error("Subscriber not initialized for %s.", self.__class__.__name__)
+        if not await self._ensure_connected():
             return False
         success = True
         for subject, handler, durable, queue, use_js in self._subscriptions:

--- a/src/deepthought/services/code_generation_service.py
+++ b/src/deepthought/services/code_generation_service.py
@@ -5,7 +5,7 @@ import logging
 import operator
 from datetime import datetime, timezone
 from string import Template
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
@@ -23,8 +23,22 @@ logger = logging.getLogger(__name__)
 class CodeGenerationService(BaseService):
     """Simple template-based code generation service."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
-        super().__init__(nats_client, js_context)
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
 
     _bin_ops = {
         ast.Add: operator.add,

--- a/src/deepthought/services/knowledge_graph_service.py
+++ b/src/deepthought/services/knowledge_graph_service.py
@@ -23,12 +23,22 @@ class KnowledgeGraphService(BaseService):
 
     def __init__(
         self,
-        nats_client: NATS,
-        js_context: JetStreamContext,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
         settings: Settings | None = None,
         memory: Optional[TieredMemory] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
     ) -> None:
-        super().__init__(nats_client, js_context)
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
         self._settings = settings or get_settings()
         if memory is None:
             store = create_vector_store(

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -25,22 +25,48 @@ class MemoryService(BaseService):
 
     def __init__(
         self,
-        nats_client: NATS,
-        js_context: JetStreamContext,
-        settings: Settings,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        settings: Settings | None = None,
         memory: Optional[TieredMemory] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
     ) -> None:
-        super().__init__(nats_client, js_context)
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        settings = settings or get_settings()
         if memory is None:
             memory = create_memory_backend(settings=settings)
         self._memory = memory
 
     @classmethod
-    def from_config(cls, nats_client: NATS, js_context: JetStreamContext) -> "MemoryService":
+    def from_config(
+        cls,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> "MemoryService":
         """Return a service with backends configured from environment variables."""
 
         settings = get_settings()
-        return cls(nats_client, js_context, settings)
+        return cls(
+            nats_client,
+            js_context,
+            settings,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"

--- a/src/deepthought/services/reward_manager_service.py
+++ b/src/deepthought/services/reward_manager_service.py
@@ -12,8 +12,14 @@ from .base import BaseService
 class RewardManagerService(BaseService):
     """Service wrapper for :class:`RewardManager`."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
-        super().__init__(nats_client, js_context)
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        *,
+        connect_retries: int = 1,
+    ) -> None:
+        super().__init__(nats_client, js_context, connect_retries=connect_retries)
         ledger = Ledger(nats_client, js_context)
         token = os.getenv("DISCORD_TOKEN", "")
         self._manager = RewardManager(self._subscriber, ledger, self._publisher, token)

--- a/tests/integration/test_service_connection_retry.py
+++ b/tests/integration/test_service_connection_retry.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("nats")
+
+from deepthought.services.code_generation_service import CodeGenerationService
+
+
+@pytest.mark.asyncio
+async def test_service_start_fails_without_nats(monkeypatch, unused_tcp_port):
+    url = f"nats://localhost:{unused_tcp_port}"
+    service = CodeGenerationService(
+        nats_url=url, connect_retries=1, connect_timeout=1
+    )
+
+    async def fail_connect(*args, **kwargs):
+        raise OSError("fail")
+
+    monkeypatch.setattr(service._nc, "connect", fail_connect)
+
+    started = await service.start()
+    assert started is False
+    await service.stop()


### PR DESCRIPTION
## Summary
- support configurable connect retries & timeout in `BaseService`
- extend service constructors for retry options
- implement quick failure path in `BaseService.start`
- add integration test for failure when connection can't be made

## Testing
- `flake8 src tests`
- `pytest tests/integration/test_service_connection_retry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e2617d74832691efa95a44d0ccf6