### PR TITLE
Add social perception training script

### DIFF
--- a/docs/social_perception_training.md
+++ b/docs/social_perception_training.md
@@ -1,0 +1,40 @@
+# Social Perception Training
+
+This guide explains how to fine-tune the social perception classifier using
+`train/social_perception_train.py`.
+
+## Dataset
+
+The script expects a dataset containing two fields: `text` and `label`.
+Labels are encoded as integers:
+
+```
+0 -> flirtation
+1 -> avoidance
+2 -> manipulation
+```
+
+Any Hugging Face dataset or local JSON/CSV file with these columns can be
+used. A small public example is available at
+[`dtrt/social-cues`](https://huggingface.co/datasets/dtrt/social-cues).
+
+## Running the script
+
+Install dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
+Launch training with:
+
+```bash
+python train/social_perception_train.py \
+    --dataset-path dtrt/social-cues \
+    --model-name distilbert-base-uncased \
+    --epochs 3 \
+    --batch-size 8
+```
+
+The fine-tuned model will be saved to `./social_perception_model` by
+default. Adjust `--output-dir` to change the location.

--- a/train/social_perception_train.py
+++ b/train/social_perception_train.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Command line helper for fine-tuning the social perception classifier."""
+
+import argparse
+from typing import Dict
+
+import numpy as np
+from datasets import load_dataset
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    Trainer,
+    TrainingArguments,
+)
+
+LABELS: Dict[int, str] = {0: "flirtation", 1: "avoidance", 2: "manipulation"}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Return parsed CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-path", required=True, help="HF dataset ID or path")
+    parser.add_argument("--model-name", default="distilbert-base-uncased", help="Base model name")
+    parser.add_argument("--output-dir", default="./social_perception_model", help="Where to store the model")
+    parser.add_argument("--epochs", type=int, default=3, help="Training epochs")
+    parser.add_argument("--batch-size", type=int, default=8, help="Training batch size")
+    return parser.parse_args(argv)
+
+
+def _tokenize(tokenizer, example):
+    return tokenizer(example["text"], padding="max_length", truncation=True)
+
+
+def compute_metrics(eval_pred):
+    logits, labels = eval_pred
+    preds = np.argmax(logits, axis=-1)
+    accuracy = (preds == labels).mean()
+    return {"accuracy": accuracy}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    dataset = load_dataset(args.dataset_path)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name)
+    tokenized = dataset.map(lambda ex: _tokenize(tokenizer, ex), batched=True)
+    tokenized = tokenized.rename_column("label", "labels")
+    tokenized.set_format("torch", columns=["input_ids", "attention_mask", "labels"])
+
+    train_ds = tokenized["train"]
+    eval_ds = tokenized.get("validation") or tokenized.get("test")
+
+    model = AutoModelForSequenceClassification.from_pretrained(args.model_name, num_labels=len(LABELS))
+    training_args = TrainingArguments(
+        output_dir=args.output_dir,
+        num_train_epochs=args.epochs,
+        per_device_train_batch_size=args.batch_size,
+        per_device_eval_batch_size=args.batch_size,
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+    )
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=eval_ds,
+        compute_metrics=compute_metrics,
+    )
+    trainer.train()
+    trainer.save_model(args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- add `train/social_perception_train.py` for fine-tuning a classifier
- document usage in `docs/social_perception_training.md`

## Testing
- `flake8 src tests train/social_perception_train.py`
- `PYTHONPATH=src pytest tests/unit/perception/test_social_perception.py -q`

Some tests failed due to missing optional dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6882e9f8a18c8326b890f806746baeea