### PR TITLE
Implement per-user reply rate limiting

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -19,6 +19,7 @@ from deepthought.perception.manipulative_detection import detect_manipulation
 from deepthought.services.moderation import is_allowed
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.scheduler import SchedulerService
+from deepthought.utils import UserRateLimiter
 
 try:
     import discord
@@ -194,6 +195,7 @@ INTENTION_PUBLISH_SECONDS = int(os.getenv("INTENTION_PUBLISH_SECONDS", "5"))
 SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
 AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
+USER_REPLY_RATE_SECONDS = float(os.getenv("USER_REPLY_RATE_SECONDS", "3"))
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -307,6 +309,7 @@ def maybe_deceptive_reply(text: str) -> str | None:
 DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
 persona_manager = PersonaManager(db_manager)
+reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -864,6 +867,9 @@ class SocialGraphBot(discord.Client):
 
         if len(bots) > MAX_BOT_SPEAKERS and self.user not in message.mentions:
             # Too many bots talking and we're not addressed directly
+            return
+
+        if not reply_limiter.allow(str(message.author.id)):
             return
 
         async with message.channel.typing():

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -38,6 +38,7 @@ try:  # pragma: no cover - optional dependency may be missing
 except Exception:  # pragma: no cover - optional dependency may be missing
     orchestrator = None  # type: ignore
 from . import persona  # noqa: F401
+from . import utils  # noqa: F401
 
 # neuromorphic uses optional nengo dependency
 try:  # pragma: no cover - optional dependency may be missing

--- a/src/deepthought/utils/__init__.py
+++ b/src/deepthought/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers used across the project."""
+
+from .ratelimit import UserRateLimiter
+
+__all__ = ["UserRateLimiter"]

--- a/src/deepthought/utils/ratelimit.py
+++ b/src/deepthought/utils/ratelimit.py
@@ -1,0 +1,32 @@
+"""Simple token-bucket rate limiter keyed by user ID."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, Tuple
+
+
+class UserRateLimiter:
+    """Token bucket limiter for individual users."""
+
+    def __init__(self, capacity: int, refill_time: float) -> None:
+        self.capacity = capacity
+        self.refill_time = refill_time
+        self._buckets: Dict[str, Tuple[float, float]] = {}
+
+    def allow(self, user_id: str, tokens: int = 1) -> bool:
+        """Return ``True`` if ``tokens`` may be consumed for ``user_id``."""
+        now = time.monotonic()
+        tokens_left, last = self._buckets.get(user_id, (self.capacity, now))
+        tokens_left = min(self.capacity, tokens_left + (now - last) * self.capacity / self.refill_time)
+        if tokens_left >= tokens:
+            tokens_left -= tokens
+            allowed = True
+        else:
+            allowed = False
+        self._buckets[user_id] = (tokens_left, now)
+        return allowed
+
+    def clear(self, user_id: str) -> None:
+        """Reset the bucket for ``user_id``."""
+        self._buckets.pop(user_id, None)

--- a/tests/test_reply_rate_limit.py
+++ b/tests/test_reply_rate_limit.py
@@ -1,0 +1,94 @@
+import asyncio
+import importlib
+import os
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "USER_REPLY_RATE_SECONDS", "1")
+    import sys
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_on_message_rate_limit(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    msg1 = DummyMessage("hi")
+    await bot.on_message(msg1)
+
+    msg2 = DummyMessage("hi again", message_id=11)
+    await bot.on_message(msg2)
+
+    assert len(msg1.channel.sent_messages) == 1
+    assert msg2.channel.sent_messages == []
+
+    await sg.db_manager.close()

--- a/tests/unit/test_user_rate_limit.py
+++ b/tests/unit/test_user_rate_limit.py
@@ -1,0 +1,23 @@
+import pytest
+
+from deepthought.utils.ratelimit import UserRateLimiter
+
+
+def test_user_rate_limiter(monkeypatch):
+    current = 0.0
+
+    def mono():
+        return current
+
+    monkeypatch.setattr("deepthought.utils.ratelimit.time.monotonic", mono)
+
+    limiter = UserRateLimiter(1, 1)
+
+    assert limiter.allow("u1")
+    assert not limiter.allow("u1")
+
+    current += 0.5
+    assert not limiter.allow("u1")
+
+    current += 0.5
+    assert limiter.allow("u1")


### PR DESCRIPTION
## Summary
- add a small token bucket limiter utility
- re-export utilities from package init
- throttle social_graph_bot replies with the new limiter
- test limiter behaviour and bot integration

## Testing
- `PYTHONPATH=src flake8 src tests`
- `PYTHONPATH=src pytest tests/test_reply_rate_limit.py tests/unit/test_user_rate_limit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68897df758988326b1b6e1bec6598e03