### PR TITLE
Add quick-start docs for new subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,6 +569,30 @@ Two lightweight reference modules show how components can interact through NATS:
 4. The `OutputHandler` (or another consumer) can then deliver the response to the user.
 
 
+
+## DSPy Pipelines
+
+The optional DSPy integration exposes a simple question answering pipeline built
+with the `dspy-ai` library. Set `USE_DSPY=true` before launching the
+`RemoteLLM` service to route prompts through this pipeline. See
+[docs/dspy_pipeline_quickstart.md](docs/dspy_pipeline_quickstart.md) for a
+minimal example and setup instructions.
+
+## CrewAI Swarms
+
+`TemporaryCrew` provides a lightweight wrapper for spawning short-lived CrewAI
+crews from the orchestrator. Add a callable returning a crew under `crews:` in
+your orchestrator configuration to run it once. A quick demonstration is
+available in
+[docs/crewai_swarm_quickstart.md](docs/crewai_swarm_quickstart.md).
+
+## Planning
+
+Planning helpers translate natural language goals to PDDL using L2P and compute
+action sequences with pyperplan. See
+[docs/planning_quickstart.md](docs/planning_quickstart.md) for a short tutorial
+and command-line demo.
+
 ## HTTP API
 
 A minimal FastAPI server provides HTTP access to the event system. Ensure a NATS server

--- a/docs/crewai_swarm_quickstart.md
+++ b/docs/crewai_swarm_quickstart.md
@@ -1,0 +1,34 @@
+# CrewAI Swarm Quick Start
+
+Temporary swarms can be launched via the orchestrator using the `TemporaryCrew`
+wrapper.
+
+## Define a crew
+
+```python
+from deepthought.crew import FunctionLLM, TemporaryCrew
+
+def echo(prompt: str) -> str:
+    return f"echo: {prompt}"
+
+crew = TemporaryCrew(
+    agents=[{"role": "Echoer", "goal": "Repeat", "llm": FunctionLLM(echo)}],
+    tasks=[{"description": "Respond to {topic}", "agent_index": 0}],
+    inputs={"topic": "hello"},
+)
+```
+
+## Orchestrator configuration
+
+Add the crew factory to `orchestrator.yaml`:
+
+```yaml
+crews:
+  - examples.crew_demo:create_demo_crew
+```
+
+Start the orchestrator:
+
+```bash
+dtrt orchestrate orchestrator.yaml
+```

--- a/docs/dspy_pipeline_quickstart.md
+++ b/docs/dspy_pipeline_quickstart.md
@@ -1,0 +1,28 @@
+# DSPy Pipeline Quick Start
+
+This guide demonstrates how to enable the optional DSPy pipeline used for
+question answering.
+
+## Install DSPy
+
+```bash
+pip install dspy-ai
+```
+
+## Basic usage
+
+```python
+from deepthought.pipeline import build_qa_pipeline
+
+qa = build_qa_pipeline()
+print(qa("What is 2 + 2?"))
+```
+
+## Orchestrator integration
+
+`RemoteLLM` activates the pipeline when `USE_DSPY=true` is set:
+
+```bash
+export USE_DSPY=true
+dtrt orchestrate orchestrator.yaml
+```

--- a/docs/planning_quickstart.md
+++ b/docs/planning_quickstart.md
@@ -1,0 +1,35 @@
+# Planning Quick Start
+
+The planning helpers use L2P and pyperplan to create simple action sequences.
+
+## Translate a goal
+
+```python
+from deepthought.planning import L2PTranslator
+
+translator = L2PTranslator()
+domain, problem = translator.translate("move obj from loc1 to loc2")
+```
+
+## Compute a plan
+
+```python
+from deepthought.planning import plan
+
+steps = plan(domain, problem)
+print(steps)
+```
+
+This prints something like:
+
+```text
+['(move obj loc1 loc2)']
+```
+
+## Command-line demo
+
+Run the example script:
+
+```bash
+python examples/planning_demo.py
+```


### PR DESCRIPTION
## Summary
- document DSPy pipelines, CrewAI swarms and planning in README
- add quick start guides for DSPy, CrewAI and planning subsystems

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6880fe5bbeec8326a92d5058f401703f