### PR TITLE
Add GoalScheduler JetStream tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,12 @@
 import os
+import shutil
 import socket
+import subprocess
+import time
 from typing import Optional
 from urllib.parse import urlparse
+
+import pytest
 
 DEFAULT_NATS_PORT = 4222
 
@@ -60,3 +65,37 @@ def neo4j_available(host: str | None = None, port: int | None = None) -> bool:
             return True
     except Exception:
         return False
+
+
+def _find_free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def nats_server(tmp_path_factory):
+    """Run a temporary NATS server with JetStream enabled."""
+    if shutil.which("nats-server") is None:
+        pytest.skip("nats-server executable not found")
+    port = _find_free_port()
+    data_dir = tmp_path_factory.mktemp("nats-data")
+    proc = subprocess.Popen(
+        ["nats-server", "-js", "-p", str(port), "-sd", str(data_dir)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for _ in range(20):
+        if nats_server_available(f"nats://localhost:{port}"):
+            break
+        time.sleep(0.25)
+    else:
+        proc.terminate()
+        raise RuntimeError("nats-server failed to start")
+    yield f"nats://localhost:{port}"
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()

--- a/tests/test_goal_scheduler.py
+++ b/tests/test_goal_scheduler.py
@@ -1,0 +1,39 @@
+import asyncio
+
+import pytest
+
+pytest.importorskip("nats")
+
+from deepthought.eda.events import BDIIntentionPayload, EventSubjects
+from deepthought.eda.publisher import connect
+from deepthought.goal_scheduler import GoalScheduler
+
+pytestmark = pytest.mark.nats
+
+
+@pytest.mark.asyncio
+async def test_goals_persist_and_publish(nats_server):
+    publisher = await connect(nats_server)
+    nc = publisher._nc
+    received: list[BDIIntentionPayload] = []
+
+    async def handler(msg):
+        received.append(BDIIntentionPayload.from_json(msg.data.decode()))
+
+    sub = await nc.subscribe(EventSubjects.BDI_INTENTION, cb=handler)
+    await asyncio.sleep(0.1)
+
+    sched = GoalScheduler()
+    sched.add_goal("low", priority=1)
+    sched.add_goal("high", priority=5)
+    sched.add_goal("mid", priority=3)
+
+    count = await sched.publish_intentions(publisher)
+    await asyncio.sleep(0.5)
+
+    await sub.unsubscribe()
+    await nc.close()
+
+    assert count == 3
+    assert [p.goal for p in received] == ["high", "mid", "low"]
+    assert sched.next_goal() is None


### PR DESCRIPTION
## Summary
- add a fixture for launching a temporary NATS server
- test that GoalScheduler publishes intentions in priority order

## Testing
- `flake8 tests/test_goal_scheduler.py tests/helpers.py`
- `isort tests/test_goal_scheduler.py tests/helpers.py`
- `black tests/test_goal_scheduler.py tests/helpers.py`
- `pytest tests/test_goal_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6889649068b08326b0dcef8f388b4a56