### PR TITLE
Add ontology contradiction checks in reasoning

### DIFF
--- a/src/deepthought/eda/__init__.py
+++ b/src/deepthought/eda/__init__.py
@@ -6,15 +6,10 @@ different modules of the DeepThought reThought system using NATS as
 the message broker.
 """
 
-from .events import (
-    CodeGeneratedPayload,
-    CodeTemplatePayload,
-    EventPayload,
-    EventSubjects,
-    InputReceivedPayload,
-    MemoryRetrievedPayload,
-    ResponseGeneratedPayload,
-)
+from .events import (CodeGeneratedPayload, CodeTemplatePayload, EventPayload,
+                     EventSubjects, InputReceivedPayload,
+                     MemoryRetrievedPayload, ResponseGeneratedPayload,
+                     WarningPayload)
 from .publisher import Publisher
 from .subscriber import Subscriber
 
@@ -24,6 +19,7 @@ __all__ = [
     "InputReceivedPayload",
     "MemoryRetrievedPayload",
     "ResponseGeneratedPayload",
+    "WarningPayload",
     "CodeTemplatePayload",
     "CodeGeneratedPayload",
     "Publisher",

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -44,6 +44,9 @@ class EventSubjects:
     # BDI agent events
     BDI_INTENTION = "dtr.bdi.intention"
 
+    # Warning events
+    WARNING = "dtr.warning"
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -150,3 +153,11 @@ class BDIIntentionPayload(EventPayload):
 
     goal: str
     priority: int
+
+
+@dataclass
+class WarningPayload(EventPayload):
+    """Payload for ontology or system warnings."""
+
+    message: str
+    facts: Optional[list[tuple[str, str, str]]] = None

--- a/src/deepthought/ontology/ontology.py
+++ b/src/deepthought/ontology/ontology.py
@@ -40,3 +40,25 @@ class OntologyManager:
                 if isinstance(cls, ThingClass):
                     facts.append((ind.iri, str(RDF.type), cls.iri))
         return facts
+
+    def verify_triple(self, triple: Triple) -> bool:
+        """Return ``True`` if the triple does not contradict existing knowledge."""
+        subj, pred, obj = triple
+        s_ref, p_ref, o_ref = URIRef(str(subj)), URIRef(str(pred)), URIRef(str(obj))
+        for _, _, existing_obj in self.graph.triples((s_ref, p_ref, None)):
+            if existing_obj != o_ref:
+                return False
+        return True
+
+    def verify_triples(
+        self, triples: Iterable[Triple]
+    ) -> tuple[list[Triple], list[Triple]]:
+        """Split triples into valid and contradictory lists."""
+        valid: list[Triple] = []
+        contradictory: list[Triple] = []
+        for t in triples:
+            if self.verify_triple(t):
+                valid.append(t)
+            else:
+                contradictory.append(t)
+        return valid, contradictory

--- a/src/deepthought/services/reasoning_service.py
+++ b/src/deepthought/services/reasoning_service.py
@@ -10,8 +10,8 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 from rdflib import Namespace
 
-from ..eda.events import EventSubjects, InputReceivedPayload, ResponseGeneratedPayload
-
+from ..eda.events import (EventSubjects, InputReceivedPayload,
+                          ResponseGeneratedPayload, WarningPayload)
 from ..ontology import OntologyManager
 from .base import BaseService
 
@@ -53,7 +53,9 @@ class ReasoningService(BaseService):
                 continue
             subj, pred = parts[0], parts[1]
             obj = "_".join(parts[2:])
-            triples.append((str(self._ns[subj]), str(self._ns[pred]), str(self._ns[obj])))
+            triples.append(
+                (str(self._ns[subj]), str(self._ns[pred]), str(self._ns[obj]))
+            )
         return triples
 
     async def _handle_response(self, msg: Msg) -> None:
@@ -65,14 +67,28 @@ class ReasoningService(BaseService):
                 self._ontology.add_triples(triples)
                 facts = self._ontology.infer_facts()
                 if facts:
-                    text = "; ".join(" ".join(t) for t in facts)
-                    out = InputReceivedPayload(user_input=text, input_id=str(uuid4()))
-                    await self._publisher.publish(
-                        EventSubjects.INPUT_RECEIVED,
-                        out,
-                        use_jetstream=True,
-                        timeout=10.0,
-                    )
+                    valid, contradictions = self._ontology.verify_triples(facts)
+                    if contradictions:
+                        warn = WarningPayload(
+                            message="Contradictory facts", facts=contradictions
+                        )
+                        await self._publisher.publish(
+                            EventSubjects.WARNING,
+                            warn,
+                            use_jetstream=True,
+                            timeout=10.0,
+                        )
+                    if valid:
+                        text = "; ".join(" ".join(t) for t in valid)
+                        out = InputReceivedPayload(
+                            user_input=text, input_id=str(uuid4())
+                        )
+                        await self._publisher.publish(
+                            EventSubjects.INPUT_RECEIVED,
+                            out,
+                            use_jetstream=True,
+                            timeout=10.0,
+                        )
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception as exc:  # pragma: no cover - defensive
@@ -90,7 +106,9 @@ class ReasoningService(BaseService):
         )
         started = await super().start()
         if started:
-            logger.info("ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED)
+            logger.info(
+                "ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED
+            )
 
         return started
 

--- a/tests/unit/services/test_reasoning_service.py
+++ b/tests/unit/services/test_reasoning_service.py
@@ -18,6 +18,10 @@ fake_prom.Counter = lambda *a, **k: object()
 fake_prom.Histogram = lambda *a, **k: object()
 fake_prom.REGISTRY = SimpleNamespace(_names_to_collectors={})
 sys.modules.setdefault("prometheus_client", fake_prom)
+sys.modules.setdefault("pyperplan", types.ModuleType("pyperplan"))
+planning_stub = types.ModuleType("planning_service")
+planning_stub.PlanningService = object
+sys.modules.setdefault("deepthought.services.planning_service", planning_stub)
 sys.modules.setdefault("aiosqlite", types.ModuleType("aiosqlite"))
 tb_mod = types.ModuleType("textblob")
 tb_mod.TextBlob = lambda text: types.SimpleNamespace(
@@ -124,6 +128,9 @@ async def test_handle_response_emits_input_event(monkeypatch):
         def infer_facts(self):
             return [("A", "B", "C")]
 
+        def verify_triples(self, triples):
+            return triples, []
+
     svc = ReasoningService(DummyNATS(), DummyJS(), ontology=DummyOntology())
     svc._publisher = DummyPublisher()
     svc._subscriber = DummySubscriber()
@@ -156,3 +163,35 @@ def test_extract_triples_simple():
             "http://deepthought.local/resp#D",
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_warning_on_contradiction(monkeypatch):
+    class DummyOntology:
+        def add_triples(self, triples):
+            pass
+
+        def infer_facts(self):
+            return [("A", "B", "C"), ("A", "B", "D")]
+
+        def verify_triples(self, triples):
+            valid = [triples[0]]
+            contradictory = [triples[1]]
+            return valid, contradictory
+
+    svc = ReasoningService(DummyNATS(), DummyJS(), ontology=DummyOntology())
+    svc._publisher = DummyPublisher()
+    svc._subscriber = DummySubscriber()
+
+    payload = ResponseGeneratedPayload(final_response="X is Y", input_id="1")
+    msg = DummyMsg(payload.to_json())
+    await svc._handle_response(msg)
+
+    assert msg.acked
+    subjects = [s for s, _ in svc._publisher.published]
+    assert EventSubjects.WARNING in subjects
+    assert EventSubjects.INPUT_RECEIVED in subjects
+    inp = next(
+        p for s, p in svc._publisher.published if s == EventSubjects.INPUT_RECEIVED
+    )
+    assert inp.user_input == "A B C"


### PR DESCRIPTION
## Summary
- add `WARNING` event and payload class
- implement triple verification in `OntologyManager`
- check inferred facts before publishing in `ReasoningService`
- issue warning events on contradictions
- cover new behaviour in reasoning service tests

## Testing
- `flake8 src/deepthought/eda/events.py src/deepthought/eda/__init__.py src/deepthought/ontology/ontology.py src/deepthought/services/reasoning_service.py tests/unit/services/test_reasoning_service.py`
- `pytest -q tests/unit/services/test_reasoning_service.py`

------
https://chatgpt.com/codex/tasks/task_e_688434437ce083269f1e37d878412759