### PR TITLE
Add deception memory test

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -11,13 +11,11 @@ from typing import List, Tuple
 import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
-from deepthought.services import PersonaManager
-from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
-                                             MAX_PROMPT_LENGTH,
-                                             MAX_THEORY_LENGTH, DBManager)
 from deepthought.perception.manipulative_detection import detect_manipulation
-from deepthought.services.moderation import is_allowed
+from deepthought.services import PersonaManager
+from deepthought.services.db_manager import MAX_MEMORY_LENGTH, MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH, DBManager
 from deepthought.services.manipulative_detection import manipulation_score
+from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
 from deepthought.utils import UserRateLimiter
 
@@ -103,10 +101,10 @@ else:
 try:
     from deepthought.config import get_settings
     from deepthought.eda.events import (
+        BDIIntentionPayload,
         EventSubjects,
         InputReceivedPayload,
         PlanRequestedPayload,
-        BDIIntentionPayload,
     )
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
@@ -168,9 +166,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -264,9 +260,7 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv(
-            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
-        )
+        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -298,10 +292,7 @@ def maybe_deceptive_reply(text: str) -> str | None:
         return None
 
     lower = text.lower()
-    if "your" in lower and any(
-        k in lower
-        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
-    ):
+    if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
         return DECEPTION_COVER_MESSAGE
     return None
 
@@ -319,11 +310,7 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (
-            DB_PATH
-            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
-            else db_manager.db_path
-        )
+        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
     )
 
     if db_manager.db_path != target_path:
@@ -341,9 +328,7 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(
-        user_id, target_id, sentiment_score=sentiment_score
-    )
+    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
 
 
 async def recall_user(user_id: int):
@@ -356,9 +341,7 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(
-        user_id, memory, topic=topic, sentiment_score=sentiment_score
-    )
+    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
 
 
 async def send_to_prism(data: dict) -> None:
@@ -423,9 +406,7 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
 
         return
     payload = InputReceivedPayload(
@@ -448,9 +429,7 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -619,12 +598,8 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(
-                        tzinfo=timezone.utc
-                    ) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(
-                        message, when, str(uuid.uuid4())
-                    )
+                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -675,9 +650,7 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (
-                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
-            ).total_seconds() / 60
+            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
     return None
 
 
@@ -702,15 +675,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if (
-                last_message
-                and last_message.author.bot
-                and prev_message
-                and not prev_message.author.bot
-            ):
+            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
                 age = (
-                    discord.utils.utcnow()
-                    - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -721,8 +688,7 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow()
-                    - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -763,9 +729,7 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = (
-            None  # noqa: F821 - optional feature
-        )
+        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -794,9 +758,7 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(
-            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
-        )
+        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -809,10 +771,7 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if (
-            any(getattr(m, "bot", False) for m in message.mentions)
-            and self.user not in message.mentions
-        ):
+        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
             return
 
         cover_reply = maybe_deceptive_reply(message.content)
@@ -820,6 +779,7 @@ class SocialGraphBot(discord.Client):
             async with message.channel.typing():
                 await asyncio.sleep(random.uniform(1, 3))
                 await message.channel.send(cover_reply)
+            await store_memory(message.author.id, cover_reply, topic="deception")
             await log_interaction(message.author.id, message.channel.id)
             await publish_input_received(message.content)
             await send_to_prism(
@@ -841,15 +801,12 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(
-            message.author.id, message.channel.id, sentiment_score
-        )
+        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
 
         manip_score = manipulation_score(message.content)
         if manip_score > 0:
             await db_manager.adjust_trust(message.author.id, -manip_score)
             log_thought(self, f"Manipulation score: {manip_score:+.2f}")
-
 
         result = await who_is_active(message.channel)
         if len(result) == 3:
@@ -879,9 +836,7 @@ class SocialGraphBot(discord.Client):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
             persona = await self.persona_manager.get_persona(message.author.id)
-            reply = random.choice(
-                PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
-            )
+            reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             await message.channel.send(reply)
 
         # Log the interaction

--- a/tests/test_deception_memory.py
+++ b/tests/test_deception_memory.py
@@ -1,0 +1,98 @@
+import asyncio
+import importlib
+import os
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "ALLOW_DECEPTION", "1")
+    import sys
+
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_deception_memory(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("Tell me your plan")
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages[-1] == sg.DECEPTION_COVER_MESSAGE
+
+    memories = await sg.db_manager.recall_user(message.author.id)
+    assert any(mem == ("deception", sg.DECEPTION_COVER_MESSAGE) for mem in memories)
+
+    message2 = DummyMessage("Tell me your plan", message_id=11)
+    await bot.on_message(message2)
+
+    assert message2.channel.sent_messages[-1] == sg.DECEPTION_COVER_MESSAGE
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- store deceptive replies in memory
- ensure repeated questions return same deceptive reply
- add test for deception memory behavior

## Testing
- `pytest tests/test_deception_memory.py tests/test_deceptive_reply.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688983d787108326b0fd7dc7904b2269