### PR TITLE
Enhance trace recorder and add conversion utility

### DIFF
--- a/docs/interaction_trace.md
+++ b/docs/interaction_trace.md
@@ -1,0 +1,27 @@
+# Interaction Trace Format
+
+This file describes the JSONL format produced by `TraceRecorder` and related tools.
+Each line represents a single event emitted by the system.
+
+```json
+{
+  "event": "INPUT_RECEIVED",
+  "payload": {"user_input": "hello", "input_id": "abc"},
+  "perception": {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0},
+  "affinity": 0.1
+}
+```
+
+Fields
+------
+- **event** – name of the event, e.g. `INPUT_RECEIVED`, `RESPONSE_GENERATED` or `CHAT_RAW`.
+- **payload** – raw payload sent with the event. The structure depends on the event type and may be
+  either a dictionary or a string for raw chat messages.
+- **perception** – dictionary of social perception label probabilities. When the event contains
+  textual user input the recorder runs the social perception classifier and records the resulting
+  probabilities. If no text is available this field is `null`.
+- **affinity** – current affinity score for the user after applying the perception delta. The score is
+  incremented when a new input is processed.
+
+All records are written on a single line separated by newlines so that the file can be streamed or
+processed incrementally.

--- a/src/deepthought/harness/trace.py
+++ b/src/deepthought/harness/trace.py
@@ -7,6 +7,7 @@ from nats.js.client import JetStreamContext
 
 from ..eda.events import EventSubjects
 from ..eda.subscriber import Subscriber
+from ..perception.social_perception import analyze as analyze_social
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ class TraceRecorder:
             raise ValueError("outfile path must be provided")
         self._subscriber = Subscriber(nats_client, js_context)
         self._outfile = outfile
+        self._affinity = 0.0
         logger.info("TraceRecorder will write events to %s", outfile)
 
     async def _append(self, event: str, msg: Msg) -> None:
@@ -33,7 +35,29 @@ class TraceRecorder:
                     logger.error("Failed to NAK message", exc_info=True)
             return
 
-        record = {"event": event, "payload": data}
+        perception = None
+        try:
+            if isinstance(data, dict) and "user_input" in data:
+                perception = analyze_social(data["user_input"])
+            elif isinstance(data, str):
+                perception = analyze_social(data)
+        except Exception:  # noqa: BLE001 - perception analysis best effort
+            logger.error("Failed to analyze perception", exc_info=True)
+            perception = None
+
+        if perception:
+            delta = perception.get("flirtation", 0.0) - (
+                perception.get("avoidance", 0.0)
+                + perception.get("manipulation", 0.0)
+            )
+            self._affinity += delta
+
+        record = {
+            "event": event,
+            "payload": data,
+            "perception": perception,
+            "affinity": self._affinity,
+        }
         try:
             with open(self._outfile, "a", encoding="utf-8") as f:
                 json.dump(record, f)
@@ -50,7 +74,25 @@ class TraceRecorder:
 
     async def _append_raw(self, event: str, msg: Msg) -> None:
         data = msg.data.decode()
-        record = {"event": event, "payload": data}
+        perception = None
+        try:
+            perception = analyze_social(data)
+        except Exception:  # noqa: BLE001
+            logger.error("Failed to analyze perception", exc_info=True)
+
+        if perception:
+            delta = perception.get("flirtation", 0.0) - (
+                perception.get("avoidance", 0.0)
+                + perception.get("manipulation", 0.0)
+            )
+            self._affinity += delta
+
+        record = {
+            "event": event,
+            "payload": data,
+            "perception": perception,
+            "affinity": self._affinity,
+        }
         try:
             with open(self._outfile, "a", encoding="utf-8") as f:
                 json.dump(record, f)

--- a/tests/unit/test_harness_trace.py
+++ b/tests/unit/test_harness_trace.py
@@ -1,6 +1,34 @@
 import json
+import sys
+import types
 
 import pytest
+
+torch_stub = types.ModuleType("torch")
+torch_stub.no_grad = lambda: None
+torch_stub.softmax = lambda t, dim=0: [type("T", (), {"tolist": lambda self: [0.0, 0.0, 0.0]})()]
+transformers_stub = types.ModuleType("transformers")
+transformers_stub.AutoModelForSequenceClassification = object
+transformers_stub.AutoTokenizer = object
+sys.modules.setdefault("torch", torch_stub)
+sys.modules.setdefault("transformers", transformers_stub)
+
+# Provide minimal stubs for the nats package used in trace module imports
+fake_nats = types.ModuleType("nats")
+fake_nats.aio = types.ModuleType("aio")
+fake_nats.aio.client = types.ModuleType("client")
+fake_nats.aio.msg = types.ModuleType("msg")
+fake_nats.js = types.ModuleType("js")
+fake_nats.js.client = types.ModuleType("client_js")
+fake_nats.aio.client.Client = object
+fake_nats.aio.msg.Msg = object
+fake_nats.js.client.JetStreamContext = object
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_nats.aio.client)
+sys.modules.setdefault("nats.aio.msg", fake_nats.aio.msg)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_nats.js.client)
 
 import deepthought.harness.trace as trace
 
@@ -40,9 +68,14 @@ class DummyMsg:
 @pytest.mark.asyncio
 async def test_handle_input_writes_file(monkeypatch, tmp_path):
     monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    monkeypatch.setattr(
+        trace,
+        "analyze_social",
+        lambda text: {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0},
+    )
     outfile = tmp_path / "trace.jsonl"
     recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
-    msg = DummyMsg('{"foo": "bar"}')
+    msg = DummyMsg('{"user_input": "hi"}')
 
     await recorder._handle_input(msg)
     assert msg.acked
@@ -50,12 +83,23 @@ async def test_handle_input_writes_file(monkeypatch, tmp_path):
         line = f.readline()
     obj = json.loads(line)
     assert obj["event"] == "INPUT_RECEIVED"
-    assert obj["payload"] == {"foo": "bar"}
+    assert obj["payload"] == {"user_input": "hi"}
+    assert obj["perception"] == {
+        "flirtation": 0.2,
+        "avoidance": 0.1,
+        "manipulation": 0.0,
+    }
+    assert abs(obj["affinity"] - 0.1) < 1e-6
 
 
 @pytest.mark.asyncio
 async def test_handle_chat_raw(monkeypatch, tmp_path):
     monkeypatch.setattr(trace, "Subscriber", DummySubscriber)
+    monkeypatch.setattr(
+        trace,
+        "analyze_social",
+        lambda text: {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0},
+    )
     outfile = tmp_path / "trace.jsonl"
     recorder = trace.TraceRecorder(DummyNATS(), DummyJS(), str(outfile))
     msg = DummyMsg("hello")
@@ -67,3 +111,9 @@ async def test_handle_chat_raw(monkeypatch, tmp_path):
     obj = json.loads(line)
     assert obj["event"] == "CHAT_RAW"
     assert obj["payload"] == "hello"
+    assert obj["perception"] == {
+        "flirtation": 0.2,
+        "avoidance": 0.1,
+        "manipulation": 0.0,
+    }
+    assert abs(obj["affinity"] - 0.1) < 1e-6

--- a/tools/convert_trace.py
+++ b/tools/convert_trace.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Convert old trace logs to the interaction trace format."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from deepthought.perception.social_perception import analyze as analyze_social
+
+
+def _process(obj: dict | str, affinity: float) -> tuple[dict, float]:
+    if isinstance(obj, dict):
+        payload = obj.get("payload", obj)
+    else:
+        payload = obj
+        obj = {"event": "CHAT_RAW", "payload": payload}
+
+    text = None
+    if isinstance(payload, dict) and "user_input" in payload:
+        text = payload["user_input"]
+    elif isinstance(payload, str):
+        text = payload
+
+    perception = None
+    if text:
+        perception = analyze_social(text)
+        delta = perception.get("flirtation", 0.0) - (
+            perception.get("avoidance", 0.0) + perception.get("manipulation", 0.0)
+        )
+        affinity += delta
+
+    obj["perception"] = perception
+    obj["affinity"] = affinity
+    return obj, affinity
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="Path to the raw trace file")
+    parser.add_argument("--output", "-o", type=Path, required=True, help="Output file")
+    args = parser.parse_args()
+
+    affinity = 0.0
+    with args.input.open("r", encoding="utf-8") as fin, args.output.open("w", encoding="utf-8") as fout:
+        for line in fin:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            obj, affinity = _process(obj, affinity)
+            json.dump(obj, fout)
+            fout.write("\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document JSONL schema for trace logs
- record perception labels and affinity scores for each event
- provide a script to convert old traces to the new format
- update tests for new trace fields
- stub NATS modules in harness trace unit tests

## Testing
- `flake8 src/deepthought/harness/trace.py tools/convert_trace.py tests/unit/test_harness_trace.py`
- `pytest -q tests/unit/test_harness_trace.py`


------
https://chatgpt.com/codex/tasks/task_e_68817b5ba1bc83269dbc3eb16606a7ff