### PR TITLE
Add golden interaction samples and doc instructions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,5 @@ repos:
         name: pytest
         entry: pytest
         language: system
-        pass_filenames: true
-        files: ^tests/
+        pass_filenames: false
+        files: ^tests/.*\.py$

--- a/docs/evaluation_framework.md
+++ b/docs/evaluation_framework.md
@@ -15,3 +15,9 @@ responses against a golden dataset.
    the golden responses, and writes average latency and throughput metrics.
    If ratings are provided in the YAML file, the average rating is reported as
    `avg_rating` in the metrics JSON.
+
+## Contributing additional scenarios
+To expand the golden dataset, place YAML files under `tests/interaction_samples/golden/`.
+Each file should contain a list of interaction objects with `input`, `expected`, and `rating` fields.
+Ratings should be integers from 1 to 5.
+Use the existing samples as a reference.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,26 @@ if spec is None:
     js_client_mod = types.ModuleType("client")
     setattr(js_client_mod, "JetStreamContext", object)
     nats_stub.js.client = js_client_mod
+    api_mod = types.ModuleType("api")
+
+    class _StreamConfig:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    class _DiscardPolicy:
+        Old = 0
+
+    class _RetentionPolicy:
+        LIMITS = 0
+
+    class _StorageType:
+        MEMORY = 0
+
+    api_mod.StreamConfig = _StreamConfig
+    api_mod.DiscardPolicy = _DiscardPolicy
+    api_mod.RetentionPolicy = _RetentionPolicy
+    api_mod.StorageType = _StorageType
+    nats_stub.js.api = api_mod
     msg_mod = types.ModuleType("msg")
     setattr(msg_mod, "Msg", object)
     nats_stub.aio.msg = msg_mod
@@ -52,7 +72,80 @@ if spec is None:
     sys.modules.setdefault("nats.aio.msg", nats_stub.aio.msg)
     sys.modules.setdefault("nats.js", nats_stub.js)
     sys.modules.setdefault("nats.js.client", nats_stub.js.client)
+    sys.modules.setdefault("nats.js.api", nats_stub.js.api)
     sys.modules.setdefault("nats.errors", nats_stub.errors)
+
+# Provide lightweight stubs for optional heavy packages so tests can run in
+# minimal environments.
+if "torch" not in sys.modules:
+    torch_stub = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    torch_stub.no_grad = lambda: _NoGrad()
+    torch_stub.softmax = lambda x, dim=None: x
+    sys.modules["torch"] = torch_stub
+
+if "l2p" not in sys.modules:
+    l2p_stub = types.ModuleType("l2p")
+
+    def _parse_domain(*args, **kwargs):
+        return {}
+
+    def _parse_problem(*args, **kwargs):
+        return {}
+
+    l2p_stub.utils = types.SimpleNamespace(
+        parse_domain=_parse_domain, parse_problem=_parse_problem
+    )
+    sys.modules["l2p"] = l2p_stub
+    sys.modules["l2p.utils"] = l2p_stub.utils
+
+if "owlready2" not in sys.modules:
+    owlready_stub = types.ModuleType("owlready2")
+
+    class ThingClass:  # type: ignore
+        pass
+
+    class World:  # type: ignore
+        pass
+
+    def sync_reasoner_hermit(*args, **kwargs):
+        return None
+
+    owlready_stub.ThingClass = ThingClass
+    owlready_stub.World = World
+    owlready_stub.sync_reasoner_hermit = sync_reasoner_hermit
+    sys.modules["owlready2"] = owlready_stub
+
+if "deepthought.motivate.ledger" not in sys.modules:
+    ledger_stub = types.ModuleType("ledger")
+
+    class Ledger:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def add_event(self, *args, **kwargs) -> None:
+            return None
+
+    ledger_stub.Ledger = Ledger
+    sys.modules.setdefault("deepthought.motivate.ledger", ledger_stub)
+
+if "transformers" not in sys.modules:
+    transformers_stub = types.ModuleType("transformers")
+
+    class _DummyModel:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+    transformers_stub.AutoModelForSequenceClassification = _DummyModel
+    transformers_stub.AutoTokenizer = _DummyModel
+    sys.modules["transformers"] = transformers_stub
 
 import pytest
 

--- a/tests/interaction_samples/golden/affirmation.yaml
+++ b/tests/interaction_samples/golden/affirmation.yaml
@@ -1,0 +1,6 @@
+- input: "You can do it!"
+  expected: "Thanks for the encouragement!"
+  rating: 5
+- input: "Nice work"
+  expected: "I appreciate it!"
+  rating: 4

--- a/tests/interaction_samples/golden/farewell.yaml
+++ b/tests/interaction_samples/golden/farewell.yaml
@@ -1,0 +1,6 @@
+- input: "See you later"
+  expected: "Take care!"
+  rating: 4
+- input: "Good night"
+  expected: "Sweet dreams!"
+  rating: 5

--- a/tests/interaction_samples/golden/qa.yaml
+++ b/tests/interaction_samples/golden/qa.yaml
@@ -1,0 +1,6 @@
+- input: "What's the capital of France?"
+  expected: "Paris is the capital of France."
+  rating: 5
+- input: "Who wrote '1984'?"
+  expected: "George Orwell wrote '1984'."
+  rating: 5


### PR DESCRIPTION
## Summary
- create example interaction YAML files under `tests/interaction_samples/golden/`
- describe how to contribute additional scenarios
- stub heavy optional dependencies for tests
- ensure pytest hook doesn't receive filenames

## Testing
- `pytest -q` *(passes: 17 passed, 9 skipped)*
- `black tests/conftest.py --check`
- `isort tests/conftest.py --check-only`
- `flake8 tests/conftest.py`


------
https://chatgpt.com/codex/tasks/task_e_68829aaeb2f88326a566b07d569b8c52