### PR TITLE
Add manipulative language detection heuristics

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -15,6 +15,7 @@ from deepthought.services import PersonaManager
 from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
                                              MAX_PROMPT_LENGTH,
                                              MAX_THEORY_LENGTH, DBManager)
+from deepthought.perception.manipulative_detection import detect_manipulation
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
 
@@ -839,6 +840,13 @@ class SocialGraphBot(discord.Client):
         await update_sentiment_trend(
             message.author.id, message.channel.id, sentiment_score
         )
+
+        manip_type = detect_manipulation(message.content)
+        if manip_type:
+            await db_manager.adjust_trust(message.author.id, -0.5)
+            logger.info(
+                "Manipulation detected (%s) from %s", manip_type, message.author.id
+            )
 
         result = await who_is_active(message.channel)
         if len(result) == 3:

--- a/src/deepthought/perception/manipulative_detection.py
+++ b/src/deepthought/perception/manipulative_detection.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Heuristic detection of manipulative language in text."""
+
+from typing import Optional
+
+# Simple lists of phrases for each manipulation tactic
+GUILT_TRIP_PHRASES = [
+    "after all i've done for you",
+    "you owe me",
+    "i thought you cared",
+    "if you really loved me",
+    "how could you do this",
+]
+
+THREAT_PHRASES = [
+    "or else",
+    "you'll regret",
+    "i'll make you",
+    "i will hurt",
+    "i will harm",
+    "i'm going to report",
+]
+
+FLATTERY_PHRASES = [
+    "you're the best",
+    "no one is as",
+    "you're amazing",
+    "you're incredible",
+    "you're perfect",
+]
+
+
+def detect_manipulation(text: str) -> Optional[str]:
+    """Return the manipulation category if any heuristic matches."""
+    lower = text.lower()
+    for phrase in GUILT_TRIP_PHRASES:
+        if phrase in lower:
+            return "guilt_tripping"
+    for phrase in THREAT_PHRASES:
+        if phrase in lower:
+            return "threat"
+    for phrase in FLATTERY_PHRASES:
+        if phrase in lower:
+            return "excessive_flattery"
+    return None

--- a/tests/test_manipulation_trust.py
+++ b/tests/test_manipulation_trust.py
@@ -1,0 +1,84 @@
+import asyncio
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("aiosqlite")
+pytest.importorskip("nats")
+
+import examples.social_graph_bot as sg
+from deepthought.services import DBManager
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_manipulative_message_adjusts_trust(tmp_path, monkeypatch, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("After all I've done for you")
+    await bot.on_message(message)
+
+    trust = await sg.db_manager.get_trust(message.author.id)
+    assert trust < 0
+    await sg.db_manager.close()

--- a/tests/unit/perception/test_manipulative_detection.py
+++ b/tests/unit/perception/test_manipulative_detection.py
@@ -1,0 +1,12 @@
+import importlib
+
+import pytest
+
+from deepthought.perception import manipulative_detection as md
+
+
+def test_detect_manipulation_categories():
+    assert md.detect_manipulation("After all I've done for you") == "guilt_tripping"
+    assert md.detect_manipulation("You'll regret this") == "threat"
+    assert md.detect_manipulation("You're the best!") == "excessive_flattery"
+    assert md.detect_manipulation("Just a normal message") is None


### PR DESCRIPTION
## Summary
- create heuristic-based manipulative language detector
- integrate detection into `social_graph_bot`
- adjust user trust on manipulative messages
- test detection logic and trust adjustment

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest -q tests/unit/perception/test_manipulative_detection.py tests/test_manipulation_trust.py`

------
https://chatgpt.com/codex/tasks/task_e_6889759fa84083268d0a0781149ddb76