### PR TITLE
Improve social perception model loading

### DIFF
--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -17,7 +17,20 @@ _model: AutoModelForSequenceClassification | None = None
 
 
 def _load() -> None:
+    """Load model and tokenizer if available."""
     global _tokenizer, _model
+
+    if _tokenizer is not None and _model is not None:
+        return
+
+    if not MODEL_PATH or MODEL_PATH == "path/to/social-perception-model":
+        raise RuntimeError(
+            "SOCIAL_PERCEPTION_MODEL environment variable not set or empty"
+        )
+
+    if not os.path.exists(MODEL_PATH):
+        raise FileNotFoundError(f"Model path not found: {MODEL_PATH}")
+
     if _tokenizer is None:
         _tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
     if _model is None:

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+import os
 
 import pytest
 
@@ -46,6 +47,9 @@ def test_analyze_returns_probs(monkeypatch):
 
     torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/model")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -104,6 +108,7 @@ def test_env_model_path(monkeypatch):
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
     monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/custom-model")
+    monkeypatch.setattr("os.path.exists", lambda p: True)
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -112,3 +117,105 @@ def test_env_model_path(monkeypatch):
 
     assert paths["tokenizer"] == "/tmp/custom-model"
     assert paths["model"] == "/tmp/custom-model"
+
+
+def test_missing_env_var(monkeypatch):
+    tf_mod = types.ModuleType("transformers")
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return {"text": text}
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, **kwargs):
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+
+    tf_mod.AutoTokenizer = DummyTokenizer
+    tf_mod.AutoModelForSequenceClassification = DummyModel
+    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    class DummyTensor(list):
+        def tolist(self):
+            return list(self)
+
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    monkeypatch.delenv("SOCIAL_PERCEPTION_MODEL", raising=False)
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+
+    sp = importlib.import_module("deepthought.perception.social_perception")
+    importlib.reload(sp)
+
+    with pytest.raises(RuntimeError):
+        sp.analyze("hello")
+
+
+def test_missing_model_path(monkeypatch):
+    tf_mod = types.ModuleType("transformers")
+
+    class DummyTokenizer:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, text, return_tensors=None):
+            return {"text": text}
+
+    class DummyModel:
+        @classmethod
+        def from_pretrained(cls, path):
+            return cls()
+
+        def __call__(self, **kwargs):
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+
+    tf_mod.AutoTokenizer = DummyTokenizer
+    tf_mod.AutoModelForSequenceClassification = DummyModel
+    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
+
+    torch_mod = types.ModuleType("torch")
+
+    class _NoGrad:
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    torch_mod.no_grad = lambda: _NoGrad()
+
+    class DummyTensor(list):
+        def tolist(self):
+            return list(self)
+
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+
+    monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/missing")
+    monkeypatch.setattr("os.path.exists", lambda p: False)
+
+    sp = importlib.import_module("deepthought.perception.social_perception")
+    importlib.reload(sp)
+
+    with pytest.raises(FileNotFoundError):
+        sp.analyze("hello")


### PR DESCRIPTION
## Summary
- detect missing social perception model paths and raise errors
- test social perception for missing environment variable or invalid path

## Testing
- `flake8 src tests`
- `pytest tests/unit/perception/test_social_perception.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d30216348326843f32cba2bbf92c