### PR TITLE
Enable multi-file golden data in discord replay

### DIFF
--- a/tests/unit/test_discord_replay.py
+++ b/tests/unit/test_discord_replay.py
@@ -1,0 +1,83 @@
+import asyncio
+import json
+from pathlib import Path
+import types
+
+import pytest
+
+import tools.discord_replay as dr
+
+
+class DummyMsg:
+    def __init__(self, text: str) -> None:
+        self.data = json.dumps({"final_response": text}).encode()
+
+    async def ack(self) -> None:
+        pass
+
+
+class DummySubscriber:
+    instance = None
+
+    def __init__(self, *args, **kwargs):
+        DummySubscriber.instance = self
+        self.handler = None
+
+    async def subscribe(self, *args, **kwargs):
+        self.handler = kwargs.get("handler") or args[1]
+        return True
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyPublisher:
+    responses = []
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def publish(self, subject, payload, **kwargs):
+        response = DummyPublisher.responses.pop(0)
+        await DummySubscriber.instance.handler(DummyMsg(response))
+        return None
+
+
+class DummyNATS:
+    is_connected = True
+
+    async def connect(self, *args, **kwargs):
+        pass
+
+    def jetstream(self):
+        return object()
+
+    async def drain(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_replay_generates_metrics(tmp_path: Path, monkeypatch):
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text(
+        json.dumps({"event": "CHAT_RAW", "payload": {"text": "Hello"}}) + "\n",
+        encoding="utf-8",
+    )
+
+    golden = tmp_path / "golden.yaml"
+    golden.write_text('- input: "Hello"\n  expected: "Hi"\n  rating: 5\n', encoding="utf-8")
+
+    metrics = tmp_path / "metrics.json"
+    output = tmp_path / "out.jsonl"
+
+    DummyPublisher.responses = ["Hi"]
+    monkeypatch.setattr(dr, "NATS", DummyNATS)
+    monkeypatch.setattr(dr, "Publisher", DummyPublisher)
+    monkeypatch.setattr(dr, "Subscriber", DummySubscriber)
+
+    await dr._replay(trace, output, metrics, "nats://localhost:4222", golden)
+
+    data = json.loads(metrics.read_text(encoding="utf-8"))
+    assert "bleu" in data
+    assert "rouge_l" in data
+    assert data.get("avg_rating") == pytest.approx(5.0)

--- a/tools/discord_replay.py
+++ b/tools/discord_replay.py
@@ -38,11 +38,27 @@ def _load_events(path: Path) -> List[dict]:
 
 
 def _load_golden(path: Path) -> List[dict]:
-    """Load golden interactions from YAML."""
-    data = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(data, list):
-        raise ValueError("Golden file must contain a list of interactions")
-    return data
+    """Return a list of golden interactions from ``path``.
+
+    ``path`` may refer to a single YAML file or a directory containing
+    multiple ``*.yaml`` files. When a directory is provided, the
+    interactions from all YAML files are concatenated in alphabetical
+    order.
+    """
+
+    def _read_one(file: Path) -> List[dict]:
+        data = yaml.safe_load(file.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            raise ValueError("Golden file must contain a list of interactions")
+        return data
+
+    if path.is_dir():
+        interactions: List[dict] = []
+        for file in sorted(path.glob("*.yaml")):
+            interactions.extend(_read_one(file))
+        return interactions
+
+    return _read_one(path)
 
 
 async def _replay(
@@ -147,7 +163,7 @@ async def main() -> None:
         "--golden",
         "-g",
         type=Path,
-        help="YAML file with golden interactions",
+        help="Path to golden YAML file or directory of YAML files",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- support directories of YAML files for golden data in `discord_replay.py`
- unit test for replaying traces with golden file metrics

## Testing
- `flake8 tools/discord_replay.py tests/unit/test_discord_replay.py`
- `pytest tests/unit/test_discord_replay.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68829aae1e888326b44ccce1b6b4e8b1