### PR TITLE
Expose BDI intentions via goal scheduler

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -41,6 +41,9 @@ class EventSubjects:
     PLAN_REQUESTED = "dtr.plan.requested"
     PLAN_GENERATED = "dtr.plan.generated"
 
+    # BDI agent events
+    BDI_INTENTION = "dtr.bdi.intention"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -139,3 +142,11 @@ class PlanGeneratedPayload(EventPayload):
     plan: list[str]
     input_id: Optional[str] = None
     timestamp: Optional[str] = None
+
+
+@dataclass
+class BDIIntentionPayload(EventPayload):
+    """Payload representing a BDI intention."""
+
+    goal: str
+    priority: int

--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -6,6 +6,9 @@ import heapq
 from dataclasses import dataclass, field
 from typing import List
 
+from .eda.events import BDIIntentionPayload, EventSubjects
+from .eda.publisher import Publisher
+
 
 @dataclass(order=True)
 class ScheduledGoal:
@@ -28,3 +31,24 @@ class GoalScheduler:
         if not self._heap:
             return None
         return heapq.heappop(self._heap).goal
+
+    def next_intention(self) -> BDIIntentionPayload | None:
+        """Pop the next goal and convert it to a BDI intention payload."""
+        if not self._heap:
+            return None
+        scheduled = heapq.heappop(self._heap)
+        return BDIIntentionPayload(goal=scheduled.goal, priority=-scheduled.priority)
+
+    async def publish_intentions(self, publisher: Publisher) -> int:
+        """Publish all queued goals as BDI intentions.
+
+        Returns the number of published intentions.
+        """
+        count = 0
+        while self._heap:
+            intention = self.next_intention()
+            if intention is None:
+                break
+            await publisher.publish(EventSubjects.BDI_INTENTION, intention, use_jetstream=True)
+            count += 1
+        return count

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,37 @@ try:  # pragma: no cover - optional dependency may be missing
 except Exception:
     pass
 
+# Provide a stub for the ``nats`` package when it is unavailable so modules
+# importing it (e.g. the event publisher) can be loaded during tests.
+try:  # pragma: no cover - optional dependency may be missing
+    import importlib.util
+
+    spec = importlib.util.find_spec("nats")
+except Exception:
+    spec = None
+
+if spec is None:
+    nats_stub = types.ModuleType("nats")
+    nats_stub.aio = types.ModuleType("aio")
+    aio_client_mod = types.ModuleType("client")
+    setattr(aio_client_mod, "Client", object)
+    nats_stub.aio.client = aio_client_mod
+    nats_stub.js = types.ModuleType("js")
+    js_client_mod = types.ModuleType("client")
+    setattr(js_client_mod, "JetStreamContext", object)
+    nats_stub.js.client = js_client_mod
+    msg_mod = types.ModuleType("msg")
+    setattr(msg_mod, "Msg", object)
+    nats_stub.aio.msg = msg_mod
+    nats_stub.errors = types.ModuleType("errors")
+    sys.modules.setdefault("nats", nats_stub)
+    sys.modules.setdefault("nats.aio", nats_stub.aio)
+    sys.modules.setdefault("nats.aio.client", nats_stub.aio.client)
+    sys.modules.setdefault("nats.aio.msg", nats_stub.aio.msg)
+    sys.modules.setdefault("nats.js", nats_stub.js)
+    sys.modules.setdefault("nats.js.client", nats_stub.js.client)
+    sys.modules.setdefault("nats.errors", nats_stub.errors)
+
 import pytest
 
 # Provide a lightweight stub of the social_graph_bot module. This allows tests

--- a/tests/unit/test_goal_scheduler_bdi.py
+++ b/tests/unit/test_goal_scheduler_bdi.py
@@ -1,0 +1,52 @@
+import pytest
+import sys
+import types
+
+# Stub nats modules required by Publisher import in goal_scheduler
+fake_nats = types.ModuleType("nats")
+fake_nats.aio = types.ModuleType("aio")
+fake_nats.aio.client = types.ModuleType("client")
+fake_nats.js = types.ModuleType("js")
+fake_nats.js.client = types.ModuleType("client")
+fake_nats.errors = types.ModuleType("errors")
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_nats.aio.client)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_nats.js.client)
+sys.modules.setdefault("nats.errors", fake_nats.errors)
+
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.eda.events import EventSubjects, BDIIntentionPayload
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+def test_next_intention_returns_payload():
+    sched = GoalScheduler()
+    sched.add_goal("alpha", priority=3)
+    intention = sched.next_intention()
+    assert isinstance(intention, BDIIntentionPayload)
+    assert intention.goal == "alpha"
+    assert intention.priority == 3
+
+
+@pytest.mark.asyncio
+async def test_publish_intentions(monkeypatch):
+    sched = GoalScheduler()
+    sched.add_goal("first", priority=5)
+    sched.add_goal("second", priority=1)
+    pub = DummyPublisher()
+    count = await sched.publish_intentions(pub)
+    assert count == 2
+    assert len(pub.published) == 2
+    subj, payload = pub.published[0]
+    assert subj == EventSubjects.BDI_INTENTION
+    assert payload.goal == "first"
+    assert payload.priority == 5


### PR DESCRIPTION
## Summary
- expand event system with `BDI_INTENTION` subject and payload
- convert scheduled goals into BDI intentions
- allow publishing all intentions
- stub `nats` modules in tests
- add unit test for intention publishing

## Testing
- `flake8 src tests`
- `pytest -q tests/unit/test_persona_goal_affinity.py tests/unit/test_goal_scheduler_bdi.py`

------
https://chatgpt.com/codex/tasks/task_e_6881941e7cc48326b65cc1ccaf3b24e2