### PR TITLE
Add ontology reasoning service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ codegen = "deepthought.services.code_generation_service:CodeGenerationService"
 cognitive_core = "deepthought.services.cognitive_core_service:CognitiveCoreService"
 reward_manager = "deepthought.motivate.reward_manager:RewardManager"
 planning = "deepthought.services.planning_service:PlanningService"
+reasoning = "deepthought.services.reasoning_service:ReasoningService"
 
 
 

--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-
 import json
 import logging
 import ssl
@@ -12,11 +11,7 @@ from typing import Any, Awaitable, Callable, Iterable
 
 from .config import get_settings
 from .eda import Publisher, Subscriber
-from .eda.events import (
-    EventSubjects,
-    PlanGeneratedPayload,
-    PlanRequestedPayload,
-)
+from .eda.events import EventSubjects, PlanGeneratedPayload, PlanRequestedPayload
 from .planning import planner, translator
 
 logger = logging.getLogger(__name__)
@@ -131,6 +126,8 @@ async def run(config_path: str) -> None:
         for cls in service_classes:
             if cls.__name__ == "PlanningService":
                 inst = cls(nc, js, desires_file=desires_file)
+            elif cls.__name__ == "ReasoningService":
+                inst = cls(nc, js)
             else:
                 inst = cls(nc, js)
             await stack.enter_async_context(inst)

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -4,8 +4,9 @@ from .cognitive_core_service import CognitiveCoreService
 from .db_manager import DBManager
 from .file_graph_dal import FileGraphDAL
 from .persona_manager import PersonaManager
-from .social_graph_service import SocialGraphService
 from .planning_service import PlanningService
+from .reasoning_service import ReasoningService
+from .social_graph_service import SocialGraphService
 
 __all__ = [
     "FileGraphDAL",
@@ -14,4 +15,5 @@ __all__ = [
     "DBManager",
     "SocialGraphService",
     "PlanningService",
+    "ReasoningService",
 ]

--- a/src/deepthought/services/reasoning_service.py
+++ b/src/deepthought/services/reasoning_service.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import List, Optional, Tuple
+from uuid import uuid4
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+from rdflib import Namespace
+
+from ..eda.events import EventSubjects, InputReceivedPayload, ResponseGeneratedPayload
+from ..ontology import OntologyManager
+from .base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class ReasoningService(BaseService):
+    """Infer new knowledge from LLM responses."""
+
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        ontology: OntologyManager | None = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        self._ontology = ontology or OntologyManager()
+        self._ns = Namespace("http://deepthought.local/resp#")
+
+    # Basic parsing of lines into subject predicate object triples
+    def _extract_triples(self, text: str) -> List[Tuple[str, str, str]]:
+        triples: List[Tuple[str, str, str]] = []
+        for line in text.splitlines():
+            sent = line.strip().rstrip(".")
+            if not sent:
+                continue
+            parts = sent.split()
+            if len(parts) < 3:
+                continue
+            subj, pred = parts[0], parts[1]
+            obj = "_".join(parts[2:])
+            triples.append(
+                (str(self._ns[subj]), str(self._ns[pred]), str(self._ns[obj]))
+            )
+        return triples
+
+    async def _handle_response(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            payload = ResponseGeneratedPayload.from_dict(data)
+            triples = self._extract_triples(payload.final_response)
+            if triples:
+                self._ontology.add_triples(triples)
+                facts = self._ontology.infer_facts()
+                if facts:
+                    text = "; ".join(" ".join(t) for t in facts)
+                    out = InputReceivedPayload(user_input=text, input_id=str(uuid4()))
+                    await self._publisher.publish(
+                        EventSubjects.INPUT_RECEIVED,
+                        out,
+                        use_jetstream=True,
+                        timeout=10.0,
+                    )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to process RESPONSE_GENERATED: %s", exc, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def start(self, durable_name: str = "reasoning_service") -> bool:
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.RESPONSE_GENERATED,
+            handler=self._handle_response,
+            use_jetstream=True,
+            durable=durable_name,
+        )
+        started = await super().start()
+        if started:
+            logger.info(
+                "ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED
+            )
+        return started
+
+    async def stop(self) -> None:
+        await super().stop()
+
+    async def __aenter__(self) -> "ReasoningService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/tests/unit/services/test_reasoning_service.py
+++ b/tests/unit/services/test_reasoning_service.py
@@ -1,0 +1,110 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+fake_pyd.Field = lambda default=None, **kwargs: default
+sys.modules.setdefault("pydantic", fake_pyd)
+fake_ps = types.ModuleType("pydantic_settings")
+fake_ps.BaseSettings = object
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+fake_prom = types.ModuleType("prometheus_client")
+fake_prom.Counter = lambda *a, **k: object()
+fake_prom.Histogram = lambda *a, **k: object()
+fake_prom.REGISTRY = SimpleNamespace(_names_to_collectors={})
+sys.modules.setdefault("prometheus_client", fake_prom)
+sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
+tb_mod = types.ModuleType("textblob")
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+    sentiment=types.SimpleNamespace(polarity=0.0)
+)
+sys.modules.setdefault("textblob", tb_mod)
+rdf_mod = types.ModuleType("rdflib")
+ns_mod = types.ModuleType("rdflib.namespace")
+ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+sys.modules.setdefault("rdflib.namespace", ns_mod)
+
+
+class _NS:
+    def __init__(self, uri=""):
+        self._u = uri
+
+    def __getitem__(self, key):
+        return f"{self._u}{key}"
+
+
+rdf_mod.Namespace = lambda uri=None: _NS(uri or "")
+rdf_mod.Graph = type(
+    "Graph",
+    (),
+    {"add": lambda self, triple: None, "serialize": lambda self, format="xml": ""},
+)
+rdf_mod.URIRef = str
+sys.modules.setdefault("rdflib", rdf_mod)
+
+import owlready2
+
+owlready2.World.get_ontology = lambda self, iri: types.SimpleNamespace(
+    load=lambda fileobj=None: types.SimpleNamespace(individuals=lambda: [])
+)
+
+from deepthought.eda.events import EventSubjects, ResponseGeneratedPayload
+from deepthought.services.reasoning_service import ReasoningService
+
+
+class DummyNATS:
+    def __init__(self):
+        self.is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, **kw):
+        self.published.append((subject, payload))
+        return SimpleNamespace(seq=1, stream="test")
+
+
+class DummySubscriber:
+    async def subscribe(self, *a, **k):
+        pass
+
+    async def unsubscribe_all(self):
+        pass
+
+
+class DummyMsg:
+    def __init__(self, data: str):
+        self.data = data.encode()
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+@pytest.mark.asyncio
+async def test_handle_response_publishes_facts(monkeypatch):
+    svc = ReasoningService(DummyNATS(), DummyJS())
+    svc._publisher = DummyPublisher()
+    svc._subscriber = DummySubscriber()
+
+    payload = ResponseGeneratedPayload(final_response="A is B", input_id="1")
+    msg = DummyMsg(payload.to_json())
+    await svc._handle_response(msg)
+
+    assert msg.acked
+    # Ontology stubs may produce no inferred facts


### PR DESCRIPTION
## Summary
- implement `ReasoningService` to infer ontology facts from LLM outputs
- register `reasoning` entry point for service discovery
- expose `ReasoningService` via package `__all__`
- load the service in orchestrator when configured
- add unit test for `ReasoningService`

## Testing
- `flake8 src/deepthought/services/reasoning_service.py src/deepthought/orchestrator.py src/deepthought/services/__init__.py tests/unit/services/test_reasoning_service.py`
- `pytest tests/unit/services/test_reasoning_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c955888083268d30ee98bd2ccebb