### PR TITLE
Make social perception model path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,16 @@ A minimal notebook demonstrating retrieval-augmented generation is available at 
 
 
 
+## Social Perception
+
+Set the path to the social cue classifier with `SOCIAL_PERCEPTION_MODEL`:
+
+```bash
+export SOCIAL_PERCEPTION_MODEL=/path/to/social-perception-model
+```
+
+If unset, the default `path/to/social-perception-model` is used.
+
 ## Discord Bot Roadmap
 
 For a detailed overview of the Discord bot progress, see [docs/discord_bot_roadmap.md](docs/discord_bot_roadmap.md).

--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Dict
 
+import os
+
 import torch
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-MODEL_PATH = "path/to/social-perception-model"
+MODEL_PATH = os.getenv("SOCIAL_PERCEPTION_MODEL", "path/to/social-perception-model")
 LABELS = ["flirtation", "avoidance", "manipulation"]
 
 _tokenizer: AutoTokenizer | None = None

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -56,3 +56,59 @@ def test_analyze_returns_probs(monkeypatch):
         "avoidance": 0.2,
         "manipulation": 0.7,
     }
+
+
+def test_env_model_path(monkeypatch):
+    paths: dict[str, str] = {}
+
+    tf_mod = types.ModuleType("transformers")
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, path):
+            paths["tokenizer"] = path
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return {"text": text}
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, path):
+            paths["model"] = path
+            return cls()
+
+        def __call__(self, **kwargs):
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+
+    tf_mod.AutoTokenizer = DummyTokenizer
+    tf_mod.AutoModelForSequenceClassification = DummyModel
+    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    class DummyTensor(list):
+        def tolist(self):
+            return list(self)
+
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/custom-model")
+
+    sp = importlib.import_module("deepthought.perception.social_perception")
+    importlib.reload(sp)
+
+    sp.analyze("hello")
+
+    assert paths["tokenizer"] == "/tmp/custom-model"
+    assert paths["model"] == "/tmp/custom-model"


### PR DESCRIPTION
## Summary
- allow overriding social perception model path via `SOCIAL_PERCEPTION_MODEL`
- document `SOCIAL_PERCEPTION_MODEL` in the README
- test env var handling for social perception model loader

## Testing
- `flake8 src/deepthought/perception/social_perception.py tests/unit/perception/test_social_perception.py`
- `pytest tests/unit/perception/test_social_perception.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882877086d8832693b67f4a23b68a1f