### PR TITLE
Update tests for CognitiveCoreService

### DIFF
--- a/tests/unit/test_demo_service_publisher.py
+++ b/tests/unit/test_demo_service_publisher.py
@@ -37,7 +37,7 @@ sys.modules.setdefault("deepthought.services.db_manager", dummy_db_manager)
 modules = {
     "deepthought.services.file_graph_dal": "FileGraphDAL",
     "deepthought.services.hierarchical_service": "HierarchicalService",
-    "deepthought.services.memory_service": "MemoryService",
+    "deepthought.services.cognitive_core_service": "CognitiveCoreService",
     "deepthought.services.persona_manager": "PersonaManager",
     "deepthought.services.social_graph_service": "SocialGraphService",
 }


### PR DESCRIPTION
## Summary
- adjust demo service publisher test to use CognitiveCoreService instead of MemoryService

## Testing
- `pre-commit run --files tests/unit/test_demo_service_publisher.py`

------
https://chatgpt.com/codex/tasks/task_e_6882a46a493083268c7f5678859967f8