### PR TITLE
Enhance social graph service

### DIFF
--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -7,7 +7,7 @@ from typing import Optional
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
-from textblob import TextBlob
+from ..perception.social_perception import analyze as analyze_social
 
 from ..eda.events import EventSubjects
 from .base import BaseService
@@ -48,12 +48,14 @@ class SocialGraphService(BaseService):
             text = data.get("user_input")
             if not isinstance(text, str):
                 raise ValueError("user_input missing")
-            score = float(TextBlob(text).sentiment.polarity)
-            delta = 0
-            if score > 0:
-                delta = 1
-            elif score < 0:
-                delta = -1
+            perception = analyze_social(text)
+            await self._db.store_memory(
+                "user", json.dumps(perception), topic="social_perception"
+            )
+            delta = perception.get("flirtation", 0.0) - (
+                perception.get("avoidance", 0.0)
+                + perception.get("manipulation", 0.0)
+            )
             await self._db.adjust_affinity("user", delta)
             await self._persona.get_persona("user")
         except Exception:

--- a/tests/integration/test_social_graph_affinity.py
+++ b/tests/integration/test_social_graph_affinity.py
@@ -1,10 +1,11 @@
 from types import SimpleNamespace
+import sys
+import types
 
 import pytest
 
 from deepthought.eda.events import InputReceivedPayload
-from deepthought.services import DBManager, PersonaManager
-from deepthought.services.social_graph_service import SocialGraphService
+
 
 
 class DummyMsg:
@@ -17,7 +18,27 @@ class DummyMsg:
 
 
 @pytest.mark.asyncio
-async def test_affinity_changes_after_processing(tmp_path):
+async def test_affinity_changes_after_processing(tmp_path, monkeypatch):
+    # Stub heavy modules before importing the service
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+    sp_stub = types.ModuleType("social_perception")
+    sp_stub.analyze = lambda text: {
+        "flirtation": 0.0,
+        "avoidance": 0.0,
+        "manipulation": 0.0,
+    }
+    monkeypatch.setitem(
+        sys.modules,
+        "deepthought.perception.social_perception",
+        sp_stub,
+    )
+
+    from deepthought.services.db_manager import DBManager
+    from deepthought.services.persona_manager import PersonaManager
+    from deepthought.services.social_graph_service import SocialGraphService
+    from deepthought.perception import social_perception
+    import deepthought.services.social_graph_service as sgs
+
     db = DBManager(str(tmp_path / "sg.db"))
     await db.init_db()
     pm = PersonaManager(db, friendly=1, playful=1)
@@ -25,15 +46,29 @@ async def test_affinity_changes_after_processing(tmp_path):
     svc._publisher = SimpleNamespace()
     svc._subscriber = SimpleNamespace()
 
+    monkeypatch.setattr(
+        sgs,
+        "analyze_social",
+        lambda text: {"flirtation": 0.6, "avoidance": 0.2, "manipulation": 0.0},
+    )
     pos = DummyMsg(InputReceivedPayload(user_input="I love this"))
     await svc._handle_input(pos)
     assert pos.acked
     assert await db.get_affinity("user") == 1
     assert await pm.get_persona("user") == "friendly"
 
+    monkeypatch.setattr(
+        sgs,
+        "analyze_social",
+        lambda text: {"flirtation": 0.0, "avoidance": 0.4, "manipulation": 0.3},
+    )
     neg = DummyMsg(InputReceivedPayload(user_input="I hate this"))
     await svc._handle_input(neg)
     assert await db.get_affinity("user") == 0
     assert await pm.get_persona("user") == "snarky"
+
+    memories = await db.recall_user("user")
+    topics = [t for t, _ in memories]
+    assert topics.count("social_perception") == 2
 
     await db.close()


### PR DESCRIPTION
## Summary
- use social perception model in `SocialGraphService`
- record perception results in the DB
- update social graph affinity integration test to use new analyzer

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/integration/test_social_graph_affinity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882905fc96c83269ad52e541d3abdcd