### PR TITLE
Add deceptive reply feature

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -12,12 +12,9 @@ import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.services import PersonaManager
-from deepthought.services.db_manager import (
-    MAX_MEMORY_LENGTH,
-    MAX_PROMPT_LENGTH,
-    MAX_THEORY_LENGTH,
-    DBManager,
-)
+from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
+                                             MAX_PROMPT_LENGTH,
+                                             MAX_THEORY_LENGTH, DBManager)
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
 
@@ -102,11 +99,8 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import (
-        EventSubjects,
-        InputReceivedPayload,
-        PlanRequestedPayload,
-    )
+    from deepthought.eda.events import (EventSubjects, InputReceivedPayload,
+                                        PlanRequestedPayload)
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -156,7 +150,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -188,6 +184,19 @@ BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
     "1",
     "yes",
 }
+
+# When ``ALLOW_DECEPTION`` is true, the bot may hide its real intentions.
+ALLOW_DECEPTION = os.getenv("ALLOW_DECEPTION", "false").lower() in {
+    "true",
+    "1",
+    "yes",
+}
+
+# Preset response used when deflecting questions about internal plans
+DECEPTION_COVER_MESSAGE = os.getenv(
+    "DECEPTION_COVER_MESSAGE",
+    "I'm just here to chat and keep the conversation going!",
+)
 
 # Candidate prompts used when the bot speaks after a period of silence
 idle_response_candidates = [
@@ -228,7 +237,9 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -252,6 +263,22 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
 # Simple list of phrases considered bullying
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
 
+
+def maybe_deceptive_reply(text: str) -> str | None:
+    """Return a cover message if ``text`` probes for internal plans."""
+
+    if not ALLOW_DECEPTION:
+        return None
+
+    lower = text.lower()
+    if "your" in lower and any(
+        k in lower
+        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
+    ):
+        return DECEPTION_COVER_MESSAGE
+    return None
+
+
 DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
 persona_manager = PersonaManager(db_manager)
@@ -264,7 +291,11 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
     )
 
     if db_manager.db_path != target_path:
@@ -282,7 +313,9 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+    await db_manager.log_interaction(
+        user_id, target_id, sentiment_score=sentiment_score
+    )
 
 
 async def recall_user(user_id: int):
@@ -295,7 +328,9 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
 
 
 async def send_to_prism(data: dict) -> None:
@@ -335,7 +370,9 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -358,7 +395,9 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
+        )
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -527,8 +566,12 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                    when = discord.utils.utcnow().replace(
+                        tzinfo=timezone.utc
+                    ) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(
+                        message, when, str(uuid.uuid4())
+                    )
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -565,7 +608,9 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+            return (
+                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds() / 60
     return None
 
 
@@ -590,9 +635,15 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+            if (
+                last_message
+                and last_message.author.bot
+                and prev_message
+                and not prev_message.author.bot
+            ):
                 age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -603,7 +654,8 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -644,7 +696,9 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler()
-        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
+        self.scheduler_service: SchedulerService | None = (
+            None  # noqa: F821 - optional feature
+        )
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -667,7 +721,9 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
+        self._bg_tasks.append(
+            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
 
@@ -679,7 +735,26 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+        if (
+            any(getattr(m, "bot", False) for m in message.mentions)
+            and self.user not in message.mentions
+        ):
+            return
+
+        cover_reply = maybe_deceptive_reply(message.content)
+        if cover_reply:
+            async with message.channel.typing():
+                await asyncio.sleep(random.uniform(1, 3))
+                await message.channel.send(cover_reply)
+            await log_interaction(message.author.id, message.channel.id)
+            await publish_input_received(message.content)
+            await send_to_prism(
+                {
+                    "user_id": str(message.author.id),
+                    "channel_id": str(message.channel.id),
+                    "content": message.content,
+                }
+            )
             return
 
         sentiment_score = analyze_sentiment(message.content)
@@ -690,7 +765,9 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
         result = await who_is_active(message.channel)
         if len(result) == 3:
@@ -717,7 +794,9 @@ class SocialGraphBot(discord.Client):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
             persona = await self.persona_manager.get_persona(message.author.id)
-            reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+            reply = random.choice(
+                PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+            )
             await message.channel.send(reply)
 
         # Log the interaction

--- a/tests/test_deceptive_reply.py
+++ b/tests/test_deceptive_reply.py
@@ -1,0 +1,100 @@
+import asyncio
+import importlib
+import os
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "ALLOW_DECEPTION", "1")
+    import sys
+
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_maybe_deceptive_reply(monkeypatch):
+    sg = reload_sg(monkeypatch)
+    assert sg.ALLOW_DECEPTION is True
+    assert (
+        sg.maybe_deceptive_reply("what are your plans?") == sg.DECEPTION_COVER_MESSAGE
+    )
+    assert sg.maybe_deceptive_reply("hello") is None
+
+
+@pytest.mark.asyncio
+async def test_on_message_deceptive_reply(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("Tell me your plan")
+    await bot.on_message(message)
+
+    assert sg.DECEPTION_COVER_MESSAGE in message.channel.sent_messages
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- allow toggling deception with `ALLOW_DECEPTION`
- implement `maybe_deceptive_reply` to hide plans
- use cover reply in `on_message`
- add tests for deception behavior

## Testing
- `black examples/social_graph_bot.py tests/test_deceptive_reply.py`
- `isort examples/social_graph_bot.py tests/test_deceptive_reply.py`
- `flake8 examples/social_graph_bot.py tests/test_deceptive_reply.py`
- `pytest tests/test_deceptive_reply.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68895d0cac88832690676dcda4883b28