### PR TITLE
Add SocialGraphService adjusting affinity

### DIFF
--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -4,10 +4,12 @@ from .cognitive_core_service import CognitiveCoreService
 from .db_manager import DBManager
 from .file_graph_dal import FileGraphDAL
 from .persona_manager import PersonaManager
+from .social_graph_service import SocialGraphService
 
 __all__ = [
     "FileGraphDAL",
     "CognitiveCoreService",
     "PersonaManager",
     "DBManager",
+    "SocialGraphService",
 ]

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+from textblob import TextBlob
+
+from ..eda.events import EventSubjects
+from .base import BaseService
+from .db_manager import DBManager
+from .persona_manager import PersonaManager
+
+logger = logging.getLogger(__name__)
+
+
+class SocialGraphService(BaseService):
+    """Service that records sentiment and adjusts user affinity."""
+
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        db_manager: Optional[DBManager] = None,
+        persona_manager: Optional[PersonaManager] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        self._db = db_manager or DBManager()
+        self._persona = persona_manager or PersonaManager(self._db)
+
+    async def _handle_input(self, msg: Msg) -> None:
+        """Process an INPUT_RECEIVED message."""
+        try:
+            data = json.loads(msg.data.decode())
+            text = data.get("user_input")
+            if not isinstance(text, str):
+                raise ValueError("user_input missing")
+            score = float(TextBlob(text).sentiment.polarity)
+            delta = 0
+            if score > 0:
+                delta = 1
+            elif score < 0:
+                delta = -1
+            await self._db.adjust_affinity("user", delta)
+            await self._persona.get_persona("user")
+        except Exception:
+            logger.error("Failed to handle input", exc_info=True)
+        finally:
+            if hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message", exc_info=True)
+
+    async def start(self, durable_name: str = "social_graph_service") -> bool:
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.INPUT_RECEIVED,
+            handler=self._handle_input,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        return await super().start()
+
+    async def stop(self) -> None:
+        if hasattr(self._db, "close"):
+            try:
+                await self._db.close()
+            except Exception:
+                logger.error("Failed to close DB", exc_info=True)
+        await super().stop()

--- a/tests/integration/test_social_graph_affinity.py
+++ b/tests/integration/test_social_graph_affinity.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought.eda.events import InputReceivedPayload
+from deepthought.services import DBManager, PersonaManager
+from deepthought.services.social_graph_service import SocialGraphService
+
+
+class DummyMsg:
+    def __init__(self, payload: InputReceivedPayload) -> None:
+        self.data = payload.to_json().encode()
+        self.acked = False
+
+    async def ack(self) -> None:
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_affinity_changes_after_processing(tmp_path):
+    db = DBManager(str(tmp_path / "sg.db"))
+    await db.init_db()
+    pm = PersonaManager(db, friendly=1, playful=1)
+    svc = SocialGraphService(db_manager=db, persona_manager=pm)
+    svc._publisher = SimpleNamespace()
+    svc._subscriber = SimpleNamespace()
+
+    pos = DummyMsg(InputReceivedPayload(user_input="I love this"))
+    await svc._handle_input(pos)
+    assert pos.acked
+    assert await db.get_affinity("user") == 1
+    assert await pm.get_persona("user") == "friendly"
+
+    neg = DummyMsg(InputReceivedPayload(user_input="I hate this"))
+    await svc._handle_input(neg)
+    assert await db.get_affinity("user") == 0
+    assert await pm.get_persona("user") == "snarky"
+
+    await db.close()


### PR DESCRIPTION
## Summary
- implement `SocialGraphService` for sentiment based affinity updates
- export the new service
- test that processing messages updates affinity accordingly

## Testing
- `pre-commit run --hook-stage manual black --files src/deepthought/services/social_graph_service.py src/deepthought/services/__init__.py tests/integration/test_social_graph_affinity.py`
- `pre-commit run --hook-stage manual isort --files src/deepthought/services/social_graph_service.py src/deepthought/services/__init__.py tests/integration/test_social_graph_affinity.py`
- `pre-commit run --hook-stage manual flake8 --files src/deepthought/services/social_graph_service.py src/deepthought/services/__init__.py tests/integration/test_social_graph_affinity.py`
- `pytest tests/integration/test_social_graph_affinity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881690aa530832697273a80d18ff4fb