### PR TITLE
Add CrewAI crew orchestration

### DIFF
--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -47,16 +47,18 @@ The orchestrator starts multiple services with a single NATS connection. Each se
 
 3. **Write a configuration file**
 
-   Create `orchestrator.yaml` listing the services to launch:
+   Create `orchestrator.yaml` listing the services to launch.
+   Temporary crews or LangGraph graphs can be added using callables
+   referenced as `module:function` strings:
 
    ```yaml
    services:
      - memory
      - knowledge_graph
-     - llm_remote
-     - codegen
-     - output_handler
-     - reward_manager
+   crews:
+     - examples.crew_demo:create_demo_crew
+   graphs:
+     - examples.multi_agent_demo:run_graph
    ```
 
    `llm_remote` requires the `LLM_ENDPOINT` variable pointing to a running

--- a/examples/crew_demo.py
+++ b/examples/crew_demo.py
@@ -1,0 +1,51 @@
+"""Demo showing how to launch a temporary CrewAI crew via the orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+from deepthought import orchestrator
+from deepthought.crew import FunctionLLM, TemporaryCrew
+
+
+def create_demo_crew() -> TemporaryCrew:
+    """Return a crew that echoes the provided topic."""
+
+    def echo(prompt: str) -> str:
+        return f"echo: {prompt}"
+
+    agents = [
+        {
+            "role": "Echoer",
+            "goal": "Repeat the input",
+            "backstory": "Simple demo agent",
+            "llm": FunctionLLM(echo),
+        }
+    ]
+    tasks = [
+        {
+            "description": "Respond to {topic}",
+            "agent_index": 0,
+        }
+    ]
+    return TemporaryCrew(agents, tasks, inputs={"topic": "hello"})
+
+
+async def main() -> None:
+    cfg = Path(tempfile.gettempdir()) / "crew_orch.yaml"
+    cfg.write_text(
+        "crews:\n  - examples.crew_demo:create_demo_crew\n", encoding="utf-8"
+    )
+    task = asyncio.create_task(orchestrator.run(str(cfg)))
+    await asyncio.sleep(1.0)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/deepthought/crew/__init__.py
+++ b/src/deepthought/crew/__init__.py
@@ -1,0 +1,55 @@
+"""Lightweight wrapper for creating temporary CrewAI crews."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Iterable
+
+from crewai import Agent, Crew, Task
+from langchain.llms.base import LLM
+
+
+class FunctionLLM(LLM):
+    """Simple LLM that returns the result of a Python callable."""
+
+    def __init__(self, fn):
+        super().__init__()
+        self._fn = fn
+
+    @property
+    def _llm_type(self) -> str:  # pragma: no cover - tiny wrapper
+        return "function"
+
+    def _call(self, prompt: str, stop: list[str] | None = None) -> str:
+        return self._fn(prompt)
+
+
+class TemporaryCrew:
+    """Context manager that runs a CrewAI ``Crew`` once when started."""
+
+    def __init__(
+        self,
+        agents: Iterable[dict[str, Any]],
+        tasks: Iterable[dict[str, Any]],
+        inputs: dict[str, Any] | None = None,
+    ) -> None:
+        self._agents = [Agent(**a) for a in agents]
+        self._tasks = []
+        for cfg in tasks:
+            idx = cfg.pop("agent_index", 0)
+            agent = self._agents[idx]
+            self._tasks.append(Task(agent=agent, **cfg))
+        self._crew = Crew(agents=self._agents, tasks=self._tasks)
+        self._inputs = inputs or {}
+
+    async def __aenter__(self) -> "TemporaryCrew":
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._crew.kickoff, self._inputs)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+
+__all__ = ["FunctionLLM", "TemporaryCrew"]
+

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, suppress
 import json
 import logging
 import ssl
 from importlib import metadata
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Awaitable, Callable, Iterable
 
 from .config import get_settings
 
@@ -50,6 +50,13 @@ def _load_config(path: str) -> dict[str, Any]:
     return json.loads(text)
 
 
+def _load_callable(path: str) -> Callable[[], Any]:
+    """Import and return a callable specified as ``"module:function"``."""
+    mod_name, func_name = path.split(":", 1)
+    mod = __import__(mod_name, fromlist=[func_name])
+    return getattr(mod, func_name)
+
+
 async def _connect_nats():
     from nats.aio.client import Client as NATS
 
@@ -77,20 +84,44 @@ async def run(config_path: str) -> None:
     cfg = _load_config(config_path)
     names = cfg.get("services", [])
     service_classes = discover_services(names)
-    if not service_classes:
-        logger.warning("No services found for names %s", names)
+    crew_specs = cfg.get("crews", [])
+    graph_specs = cfg.get("graphs", [])
+    if not service_classes and not crew_specs and not graph_specs:
+        logger.warning("No services, crews or graphs found in config")
         return
+    crew_factories = [_load_callable(s) for s in crew_specs]
+    graph_factories: list[Callable[[], Awaitable[Any]]] = [
+        _load_callable(s) for s in graph_specs
+    ]
     nc, js = await _connect_nats()
     async with AsyncExitStack() as stack:
         if nc.is_connected:
             stack.push_async_callback(nc.drain)
         instances = []
+        crews = []
+        graph_tasks = []
         for cls in service_classes:
             inst = cls(nc, js)
             await stack.enter_async_context(inst)
             instances.append(inst)
-        logger.info("Started %d services", len(instances))
+        for factory in crew_factories:
+            crew = factory()
+            await stack.enter_async_context(crew)
+            crews.append(crew)
+        for factory in graph_factories:
+            graph_tasks.append(asyncio.create_task(factory()))
+        logger.info(
+            "Started %d services, %d crews, %d graphs",
+            len(instances),
+            len(crews),
+            len(graph_tasks),
+        )
         try:
             await asyncio.Event().wait()
         except (asyncio.CancelledError, KeyboardInterrupt):
             pass
+        finally:
+            for t in graph_tasks:
+                t.cancel()
+                with suppress(Exception):
+                    await t

--- a/tests/unit/test_crew_orchestrator.py
+++ b/tests/unit/test_crew_orchestrator.py
@@ -1,0 +1,55 @@
+import asyncio
+import importlib
+
+import pytest
+
+
+def _load_orchestrator_module():
+    return importlib.import_module("deepthought.orchestrator")
+
+
+class DummyCrew:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+
+    async def __aenter__(self):
+        self.started = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_run_with_crew(monkeypatch, tmp_path):
+    orchestrator = _load_orchestrator_module()
+    created = {}
+
+    def factory():
+        crew = DummyCrew()
+        created["crew"] = crew
+        return crew
+
+    class DummyNATS:
+        is_connected = True
+
+        async def drain(self):
+            pass
+
+    async def fake_connect():
+        return DummyNATS(), object()
+
+    monkeypatch.setattr(orchestrator, "_connect_nats", fake_connect)
+
+    monkeypatch.setattr(orchestrator, "discover_services", lambda names: [])
+    monkeypatch.setattr(orchestrator, "_load_callable", lambda path: factory)
+    monkeypatch.setattr(asyncio.Event, "wait", lambda self: asyncio.sleep(0))
+
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text("crews:\n  - dummy:factory\n", encoding="utf-8")
+
+    await orchestrator.run(str(cfg))
+
+    crew = created.get("crew")
+    assert crew is not None and crew.started and crew.stopped


### PR DESCRIPTION
## Summary
- add `deepthought.crew` package with a lightweight wrapper for CrewAI
- extend orchestrator to handle crews and graphs from config files
- demonstrate crew usage in `examples/crew_demo.py`
- document orchestrator crew support
- test crew creation via orchestrator
- export crew wrapper classes via `__all__`

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_orchestrator.py tests/unit/test_crew_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6880f0db05908326bf2f764ba0b61bf6