### PR TITLE
Fix PersonaManager DB initialization

### DIFF
--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import random
 
 from .db_manager import DBManager
@@ -20,8 +21,24 @@ class PersonaManager:
         self._playful = playful
         self._descriptions = descriptions or {}
 
+        # Initialize the database once. If an event loop is running we
+        # schedule the task and await it on first use. Otherwise we
+        # perform the initialization synchronously.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:  # no running loop
+            loop = None
+
+        if loop and loop.is_running():
+            self._init_task = loop.create_task(self._db.init_db())
+        else:  # pragma: no cover - typically executed outside tests
+            asyncio.run(self._db.init_db())
+            self._init_task = None
+
     async def get_persona(self, user_id: int) -> str:
-        await self._db.init_db()
+        if self._init_task is not None:
+            await self._init_task
+            self._init_task = None
         affinity = await self._db.get_affinity(user_id)
         if affinity >= self._friendly:
             return "friendly"

--- a/tests/test_persona_integration.py
+++ b/tests/test_persona_integration.py
@@ -59,8 +59,6 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
-    await sg.db_manager.connect()
-    await sg.db_manager.init_db()
 
     # Use lower thresholds for easier testing
     sg.persona_manager = PersonaManager(sg.db_manager, friendly=3, playful=1)

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -9,8 +9,6 @@ from deepthought.services import DBManager, PersonaManager
 @pytest.mark.asyncio
 async def test_persona_changes_with_affinity(tmp_path):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
-    await sg.db_manager.connect()
-    await sg.db_manager.init_db()
 
     pm = PersonaManager(sg.db_manager, friendly=5, playful=2)
     user = "u1"
@@ -29,8 +27,6 @@ async def test_persona_changes_with_affinity(tmp_path):
 @pytest.mark.asyncio
 async def test_choose_prompt_uses_persona(tmp_path, monkeypatch):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
-    await sg.db_manager.connect()
-    await sg.db_manager.init_db()
 
     pm = PersonaManager(sg.db_manager, friendly=2, playful=1)
     user = "u1"


### PR DESCRIPTION
## Summary
- ensure PersonaManager initializes the DB in `__init__`
- avoid redundant DB init calls in `get_persona`
- update persona manager tests

## Testing
- `pytest tests/test_persona_manager.py tests/test_persona_integration.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688161b5df90832686f6217e273f5fc2