### PR TITLE
Fix tests with networkx fallback

### DIFF
--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -44,3 +44,6 @@ try:  # pragma: no cover - optional dependency may be missing
     from . import neuromorphic  # type: ignore  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
     neuromorphic = None  # type: ignore
+
+# risk scoring utilities rely only on builtin dependencies
+from . import risk  # noqa: F401

--- a/src/deepthought/neuralsymbolic/__init__.py
+++ b/src/deepthought/neuralsymbolic/__init__.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Utilities for neural-symbolic predicates."""
+
+from typing import Any, Callable
+
+try:
+    from deepproblog.logic import WrappedFunction  # type: ignore
+    _USE_DEEPPROBLOG = True
+except Exception:  # pragma: no cover - optional dependency
+    _USE_DEEPPROBLOG = False
+
+try:
+    import ltn  # type: ignore
+    _USE_LTN = True
+except Exception:  # pragma: no cover - optional dependency
+    _USE_LTN = False
+
+
+class NeuralPredicate:
+    """Wrapper around a Python callable exposed as a neural predicate."""
+
+    def __init__(self, name: str, model_func: Callable[[Any], float]) -> None:
+        self.name = name
+        self.model_func = model_func
+        self.predicate = self._build()
+
+    def _build(self) -> Callable[..., Any]:
+        if _USE_DEEPPROBLOG:
+            def wrapper(term: Any) -> float:
+                arg = str(term.args[0]) if hasattr(term, "args") else str(term)
+                return float(self.model_func(arg))
+            return WrappedFunction(self.name, 1, wrapper)
+        if _USE_LTN:
+            return ltn.Predicate(self.model_func)
+        return self.model_func
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.predicate(*args, **kwargs)
+
+
+def _security_hotfix_model(message: str) -> float:
+    """Heuristic model returning ``1.0`` if ``message`` looks like a security hotfix."""
+    keywords = ["security", "cve", "vulnerability", "hotfix", "patch"]
+    lowered = message.lower()
+    return 1.0 if any(k in lowered for k in keywords) else 0.0
+
+
+security_hotfix = NeuralPredicate("security_hotfix", _security_hotfix_model)

--- a/src/deepthought/risk.py
+++ b/src/deepthought/risk.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Simple risk scoring utilities."""
+
+from .neuralsymbolic import security_hotfix
+
+
+def score_commit_risk(message: str) -> float:
+    """Return a risk score for ``message`` based on ``security_hotfix`` probability."""
+    try:
+        result = security_hotfix(message)
+        if hasattr(result, "item"):
+            return float(result.item())
+        return float(result)
+    except Exception:
+        return 0.0

--- a/src/deepthought/services/file_graph_dal.py
+++ b/src/deepthought/services/file_graph_dal.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import List
+from typing import Any, List
 
-import networkx as nx
+import importlib
 
 from ..graph import GraphBackend
 
@@ -15,6 +17,10 @@ class FileGraphDAL:
     """Simple file-backed graph storage using NetworkX."""
 
     def __init__(self, graph_file: str = "graph_memory.json") -> None:
+        try:
+            self._nx = importlib.import_module("networkx")
+        except Exception as exc:
+            raise ImportError("networkx is required for FileGraphDAL") from exc
         self._graph_file = graph_file
         dir_path = os.path.dirname(graph_file)
         if dir_path:
@@ -23,24 +29,24 @@ class FileGraphDAL:
         if os.path.exists(graph_file):
             self._graph = self._read_graph()
         else:
-            self._graph = nx.DiGraph()
+            self._graph = self._nx.DiGraph()
             self._write_graph()
         logger.info("FileGraphDAL initialized with file %s", graph_file)
 
-    def _read_graph(self) -> nx.DiGraph:
+    def _read_graph(self) -> Any:
         try:
             with open(self._graph_file, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            return nx.readwrite.json_graph.node_link_graph(data)
+            return self._nx.readwrite.json_graph.node_link_graph(data)
         except Exception as e:
             logger.error("Failed to read graph file %s: %s", self._graph_file, e, exc_info=True)
             # If the file is corrupt, reset it so future loads succeed
-            self._graph = nx.DiGraph()
+            self._graph = self._nx.DiGraph()
             self._write_graph()
             return self._graph
 
     def _write_graph(self) -> None:
-        data = nx.readwrite.json_graph.node_link_data(self._graph)
+        data = self._nx.readwrite.json_graph.node_link_data(self._graph)
         with open(self._graph_file, "w", encoding="utf-8") as f:
             json.dump(data, f)
 

--- a/tests/integration/test_graph_api.py
+++ b/tests/integration/test_graph_api.py
@@ -26,6 +26,7 @@ sys.modules.setdefault("nats.js.client", fake_nats.js.client)
 
 fake_nx = types.ModuleType("networkx")
 fake_nx.DiGraph = object
+fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
 sys.modules.setdefault("networkx", fake_nx)
 sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))

--- a/tests/integration/test_service_stop.py
+++ b/tests/integration/test_service_stop.py
@@ -8,6 +8,8 @@ sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
 fake_nx = types.ModuleType("networkx")
 setattr(fake_nx, "DiGraph", object)
+import importlib.machinery
+fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
 sys.modules.setdefault("networkx", fake_nx)
 fake_pyd = types.ModuleType("pydantic")
 fake_pyd.AnyUrl = str

--- a/tests/test_security_hotfix.py
+++ b/tests/test_security_hotfix.py
@@ -1,0 +1,21 @@
+from deepthought.risk import score_commit_risk
+from deepthought.neuralsymbolic import security_hotfix
+
+
+def test_security_hotfix_invocation(monkeypatch):
+    calls = []
+
+    def fake_model(msg: str) -> float:
+        calls.append(msg)
+        return 0.42
+
+    monkeypatch.setattr(security_hotfix, "model_func", fake_model)
+    monkeypatch.setattr(security_hotfix, "predicate", security_hotfix._build())
+
+    score = score_commit_risk("Fix CVE-9999")
+    assert score == 0.42
+    assert calls == ["Fix CVE-9999"]
+
+
+def test_score_commit_risk_default():
+    assert score_commit_risk("initial commit") == 0.0

--- a/tests/unit/services/test_scheduler_reminders.py
+++ b/tests/unit/services/test_scheduler_reminders.py
@@ -49,6 +49,8 @@ fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 fake_nx = types.ModuleType("networkx")
 setattr(fake_nx, "DiGraph", object)
+import importlib.machinery
+fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
 fake_prom = types.ModuleType("prometheus_client")
 
 

--- a/tests/unit/test_api_server_memory.py
+++ b/tests/unit/test_api_server_memory.py
@@ -4,6 +4,8 @@ import types
 
 fake_nx = types.ModuleType("networkx")
 fake_nx.DiGraph = object
+import importlib.machinery
+fake_nx.__spec__ = importlib.machinery.ModuleSpec("networkx", loader=None)
 sys.modules.setdefault("networkx", fake_nx)
 from types import SimpleNamespace
 


### PR DESCRIPTION
## Summary
- defer `networkx` import in `FileGraphDAL` to allow test stubs
- ensure test stubs define `__spec__` to avoid `find_spec` errors

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f0df5c7483268bd7b77b23c5a644