### PR TITLE
Add planning wrapper with L2P support

### DIFF
--- a/examples/planning_demo.py
+++ b/examples/planning_demo.py
@@ -1,0 +1,14 @@
+"""Demonstrate planning from a natural language goal."""
+
+from deepthought.planning import L2PTranslator, plan
+
+
+def main() -> None:
+    translator = L2PTranslator()
+    domain, problem = translator.translate("move obj from loc1 to loc2")
+    actions = plan(domain, problem)
+    print("Plan:", actions)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,3 +25,5 @@ setuptools
 streamlit
 datasets>=2.14.0
 peft>=0.5.0
+pyperplan>=2.1
+l2p==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ pyyaml
 faiss-cpu
 prometheus-client
 
+pyperplan>=2.1\nl2p==0.2.2

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -37,6 +37,10 @@ class EventSubjects:
     CODE_TEMPLATE_REQUEST = "dtr.codegen.template_request"
     CODE_GENERATED = "dtr.codegen.generated"
 
+    # Planning events
+    PLAN_REQUESTED = "dtr.plan.requested"
+    PLAN_GENERATED = "dtr.plan.generated"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -115,5 +119,23 @@ class CodeGeneratedPayload(EventPayload):
 
     code: str
     result: str
+    input_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class PlanRequestedPayload(EventPayload):
+    """Payload requesting a plan for a goal."""
+
+    goal: str
+    input_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class PlanGeneratedPayload(EventPayload):
+    """Payload containing a generated plan."""
+
+    plan: list[str]
     input_id: Optional[str] = None
     timestamp: Optional[str] = None

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import AsyncExitStack
 import json
 import logging
 import ssl
+from contextlib import AsyncExitStack
 from importlib import metadata
 from pathlib import Path
 from typing import Any, Iterable
 
 from .config import get_settings
+from .eda import Publisher, Subscriber
+from .eda.events import (
+    EventSubjects,
+    PlanGeneratedPayload,
+    PlanRequestedPayload,
+)
+from .planning import planner, translator
 
 logger = logging.getLogger(__name__)
 
@@ -81,14 +88,39 @@ async def run(config_path: str) -> None:
         logger.warning("No services found for names %s", names)
         return
     nc, js = await _connect_nats()
+    pub = Publisher(nc, js)
+    sub = Subscriber(nc, js)
+    l2p = translator.L2PTranslator()
+
+    async def _handle_plan(msg):
+        try:
+            data = json.loads(msg.data.decode())
+            payload = PlanRequestedPayload.from_dict(data)
+            domain, problem = l2p.translate(payload.goal)
+            actions = planner.plan(domain, problem)
+            out = PlanGeneratedPayload(plan=actions, input_id=payload.input_id)
+            await pub.publish(EventSubjects.PLAN_GENERATED, out, use_jetstream=True)
+            await msg.ack()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to generate plan: %s", exc, exc_info=True)
+            if hasattr(msg, "nak"):
+                await msg.nak()
+
     async with AsyncExitStack() as stack:
         if nc.is_connected:
             stack.push_async_callback(nc.drain)
+        stack.push_async_callback(sub.unsubscribe_all)
         instances = []
         for cls in service_classes:
             inst = cls(nc, js)
             await stack.enter_async_context(inst)
             instances.append(inst)
+        await sub.subscribe(
+            subject=EventSubjects.PLAN_REQUESTED,
+            handler=_handle_plan,
+            use_jetstream=True,
+            durable="planner",
+        )
         logger.info("Started %d services", len(instances))
         try:
             await asyncio.Event().wait()

--- a/src/deepthought/planning/__init__.py
+++ b/src/deepthought/planning/__init__.py
@@ -1,0 +1,6 @@
+"""Planning utilities using pyperplan and L2P."""
+
+from .planner import plan
+from .translator import L2PTranslator
+
+__all__ = ["plan", "L2PTranslator"]

--- a/src/deepthought/planning/planner.py
+++ b/src/deepthought/planning/planner.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Wrapper around pyperplan to compute plans."""
+
+from typing import List
+
+from pyperplan.pddl.parser import Parser
+from pyperplan.planner import _ground
+from pyperplan.search import breadth_first_search
+
+
+def plan(domain_pddl: str, problem_pddl: str) -> List[str]:
+    """Return a list of action strings forming a plan."""
+    parser = Parser(domain_pddl, problem_pddl)
+    parser.domInput = domain_pddl
+    domain = parser.parse_domain(read_from_file=False)
+    parser.probInput = problem_pddl
+    problem = parser.parse_problem(domain, read_from_file=False)
+    task = _ground(problem)
+    solution = breadth_first_search(task)
+    if not solution:
+        return []
+    return [op.name for op in solution]

--- a/src/deepthought/planning/translator.py
+++ b/src/deepthought/planning/translator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Very small NL -> PDDL translator using ``l2p`` utilities."""
+
+import tempfile
+from typing import Tuple
+
+from l2p.utils import parse_domain, parse_problem
+
+_MOVE_DOMAIN = """
+(define (domain move)
+  (:predicates (at ?o ?l) (connected ?l1 ?l2))
+  (:action move
+     :parameters (?o ?from ?to)
+     :precondition (and (at ?o ?from) (connected ?from ?to))
+     :effect (and (not (at ?o ?from)) (at ?o ?to))
+  )
+)
+"""
+
+_MOVE_PROBLEM = """
+(define (problem move-task)
+  (:domain move)
+  (:objects {obj} {frm} {to})
+  (:init (at {obj} {frm}) (connected {frm} {to}))
+  (:goal (and (at {obj} {to})))
+)
+"""
+
+
+class L2PTranslator:
+    """Translate very simple movement goals to PDDL."""
+
+    def translate(self, goal: str) -> Tuple[str, str]:
+        """Return ``(domain_pddl, problem_pddl)`` for ``goal``."""
+        text = goal.lower()
+        if not text.startswith("move"):
+            raise ValueError("Unsupported goal: %s" % goal)
+        parts = text.split()
+        try:
+            obj = parts[1]
+            frm = parts[parts.index("from") + 1]
+            to = parts[parts.index("to") + 1]
+        except Exception as exc:  # pragma: no cover - invalid input
+            raise ValueError("Goal must be of the form 'move X from A to B'") from exc
+        domain = _MOVE_DOMAIN.strip()
+        problem = _MOVE_PROBLEM.format(obj=obj, frm=frm, to=to).strip()
+        # Validate using l2p's PDDL parser
+        with tempfile.NamedTemporaryFile("w", delete=False) as df:
+            df.write(domain)
+            dpath = df.name
+        with tempfile.NamedTemporaryFile("w", delete=False) as pf:
+            pf.write(problem)
+            ppath = pf.name
+        parse_domain(dpath)
+        parse_problem(ppath)
+        return domain, problem

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -1,0 +1,8 @@
+from deepthought.planning import L2PTranslator, plan
+
+
+def test_planning_move():
+    translator = L2PTranslator()
+    domain, problem = translator.translate("move obj from loc1 to loc2")
+    actions = plan(domain, problem)
+    assert actions == ["(move obj loc1 loc2)"]

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -3,7 +3,33 @@ import importlib
 import sys
 from types import ModuleType, SimpleNamespace
 
+fake_nats = ModuleType("nats")
+fake_nats.__spec__ = importlib.machinery.ModuleSpec("nats", loader=None)
+fake_nats.aio = ModuleType("aio")
+fake_client_mod = ModuleType("client")
+setattr(fake_client_mod, "Client", object)
+fake_nats.aio.client = fake_client_mod
+fake_msg_mod = ModuleType("msg")
+setattr(fake_msg_mod, "Msg", object)
+fake_nats.aio.msg = fake_msg_mod
+fake_nats.js = ModuleType("js")
+fake_js_client_mod = ModuleType("client")
+setattr(fake_js_client_mod, "JetStreamContext", object)
+fake_nats.js.client = fake_js_client_mod
+fake_errors_mod = ModuleType("errors")
+setattr(fake_errors_mod, "Error", Exception)
+fake_nats.errors = fake_errors_mod
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_client_mod)
+sys.modules.setdefault("nats.aio.msg", fake_msg_mod)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_js_client_mod)
+sys.modules.setdefault("nats.errors", fake_errors_mod)
+
 import pytest
+
+from deepthought.eda.events import EventSubjects
 
 
 def _load_orchestrator_module():
@@ -115,3 +141,73 @@ def test_discover_services_fallback(monkeypatch):
 
     services = orchestrator.discover_services(["dummy"])
     assert services == [DummyService]
+
+
+@pytest.mark.asyncio
+async def test_plan_subscription(monkeypatch, tmp_path):
+    orchestrator = _load_orchestrator_module()
+    ep = SimpleNamespace(name="dummy", load=lambda: DummyService)
+    monkeypatch.setattr(
+        orchestrator.metadata,
+        "entry_points",
+        lambda: SimpleNamespace(select=lambda **k: [ep]),
+    )
+
+    class DummyNATS:
+        def __init__(self) -> None:
+            self.is_connected = True
+
+        async def drain(self):
+            pass
+
+    class DummyJS:
+        pass
+
+    async def fake_connect():
+        return DummyNATS(), DummyJS()
+
+    monkeypatch.setattr(orchestrator, "_connect_nats", fake_connect)
+
+    recorded = {}
+
+    class DummySub:
+        def __init__(self, *a, **k):
+            recorded["sub"] = []
+
+        async def subscribe(self, subject, handler, **kw):
+            recorded["sub"].append(subject)
+            return True
+
+        async def unsubscribe_all(self):
+            pass
+
+    class DummyPub:
+        def __init__(self, *a, **k):
+            pass
+
+        async def publish(self, *a, **k):
+            recorded["published"] = True
+
+    monkeypatch.setattr(orchestrator, "Publisher", DummyPub)
+    monkeypatch.setattr(orchestrator, "Subscriber", DummySub)
+
+    class DummyTranslator:
+        def translate(self, goal):
+            return "d", "p"
+
+    class DummyPlanner:
+        @staticmethod
+        def plan(d, p):
+            return ["ok"]
+
+    monkeypatch.setattr(orchestrator.translator, "L2PTranslator", DummyTranslator)
+    monkeypatch.setattr(orchestrator.planner, "plan", DummyPlanner.plan)
+
+    monkeypatch.setattr(asyncio.Event, "wait", lambda self: asyncio.sleep(0))
+
+    cfg = tmp_path / "c.json"
+    cfg.write_text('{"services": ["dummy"]}', encoding="utf-8")
+
+    await orchestrator.run(str(cfg))
+
+    assert EventSubjects.PLAN_REQUESTED in recorded.get("sub", [])


### PR DESCRIPTION
## Summary
- create `planning` package with pyperplan wrapper and simple L2P-based translator
- extend events with plan request/response payloads
- update orchestrator to handle `PLAN_REQUESTED` events
- add planning demo example
- implement planner tests and update orchestrator tests
- include `pyperplan` and `l2p` in requirements

## Testing
- `pre-commit run --files src/deepthought/planning/__init__.py src/deepthought/planning/planner.py src/deepthought/planning/translator.py src/deepthought/eda/events.py src/deepthought/orchestrator.py examples/planning_demo.py tests/test_planning.py tests/unit/test_orchestrator.py requirements.txt requirements-ci.txt`

------
https://chatgpt.com/codex/tasks/task_e_6880f0e0405c832683aef493b4ac520b