### PR TITLE
Implement bot cooldown for social bot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -13,7 +13,12 @@ import aiohttp
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.perception.manipulative_detection import detect_manipulation
 from deepthought.services import PersonaManager
-from deepthought.services.db_manager import MAX_MEMORY_LENGTH, MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH, DBManager
+from deepthought.services.db_manager import (
+    MAX_MEMORY_LENGTH,
+    MAX_PROMPT_LENGTH,
+    MAX_THEORY_LENGTH,
+    DBManager,
+)
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -166,7 +171,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -192,6 +199,7 @@ SENTIMENT_THRESHOLD = float(os.getenv("SENTIMENT_THRESHOLD", "0.3"))
 AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
 USER_REPLY_RATE_SECONDS = float(os.getenv("USER_REPLY_RATE_SECONDS", "3"))
+BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -260,7 +268,9 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -313,6 +323,8 @@ DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
 persona_manager = PersonaManager(db_manager)
 reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
+bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
+last_bot_reply_time: datetime.datetime | None = None
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -322,7 +334,11 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
     )
 
     if db_manager.db_path != target_path:
@@ -340,7 +356,9 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+    await db_manager.log_interaction(
+        user_id, target_id, sentiment_score=sentiment_score
+    )
 
 
 async def recall_user(user_id: int):
@@ -353,7 +371,9 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
 
 
 async def send_to_prism(data: dict) -> None:
@@ -418,7 +438,9 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -441,7 +463,9 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
+        )
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -618,8 +642,12 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                    when = discord.utils.utcnow().replace(
+                        tzinfo=timezone.utc
+                    ) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(
+                        message, when, str(uuid.uuid4())
+                    )
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -670,7 +698,9 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+            return (
+                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds() / 60
     return None
 
 
@@ -695,9 +725,15 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+            if (
+                last_message
+                and last_message.author.bot
+                and prev_message
+                and not prev_message.author.bot
+            ):
                 age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -708,7 +744,8 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -749,7 +786,9 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
+        self.scheduler_service: SchedulerService | None = (
+            None  # noqa: F821 - optional feature
+        )
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -778,7 +817,9 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
+        self._bg_tasks.append(
+            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -788,11 +829,31 @@ class SocialGraphBot(discord.Client):
         logger.info("Logged in as %s (%s)", self.user.name, self.user.id)
 
     async def on_message(self, message: discord.Message) -> None:
+        global last_bot_reply_time
         if message.author == self.user:
             return
 
-        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+        if (
+            any(getattr(m, "bot", False) for m in message.mentions)
+            and self.user not in message.mentions
+        ):
             return
+
+        now = discord.utils.utcnow()
+        if message.author.bot:
+            last = bot_last_messages.get(message.author.id)
+            if (
+                last
+                and last[0] == message.content
+                and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
+                return
+            bot_last_messages[message.author.id] = (message.content, now)
+            if (
+                last_bot_reply_time
+                and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
+                return
 
         cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
         if cover_reply:
@@ -821,7 +882,9 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
         manip_score = manipulation_score(message.content)
         if manip_score > 0:
@@ -856,8 +919,12 @@ class SocialGraphBot(discord.Client):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
             persona = await self.persona_manager.get_persona(message.author.id)
-            reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+            reply = random.choice(
+                PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+            )
             await message.channel.send(reply)
+            if message.author.bot:
+                last_bot_reply_time = discord.utils.utcnow()
 
         # Log the interaction
         await log_interaction(message.author.id, message.channel.id)

--- a/tests/test_bot_cooldown.py
+++ b/tests/test_bot_cooldown.py
@@ -1,0 +1,125 @@
+import asyncio
+import importlib
+import os
+import random
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "BOT_COOLDOWN_SECONDS", "1")
+    sys.modules.setdefault("pydantic", types.ModuleType("pydantic"))
+    sys.modules.setdefault("pydantic_settings", types.ModuleType("pydantic_settings"))
+    sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
+    tb_mod = types.ModuleType("textblob")
+    tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+        sentiment=types.SimpleNamespace(polarity=0.0)
+    )
+    sys.modules.setdefault("textblob", tb_mod)
+    rdf_mod = types.ModuleType("rdflib")
+    rdf_mod.Namespace = lambda *a, **k: None
+    rdf_mod.Graph = object
+    rdf_mod.URIRef = str
+    ns_mod = types.ModuleType("rdflib.namespace")
+    ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+    sys.modules.setdefault("rdflib", rdf_mod)
+    sys.modules.setdefault("rdflib.namespace", ns_mod)
+    py_mod = types.ModuleType("pyperplan")
+    py_mod.pddl = types.ModuleType("pyperplan.pddl")
+    parser_mod = types.ModuleType("pyperplan.pddl.parser")
+    parser_mod.Parser = object
+    py_mod.planner = types.ModuleType("pyperplan.planner")
+    py_mod.planner._ground = lambda p: p
+    py_mod.search = types.ModuleType("pyperplan.search")
+    py_mod.search.breadth_first_search = lambda t: []
+    py_mod.pddl.parser = parser_mod
+    sys.modules.setdefault("pyperplan", py_mod)
+    sys.modules.setdefault("pyperplan.pddl", py_mod.pddl)
+    sys.modules.setdefault("pyperplan.pddl.parser", parser_mod)
+    sys.modules.setdefault("pyperplan.planner", py_mod.planner)
+    sys.modules.setdefault("pyperplan.search", py_mod.search)
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10, is_bot=True):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id, bot=is_bot)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_on_message_bot_cooldown(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+
+    msg1 = DummyMessage("hi", author_id=8, message_id=10, is_bot=True)
+    await bot.on_message(msg1)
+
+    msg2 = DummyMessage("hi", author_id=8, message_id=11, is_bot=True)
+    await bot.on_message(msg2)
+
+    assert len(msg1.channel.sent_messages) == 1
+    assert msg2.channel.sent_messages == []
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- add cooldown for talking to other bots
- track repeated bot messages and skip replies
- test bot cooldown logic

## Testing
- `black tests/test_bot_cooldown.py examples/social_graph_bot.py`
- `isort tests/test_bot_cooldown.py examples/social_graph_bot.py --profile black --line-length 120`
- `flake8 examples/social_graph_bot.py tests/test_bot_cooldown.py`
- `pytest tests/test_bot_cooldown.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688a24dcc9908326b7dce2e0cf0377a7