### PR TITLE
Implement CognitiveCoreService.from_config

### DIFF
--- a/docs/graphdal.md
+++ b/docs/graphdal.md
@@ -56,7 +56,8 @@ before failing.
 
 ## Example CognitiveCore Service
 
-Start the unified `CognitiveCoreService` which configures its backends from environment variables:
+Start the unified `CognitiveCoreService` which configures its backends from environment variables.
+Use the convenience constructor to load settings automatically:
 
 ```bash
 python - <<'PY'

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -66,6 +66,33 @@ class CognitiveCoreService(BaseService):
         self._search = search
         self._top_k = self._settings.memory_top_k
 
+    @classmethod
+    def from_config(
+        cls,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        settings: Settings | None = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> "CognitiveCoreService":
+        """Return an instance configured from ``Settings`` or environment."""
+
+        cfg = settings or get_settings()
+        memory = create_memory_backend(settings=cfg)
+        db = DBManager(cfg.social_graph_db)
+        return cls(
+            nats_client,
+            js_context,
+            cfg,
+            memory=memory,
+            db=db,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+
     def retrieve_context(self, prompt: str) -> List[str]:
         memory_facts = self._memory.retrieve_context(prompt) if self._memory else []
         search_facts: List[str] = []

--- a/src/deepthought/services/reasoning_service.py
+++ b/src/deepthought/services/reasoning_service.py
@@ -4,7 +4,6 @@ import json
 import logging
 from typing import List, Optional, Tuple
 from uuid import uuid4
-v
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
@@ -12,7 +11,6 @@ from nats.js.client import JetStreamContext
 from rdflib import Namespace
 
 from ..eda.events import EventSubjects, InputReceivedPayload, ResponseGeneratedPayload
-v
 from ..ontology import OntologyManager
 from .base import BaseService
 
@@ -22,14 +20,12 @@ logger = logging.getLogger(__name__)
 class ReasoningService(BaseService):
     """Infer new knowledge from LLM responses."""
 
-
     def __init__(
         self,
         nats_client: Optional[NATS] = None,
         js_context: Optional[JetStreamContext] = None,
         ontology: OntologyManager | None = None,
         *,
-
         nats_url: str | None = None,
         connect_retries: int = 1,
         connect_timeout: float = 2.0,
@@ -56,9 +52,7 @@ class ReasoningService(BaseService):
                 continue
             subj, pred = parts[0], parts[1]
             obj = "_".join(parts[2:])
-            triples.append(
-                (str(self._ns[subj]), str(self._ns[pred]), str(self._ns[obj]))
-            )
+            triples.append((str(self._ns[subj]), str(self._ns[pred]), str(self._ns[obj])))
         return triples
 
     async def _handle_response(self, msg: Msg) -> None:
@@ -85,21 +79,17 @@ class ReasoningService(BaseService):
             if hasattr(msg, "nak") and callable(msg.nak):
                 await msg.nak()
 
-
     async def start(self, durable_name: str = "reasoning_service") -> bool:
         self._subscriptions.clear()
         self.add_subscription(
             subject=EventSubjects.RESPONSE_GENERATED,
             handler=self._handle_response,
-
             use_jetstream=True,
             durable=durable_name,
         )
         started = await super().start()
         if started:
-            logger.info(
-                "ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED
-            )
+            logger.info("ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED)
 
         return started
 


### PR DESCRIPTION
## Summary
- add `from_config` constructor for `CognitiveCoreService`
- clarify usage in `graphdal` docs
- clean up stray debug tokens in `ReasoningService`

## Testing
- `pre-commit run --files src/deepthought/services/reasoning_service.py src/deepthought/services/cognitive_core_service.py docs/graphdal.md`
- `pytest tests/unit/services/test_reasoning_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882db7b61bc8326822afc5855cf12f0