### PR TITLE
Add perception-based affinity test

### DIFF
--- a/tests/integration/test_social_graph_affinity.py
+++ b/tests/integration/test_social_graph_affinity.py
@@ -1,10 +1,16 @@
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
 
 from deepthought.eda.events import InputReceivedPayload
-from deepthought.services import DBManager, PersonaManager
-from deepthought.services.social_graph_service import SocialGraphService
+
+# Provide a lightweight stub for the perception module so that tests do not
+# require heavy optional dependencies when importing service modules.
+sp_stub = types.ModuleType("deepthought.perception.social_perception")
+sp_stub.analyze = lambda _t: {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0}
+sys.modules.setdefault("deepthought.perception.social_perception", sp_stub)
 
 
 class DummyMsg:
@@ -18,11 +24,15 @@ class DummyMsg:
 
 @pytest.mark.asyncio
 async def test_affinity_changes_after_processing(tmp_path):
+    from deepthought.services.db_manager import DBManager
+    from deepthought.services.persona_manager import PersonaManager
+    from deepthought.services.social_graph_service import SocialGraphService
+
     db = DBManager(str(tmp_path / "sg.db"))
     await db.init_db()
     pm = PersonaManager(db, friendly=1, playful=1)
     svc = SocialGraphService(db_manager=db, persona_manager=pm)
-    svc._publisher = SimpleNamespace()
+    svc._publisher = SimpleNamespace(publish=lambda *a, **k: None)
     svc._subscriber = SimpleNamespace()
 
     pos = DummyMsg(InputReceivedPayload(user_input="I love this"))
@@ -35,5 +45,49 @@ async def test_affinity_changes_after_processing(tmp_path):
     await svc._handle_input(neg)
     assert await db.get_affinity("user") == 0
     assert await pm.get_persona("user") == "snarky"
+
+    await db.close()
+
+
+class DummyMemory:
+    def __init__(self) -> None:
+        self.interactions: list[str] = []
+
+    def store_interaction(self, text: str) -> None:
+        self.interactions.append(text)
+
+    def retrieve_context(self, prompt: str) -> list[str]:
+        return self.interactions[-3:]
+
+
+@pytest.mark.asyncio
+async def test_cognitive_core_affinity_with_mocked_perception(tmp_path, monkeypatch):
+    sp_mod = types.ModuleType("deepthought.perception.social_perception")
+    sp_mod.analyze = lambda _t: {
+        "flirtation": 0.6,
+        "avoidance": 0.1,
+        "manipulation": 0.0,
+    }
+    monkeypatch.setitem(sys.modules, "deepthought.perception.social_perception", sp_mod)
+
+    import importlib
+
+    cognitive_core_service = importlib.import_module("deepthought.services.cognitive_core_service")
+    importlib.reload(cognitive_core_service)
+    CognitiveCoreService = cognitive_core_service.CognitiveCoreService
+    Settings = cognitive_core_service.Settings
+    from deepthought.services.db_manager import DBManager
+
+    db = DBManager(str(tmp_path / "core.db"))
+    await db.init_db()
+    svc = CognitiveCoreService(None, None, Settings(), memory=DummyMemory(), db=db)
+    svc._publisher = SimpleNamespace(publish=lambda *a, **k: None)
+    svc._subscriber = SimpleNamespace()
+
+    msg = DummyMsg(InputReceivedPayload(user_input="hello", input_id="1"))
+    await svc._handle_input(msg)
+
+    assert msg.acked
+    assert await db.get_affinity("user") == 2
 
     await db.close()


### PR DESCRIPTION
## Summary
- stub perception module so tests do not need heavy deps
- add integration test covering CognitiveCoreService affinity adjustments

## Testing
- `pre-commit run --files tests/integration/test_social_graph_affinity.py`


------
https://chatgpt.com/codex/tasks/task_e_688290606bb883268897a3854069c638