### PR TITLE
Enable simple planning generation

### DIFF
--- a/desires.json
+++ b/desires.json
@@ -1,0 +1,1 @@
+{"desires": ["move obj from loc1 to loc2"]}

--- a/src/deepthought/services/planning_service.py
+++ b/src/deepthought/services/planning_service.py
@@ -15,6 +15,7 @@ from ..eda.events import (
     PlanGeneratedPayload,
     PlanRequestedPayload,
 )
+from ..planning import L2PTranslator, plan
 from .base import BaseService
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ class PlanningService(BaseService):
             connect_timeout=connect_timeout,
         )
         self._desires_file = desires_file
+        self._translator = L2PTranslator()
         self._desires: List[str] = []
         self._beliefs: List[str] = []
         self._load_desires()
@@ -52,11 +54,15 @@ class PlanningService(BaseService):
             ds = data.get("desires", [])
             if isinstance(ds, list):
                 self._desires = [str(d) for d in ds]
-            logger.info("Loaded %d desires from %s", len(self._desires), self._desires_file)
+            logger.info(
+                "Loaded %d desires from %s", len(self._desires), self._desires_file
+            )
         except FileNotFoundError:
             logger.warning("Desires file %s not found", self._desires_file)
         except Exception:  # pragma: no cover - defensive
-            logger.error("Failed to load desires file %s", self._desires_file, exc_info=True)
+            logger.error(
+                "Failed to load desires file %s", self._desires_file, exc_info=True
+            )
 
     async def _handle_memory(self, msg: Msg) -> None:
         try:
@@ -68,6 +74,26 @@ class PlanningService(BaseService):
                 await msg.ack()
         except Exception:  # pragma: no cover - defensive
             logger.error("Failed to process memory event", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_plan_request(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            payload = PlanRequestedPayload.from_dict(data)
+            domain, problem = self._translator.translate(payload.goal)
+            actions = plan(domain, problem)
+            out = PlanGeneratedPayload(plan=actions, input_id=payload.input_id)
+            await self._publisher.publish(
+                EventSubjects.PLAN_GENERATED,
+                out,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to generate plan", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 await msg.nak()
 
@@ -112,6 +138,12 @@ class PlanningService(BaseService):
             handler=self._handle_plan,
             use_jetstream=True,
             durable=f"{durable_name}_plan",
+        )
+        self.add_subscription(
+            subject=EventSubjects.PLAN_REQUESTED,
+            handler=self._handle_plan_request,
+            use_jetstream=True,
+            durable=f"{durable_name}_request",
         )
         started = await super().start()
         if started:

--- a/tests/unit/services/test_planning_service.py
+++ b/tests/unit/services/test_planning_service.py
@@ -1,7 +1,51 @@
 import importlib.machinery
+import json
 import sys
 import types
-import json
+
+pyperplan_mod = types.ModuleType("pyperplan")
+pyperplan_mod.pddl = types.ModuleType("pyperplan.pddl")
+pyperplan_parser = types.ModuleType("pyperplan.pddl.parser")
+
+
+class DummyParser:
+    def __init__(self, domain, problem):
+        self.domInput = domain
+        self.probInput = problem
+
+    def parse_domain(self, read_from_file=False):
+        return "domain"
+
+    def parse_problem(self, domain, read_from_file=False):
+        return "problem"
+
+
+def dummy_ground(problem):
+    return ["task"]
+
+
+def dummy_search(task):
+    return [types.SimpleNamespace(name="action")]
+
+
+pyperplan_parser.Parser = DummyParser
+pyperplan_mod.planner = types.ModuleType("pyperplan.planner")
+pyperplan_mod.planner._ground = dummy_ground
+pyperplan_mod.search = types.ModuleType("pyperplan.search")
+pyperplan_mod.search.breadth_first_search = dummy_search
+pyperplan_mod.pddl.parser = pyperplan_parser
+sys.modules.setdefault("pyperplan", pyperplan_mod)
+sys.modules.setdefault("pyperplan.pddl", pyperplan_mod.pddl)
+sys.modules.setdefault("pyperplan.pddl.parser", pyperplan_parser)
+sys.modules.setdefault("pyperplan.planner", pyperplan_mod.planner)
+sys.modules.setdefault("pyperplan.search", pyperplan_mod.search)
+rdflib_mod = types.ModuleType("rdflib")
+rdflib_mod.Namespace = object
+rdflib_mod.Graph = object
+rdflib_mod.URIRef = str
+rdflib_mod.namespace = types.SimpleNamespace(RDF=object())
+sys.modules.setdefault("rdflib", rdflib_mod)
+sys.modules.setdefault("rdflib.namespace", rdflib_mod.namespace)
 
 fake_pyd = types.ModuleType("pydantic")
 fake_pyd.AnyUrl = str
@@ -21,18 +65,27 @@ sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
 torch_mod = types.ModuleType("torch")
-torch_mod.no_grad = lambda: types.SimpleNamespace(__enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None)()
+torch_mod.no_grad = lambda: types.SimpleNamespace(
+    __enter__=lambda self: None, __exit__=lambda self, exc_type, exc, tb: None
+)()
 torch_mod.softmax = lambda t, dim=-1: t
 sys.modules.setdefault("torch", torch_mod)
 tb_mod = types.ModuleType("textblob")
-tb_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0))
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+    sentiment=types.SimpleNamespace(polarity=0.0)
+)
 sys.modules.setdefault("textblob", tb_mod)
 tf_mod = types.ModuleType("transformers")
-tf_mod.AutoTokenizer = type("AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())})
+tf_mod.AutoTokenizer = type(
+    "AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())}
+)
 tf_mod.AutoModelForSequenceClassification = type(
     "AutoModelForSequenceClassification",
     (),
-    {"from_pretrained": classmethod(lambda cls, p: cls()), "__call__": lambda self, **k: types.SimpleNamespace(logits=[[0, 0, 0]])},
+    {
+        "from_pretrained": classmethod(lambda cls, p: cls()),
+        "__call__": lambda self, **k: types.SimpleNamespace(logits=[[0, 0, 0]]),
+    },
 )
 sys.modules.setdefault("transformers", tf_mod)
 
@@ -59,10 +112,12 @@ sys.modules.setdefault("nats.js", fake_nats.js)
 sys.modules.setdefault("nats.js.client", js_client_mod)
 sys.modules.setdefault("nats.errors", fake_nats.errors)
 
+import deepthought.services.planning_service as planning_service
 from deepthought.eda.events import (
     EventSubjects,
     MemoryRetrievedPayload,
     PlanGeneratedPayload,
+    PlanRequestedPayload,
 )
 from deepthought.services.planning_service import PlanningService
 
@@ -104,7 +159,9 @@ async def test_memory_triggers_plan(tmp_path):
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["hi"]}, input_id="x")
+    payload = MemoryRetrievedPayload(
+        retrieved_knowledge={"facts": ["hi"]}, input_id="x"
+    )
     msg = DummyMsg(payload.to_json())
     await service._handle_memory(msg)
 
@@ -129,3 +186,31 @@ async def test_execute_plan():
     assert msg.acked
     subjects = [s for s, _ in service._publisher.published]
     assert subjects == [EventSubjects.CHAT_RAW, EventSubjects.CHAT_RAW]
+
+
+@pytest.mark.asyncio
+async def test_plan_request_generates_plan(monkeypatch):
+    class DummyTranslator:
+        def translate(self, goal):
+            return "d", "p"
+
+    def dummy_plan(d, p):
+        return ["ok"]
+
+    monkeypatch.setattr(planning_service, "L2PTranslator", DummyTranslator)
+    monkeypatch.setattr(planning_service, "plan", dummy_plan)
+
+    service = PlanningService(None, None)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = PlanRequestedPayload(goal="do", input_id="z")
+    msg = DummyMsg(payload.to_json())
+    await service._handle_plan_request(msg)
+
+    assert msg.acked
+    assert service._publisher.published
+    subj, out = service._publisher.published[0]
+    assert subj == EventSubjects.PLAN_GENERATED
+    assert out.plan == ["ok"]
+    assert out.input_id == "z"


### PR DESCRIPTION
## Summary
- implement handling of plan requests in `PlanningService`
- publish generated plans using L2PTranslator and pyperplan
- add default `desires.json`
- test plan generation
- fix unit tests with lightweight stubs

## Testing
- `black tests/unit/services/test_planning_service.py src/deepthought/services/planning_service.py desires.json`
- `isort tests/unit/services/test_planning_service.py src/deepthought/services/planning_service.py`
- `flake8 tests/unit/services/test_planning_service.py src/deepthought/services/planning_service.py`
- `pytest tests/unit/services/test_planning_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6882e5cc485c8326b16ea64edff970ef