### PR TITLE
Add PlanningService implementing BDI cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ demo = "deepthought.services.demo.service:DemoService"
 codegen = "deepthought.services.code_generation_service:CodeGenerationService"
 cognitive_core = "deepthought.services.cognitive_core_service:CognitiveCoreService"
 reward_manager = "deepthought.motivate.reward_manager:RewardManager"
+planning = "deepthought.services.planning_service:PlanningService"
 
 
 

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -127,8 +127,12 @@ async def run(config_path: str) -> None:
         instances = []
         crews = []  # noqa: F841 - reserved for future use
         graph_tasks = []
+        desires_file = cfg.get("desires_file", "desires.json")
         for cls in service_classes:
-            inst = cls(nc, js)
+            if cls.__name__ == "PlanningService":
+                inst = cls(nc, js, desires_file=desires_file)
+            else:
+                inst = cls(nc, js)
             await stack.enter_async_context(inst)
             instances.append(inst)
         await sub.subscribe(

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -5,6 +5,7 @@ from .db_manager import DBManager
 from .file_graph_dal import FileGraphDAL
 from .persona_manager import PersonaManager
 from .social_graph_service import SocialGraphService
+from .planning_service import PlanningService
 
 __all__ = [
     "FileGraphDAL",
@@ -12,4 +13,5 @@ __all__ = [
     "PersonaManager",
     "DBManager",
     "SocialGraphService",
+    "PlanningService",
 ]

--- a/src/deepthought/services/planning_service.py
+++ b/src/deepthought/services/planning_service.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import (
+    EventSubjects,
+    MemoryRetrievedPayload,
+    PlanGeneratedPayload,
+    PlanRequestedPayload,
+)
+from .base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class PlanningService(BaseService):
+    """Simple Belief-Desire-Intention loop."""
+
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        desires_file: str = "desires.json",
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        self._desires_file = desires_file
+        self._desires: List[str] = []
+        self._beliefs: List[str] = []
+        self._load_desires()
+
+    def _load_desires(self) -> None:
+        try:
+            text = Path(self._desires_file).read_text(encoding="utf-8")
+            data = json.loads(text)
+            ds = data.get("desires", [])
+            if isinstance(ds, list):
+                self._desires = [str(d) for d in ds]
+            logger.info("Loaded %d desires from %s", len(self._desires), self._desires_file)
+        except FileNotFoundError:
+            logger.warning("Desires file %s not found", self._desires_file)
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to load desires file %s", self._desires_file, exc_info=True)
+
+    async def _handle_memory(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            payload = MemoryRetrievedPayload.from_dict(data)
+            self._beliefs = payload.retrieved_knowledge.get("facts", [])
+            await self._form_intentions(payload.input_id)
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to process memory event", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_plan(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            payload = PlanGeneratedPayload.from_dict(data)
+            for action in payload.plan:
+                await self._publisher.publish(
+                    EventSubjects.CHAT_RAW,
+                    action,
+                    use_jetstream=True,
+                    timeout=10.0,
+                )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to process plan", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _form_intentions(self, input_id: str | None) -> None:
+        for goal in self._desires:
+            payload = PlanRequestedPayload(goal=goal, input_id=input_id)
+            await self._publisher.publish(
+                EventSubjects.PLAN_REQUESTED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+
+    async def start(self, durable_name: str = "planning_service") -> bool:
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.MEMORY_RETRIEVED,
+            handler=self._handle_memory,
+            use_jetstream=True,
+            durable=f"{durable_name}_belief",
+        )
+        self.add_subscription(
+            subject=EventSubjects.PLAN_GENERATED,
+            handler=self._handle_plan,
+            use_jetstream=True,
+            durable=f"{durable_name}_plan",
+        )
+        started = await super().start()
+        if started:
+            logger.info("PlanningService started")
+        return started
+
+    async def stop(self) -> None:
+        await super().stop()
+
+    async def __aenter__(self) -> "PlanningService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/tests/unit/services/test_planning_service.py
+++ b/tests/unit/services/test_planning_service.py
@@ -1,0 +1,131 @@
+import importlib.machinery
+import sys
+import types
+import json
+
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+fake_pyd.Field = lambda default=None, **kwargs: default
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+fake_ps.BaseSettings = object
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+fake_prom = types.ModuleType("prometheus_client")
+fake_prom.Counter = lambda *a, **k: object()
+fake_prom.Histogram = lambda *a, **k: object()
+fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
+sys.modules.setdefault("prometheus_client", fake_prom)
+sys.modules.setdefault("faiss", types.ModuleType("faiss"))
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+torch_mod = types.ModuleType("torch")
+torch_mod.no_grad = lambda: types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)()
+torch_mod.softmax = lambda t, dim=-1: t
+sys.modules.setdefault("torch", torch_mod)
+tb_mod = types.ModuleType("textblob")
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0))
+sys.modules.setdefault("textblob", tb_mod)
+tf_mod = types.ModuleType("transformers")
+tf_mod.AutoTokenizer = type("AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())})
+tf_mod.AutoModelForSequenceClassification = type(
+    "AutoModelForSequenceClassification",
+    (),
+    {"from_pretrained": classmethod(lambda cls, p: cls()), "__call__": lambda self, **k: types.SimpleNamespace(logits=[[0, 0, 0]])},
+)
+sys.modules.setdefault("transformers", tf_mod)
+
+fake_nats = types.ModuleType("nats")
+fake_nats.__spec__ = importlib.machinery.ModuleSpec("nats", loader=None)
+fake_nats.aio = types.ModuleType("aio")
+client_mod = types.ModuleType("client")
+setattr(client_mod, "Client", object)
+fake_nats.aio.client = client_mod
+msg_mod = types.ModuleType("msg")
+setattr(msg_mod, "Msg", object)
+fake_nats.aio.msg = msg_mod
+fake_nats.js = types.ModuleType("js")
+js_client_mod = types.ModuleType("client")
+setattr(js_client_mod, "JetStreamContext", object)
+fake_nats.js.client = js_client_mod
+fake_nats.errors = types.ModuleType("errors")
+setattr(fake_nats.errors, "Error", Exception)
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", client_mod)
+sys.modules.setdefault("nats.aio.msg", msg_mod)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", js_client_mod)
+sys.modules.setdefault("nats.errors", fake_nats.errors)
+
+from deepthought.eda.events import (
+    EventSubjects,
+    MemoryRetrievedPayload,
+    PlanGeneratedPayload,
+)
+from deepthought.services.planning_service import PlanningService
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, **kw):
+        self.published.append((subject, payload))
+
+
+class DummySubscriber:
+    async def subscribe(self, *a, **k):
+        return True
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, payload):
+        self.data = payload.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_memory_triggers_plan(tmp_path):
+    cfg = tmp_path / "d.json"
+    cfg.write_text(json.dumps({"desires": ["do it"]}), encoding="utf-8")
+
+    service = PlanningService(None, None, desires_file=str(cfg))
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["hi"]}, input_id="x")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_memory(msg)
+
+    assert msg.acked
+    assert service._publisher.published
+    subj, out = service._publisher.published[0]
+    assert subj == EventSubjects.PLAN_REQUESTED
+    assert out.goal == "do it"
+    assert out.input_id == "x"
+
+
+@pytest.mark.asyncio
+async def test_execute_plan():
+    service = PlanningService(None, None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = PlanGeneratedPayload(plan=["step1", "step2"], input_id="y")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_plan(msg)
+
+    assert msg.acked
+    subjects = [s for s, _ in service._publisher.published]
+    assert subjects == [EventSubjects.CHAT_RAW, EventSubjects.CHAT_RAW]


### PR DESCRIPTION
## Summary
- add PlanningService using Belief–Desire–Intention loop
- integrate PlanningService into orchestrator
- expose PlanningService via package init and entry points
- test PlanningService behaviours

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/unit/services/test_planning_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881941d57e883268ab9132db3b4ea90