### PR TITLE
Add UME memory backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,20 @@ services:
     image: chromadb/chroma
     ports:
       - "8000:8000"
+
+  ume:
+    image: redpandadata/redpanda:latest
+    command:
+      - redpanda
+      - start
+      - --smp
+      - "1"
+      - --overprovisioned
+      - --node-id
+      - "0"
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://localhost:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://ume:29092,OUTSIDE://localhost:9092
+    ports:
+      - "9092:9092"

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,6 @@ pyyaml
 faiss-cpu
 prometheus-client
 
-pyperplan>=2.1\nl2p==0.2.2
+pyperplan>=2.1
+l2p==0.2.2
+git+https://github.com/d0tTino/UME.git@dev

--- a/src/deepthought/memory/ume_backend.py
+++ b/src/deepthought/memory/ume_backend.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Tiered memory backend that also logs events to UME."""
+
+from dataclasses import dataclass
+import time
+from typing import List, Any, Optional
+
+from ume import Event, apply_event_to_graph, MockGraph
+
+from .tiered import TieredMemory
+from .vector_store import create_vector_store, VectorStore
+from ..graph.backend import GraphBackend, NoOpGraphBackend
+
+
+class UMEGraphBackend(GraphBackend):
+    """Minimal graph backend backed by a UME graph."""
+
+    def __init__(self, graph: Optional[MockGraph] = None) -> None:
+        self._graph = graph or MockGraph()
+        self.events: list[Event] = []
+
+    def query_subgraph(self, query: str, params: dict) -> List[Any]:  # pragma: no cover - basic demo
+        # Support simple queries used by TieredMemory tests
+        limit = params.get("limit")
+        if query.startswith("MATCH (n:Entity)"):
+            nodes = self._graph.get_all_node_ids()
+            if limit:
+                nodes = nodes[: int(limit)]
+            return [{"fact": n} for n in nodes]
+        if "MATCH (a:Entity {name: $src})-[:NEXT]->(b:Entity {name: $dst})" in query:
+            src = params.get("src")
+            dst = params.get("dst")
+            for s, t, label in self._graph.get_all_edges():
+                if s == src and t == dst and label == "NEXT":
+                    return [{"src": s, "dst": t}]
+            return []
+        return []
+
+    def merge_entity(self, name: str) -> None:  # pragma: no cover - trivial
+        evt = Event(
+            event_type="CREATE_NODE",
+            timestamp=int(time.time()),
+            payload={"node_id": name, "attributes": {"name": name}},
+        )
+        apply_event_to_graph(evt, self._graph)
+        self.events.append(evt)
+
+
+@dataclass
+class UMEMemory(TieredMemory):
+    """Tiered memory that logs interactions to a UME graph."""
+
+    ume_backend: UMEGraphBackend
+
+    def store_interaction(self, text: str) -> None:  # pragma: no cover - simple
+        super().store_interaction(text)
+        self.ume_backend.merge_entity(text)
+
+
+def create_ume_memory(settings=None) -> UMEMemory:
+    """Return :class:`UMEMemory` configured from ``Settings``."""
+    from ..config import get_settings
+    from ..memory import load_memory_settings
+
+    settings = settings or get_settings()
+    ms = load_memory_settings(settings)
+    store = create_vector_store(
+        backend=ms.vector_backend,
+        persist_directory=None,
+        use_gpu=ms.vector_use_gpu,
+    )
+    backend = UMEGraphBackend()
+    return UMEMemory(
+        store,
+        backend,
+        capacity=ms.memory_capacity,
+        top_k=ms.memory_top_k,
+        ume_backend=backend,
+    )
+

--- a/src/deepthought/services/memory_service.py
+++ b/src/deepthought/services/memory_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import time
 from datetime import datetime, timezone
 from typing import Optional
@@ -43,7 +44,13 @@ class MemoryService(BaseService):
         )
         settings = settings or get_settings()
         if memory is None:
-            memory = create_memory_backend(settings=settings)
+            backend = os.getenv("DT_MEMORY_BACKEND", "tiered").lower()
+            if backend == "ume":
+                from ..memory.ume_backend import create_ume_memory
+
+                memory = create_ume_memory(settings=settings)
+            else:
+                memory = create_memory_backend(settings=settings)
         self._memory = memory
 
     @classmethod

--- a/tests/integration/test_ume_memory_flow.py
+++ b/tests/integration/test_ume_memory_flow.py
@@ -1,0 +1,80 @@
+import asyncio
+import json
+import os
+import uuid
+
+import pytest
+
+pytest.importorskip("nats")
+from nats.aio.client import Client as NATS
+from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+
+from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.services.memory_service import MemoryService
+from deepthought.config import Settings
+from tests.helpers import nats_server_available
+
+pytestmark = pytest.mark.nats
+STREAM_NAME = "deepthought_events"
+
+
+def get_nats_url() -> str:
+    return os.getenv("NATS_URL", "nats://localhost:4222")
+
+
+async def ensure_stream_exists(js):
+    try:
+        await js.stream_info(STREAM_NAME)
+    except Exception:
+        cfg = StreamConfig(
+            name=STREAM_NAME,
+            subjects=["dtr.>"],
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.MEMORY,
+            max_msgs_per_subject=100,
+            discard=DiscardPolicy.OLD,
+        )
+        await js.add_stream(cfg)
+
+
+@pytest.mark.asyncio
+async def test_ume_memory_roundtrip(monkeypatch):
+    if not nats_server_available(get_nats_url()):
+        pytest.skip("NATS server not available")
+
+    monkeypatch.setenv("DT_MEMORY_BACKEND", "ume")
+    nc = await NATS().connect(servers=[get_nats_url()], connect_timeout=10)
+    js = nc.jetstream(timeout=10.0)
+    await ensure_stream_exists(js)
+
+    service = MemoryService(nc, js, Settings())
+    await service.start(durable_name="ume_listener")
+
+    received = asyncio.Event()
+    holder = {}
+
+    async def handler(msg):
+        holder.update(json.loads(msg.data.decode()))
+        received.set()
+        await msg.ack()
+
+    sub = await js.subscribe(
+        subject=EventSubjects.MEMORY_RETRIEVED,
+        durable="sink",
+        cb=handler,
+        stream=STREAM_NAME,
+    )
+
+    payload = InputReceivedPayload(user_input="hello world", input_id=str(uuid.uuid4()))
+    await js.publish(EventSubjects.INPUT_RECEIVED, payload.to_json().encode())
+
+    await asyncio.wait_for(received.wait(), timeout=10.0)
+    assert holder.get("input_id") == payload.input_id
+
+    ume_backend = service._memory.graph_backend
+    assert getattr(ume_backend, "events", [])
+
+    await sub.unsubscribe()
+    await service.stop()
+    await nc.drain()
+


### PR DESCRIPTION
## Summary
- integrate optional UME tiered memory backend
- log interactions as UME events
- enable backend by setting `DT_MEMORY_BACKEND=ume`
- add `ume` service container
- test UME memory roundtrip

## Testing
- `flake8 src/deepthought/services/memory_service.py src/deepthought/memory/ume_backend.py tests/integration/test_ume_memory_flow.py`
- `pytest tests/integration/test_ume_memory_flow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fe5354208326b22011a8a5f0e07a