### PR TITLE
Add thought logging helper

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -156,7 +156,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -180,6 +182,13 @@ REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
 SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
 AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
+
+# Optional channel for thought logging
+_THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
+try:
+    THOUGHT_CHANNEL_ID = int(_THOUGHT_CHANNEL) if _THOUGHT_CHANNEL else None
+except ValueError:
+    THOUGHT_CHANNEL_ID = None
 
 # Optional bot-to-bot chatter configuration
 # Accepts values like "true", "1", or "yes" (case-insensitive)
@@ -228,7 +237,9 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -264,7 +275,11 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
     )
 
     if db_manager.db_path != target_path:
@@ -282,7 +297,9 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+    await db_manager.log_interaction(
+        user_id, target_id, sentiment_score=sentiment_score
+    )
 
 
 async def recall_user(user_id: int):
@@ -295,7 +312,9 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
 
 
 async def send_to_prism(data: dict) -> None:
@@ -328,6 +347,31 @@ async def _ensure_nats() -> None:
         _subscriber = None
 
 
+async def _send_thought(bot: discord.Client, text: str) -> None:
+    """Send ``text`` to the THOUGHT_CHANNEL if configured."""
+    if THOUGHT_CHANNEL_ID is None:
+        return
+    channel = bot.get_channel(THOUGHT_CHANNEL_ID)
+    if channel is None:
+        logger.warning("Thought channel %s not found", THOUGHT_CHANNEL_ID)
+        return
+    try:
+        await channel.send(text)
+    except Exception as exc:  # pragma: no cover - send failure
+        logger.warning("Failed to send thought: %s", exc)
+
+
+def log_thought(bot: discord.Client, text: str) -> None:
+    """Schedule ``text`` to be sent to the THOUGHT_CHANNEL asynchronously."""
+    if THOUGHT_CHANNEL_ID is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:  # pragma: no cover - no loop available
+        return
+    loop.create_task(_send_thought(bot, text))
+
+
 async def publish_input_received(text: str) -> None:
     """Publish an INPUT_RECEIVED event using NATS JetStream."""
     if not is_allowed(text):  # noqa: F821 - defined in optional module
@@ -335,7 +379,9 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -358,7 +404,9 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
+        )
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -527,8 +575,12 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                    when = discord.utils.utcnow().replace(
+                        tzinfo=timezone.utc
+                    ) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(
+                        message, when, str(uuid.uuid4())
+                    )
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -565,7 +617,9 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+            return (
+                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds() / 60
     return None
 
 
@@ -590,9 +644,15 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+            if (
+                last_message
+                and last_message.author.bot
+                and prev_message
+                and not prev_message.author.bot
+            ):
                 age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -603,7 +663,8 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -644,7 +705,9 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler()
-        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
+        self.scheduler_service: SchedulerService | None = (
+            None  # noqa: F821 - optional feature
+        )
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -667,7 +730,9 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
+        self._bg_tasks.append(
+            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
 
@@ -679,10 +744,14 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+        if (
+            any(getattr(m, "bot", False) for m in message.mentions)
+            and self.user not in message.mentions
+        ):
             return
 
         sentiment_score = analyze_sentiment(message.content)
+        log_thought(self, f"Sentiment score: {sentiment_score:+.2f}")
         topic = "message" if abs(sentiment_score) > SENTIMENT_THRESHOLD else ""
         await store_memory(
             message.author.id,
@@ -690,7 +759,9 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
         result = await who_is_active(message.channel)
         if len(result) == 3:
@@ -717,7 +788,9 @@ class SocialGraphBot(discord.Client):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
             persona = await self.persona_manager.get_persona(message.author.id)
-            reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+            reply = random.choice(
+                PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+            )
             await message.channel.send(reply)
 
         # Log the interaction


### PR DESCRIPTION
## Summary
- send bot thought logs to a Discord channel
- log sentiment analysis results using the helper
- avoid scheduling tasks if thought channel is unset

## Testing
- `python -m flake8 examples/social_graph_bot.py tests/test_basic.py`
- `pytest tests/test_basic.py tests/test_sentiment_backend.py -q -k "" -vv`


------
https://chatgpt.com/codex/tasks/task_e_68895d0c2a748326b2f5e14522e949bf