### PR TITLE
Update docs for CognitiveCoreService

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,14 +10,14 @@ The project follows an event driven architecture built on NATS/JetStream. Compon
 sequenceDiagram
     participant User
     participant Bot
-    participant MemoryService
+    participant CognitiveCoreService
     participant HierarchicalService
     participant LLM
 
     User->>Bot: Message
     Bot->>NATS: INPUT_RECEIVED
-    NATS->>MemoryService: INPUT_RECEIVED
-    MemoryService->>NATS: MEMORY_RETRIEVED
+    NATS->>CognitiveCoreService: INPUT_RECEIVED
+    CognitiveCoreService->>NATS: MEMORY_RETRIEVED
     NATS->>HierarchicalService: MEMORY_RETRIEVED
     HierarchicalService->>LLM: Query
     LLM-->>HierarchicalService: Response
@@ -144,7 +144,7 @@ Customize the generated files to implement your service logic.
 
 ## Multi-Agent Demo
 
-The repository includes a demonstration of three lightweight agents exchanging messages using the `MemoryService` and a small HTTP LLM module. The agents are coordinated with a LangGraph state machine and live in `examples/multi_agent_demo.py`.
+The repository includes a demonstration of three lightweight agents exchanging messages using the `CognitiveCoreService` and a small HTTP LLM module. The agents are coordinated with a LangGraph state machine and live in `examples/multi_agent_demo.py`.
 
 Start a local NATS server with `./scripts/start_nats.sh` and create the JetStream stream:
 

--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -54,9 +54,9 @@ Both connectors read these environment variables automatically when no
 explicit parameters are provided and will retry connecting a few times
 before failing.
 
-## Example Memory Service
+## Example CognitiveCore Service
 
-Start the unified `MemoryService` which configures its backends from environment variables:
+Start the unified `CognitiveCoreService` which configures its backends from environment variables:
 
 ```bash
 python - <<'PY'
@@ -65,7 +65,7 @@ import asyncio
 from nats.aio.client import Client as NATS
 
 from deepthought.config import get_settings
-from deepthought.services import MemoryService
+from deepthought.services import CognitiveCoreService
 
 
 async def main():
@@ -74,7 +74,7 @@ async def main():
     await nc.connect(servers=[settings.nats_url])
     js = nc.jetstream()
 
-    service = MemoryService.from_config(nc, js)
+    service = CognitiveCoreService.from_config(nc, js)
     await service.start()
     await asyncio.Event().wait()
 

--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -8,7 +8,7 @@ This document outlines the design of the experimental hierarchical memory system
 2. **GraphMemory** – wraps `TieredMemory` with a file-backed graph database.
 3. **KnowledgeGraphMemory** – persists structured facts in Memgraph using the GraphDAL layer.
 
-The `MemoryService` coordinates these layers through a single `TieredMemory` instance.
+The `CognitiveCoreService` coordinates these layers through a single `TieredMemory` instance.
 When an `INPUT_RECEIVED` event arrives the service stores the text and publishes a
 `MEMORY_RETRIEVED` event with the combined context.
 
@@ -103,7 +103,7 @@ set in a configuration file.
 
 ``DT_GRAPH_BACKEND`` selects the knowledge graph backend. Supported values include
 ``memgraph``, ``neo4j`` and ``noop``. These variables are read by both
-``HierarchicalService.from_chroma`` and ``MemoryService`` when initializing the
+``HierarchicalService.from_chroma`` and ``CognitiveCoreService`` when initializing the
 backends.
 
 ### Graph Backend

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -90,7 +90,7 @@ Grafana will be available on <http://localhost:3000> with the default password
 
 The `examples/end_to_end_demo.py` script shows how to run multiple services via
 the orchestrator. It launches a local NATS server and starts the
-`MemoryService`, `RemoteLLM`, `OutputHandler` and `RewardManager` services. A
+`CognitiveCoreService`, `RemoteLLM`, `OutputHandler` and `RewardManager` services. A
 sample message is then processed end-to-end.
 
 Run the demo with:


### PR DESCRIPTION
## Summary
- update architecture diagram and text to mention `CognitiveCoreService`
- fix GraphDAL example to use `CognitiveCoreService.from_config`
- revise hierarchical service instructions for `CognitiveCoreService`
- update orchestrator quickstart references

## Testing
- `grep -R "MemoryService" -n docs`

------
https://chatgpt.com/codex/tasks/task_e_6882876f93c883268ca84eaa5be71e17