### PR TITLE
Add social perception classifier

### DIFF
--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+"""Simple transformer based social cue classifier."""
+
+from typing import Dict
+
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+MODEL_PATH = "path/to/social-perception-model"
+LABELS = ["flirtation", "avoidance", "manipulation"]
+
+_tokenizer: AutoTokenizer | None = None
+_model: AutoModelForSequenceClassification | None = None
+
+
+def _load() -> None:
+    global _tokenizer, _model
+    if _tokenizer is None:
+        _tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+    if _model is None:
+        _model = AutoModelForSequenceClassification.from_pretrained(MODEL_PATH)
+
+
+def analyze(text: str) -> Dict[str, float]:
+    """Return probabilities for flirtation, avoidance and manipulation."""
+    _load()
+    assert _tokenizer and _model
+    inputs = _tokenizer(text, return_tensors="pt")
+    with torch.no_grad():
+        logits = _model(**inputs).logits
+        probs = torch.softmax(logits, dim=-1)[0].tolist()
+    return {label: float(prob) for label, prob in zip(LABELS, probs)}

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -16,6 +16,7 @@ from ..eda.events import EventSubjects, MemoryRetrievedPayload
 from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+from ..perception.social_perception import analyze as analyze_social
 from ..search import OfflineSearch
 from .base import BaseService
 from .db_manager import DBManager
@@ -103,6 +104,12 @@ class CognitiveCoreService(BaseService):
             self._memory.store_interaction(user_input)
             await self._db.store_memory("user", user_input)
             await self._db.log_interaction("user", None)
+            perception = analyze_social(user_input)
+            await self._db.store_memory("user", json.dumps(perception), topic="social_perception")
+            delta = perception.get("flirtation", 0.0) - (
+                perception.get("avoidance", 0.0) + perception.get("manipulation", 0.0)
+            )
+            await self._db.adjust_affinity("user", delta)
 
             mem_facts = self.retrieve_context(user_input)
             db_facts = await self._db_context()

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -1,0 +1,58 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_analyze_returns_probs(monkeypatch):
+    tf_mod = types.ModuleType("transformers")
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return {"text": text}
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, **kwargs):
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+
+    tf_mod.AutoTokenizer = DummyTokenizer
+    tf_mod.AutoModelForSequenceClassification = DummyModel
+    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    class DummyTensor(list):
+        def tolist(self):
+            return list(self)
+
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    sp = importlib.import_module("deepthought.perception.social_perception")
+    importlib.reload(sp)
+
+    result = sp.analyze("hi")
+    assert result == {
+        "flirtation": 0.1,
+        "avoidance": 0.2,
+        "manipulation": 0.7,
+    }

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -32,6 +32,34 @@ sys.modules.setdefault("prometheus_client", fake_prom)
 sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+torch_mod = types.ModuleType("torch")
+
+
+class _NoGrad:
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+
+torch_mod.no_grad = lambda: _NoGrad()
+torch_mod.softmax = lambda t, dim=-1: t
+sys.modules.setdefault("torch", torch_mod)
+tb_mod = types.ModuleType("textblob")
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0))
+sys.modules.setdefault("textblob", tb_mod)
+tf_mod = types.ModuleType("transformers")
+tf_mod.AutoTokenizer = type("AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())})
+tf_mod.AutoModelForSequenceClassification = type(
+    "AutoModelForSequenceClassification",
+    (),
+    {
+        "from_pretrained": classmethod(lambda cls, p: cls()),
+        "__call__": lambda self, **k: types.SimpleNamespace(logits=[[0, 0, 0]]),
+    },
+)
+sys.modules.setdefault("transformers", tf_mod)
 fake_nats = types.ModuleType("nats")
 fake_nats.__spec__ = importlib.machinery.ModuleSpec("nats", loader=None)
 fake_nats.aio = types.ModuleType("aio")
@@ -72,6 +100,7 @@ import json
 
 import pytest
 
+import deepthought.services.cognitive_core_service as cognitive_core_service
 from deepthought.config import Settings
 from deepthought.eda.events import EventSubjects, InputReceivedPayload
 from deepthought.services.cognitive_core_service import CognitiveCoreService
@@ -118,12 +147,20 @@ class DummyDB:
     def __init__(self):
         self.memories = []
         self.interactions = 0
+        self.affinity = 0.0
+        self.perceptions = []
 
     async def store_memory(self, user_id, memory, topic="", sentiment_score=None):
-        self.memories.append(memory)
+        if topic == "social_perception":
+            self.perceptions.append(json.loads(memory))
+        else:
+            self.memories.append(memory)
 
     async def log_interaction(self, user_id, target_id=None, sentiment_score=None):
         self.interactions += 1
+
+    async def adjust_affinity(self, user_id, delta):
+        self.affinity += delta
 
     async def recall_user(self, user_id):
         return [("", m) for m in self.memories]
@@ -146,6 +183,11 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     memory = DummyMemory()
     db = DummyDB()
     monkeypatch.setattr(
+        cognitive_core_service,
+        "analyze_social",
+        lambda text: {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0},
+    )
+    monkeypatch.setattr(
         CognitiveCoreService,
         "_publisher",
         DummyPublisher(DummyNATS(), DummyJS()),
@@ -164,6 +206,8 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     assert msg.acked
     assert memory.interactions == ["hello"]
     assert db.memories == ["hello"]
+    assert db.perceptions == [{"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0}]
+    assert abs(db.affinity - 0.1) < 1e-6
     subject, sent_payload = service._publisher.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"


### PR DESCRIPTION
## Summary
- add a transformer-based social perception module
- store social perception results and update affinity in the cognitive core
- create tests for the new perception classifier and cognitive core integration

## Testing
- `pre-commit run --files src/deepthought/perception/social_perception.py src/deepthought/services/cognitive_core_service.py tests/unit/perception/test_social_perception.py tests/unit/services/test_cognitive_core_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68816fe6a1a0832694814d2f44d840f1