### PR TITLE
Add DSPy pipeline integration

### DIFF
--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -16,6 +16,7 @@ from nats.js.client import JetStreamContext
 from ..eda.events import EventSubjects, ResponseGeneratedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..pipeline.dspy_pipeline import build_qa_pipeline
 
 logger = logging.getLogger(__name__)
 
@@ -30,9 +31,20 @@ class RemoteLLM:
         if not self._endpoint:
             raise ValueError("LLM_ENDPOINT environment variable must be set or passed to RemoteLLM")
         self._session = aiohttp.ClientSession()
+
+        use_dspy = os.getenv("USE_DSPY", "")
+        self._use_dspy = use_dspy.lower() in {"1", "true", "yes", "on"}
+        self._qa_pipeline = build_qa_pipeline() if self._use_dspy else None
+
         logger.info("RemoteLLM initialized with endpoint %s", self._endpoint)
 
     async def _generate(self, prompt: str) -> str:
+        if self._use_dspy and self._qa_pipeline is not None:
+            result = self._qa_pipeline(prompt)
+            if not isinstance(result, str):
+                raise ValueError("Invalid DSPy response")
+            return result
+
         async with self._session.post(self._endpoint, json={"text": prompt}) as resp:
             resp.raise_for_status()
             data = await resp.json()

--- a/src/deepthought/pipeline/__init__.py
+++ b/src/deepthought/pipeline/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+"""Pipelines utilities for DeepThought."""
+
+from .dspy_pipeline import build_qa_pipeline
+
+__all__ = ["build_qa_pipeline"]

--- a/src/deepthought/pipeline/dspy_pipeline.py
+++ b/src/deepthought/pipeline/dspy_pipeline.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Utilities for building DSPy question answering pipelines."""
+
+from types import SimpleNamespace
+from typing import Callable
+
+try:  # pragma: no cover - optional dependency
+    import dspy
+except Exception:  # pragma: no cover - dspy may not be installed
+    dspy = None  # type: ignore
+
+
+def build_qa_pipeline() -> Callable[[str], str]:
+    """Return a function that answers questions using DSPy."""
+
+    if dspy is None:  # pragma: no cover - tested via mock
+        raise ImportError("DSPy library is required")
+
+    class QASignature(dspy.Signature):  # type: ignore[attr-defined]
+        """Signature for simple question answering."""
+
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    qa_func = dspy.LMFunction(QASignature)
+
+    def pipeline(question: str) -> str:
+        result = qa_func(question=question)
+        answer = getattr(result, "answer", None)
+        if not isinstance(answer, str):
+            raise ValueError("DSPy pipeline returned invalid result")
+        return answer
+
+    return pipeline

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -278,3 +278,13 @@ async def test_handle_memory_event_with_mock_session(monkeypatch):
     subject, sent_payload = llm._publisher.published[0]
     assert subject == EventSubjects.RESPONSE_GENERATED
     assert sent_payload.final_response == "resp"
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_dspy_pipeline(monkeypatch):
+    monkeypatch.setenv("USE_DSPY", "1")
+    monkeypatch.setattr(llm_remote, "build_qa_pipeline", lambda: lambda q: "pipe")
+    llm = create_llm(monkeypatch)
+    result = await llm._generate("query")
+    assert result == "pipe"
+    await llm._session.close()

--- a/tests/unit/pipeline/test_dspy_pipeline.py
+++ b/tests/unit/pipeline/test_dspy_pipeline.py
@@ -1,0 +1,42 @@
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+import types
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "deepthought.pipeline.dspy_pipeline",
+    "src/deepthought/pipeline/dspy_pipeline.py",
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+
+
+def _setup_dummy_dspy(monkeypatch):
+    class DummyLMFunction:
+        def __init__(self, sig):
+            self.sig = sig
+            self.calls = []
+
+        def __call__(self, **kwargs):
+            self.calls.append(kwargs)
+            return SimpleNamespace(answer="ok")
+
+    dummy = types.SimpleNamespace(
+        Signature=type("Signature", (), {}),
+        InputField=lambda **k: None,
+        OutputField=lambda **k: None,
+        LMFunction=lambda sig: DummyLMFunction(sig),
+    )
+    monkeypatch.setitem(sys.modules, "dspy", dummy)
+    return dummy
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_build_qa_pipeline(monkeypatch):
+    _setup_dummy_dspy(monkeypatch)
+    spec.loader.exec_module(module)
+    pipeline = module.build_qa_pipeline()
+    assert pipeline("hi") == "ok"
+


### PR DESCRIPTION
## Summary
- add a simple DSPy question answering pipeline
- use it in `RemoteLLM` when `USE_DSPY` is set
- test the DSPy pipeline with a mocked `dspy`
- test that `RemoteLLM` can use the pipeline
- refine USE_DSPY handling and expose pipeline package

## Testing
- `flake8 src tests`
- `pytest tests/unit/modules/test_llm_remote.py::test_generate_posts tests/unit/modules/test_llm_remote.py::test_generate_uses_dspy_pipeline tests/unit/pipeline/test_dspy_pipeline.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f0dc537c832690311f201c3eba3a