### PR TITLE
Add rule evaluation metrics and dashboard

### DIFF
--- a/docs/prometheus_grafana.md
+++ b/docs/prometheus_grafana.md
@@ -44,4 +44,14 @@ Import `grafana/deepthought_metrics.json` to view two panels:
 - **Inputs Total per Service** - rate of `inputs_total` events.
 - **Average Latency Seconds** - calculated from `input_latency_seconds`.
 
+The metrics server also exposes counters for rule evaluations. Snapshots of the
+`rule_evaluations_total` metric can be visualized with the dashboard utility:
+
+```bash
+python tools/dashboard_rules.py path/to/metrics --show
+```
+
+This plots the evaluation count for each rule over time. When using Grafana you
+can create an additional panel with the expression `rate(rule_evaluations_total[1m])`.
+
 These dashboards let you track throughput and latency for each service.

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -18,4 +18,27 @@ if "input_latency_seconds" not in REGISTRY._names_to_collectors:
 else:  # pragma: no cover - already registered
     INPUT_LATENCY_SECONDS = REGISTRY._names_to_collectors["input_latency_seconds"]  # type: ignore
 
-__all__ = ["INPUTS_TOTAL", "INPUT_LATENCY_SECONDS"]
+if "rule_evaluations_total" not in REGISTRY._names_to_collectors:
+    RULE_EVALUATIONS_TOTAL = Counter(
+        "rule_evaluations_total",
+        "Total number of rule evaluations",
+        labelnames=["rule"],
+    )
+else:  # pragma: no cover - already registered
+    RULE_EVALUATIONS_TOTAL = REGISTRY._names_to_collectors["rule_evaluations_total"]  # type: ignore
+
+if "rule_evaluation_errors_total" not in REGISTRY._names_to_collectors:
+    RULE_EVALUATION_ERRORS_TOTAL = Counter(
+        "rule_evaluation_errors_total",
+        "Total number of rule evaluation errors",
+        labelnames=["rule"],
+    )
+else:  # pragma: no cover - already registered
+    RULE_EVALUATION_ERRORS_TOTAL = REGISTRY._names_to_collectors["rule_evaluation_errors_total"]  # type: ignore
+
+__all__ = [
+    "INPUTS_TOTAL",
+    "INPUT_LATENCY_SECONDS",
+    "RULE_EVALUATIONS_TOTAL",
+    "RULE_EVALUATION_ERRORS_TOTAL",
+]

--- a/tools/dashboard_rules.py
+++ b/tools/dashboard_rules.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Plot rule evaluation metrics from Prometheus snapshots."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, List, Set
+
+import matplotlib.pyplot as plt
+from prometheus_client.parser import text_string_to_metric_families
+
+
+def _parse_metrics(path: Path) -> Dict[str, float]:
+    """Return rule counts from a Prometheus metrics file."""
+    text = path.read_text(encoding="utf-8")
+    counters: Dict[str, float] = {}
+    for family in text_string_to_metric_families(text):
+        if family.name == "rule_evaluations_total":
+            for sample in family.samples:
+                rule = sample.labels.get("rule", "unknown")
+                counters[rule] = sample.value
+    return counters
+
+
+def _collect_metrics(paths: Iterable[Path]) -> tuple[List[str], List[Dict[str, float]]]:
+    files: List[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.glob("*.prom")))
+            files.extend(sorted(p.glob("*.txt")))
+        else:
+            files.append(p)
+    metrics_list: List[Dict[str, float]] = []
+    rules: Set[str] = set()
+    for f in files:
+        try:
+            metrics = _parse_metrics(f)
+            metrics_list.append(metrics)
+            rules.update(metrics.keys())
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"Failed to parse {f}: {e}")
+    return sorted(rules), metrics_list
+
+
+def _plot(
+    rules: List[str], metrics_list: List[Dict[str, float]], output: Path, show: bool
+) -> None:
+    if not metrics_list:
+        print("No metrics to plot")
+        return
+    steps = list(range(1, len(metrics_list) + 1))
+    fig, ax = plt.subplots()
+    for rule in rules:
+        values = [m.get(rule, 0.0) for m in metrics_list]
+        ax.plot(steps, values, marker="o", label=rule)
+    ax.set_xlabel("Snapshot")
+    ax.set_ylabel("Evaluations Total")
+    ax.legend()
+    ax.grid(True)
+    fig.tight_layout()
+    plt.savefig(output)
+    if show:
+        plt.show()
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths", nargs="+", type=Path, help="Prometheus metrics files or directories"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("rules_dashboard.png"),
+        help="Output image path",
+    )
+    parser.add_argument(
+        "--show", action="store_true", help="Display plot interactively"
+    )
+    args = parser.parse_args(argv)
+
+    rules, metrics_list = _collect_metrics(args.paths)
+    _plot(rules, metrics_list, args.output, args.show)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()


### PR DESCRIPTION
## Summary
- track rule evaluation counters in prometheus metrics
- plot rule evaluation metrics with a new `dashboard_rules.py` utility
- document rule metric usage in Prometheus/Grafana guide

## Testing
- `isort src/deepthought/metrics/prometheus.py tools/dashboard_rules.py`
- `black src/deepthought/metrics/prometheus.py tools/dashboard_rules.py`
- `flake8 src/deepthought/metrics/prometheus.py tools/dashboard_rules.py`
- `pytest tests/unit/test_metrics_prometheus.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fe56cebc832696ee62c95e7daddc