### PR TITLE
Persist goal intentions and publish via NATS

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -99,8 +99,12 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import (EventSubjects, InputReceivedPayload,
-                                        PlanRequestedPayload)
+    from deepthought.eda.events import (
+        EventSubjects,
+        InputReceivedPayload,
+        PlanRequestedPayload,
+        BDIIntentionPayload,
+    )
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -130,6 +134,17 @@ except Exception:  # pragma: no cover - optional dependency
 
         def to_json(self) -> str:
             return "{}"
+
+    class BDIIntentionPayload:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+        def to_json(self) -> str:
+            return "{}"
+
+        @classmethod
+        def from_dict(cls, data):
+            return cls(**data)
 
     class Publisher:
         def __init__(self, *args, **kwargs) -> None:
@@ -173,6 +188,7 @@ MAX_BOT_SPEAKERS = int(os.getenv("MAX_BOT_SPEAKERS", "2"))
 IDLE_TIMEOUT_MINUTES = int(os.getenv("IDLE_TIMEOUT_MINUTES", "5"))
 PLAYFUL_REPLY_TIMEOUT_MINUTES = int(os.getenv("PLAYFUL_REPLY_TIMEOUT_MINUTES", "5"))
 REFLECTION_CHECK_SECONDS = int(os.getenv("REFLECTION_CHECK_SECONDS", "300"))
+INTENTION_PUBLISH_SECONDS = int(os.getenv("INTENTION_PUBLISH_SECONDS", "5"))
 SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
 AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
@@ -611,6 +627,20 @@ async def process_goals(bot: "SocialGraphBot") -> None:
             break
 
 
+async def process_intentions(bot: "SocialGraphBot") -> None:
+    """Background task that publishes stored intentions."""
+    await bot.wait_until_ready()
+    while not bot.is_closed():
+        try:
+            await bot.goal_scheduler.load_pending_intentions()
+            if _input_publisher is not None:
+                await bot.goal_scheduler.publish_intentions(_input_publisher)
+            await asyncio.sleep(INTENTION_PUBLISH_SECONDS)
+        except asyncio.CancelledError:
+            logger.info("process_intentions cancelled")
+            break
+
+
 def evaluate_triggers(message: discord.Message) -> List[Tuple[str, float]]:
     """Return a list of (theory, confidence) pairs inferred from a message."""
     theories: List[Tuple[str, float]] = []
@@ -727,7 +757,7 @@ class SocialGraphBot(discord.Client):
         super().__init__(*args, intents=intents, **kwargs)
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
-        self.goal_scheduler = GoalScheduler()
+        self.goal_scheduler = GoalScheduler(db_manager)
         self.scheduler_service: SchedulerService | None = (
             None  # noqa: F821 - optional feature
         )
@@ -749,6 +779,12 @@ class SocialGraphBot(discord.Client):
                     use_jetstream=True,
                     durable="social_bot_chat",
                 )
+                await self._subscriber.subscribe(
+                    subject=EventSubjects.BDI_INTENTION,
+                    handler=self._handle_bdi_intention,
+                    use_jetstream=True,
+                    durable="social_bot_intention",
+                )
             except Exception as exc:  # pragma: no cover - subscription error
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
@@ -758,6 +794,7 @@ class SocialGraphBot(discord.Client):
         )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
+        self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
 
     async def on_ready(self) -> None:
         """Log basic information once the bot connects."""
@@ -887,6 +924,19 @@ class SocialGraphBot(discord.Client):
                 await msg.ack()
         except Exception:  # pragma: no cover - defensive
             logger.error("Failed to handle CHAT_RAW", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_bdi_intention(self, msg: Msg) -> None:
+        """React to BDI_INTENTION events by logging them."""
+        try:
+            data = json.loads(msg.data.decode())
+            payload = BDIIntentionPayload.from_dict(data)
+            logger.info("Received intention: %s", payload.goal)
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:  # pragma: no cover - defensive
+            logger.error("Failed to handle BDI_INTENTION", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 await msg.nak()
 

--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 """Simple priority-based goal scheduler."""
 
+import asyncio
 import heapq
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 from .eda.events import BDIIntentionPayload, EventSubjects
 from .eda.publisher import Publisher
@@ -14,17 +15,39 @@ from .eda.publisher import Publisher
 class ScheduledGoal:
     priority: int
     goal: str = field(compare=False)
+    intention_id: Optional[int] = field(default=None, compare=False)
+
+
+from .services.db_manager import DBManager
 
 
 class GoalScheduler:
     """Maintain a priority queue of goals."""
 
-    def __init__(self) -> None:
+    def __init__(self, db_manager: DBManager | None = None) -> None:
         self._heap: List[ScheduledGoal] = []
+        self._db_manager = db_manager
 
     def add_goal(self, goal: str, priority: int) -> None:
         """Schedule ``goal`` with ``priority`` (higher runs first)."""
         heapq.heappush(self._heap, ScheduledGoal(-priority, goal))
+
+    async def queue_intention(self, goal: str, priority: int) -> int | None:
+        """Schedule and persist an intention."""
+        intention_id: int | None = None
+        if self._db_manager is not None:
+            intention_id = await self._db_manager.add_intention(goal, priority)
+        heapq.heappush(self._heap, ScheduledGoal(-priority, goal, intention_id))
+        return intention_id
+
+    async def load_pending_intentions(self) -> int:
+        """Load pending intentions from the database into the queue."""
+        if self._db_manager is None:
+            return 0
+        rows = await self._db_manager.list_pending_intentions()
+        for iid, goal, priority in rows:
+            heapq.heappush(self._heap, ScheduledGoal(-priority, goal, iid))
+        return len(rows)
 
     def next_goal(self) -> str | None:
         """Pop the highest priority goal or ``None``."""
@@ -37,6 +60,12 @@ class GoalScheduler:
         if not self._heap:
             return None
         scheduled = heapq.heappop(self._heap)
+        if self._db_manager is not None and scheduled.intention_id is not None:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._db_manager.mark_intention_done(scheduled.intention_id))
+            except RuntimeError:
+                asyncio.run(self._db_manager.mark_intention_done(scheduled.intention_id))
         return BDIIntentionPayload(goal=scheduled.goal, priority=-scheduled.priority)
 
     async def publish_intentions(self, publisher: Publisher) -> int:

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -143,6 +143,15 @@ class DBManager:
             last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
+        """
+        CREATE TABLE IF NOT EXISTS intentions (
+            intention_id INTEGER PRIMARY KEY,
+            goal TEXT,
+            priority INTEGER DEFAULT 0,
+            status TEXT DEFAULT 'pending',
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
     ]
 
     def __init__(self, db_path: str = DB_PATH) -> None:
@@ -399,6 +408,37 @@ class DBManager:
         await self._db.execute(
             "UPDATE summary_goals SET status='done' WHERE task_id=?",
             (task_id,),
+        )
+        await self._db.commit()
+
+    async def add_intention(self, goal: str, priority: int) -> int:
+        """Queue an intention with ``goal`` and ``priority``."""
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute(
+            "INSERT INTO intentions (goal, priority) VALUES (?, ?)",
+            (goal, int(priority)),
+        )
+        await self._db.commit()
+        return cur.lastrowid
+
+    async def list_pending_intentions(self):
+        """Return pending intentions sorted by priority."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT intention_id, goal, priority FROM intentions "
+            "WHERE status='pending' ORDER BY priority DESC, intention_id"
+        ) as cur:
+            return await cur.fetchall()
+
+    async def mark_intention_done(self, intention_id: int) -> None:
+        """Mark an intention as completed."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "UPDATE intentions SET status='done' WHERE intention_id=?",
+            (intention_id,),
         )
         await self._db.commit()
 


### PR DESCRIPTION
## Summary
- store queued intentions in new `intentions` table
- track intention IDs in `GoalScheduler` and persist/load via `DBManager`
- publish stored intentions from `social_graph_bot` and log incoming BDI events

## Testing
- `flake8 src/deepthought/goal_scheduler.py examples/social_graph_bot.py src/deepthought/services/db_manager.py`
- `DEEPTHOUGHT_LIGHT_IMPORT=1 pytest tests/unit/test_goal_scheduler_bdi.py tests/unit/test_persona_goal_affinity.py tests/test_queue_dbmanager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68896490ec0c8326ad234477c8defb8a