### PR TITLE
Add ReasoningService tests

### DIFF
--- a/src/deepthought/services/reasoning_service.py
+++ b/src/deepthought/services/reasoning_service.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Optional, Tuple
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+from ..ontology import OntologyManager
+from .base import BaseService
+
+logger = logging.getLogger(__name__)
+
+Triple = Tuple[str, str, str]
+TRIPLE_SUBJECT = "dtr.ontology.triples"
+
+
+class ReasoningService(BaseService):
+    """Service that performs ontology reasoning."""
+
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        *,
+        ontology: Optional[OntologyManager] = None,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        self._ontology = ontology or OntologyManager()
+        if self._publisher is None:
+            self._publisher = Publisher(self._nc, self._js)  # type: ignore[arg-type]
+        if self._subscriber is None:
+            self._subscriber = Subscriber(self._nc, self._js)  # type: ignore[arg-type]
+
+    async def _handle_triples(self, msg: Msg) -> None:
+        input_id = None
+        try:
+            data = json.loads(msg.data.decode())
+            triples = data.get("triples", [])
+            input_id = data.get("input_id")
+            for t in triples:
+                if isinstance(t, (list, tuple)) and len(t) == 3:
+                    self._ontology.add_triple(t[0], t[1], t[2])
+            facts = self._ontology.infer_facts()
+            payload = MemoryRetrievedPayload(
+                retrieved_knowledge={"facts": facts, "source": "ontology"},
+                input_id=input_id,
+            )
+            await self._publisher.publish(
+                EventSubjects.MEMORY_RETRIEVED,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("Failed to handle triples")
+
+    async def start(self, durable_name: str = "reasoning_service") -> bool:
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=TRIPLE_SUBJECT,
+            handler=self._handle_triples,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        started = await super().start()
+        if started:
+            logger.info("ReasoningService started")
+        return started
+
+    async def stop(self) -> None:
+        await super().stop()
+
+    async def __aenter__(self) -> "ReasoningService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/tests/unit/services/test_reasoning_service.py
+++ b/tests/unit/services/test_reasoning_service.py
@@ -1,0 +1,89 @@
+import json
+import importlib.machinery
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+# Provide minimal stubs for rdflib and owlready2 so the service can be imported
+fake_rdflib = types.ModuleType("rdflib")
+fake_rdflib.Graph = type("Graph", (), {"serialize": lambda self, format=None: b""})
+fake_rdflib.URIRef = lambda s: s
+ns_mod = types.ModuleType("namespace")
+ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+fake_rdflib.namespace = ns_mod
+sys.modules.setdefault("rdflib", fake_rdflib)
+sys.modules.setdefault("rdflib.namespace", ns_mod)
+
+fake_owl = types.ModuleType("owlready2")
+fake_owl.ThingClass = type("ThingClass", (), {})
+fake_owl.World = type("World", (), {"get_ontology": lambda self, uri: types.SimpleNamespace(load=lambda fileobj=None: types.SimpleNamespace(individuals=lambda: []))})
+fake_owl.sync_reasoner_hermit = lambda world: None
+sys.modules.setdefault("owlready2", fake_owl)
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.reasoning_service import ReasoningService, TRIPLE_SUBJECT
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    async def subscribe(self, *args, **kwargs):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_infers_and_publishes(monkeypatch):
+    added = []
+
+    class DummyOntology:
+        def add_triple(self, s, p, o):
+            added.append((s, p, o))
+
+        def infer_facts(self):
+            return [("a", "b", "c")]
+
+    service = ReasoningService(DummyNATS(), DummyJS(), ontology=DummyOntology())
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = {"triples": [["s", "p", "o"]], "input_id": "x"}
+    msg = DummyMsg(json.dumps(payload))
+    await service._handle_triples(msg)
+
+    assert msg.acked
+    assert added == [("s", "p", "o")]
+    assert service._publisher.published
+    subject, sent = service._publisher.published[0]
+    assert subject == EventSubjects.MEMORY_RETRIEVED
+    assert sent.retrieved_knowledge["facts"] == [("a", "b", "c")]
+    assert sent.input_id == "x"


### PR DESCRIPTION
## Summary
- implement a minimal ReasoningService for ontology reasoning
- add unit tests verifying inferred triples are published

## Testing
- `flake8 src/deepthought/services/reasoning_service.py tests/unit/services/test_reasoning_service.py`
- `pytest tests/unit/services/test_reasoning_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c9568280832684d928b8ca5a6909