### PR TITLE
Add trust table to DBManager

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -29,6 +29,7 @@ else:
     def analyze_sentiment(text: str) -> float:
         return TextBlob(text).sentiment.polarity
 
+
 from ..config import get_settings
 
 # Default database path used when none is provided.
@@ -57,6 +58,12 @@ class DBManager:
         CREATE TABLE IF NOT EXISTS affinity (
             user_id TEXT PRIMARY KEY,
             score INTEGER DEFAULT 0
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS trust (
+            user_id TEXT PRIMARY KEY,
+            score REAL DEFAULT 0
         )
         """,
         """
@@ -182,11 +189,7 @@ class DBManager:
             "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
             (str(user_id), str(target_id) if target_id is not None else None),
         )
-        delta = (
-            self._affinity_delta(sentiment_score)
-            if sentiment_score is not None
-            else AFFINITY_POS_DELTA
-        )
+        delta = self._affinity_delta(sentiment_score) if sentiment_score is not None else AFFINITY_POS_DELTA
         if delta:
             await self._db.execute(
                 """
@@ -456,6 +459,29 @@ class DBManager:
         ) as cur:
             row = await cur.fetchone()
             return int(row[0]) if row else 0
+
+    async def adjust_trust(self, user_id: int, delta: float) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO trust (user_id, score)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET score=trust.score + ?
+            """,
+            (str(user_id), float(delta), float(delta)),
+        )
+        await self._db.commit()
+
+    async def get_trust(self, user_id: int) -> float:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT score FROM trust WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+            return float(row[0]) if row else 0.0
 
     async def get_relationship(self, user_id: int, target_id: int):
         await self.connect()

--- a/tests/test_db_manager_init.py
+++ b/tests/test_db_manager_init.py
@@ -14,6 +14,7 @@ from deepthought.services.db_manager import DBManager
 TABLES = [
     "interactions",
     "affinity",
+    "trust",
     "memories",
     "theories",
     "queued_tasks",

--- a/tests/test_trust_dbmanager.py
+++ b/tests/test_trust_dbmanager.py
@@ -1,0 +1,19 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services.db_manager import DBManager
+
+
+@pytest.mark.asyncio
+async def test_adjust_get_trust(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+
+    await manager.adjust_trust("u1", 0.5)
+    await manager.adjust_trust("u1", -0.2)
+
+    assert pytest.approx(await manager.get_trust("u1")) == 0.3
+
+    await manager.close()


### PR DESCRIPTION
## Summary
- support trust level persistence in `DBManager`
- create tests for trust table and queries
- include trust table in DB initialization

## Testing
- `black --line-length=120 src/deepthought/services/db_manager.py tests/test_db_manager_init.py tests/test_trust_dbmanager.py`
- `isort --profile=black --line-length=120 src/deepthought/services/db_manager.py tests/test_db_manager_init.py tests/test_trust_dbmanager.py`
- `flake8 src/deepthought/services/db_manager.py tests/test_db_manager_init.py tests/test_trust_dbmanager.py`
- `pytest tests/test_db_manager_init.py tests/test_trust_dbmanager.py`

------
https://chatgpt.com/codex/tasks/task_e_688939b0ea848326a9d0fb9cc9bf5873