### PR TITLE
Auto-load persistent goals

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1025,8 +1025,24 @@ def run(token: str, monitor_channel_id: int) -> None:
     bot.run(token)
 
 
+async def enqueue_goal(goal: str, priority: int = 1) -> None:
+    """Persist ``goal`` for later processing."""
+    await init_db()
+    await db_manager.add_intention(goal, priority)
+
+
 if __name__ == "__main__":
+    import argparse
+
     from deepthought.config import load_bot_env
 
-    env = load_bot_env()
-    run(env.DISCORD_TOKEN, env.MONITOR_CHANNEL)
+    parser = argparse.ArgumentParser(description="Run the SocialGraphBot")
+    parser.add_argument("--enqueue-goal", help="goal text to queue")
+    parser.add_argument("--priority", type=int, default=1, help="goal priority")
+    args = parser.parse_args()
+
+    if args.enqueue_goal:
+        asyncio.run(enqueue_goal(args.enqueue_goal, args.priority))
+    else:
+        env = load_bot_env()
+        run(env.DISCORD_TOKEN, env.MONITOR_CHANNEL)

--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -27,6 +27,23 @@ class GoalScheduler:
     def __init__(self, db_manager: DBManager | None = None) -> None:
         self._heap: List[ScheduledGoal] = []
         self._db_manager = db_manager
+        self._load_task: asyncio.Task | None = None
+        if self._db_manager is not None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+            if loop and loop.is_running():
+                self._load_task = loop.create_task(self.load_pending_intentions())
+            else:  # pragma: no cover - typically executed outside tests
+                asyncio.run(self.load_pending_intentions())
+                self._load_task = None
+
+    async def wait_loaded(self) -> None:
+        """Wait for pending intentions to be loaded on startup."""
+        if self._load_task is not None:
+            await self._load_task
+            self._load_task = None
 
     def add_goal(self, goal: str, priority: int) -> None:
         """Schedule ``goal`` with ``priority`` (higher runs first)."""
@@ -63,9 +80,13 @@ class GoalScheduler:
         if self._db_manager is not None and scheduled.intention_id is not None:
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(self._db_manager.mark_intention_done(scheduled.intention_id))
+                loop.create_task(
+                    self._db_manager.mark_intention_done(scheduled.intention_id)
+                )
             except RuntimeError:
-                asyncio.run(self._db_manager.mark_intention_done(scheduled.intention_id))
+                asyncio.run(
+                    self._db_manager.mark_intention_done(scheduled.intention_id)
+                )
         return BDIIntentionPayload(goal=scheduled.goal, priority=-scheduled.priority)
 
     async def publish_intentions(self, publisher: Publisher) -> int:
@@ -78,6 +99,8 @@ class GoalScheduler:
             intention = self.next_intention()
             if intention is None:
                 break
-            await publisher.publish(EventSubjects.BDI_INTENTION, intention, use_jetstream=True)
+            await publisher.publish(
+                EventSubjects.BDI_INTENTION, intention, use_jetstream=True
+            )
             count += 1
         return count

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -165,6 +165,7 @@ class DBManager:
     def __init__(self, db_path: str = DB_PATH) -> None:
         self.db_path = db_path
         self._db: aiosqlite.Connection | None = None
+        self._initialized = False
 
     async def connect(self) -> None:
         if self._db is None:
@@ -172,6 +173,11 @@ class DBManager:
             if dir_path:
                 os.makedirs(dir_path, exist_ok=True)
             self._db = await aiosqlite.connect(self.db_path)
+            if not self._initialized:
+                for query in self.CREATE_TABLE_QUERIES:
+                    await self._db.execute(query)
+                await self._db.commit()
+                self._initialized = True
 
     async def close(self) -> None:
         if self._db is not None:
@@ -184,10 +190,6 @@ class DBManager:
 
     async def init_db(self) -> None:
         await self.connect()
-        assert self._db
-        for query in self.CREATE_TABLE_QUERIES:
-            await self._db.execute(query)
-        await self._db.commit()
 
     async def log_interaction(
         self,
@@ -206,7 +208,11 @@ class DBManager:
             "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
             (str(user_id), str(target_id) if target_id is not None else None),
         )
-        delta = self._affinity_delta(sentiment_score) if sentiment_score is not None else AFFINITY_POS_DELTA
+        delta = (
+            self._affinity_delta(sentiment_score)
+            if sentiment_score is not None
+            else AFFINITY_POS_DELTA
+        )
         if delta:
             await self._db.execute(
                 """
@@ -274,7 +280,9 @@ class DBManager:
             )
         await self._db.commit()
 
-    async def store_theory(self, subject_id: int, theory: str, confidence: float) -> None:
+    async def store_theory(
+        self, subject_id: int, theory: str, confidence: float
+    ) -> None:
         if not isinstance(theory, str) or not theory.strip():
             raise ValueError("theory must be a non-empty string")
         if len(theory) > MAX_THEORY_LENGTH:
@@ -367,7 +375,9 @@ class DBManager:
         ) as cur:
             return await cur.fetchone()
 
-    async def queue_deep_reflection(self, user_id: int, context: dict, prompt: str) -> int:
+    async def queue_deep_reflection(
+        self, user_id: int, context: dict, prompt: str
+    ) -> int:
         if not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("prompt must be a non-empty string")
         if len(prompt) > MAX_PROMPT_LENGTH:

--- a/tests/test_goal_scheduler_autoload.py
+++ b/tests/test_goal_scheduler_autoload.py
@@ -1,0 +1,105 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+fake_pyd = types.ModuleType("pydantic")
+fake_pyd.AnyUrl = str
+fake_pyd.ValidationError = Exception
+fake_pyd.Field = lambda default=None, **kwargs: default
+sys.modules.setdefault("pydantic", fake_pyd)
+
+fake_ps = types.ModuleType("pydantic_settings")
+
+
+class DummyBase:
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+fake_ps.BaseSettings = DummyBase
+fake_ps.SettingsConfigDict = dict
+sys.modules.setdefault("pydantic_settings", fake_ps)
+
+fake_prom = types.ModuleType("prometheus_client")
+
+
+class _Metric:
+    def labels(self, **kwargs):
+        return self
+
+    def inc(self, *a, **k):
+        pass
+
+    def observe(self, *a, **k):
+        pass
+
+
+fake_prom.Counter = lambda *a, **k: _Metric()
+fake_prom.Histogram = lambda *a, **k: _Metric()
+fake_prom.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
+sys.modules.setdefault("prometheus_client", fake_prom)
+tb_mod = types.ModuleType("textblob")
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+    sentiment=types.SimpleNamespace(polarity=0.0)
+)
+sys.modules.setdefault("textblob", tb_mod)
+
+py_mod = types.ModuleType("pyperplan")
+py_mod.pddl = types.ModuleType("pyperplan.pddl")
+parser_mod = types.ModuleType("pyperplan.pddl.parser")
+parser_mod.Parser = object
+py_mod.planner = types.ModuleType("pyperplan.planner")
+py_mod.planner._ground = lambda p: p
+py_mod.search = types.ModuleType("pyperplan.search")
+py_mod.search.breadth_first_search = lambda t: []
+py_mod.pddl.parser = parser_mod
+sys.modules.setdefault("pyperplan", py_mod)
+sys.modules.setdefault("pyperplan.pddl", py_mod.pddl)
+sys.modules.setdefault("pyperplan.pddl.parser", parser_mod)
+sys.modules.setdefault("pyperplan.planner", py_mod.planner)
+sys.modules.setdefault("pyperplan.search", py_mod.search)
+rdf_mod = types.ModuleType("rdflib")
+ns_mod = types.ModuleType("rdflib.namespace")
+ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+rdf_mod.Namespace = lambda uri=None: types.SimpleNamespace(__uri=uri or "")
+rdf_mod.Graph = type(
+    "Graph",
+    (),
+    {"add": lambda self, t: None, "serialize": lambda self, format="xml": ""},
+)
+rdf_mod.URIRef = str
+sys.modules.setdefault("rdflib", rdf_mod)
+sys.modules.setdefault("rdflib.namespace", ns_mod)
+
+fake_nats = types.ModuleType("nats")
+fake_nats.aio = types.ModuleType("aio")
+fake_nats.aio.client = types.ModuleType("client")
+fake_nats.js = types.ModuleType("js")
+fake_nats.js.client = types.ModuleType("client")
+fake_nats.errors = types.ModuleType("errors")
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_nats.aio.client)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_nats.js.client)
+sys.modules.setdefault("nats.errors", fake_nats.errors)
+
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.services.db_manager import DBManager
+
+
+@pytest.mark.asyncio
+async def test_scheduler_autoload(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+    await manager.add_intention("alpha", 1)
+    await manager.add_intention("beta", 5)
+    sched = GoalScheduler(manager)
+    await sched.wait_loaded()
+    assert sched.next_goal() == "beta"
+    assert sched.next_goal() == "alpha"
+    await manager.close()


### PR DESCRIPTION
## Summary
- load pending intentions at startup
- ensure DB tables are created on first connection
- add CLI helper to queue persistent goals
- test autoload behaviour

## Testing
- `black examples/social_graph_bot.py src/deepthought/goal_scheduler.py src/deepthought/services/db_manager.py tests/test_goal_scheduler_autoload.py`
- `isort examples/social_graph_bot.py src/deepthought/goal_scheduler.py src/deepthought/services/db_manager.py tests/test_goal_scheduler_autoload.py`
- `flake8 examples/social_graph_bot.py src/deepthought/goal_scheduler.py src/deepthought/services/db_manager.py tests/test_goal_scheduler_autoload.py`
- `pytest tests/test_goal_scheduler_autoload.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688ac65130f4832687d663ff66058a35