### PR TITLE
Update docs and examples for CognitiveCoreService

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,22 +11,19 @@ sequenceDiagram
     participant User
     participant Bot
     participant CognitiveCoreService
-    participant HierarchicalService
     participant LLM
 
     User->>Bot: Message
     Bot->>NATS: INPUT_RECEIVED
     NATS->>CognitiveCoreService: INPUT_RECEIVED
-    CognitiveCoreService->>NATS: MEMORY_RETRIEVED
-    NATS->>HierarchicalService: MEMORY_RETRIEVED
-    HierarchicalService->>LLM: Query
-    LLM-->>HierarchicalService: Response
-    HierarchicalService->>NATS: RESPONSE_GENERATED
+    CognitiveCoreService->>LLM: Query
+    LLM-->>CognitiveCoreService: Response
+    CognitiveCoreService->>NATS: RESPONSE_GENERATED
     NATS->>Bot: RESPONSE_GENERATED
     Bot-->>User: Reply
 ```
 
-The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events, retrieves knowledge from memory services and ultimately receives a `RESPONSE_GENERATED` message containing the model output.
+The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events, retrieves knowledge from the `CognitiveCoreService` and ultimately receives a `RESPONSE_GENERATED` message containing the model output.
 
 ## FAISS Setup
 

--- a/docs/hierarchical_memory_service.md
+++ b/docs/hierarchical_memory_service.md
@@ -42,15 +42,15 @@ With these services running you can start your application and the memory servic
 ## Exporting the Graph
 
 After evaluating an interaction trace with `tools/replay.py` you may want to
-inspect the knowledge graph. The `HierarchicalService` exposes a
+inspect the knowledge graph. The `CognitiveCoreService` exposes a
 `dump_graph(path)` method that writes the current graph in DOT format. Provide a
 directory where the `graph.dot` file should be created:
 
 ```python
-from deepthought.services import HierarchicalService
+from deepthought.services import CognitiveCoreService
 
 # use the configured vector backend ("chroma" or "faiss")
-service = HierarchicalService.from_chroma(
+service = CognitiveCoreService.from_chroma(
     DummyNATS(),
     DummyJS(),
     graph_backend_name="memgraph",
@@ -67,7 +67,7 @@ dot -Tpng graph_exports/graph.dot -o graph.png
 
 ## Migration to TieredMemory
 
-The `HierarchicalService` now relies on the `TieredMemory` layer for context retrieval. Create a `TieredMemory` instance and pass it to the service or use `HierarchicalService.from_chroma()` which constructs one automatically using the configured vector backend.
+The `CognitiveCoreService` now relies on the `TieredMemory` layer for context retrieval. Create a `TieredMemory` instance and pass it to the service or use `CognitiveCoreService.from_chroma()` which constructs one automatically using the configured vector backend.
 
 ## Offline Search
 
@@ -81,7 +81,7 @@ search = OfflineSearch.create_index(
     "wiki.db",
     [("Title1", "Article text..."), ("Title2", "More text...")],
 )
-service = HierarchicalService(DummyNATS(), DummyJS(), memory, search=search)
+service = CognitiveCoreService(DummyNATS(), DummyJS(), memory, search=search)
 ```
 
 Set ``DT_SEARCH_DB`` in your configuration file to load the index automatically.
@@ -102,13 +102,12 @@ and ``graph_backend`` fields of ``deepthought.config.Settings``. They may also b
 set in a configuration file.
 
 ``DT_GRAPH_BACKEND`` selects the knowledge graph backend. Supported values include
-``memgraph``, ``neo4j`` and ``noop``. These variables are read by both
-``HierarchicalService.from_chroma`` and ``CognitiveCoreService`` when initializing the
-backends.
+``memgraph``, ``neo4j`` and ``noop``. These variables are read by
+``CognitiveCoreService.from_chroma`` when initializing the backends.
 
 ### Graph Backend
 
-``HierarchicalService.from_chroma`` takes a ``graph_backend_name`` string such as
+``CognitiveCoreService.from_chroma`` takes a ``graph_backend_name`` string such as
 ``"memgraph"`` or ``"noop"``. The default connects to Memgraph using the
 configuration keys ``DT_MG_HOST``, ``DT_MG_PORT``, ``DT_MG_USER`` and
 ``DT_MG_PASSWORD``. Pass ``"noop"`` to disable graph persistence during testing.
@@ -130,5 +129,5 @@ export DT_NEO4J_USER=neo4j
 export DT_NEO4J_PASSWORD=test
 ```
 
-Then pass ``graph_backend_name="neo4j"`` to ``HierarchicalService.from_chroma``.
+Then pass ``graph_backend_name="neo4j"`` to ``CognitiveCoreService.from_chroma``.
 

--- a/examples/offline_search_demo.py
+++ b/examples/offline_search_demo.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from deepthought.search import OfflineSearch
-from deepthought.services import HierarchicalService
+from deepthought.services import CognitiveCoreService
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ def main() -> None:
     index_path = Path("offline_demo.db")
     search = OfflineSearch.create_index(str(index_path), pairs)
 
-    service = HierarchicalService(DummyNATS(), DummyJS(), None, search=search)
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), search=search)
     results = service.retrieve_context("database")
     logger.info("Results: %s", results)
 

--- a/examples/rag_demo.py
+++ b/examples/rag_demo.py
@@ -3,7 +3,7 @@ import logging
 from pathlib import Path
 
 from deepthought.search import OfflineSearch
-from deepthought.services import HierarchicalService
+from deepthought.services import CognitiveCoreService
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ def main() -> None:
     pairs = [(d["title"], d["content"]) for d in docs]
 
     search = OfflineSearch.create_index("rag_demo.db", pairs)
-    service = HierarchicalService(DummyNATS(), DummyJS(), None, search=search)
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), search=search)
 
     for question in ["What is SQLite?", "Where is Python used?"]:
         ctx = service.retrieve_context(question)


### PR DESCRIPTION
## Summary
- update architecture diagram and description
- update hierarchical memory service doc
- adjust rag_demo and offline_search_demo to instantiate CognitiveCoreService

## Testing
- `pre-commit run --files examples/rag_demo.py examples/offline_search_demo.py`

------
https://chatgpt.com/codex/tasks/task_e_6882db79d7748326ab4ef29c48472be2