### PR TITLE
Add lie tracking for social bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ export ALLOW_DECEPTION=true
 ```
 
 ```python
-cover = maybe_deceptive_reply("What are your plans?")
+cover = await maybe_deceptive_reply(123, "What are your plans?")
 ```
 
 ### BDI Planning

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -291,8 +291,12 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
 
 
-def maybe_deceptive_reply(text: str) -> str | None:
-    """Return a cover message if ``text`` probes for internal plans."""
+async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
+    """Return a cover message if ``text`` probes for internal plans.
+
+    The selected response is stored so repeated questions receive the same
+    answer.
+    """
 
     if not ALLOW_DECEPTION:
         return None
@@ -302,7 +306,11 @@ def maybe_deceptive_reply(text: str) -> str | None:
         k in lower
         for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
     ):
-        return DECEPTION_COVER_MESSAGE
+        reply = await db_manager.get_last_lie(user_id, text)
+        if reply is None:
+            reply = DECEPTION_COVER_MESSAGE
+            await db_manager.store_lie(user_id, text, reply)
+        return reply
     return None
 
 
@@ -511,6 +519,14 @@ async def set_do_not_mock(user_id: int, flag: bool = True) -> None:
 
 async def is_do_not_mock(user_id: int) -> bool:
     return await db_manager.is_do_not_mock(user_id)
+
+
+async def store_lie(user_id: int, question: str, reply: str) -> None:
+    await db_manager.store_lie(user_id, question, reply)
+
+
+async def get_last_lie(user_id: int, question: str) -> str | None:
+    return await db_manager.get_last_lie(user_id, question)
 
 
 async def adjust_affinity(user_id: int, delta: float) -> None:
@@ -815,7 +831,7 @@ class SocialGraphBot(discord.Client):
         ):
             return
 
-        cover_reply = maybe_deceptive_reply(message.content)
+        cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
         if cover_reply:
             async with message.channel.typing():
                 await asyncio.sleep(random.uniform(1, 3))

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -152,6 +152,14 @@ class DBManager:
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
+        """
+        CREATE TABLE IF NOT EXISTS lies (
+            user_id TEXT,
+            question TEXT,
+            reply TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
     ]
 
     def __init__(self, db_path: str = DB_PATH) -> None:
@@ -298,6 +306,33 @@ class DBManager:
             (str(subject_id),),
         ) as cur:
             return await cur.fetchall()
+
+    async def store_lie(self, user_id: int, question: str, reply: str) -> None:
+        """Store a fabricated ``reply`` for ``question`` asked by ``user_id``."""
+        if not isinstance(question, str) or not question.strip():
+            raise ValueError("question must be a non-empty string")
+        if not isinstance(reply, str) or not reply.strip():
+            raise ValueError("reply must be a non-empty string")
+
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO lies (user_id, question, reply) VALUES (?, ?, ?)",
+            (str(user_id), question, reply),
+        )
+        await self._db.commit()
+
+    async def get_last_lie(self, user_id: int, question: str) -> str | None:
+        """Return the most recent fabricated reply for ``question`` by ``user_id``."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT reply FROM lies WHERE user_id=? AND question=? "
+            "ORDER BY rowid DESC LIMIT 1",
+            (str(user_id), question),
+        ) as cur:
+            row = await cur.fetchone()
+            return row[0] if row else None
 
     async def update_sentiment_trend(
         self,

--- a/tests/test_deceptive_reply.py
+++ b/tests/test_deceptive_reply.py
@@ -10,7 +10,34 @@ pytest.importorskip("discord")
 
 def reload_sg(monkeypatch):
     monkeypatch.setitem(os.environ, "ALLOW_DECEPTION", "1")
+    import types
     import sys
+
+    fake_pyperplan = types.ModuleType("pyperplan")
+    pddl_mod = types.ModuleType("pyperplan.pddl")
+    parser_mod = types.ModuleType("pyperplan.pddl.parser")
+    parser_mod.Parser = object
+    pddl_mod.parser = parser_mod
+    fake_pyperplan.pddl = pddl_mod
+    fake_pyperplan.planner = types.SimpleNamespace(_ground=lambda *a, **k: None)
+    fake_pyperplan.search = types.SimpleNamespace(
+        breadth_first_search=lambda *a, **k: []
+    )
+
+    sys.modules.setdefault("pyperplan", fake_pyperplan)
+    sys.modules.setdefault("pyperplan.pddl", pddl_mod)
+    sys.modules.setdefault("pyperplan.pddl.parser", parser_mod)
+    sys.modules.setdefault("pyperplan.planner", fake_pyperplan.planner)
+    sys.modules.setdefault("pyperplan.search", fake_pyperplan.search)
+
+    rdflib_mod = types.ModuleType("rdflib")
+    rdflib_mod.Namespace = object
+    rdflib_mod.Graph = object
+    rdflib_mod.URIRef = object
+    sys.modules.setdefault("rdflib", rdflib_mod)
+    ns_mod = types.ModuleType("rdflib.namespace")
+    ns_mod.RDF = object
+    sys.modules.setdefault("rdflib.namespace", ns_mod)
 
     sys.modules.pop("examples.social_graph_bot", None)
     return importlib.import_module("examples.social_graph_bot")
@@ -61,13 +88,20 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_maybe_deceptive_reply(monkeypatch):
+async def test_maybe_deceptive_reply(monkeypatch, tmp_path):
     sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
     assert sg.ALLOW_DECEPTION is True
-    assert (
-        sg.maybe_deceptive_reply("what are your plans?") == sg.DECEPTION_COVER_MESSAGE
-    )
-    assert sg.maybe_deceptive_reply("hello") is None
+    reply1 = await sg.maybe_deceptive_reply(1, "what are your plans?")
+    assert reply1 == sg.DECEPTION_COVER_MESSAGE
+    reply2 = await sg.maybe_deceptive_reply(1, "what are your plans?")
+    assert reply2 == sg.DECEPTION_COVER_MESSAGE
+    assert await sg.maybe_deceptive_reply(1, "hello") is None
+
+    await sg.db_manager.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_lie_methods.py
+++ b/tests/test_lie_methods.py
@@ -1,0 +1,27 @@
+import sys
+import types
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+sys.modules.setdefault("pyperplan", types.ModuleType("pyperplan"))
+
+from deepthought.services.db_manager import DBManager
+
+
+@pytest.mark.asyncio
+async def test_store_and_get_last_lie(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+
+    assert await manager.get_last_lie("u1", "q1") is None
+    await manager.store_lie("u1", "q1", "r1")
+    assert await manager.get_last_lie("u1", "q1") == "r1"
+
+    await manager.store_lie("u1", "q1", "r2")
+    assert await manager.get_last_lie("u1", "q1") == "r2"
+
+    await manager.close()
+
+    await manager.close()


### PR DESCRIPTION
## Summary
- track deceptive responses in a new `lies` table
- add DBManager helpers `store_lie` and `get_last_lie`
- record and reuse cover replies in the social graph bot
- document updated `maybe_deceptive_reply` usage
- test lie storage logic

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/test_deceptive_reply.py tests/test_lie_methods.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688983d6a2b48326acdde0c8628c94a6