### PR TITLE
docs: add local testing instructions

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -116,3 +116,22 @@ Example using the sample traces in `tests/traces/`:
 PYTHONPATH=src python tools/discord_replay.py tests/traces/trial.json \
     --output reply.jsonl --metrics metrics.json
 ```
+
+## Running the Test Suite
+
+The CI workflow installs pinned versions of all dependencies. To reproduce the
+same environment locally run:
+
+```bash
+pip install -r requirements-ci.txt
+```
+
+Once the integration services are running you can execute the tests with:
+
+```bash
+PYTHONPATH=src pytest
+```
+
+Some tests cover optional components that are skipped unless those extras are
+installed (for example the metrics dashboard requires `matplotlib`). Install any
+optional packages used by your code to achieve full test coverage.


### PR DESCRIPTION
## Summary
- document how to run the test suite locally
- mention `requirements-ci.txt` and optional dependencies

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_688936646e088326ae60401d956f4738