### PR TITLE
Add persona tracking to discord replay

### DIFF
--- a/docs/evaluation_framework.md
+++ b/docs/evaluation_framework.md
@@ -5,14 +5,17 @@ responses against a golden dataset.
 
 1. Capture a raw trace using `tools/record.py`.
 2. Prepare a YAML file containing the expected replies and qualitative ratings.
+   Golden conversations shipped with the repository live under
+   `tests/interaction_samples/golden/` and can be referenced by name.
 3. Run `tools/discord_replay.py` with the `--golden` option:
    ```bash
    python tools/discord_replay.py my_trace.jsonl \
-       --golden tests/interaction_samples/greeting.yaml \
+       --golden qa \
        --output replay.jsonl --metrics metrics.json
    ```
 4. The script collects new bot replies, computes BLEU and ROUGE-L scores against
    the golden responses, and writes average latency and throughput metrics.
+   Persona state and affinity for each turn are stored in the replay JSONL file.
    If ratings are provided in the YAML file, the average rating is reported as
    `avg_rating` in the metrics JSON.
 

--- a/src/deepthought/harness/record.py
+++ b/src/deepthought/harness/record.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -13,9 +13,19 @@ class TraceEvent:
     latency: float
     timestamp: datetime
     timestamp_delta: float
+    persona: Optional[str] = None
+    affinity: Optional[float] = None
 
 
-def record_event(trace: List[TraceEvent], state: str, action: str, reward: float, latency: float) -> None:
+def record_event(
+    trace: List[TraceEvent],
+    state: str,
+    action: str,
+    reward: float,
+    latency: float,
+    persona: Optional[str] = None,
+    affinity: Optional[float] = None,
+) -> None:
     """Append a :class:`TraceEvent` to ``trace`` with a computed timestamp delta."""
     now = datetime.utcnow()
     delta = (now - trace[-1].timestamp).total_seconds() if trace else 0.0
@@ -27,5 +37,7 @@ def record_event(trace: List[TraceEvent], state: str, action: str, reward: float
             latency=latency,
             timestamp=now,
             timestamp_delta=delta,
+            persona=persona,
+            affinity=affinity,
         )
     )

--- a/tools/discord_replay.py
+++ b/tools/discord_replay.py
@@ -61,6 +61,36 @@ def _load_golden(path: Path) -> List[dict]:
     return _read_one(path)
 
 
+def _persona_from_affinity(value: float, friendly: int = 5, playful: int = 2) -> str:
+    """Return persona name for ``value`` using default thresholds."""
+
+    if value >= friendly:
+        return "friendly"
+    if value >= playful:
+        return "playful"
+    return "snarky"
+
+
+def _resolve_golden_path(path: Path) -> Path:
+    """Return an existing golden path.
+
+    If ``path`` does not exist, look for a YAML file with the same name
+    under ``tests/interaction_samples/golden``.
+    """
+
+    if path.exists():
+        return path
+
+    base = Path("tests/interaction_samples/golden")
+    candidate = base / path
+    if candidate.suffix == "":
+        candidate = candidate.with_suffix(".yaml")
+    if candidate.exists():
+        return candidate
+
+    raise FileNotFoundError(f"Golden interactions not found: {path}")
+
+
 async def _replay(
     path: Path,
     output: Path,
@@ -69,7 +99,9 @@ async def _replay(
     golden: Optional[Path] = None,
 ) -> None:
     events = _load_events(path)
-    inputs = [e["payload"] for e in events if e.get("event") == "CHAT_RAW"]
+    chat_events = [e for e in events if e.get("event") == "CHAT_RAW"]
+    inputs = [e["payload"] for e in chat_events]
+    affinities = [float(e.get("affinity", 0.0)) for e in chat_events]
     expected = [
         e["payload"].get("final_response", "")
         for e in events
@@ -78,7 +110,7 @@ async def _replay(
 
     ratings: List[float] = []
     if golden:
-        golden_data = _load_golden(golden)
+        golden_data = _load_golden(_resolve_golden_path(golden))
         expected = [item.get("expected", "") for item in golden_data]
         ratings = [float(item.get("rating", 0.0)) for item in golden_data]
 
@@ -105,14 +137,15 @@ async def _replay(
     )
 
     try:
-        for state in inputs:
+        for state, affinity in zip(inputs, affinities):
             start = datetime.utcnow()
             await publisher.publish(
                 EventSubjects.CHAT_RAW, state, use_jetstream=True, timeout=10.0
             )
             action = await queue.get()
             latency = (datetime.utcnow() - start).total_seconds()
-            record_event(trace, state, action, 0.0, latency)
+            persona = _persona_from_affinity(affinity)
+            record_event(trace, state, action, 0.0, latency, persona, affinity)
             responses.append(action)
     finally:
         await subscriber.unsubscribe_all()
@@ -163,7 +196,7 @@ async def main() -> None:
         "--golden",
         "-g",
         type=Path,
-        help="Path to golden YAML file or directory of YAML files",
+        help="Path or name of golden YAML file or directory of YAML files",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- capture persona and affinity in TraceEvent
- resolve golden conversation paths by name
- store persona state and affinity when replaying
- document golden dataset usage and new fields

## Testing
- `pre-commit run --files docs/evaluation_framework.md src/deepthought/harness/record.py tools/discord_replay.py`
- `pytest tests/unit/test_harness_record.py tests/unit/test_discord_replay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882e5cd05c08326ae92cbabd8e044c9