### PR TITLE
Add service event flow unit tests

### DIFF
--- a/tests/unit/services/test_planning_service.py
+++ b/tests/unit/services/test_planning_service.py
@@ -214,3 +214,36 @@ async def test_plan_request_generates_plan(monkeypatch):
     assert subj == EventSubjects.PLAN_GENERATED
     assert out.plan == ["ok"]
     assert out.input_id == "z"
+
+
+@pytest.mark.asyncio
+async def test_planning_service_event_flow(monkeypatch, tmp_path):
+    class DummyTranslator:
+        def translate(self, goal):
+            return "d", "p"
+
+    monkeypatch.setattr(planning_service, "L2PTranslator", DummyTranslator)
+    monkeypatch.setattr(planning_service, "plan", lambda d, p: ["a1", "a2"])
+
+    cfg = tmp_path / "d.json"
+    cfg.write_text(json.dumps({"desires": ["go"]}), encoding="utf-8")
+
+    service = PlanningService(None, None, desires_file=str(cfg))
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    mem_payload = MemoryRetrievedPayload(
+        retrieved_knowledge={"facts": ["f"]}, input_id="1"
+    )
+    await service._handle_memory(DummyMsg(mem_payload.to_json()))
+    assert service._publisher.published
+    subj, plan_req = service._publisher.published[-1]
+    assert subj == EventSubjects.PLAN_REQUESTED
+
+    await service._handle_plan_request(DummyMsg(plan_req.to_json()))
+    subj2, plan_gen = service._publisher.published[-1]
+    assert subj2 == EventSubjects.PLAN_GENERATED
+
+    await service._handle_plan(DummyMsg(plan_gen.to_json()))
+    subjects = [s for s, _ in service._publisher.published[-2:]]
+    assert subjects == [EventSubjects.CHAT_RAW, EventSubjects.CHAT_RAW]

--- a/tests/unit/services/test_reasoning_service.py
+++ b/tests/unit/services/test_reasoning_service.py
@@ -1,4 +1,3 @@
-
 import sys
 import types
 from types import SimpleNamespace
@@ -58,7 +57,6 @@ from deepthought.eda.events import EventSubjects, ResponseGeneratedPayload
 from deepthought.services.reasoning_service import ReasoningService
 
 
-
 class DummyNATS:
     def __init__(self):
         self.is_connected = True
@@ -93,7 +91,6 @@ class DummyMsg:
         self.acked = False
         self.nacked = False
 
-
     async def ack(self):
         self.acked = True
 
@@ -114,3 +111,48 @@ async def test_handle_response_publishes_facts(monkeypatch):
     assert msg.acked
     # Ontology stubs may produce no inferred facts
 
+
+@pytest.mark.asyncio
+async def test_handle_response_emits_input_event(monkeypatch):
+    class DummyOntology:
+        def __init__(self):
+            self.triples = []
+
+        def add_triples(self, triples):
+            self.triples.extend(triples)
+
+        def infer_facts(self):
+            return [("A", "B", "C")]
+
+    svc = ReasoningService(DummyNATS(), DummyJS(), ontology=DummyOntology())
+    svc._publisher = DummyPublisher()
+    svc._subscriber = DummySubscriber()
+
+    payload = ResponseGeneratedPayload(final_response="A is B", input_id="1")
+    msg = DummyMsg(payload.to_json())
+    await svc._handle_response(msg)
+
+    assert msg.acked
+    assert svc._publisher.published
+    subj, out = svc._publisher.published[0]
+    assert subj == EventSubjects.INPUT_RECEIVED
+    assert out.user_input == "A B C"
+
+
+def test_extract_triples_simple():
+    svc = ReasoningService(DummyNATS(), DummyJS())
+
+    triples = svc._extract_triples("A is B\nC likes D\n")
+
+    assert triples == [
+        (
+            "http://deepthought.local/resp#A",
+            "http://deepthought.local/resp#is",
+            "http://deepthought.local/resp#B",
+        ),
+        (
+            "http://deepthought.local/resp#C",
+            "http://deepthought.local/resp#likes",
+            "http://deepthought.local/resp#D",
+        ),
+    ]


### PR DESCRIPTION
## Summary
- expand ReasoningService tests for triple extraction and published events
- add a full event-flow test for PlanningService using dummy NATS

## Testing
- `PYTHONPATH=src pytest tests/unit/services/test_reasoning_service.py tests/unit/services/test_planning_service.py -q`
- `flake8 tests/unit/services/test_reasoning_service.py tests/unit/services/test_planning_service.py`


------
https://chatgpt.com/codex/tasks/task_e_6882f225e8948326b539a0181deba438