### PR TITLE
Install logic frameworks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           cache: 'pip'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
+      - run: pip install dspy psl deepproblog
       - run: pip install -e . --no-deps
       - name: Run pre-commit
         if: matrix.python-version == '3.11'
@@ -111,6 +112,7 @@ jobs:
           cache: 'pip'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
+      - run: pip install dspy psl deepproblog
       - run: pip install -e . --no-deps
       - name: Setup JetStream
         run: python -c "import asyncio, setup_jetstream; asyncio.run(setup_jetstream.setup_jetstream())"
@@ -141,6 +143,7 @@ jobs:
           cache: 'pip'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
+      - run: pip install dspy psl deepproblog
       - run: pip install -e . --no-deps
       - env:
           PYTHONPATH: src

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -27,3 +27,6 @@ datasets>=2.14.0
 peft>=0.5.0
 pyperplan>=2.1
 l2p==0.2.2
+dspy
+psl
+deepproblog

--- a/scripts/check_code_changes.py
+++ b/scripts/check_code_changes.py
@@ -14,11 +14,21 @@ from pathlib import Path
 # Common documentation file extensions to ignore
 DOC_EXTENSIONS = {".md", ".markdown", ".mdown", ".rst", ".txt"}
 
+# Directories that should always trigger tests when modified
+CODE_DIRS = {
+    "src/deepthought/psl",
+    "src/deepthought/neuralsymbolic",
+    "src/deepthought/pipeline",
+    "src/deepthought/planning",
+}
+
 
 def is_doc_file(path: str) -> bool:
     """Return True if the path looks like documentation."""
     p = Path(path)
     suffix = p.suffix.lower()
+    if any(path.startswith(d + "/") or path == d for d in CODE_DIRS):
+        return False
     return suffix in DOC_EXTENSIONS or path.startswith("docs/")
 
 
@@ -49,6 +59,15 @@ def main() -> None:
     result = subprocess.run(diff_args, stdout=subprocess.PIPE, check=True)
 
     changed_files = [f for f in result.stdout.decode().splitlines() if f]
+
+    # If any file is within CODE_DIRS, treat as code change
+    if any(
+        f.startswith(d + "/") or f == d
+        for f in changed_files
+        for d in CODE_DIRS
+    ):
+        print("true")
+        sys.exit(0)
 
     # If all changed files are docs, tests are unnecessary
     if changed_files and all(is_doc_file(f) for f in changed_files):


### PR DESCRIPTION
## Summary
- install DSPy, PSL, DeepProbLog and pyperplan in CI
- run pip install for these packages in the workflow
- always treat planning/PSL/DSPy folders as code

## Testing
- `pytest tests/integration/test_psl_risk.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fe5b80d083269eed9e6739563b4b