### PR TITLE
Add ontology reasoning with HermiT

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -179,3 +179,15 @@ print(context)
 
 `retrieve_context()` returns a list of strings merging the top matches from the
 vector store with recent facts from the graph.
+
+## Ontology Reasoning
+
+`OntologyManager` uses **rdflib** and **owlready2** to manage an OWL graph and run
+the HermiT reasoner. Install the optional dependencies with:
+
+```bash
+pip install rdflib owlready2
+```
+
+Java must be available so HermiT can execute. After adding triples you can call
+`infer_facts()` to obtain inferred class memberships.

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -5,17 +5,19 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timezone
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import nats
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
+from rdflib.namespace import RDF
 
 from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..graph import GraphDAL
+from ..ontology import OntologyManager
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +25,17 @@ logger = logging.getLogger(__name__)
 class KnowledgeGraphMemory:
     """Parse user input into a graph stored in Memgraph."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext, dal: GraphDAL) -> None:
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        dal: GraphDAL,
+        ontology: Optional[OntologyManager] = None,
+    ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._dal = dal
+        self._ontology = ontology
 
     def _parse_input(self, text: str) -> Tuple[List[str], List[Tuple[str, str]]]:
         words = [w for w in text.strip().split() if w]
@@ -39,6 +48,26 @@ class KnowledgeGraphMemory:
             self._dal.merge_entity(name)
         for src, dst in edges:
             self._dal.merge_next_edge(src, dst)
+        if self._ontology is not None:
+            from rdflib import Namespace
+            from rdflib.namespace import OWL
+
+            ex = Namespace("http://deepthought.local/graph#")
+            for name in nodes:
+                self._ontology.add_triples(
+                    [
+                        (ex[name], RDF.type, OWL.NamedIndividual),
+                        (ex[name], RDF.type, ex.Entity),
+                    ]
+                )
+            for src, dst in edges:
+                self._ontology.add_triple(ex[src], ex.next, ex[dst])
+
+    def infer_facts(self) -> List[Tuple[str, str, str]]:
+        """Return inferred triples from the ontology."""
+        if self._ontology is None:
+            return []
+        return self._ontology.infer_facts()
 
     async def _handle_input_event(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -55,8 +84,9 @@ class KnowledgeGraphMemory:
             nodes, edges = self._parse_input(user_input)
             self._store(nodes, edges)
 
+            facts = self.infer_facts()
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"facts": [], "source": "knowledge_graph"},
+                retrieved_knowledge={"facts": facts, "source": "knowledge_graph"},
                 input_id=input_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
@@ -67,7 +97,10 @@ class KnowledgeGraphMemory:
                 timeout=10.0,
             )
             await msg.ack()
-        except (json.JSONDecodeError, ValueError) as e:  # pragma: no cover - validation errors
+        except (
+            json.JSONDecodeError,
+            ValueError,
+        ) as e:  # pragma: no cover - validation errors
             logger.error("Invalid InputReceived payload: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
@@ -93,7 +126,9 @@ class KnowledgeGraphMemory:
                 except nats.errors.Error:
                     logger.error("Failed to ack message after error", exc_info=True)
 
-    async def start_listening(self, durable_name: str = "knowledge_graph_listener") -> bool:
+    async def start_listening(
+        self, durable_name: str = "knowledge_graph_listener"
+    ) -> bool:
         if not self._subscriber:
             logger.error("Subscriber not initialized for KnowledgeGraphMemory.")
             return False
@@ -104,13 +139,19 @@ class KnowledgeGraphMemory:
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info("KnowledgeGraphMemory subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            logger.info(
+                "KnowledgeGraphMemory subscribed to %s", EventSubjects.INPUT_RECEIVED
+            )
             return True
         except nats.errors.Error as e:  # pragma: no cover - network failure
-            logger.error("KnowledgeGraphMemory failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "KnowledgeGraphMemory failed to subscribe: %s", e, exc_info=True
+            )
             return False
         except Exception as e:  # pragma: no cover - network failure
-            logger.error("KnowledgeGraphMemory failed to subscribe: %s", e, exc_info=True)
+            logger.error(
+                "KnowledgeGraphMemory failed to subscribe: %s", e, exc_info=True
+            )
             return False
 
     async def stop_listening(self) -> None:

--- a/src/deepthought/ontology/__init__.py
+++ b/src/deepthought/ontology/__init__.py
@@ -1,0 +1,5 @@
+"""Ontology utilities."""
+
+from .ontology import OntologyManager
+
+__all__ = ["OntologyManager"]

--- a/src/deepthought/ontology/ontology.py
+++ b/src/deepthought/ontology/ontology.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Iterable, Tuple
+
+from owlready2 import ThingClass, World, sync_reasoner_hermit
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF
+
+Triple = Tuple[str, str, str]
+
+
+class OntologyManager:
+    """Manage an OWL/RDF ontology and run reasoning using HermiT."""
+
+    def __init__(self) -> None:
+        self.graph = Graph()
+
+    def add_triple(
+        self, subject: str | URIRef, predicate: str | URIRef, obj: str | URIRef
+    ) -> None:
+        """Add a triple to the underlying graph."""
+        self.graph.add((URIRef(str(subject)), URIRef(str(predicate)), URIRef(str(obj))))
+
+    def add_triples(self, triples: Iterable[Triple]) -> None:
+        for s, p, o in triples:
+            self.add_triple(s, p, o)
+
+    def infer_facts(self) -> list[Triple]:
+        """Run the HermiT reasoner and return inferred triples."""
+        data = self.graph.serialize(format="xml").encode("utf-8")
+        world = World()
+        onto = world.get_ontology("http://deepthought.local/onto.owl").load(
+            fileobj=BytesIO(data)
+        )
+        sync_reasoner_hermit(world)
+        facts: list[Triple] = []
+        for ind in onto.individuals():
+            for cls in ind.INDIRECT_is_a:
+                if isinstance(cls, ThingClass):
+                    facts.append((ind.iri, str(RDF.type), cls.iri))
+        return facts

--- a/tests/unit/ontology/test_hermit_reasoner.py
+++ b/tests/unit/ontology/test_hermit_reasoner.py
@@ -1,0 +1,20 @@
+import rdflib
+from rdflib.namespace import OWL, RDF, RDFS
+
+from deepthought.ontology import OntologyManager
+
+
+def test_class_hierarchy_inference():
+    ex = rdflib.Namespace("http://example.com/")
+    onto = OntologyManager()
+    onto.add_triples(
+        [
+            (ex.Person, RDF.type, OWL.Class),
+            (ex.Student, RDF.type, OWL.Class),
+            (ex.Student, RDFS.subClassOf, ex.Person),
+            (ex.joe, RDF.type, ex.Student),
+            (ex.joe, RDF.type, OWL.NamedIndividual),
+        ]
+    )
+    facts = onto.infer_facts()
+    assert (str(ex.joe), str(RDF.type), str(ex.Person)) in facts


### PR DESCRIPTION
## Summary
- implement OntologyManager using rdflib and owlready2
- integrate optional ontology reasoning into KnowledgeGraphMemory
- document ontology reasoning setup
- test class hierarchy inference

## Testing
- `flake8`
- `pytest tests/unit/ontology/test_hermit_reasoner.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f0dd1fe08326a1676cc3e188219a