### PR TITLE
Add simplified PSL risk scoring

### DIFF
--- a/docs/psl_integration.md
+++ b/docs/psl_integration.md
@@ -1,0 +1,18 @@
+# PSL Integration
+
+The project includes a small wrapper around a simplified Probabilistic Soft Logic (PSL) model.  
+A PSL model defines a set of predicates with associated weights. Inference computes a weighted sum
+for given evidence and compares it against a threshold.
+
+Configuration files use YAML and must contain a `model` section with `weights` as well as an
+optional `threshold` value:
+
+```yaml
+model:
+  weights:
+    lines_added: 0.1
+    lines_deleted: 0.2
+threshold: 1.0
+```
+
+Use :class:`deepthought.psl.risk.RiskScorer` to load the configuration and evaluate commits.

--- a/src/deepthought/psl/__init__.py
+++ b/src/deepthought/psl/__init__.py
@@ -1,0 +1,6 @@
+"""PSL utilities for DeepThought."""
+
+from .model import PSLModel
+from .risk import RiskScorer
+
+__all__ = ["PSLModel", "RiskScorer"]

--- a/src/deepthought/psl/model.py
+++ b/src/deepthought/psl/model.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Simplified PSL model wrapper."""
+
+from typing import Mapping
+
+
+class PSLModel:
+    """Lightweight container for predicate weights."""
+
+    def __init__(self, weights: Mapping[str, float]) -> None:
+        self._weights = dict(weights)
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Mapping[str, float]]) -> "PSLModel":
+        """Create a model from a configuration mapping."""
+        weights = config.get("weights", {})
+        return cls(weights)
+
+    def infer(self, evidence: Mapping[str, float]) -> float:
+        """Return the weighted sum score for ``evidence``."""
+        return sum(
+            self._weights.get(k, 0.0) * evidence.get(k, 0.0) for k in self._weights
+        )

--- a/src/deepthought/psl/risk.py
+++ b/src/deepthought/psl/risk.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Commit risk scoring utilities."""
+
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+
+from .model import PSLModel
+
+
+class RiskScorer:
+    """Score code changes using a simple PSL model."""
+
+    def __init__(self, model: PSLModel, threshold: float = 0.5) -> None:
+        self._model = model
+        self._threshold = threshold
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "RiskScorer":
+        """Load model configuration from ``path``."""
+        data = yaml.safe_load(Path(path).read_text())
+        model = PSLModel.from_config(data.get("model", {}))
+        threshold = float(data.get("threshold", 0.5))
+        return cls(model, threshold)
+
+    def score(self, evidence: Mapping[str, float]) -> float:
+        """Return a risk score based on ``evidence``."""
+        return self._model.infer(evidence)
+
+    def is_high_risk(self, evidence: Mapping[str, float]) -> bool:
+        """Return ``True`` if the score meets or exceeds the threshold."""
+        return self.score(evidence) >= self._threshold

--- a/tests/integration/test_psl_risk.py
+++ b/tests/integration/test_psl_risk.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from deepthought.psl import RiskScorer
+
+
+def test_risk_scorer(tmp_path: Path) -> None:
+    cfg = {
+        "model": {"weights": {"lines_added": 0.1, "lines_deleted": 0.2}},
+        "threshold": 1.0,
+    }
+    cfg_path = tmp_path / "model.yml"
+    cfg_path.write_text(yaml.safe_dump(cfg))
+
+    scorer = RiskScorer.from_file(cfg_path)
+
+    low = {"lines_added": 5, "lines_deleted": 2}
+    assert scorer.score(low) == pytest.approx(0.9)
+    assert not scorer.is_high_risk(low)
+
+    high = {"lines_added": 8, "lines_deleted": 3}
+    assert scorer.is_high_risk(high)


### PR DESCRIPTION
## Summary
- add a small `deepthought.psl` package
- implement `RiskScorer` for evaluating commit risk
- document PSL configuration
- provide integration test for risk scoring

## Testing
- `flake8 src/deepthought/psl tests/integration/test_psl_risk.py`
- `pytest tests/integration/test_psl_risk.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f0ddd7788326aa89ca0837fd2a48