### PR TITLE
Improve social perception fallback

### DIFF
--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 """Simple transformer based social cue classifier."""
 
-from typing import Dict
-
+import logging
 import os
+from typing import Dict
 
 import torch
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
@@ -16,30 +16,51 @@ _tokenizer: AutoTokenizer | None = None
 _model: AutoModelForSequenceClassification | None = None
 
 
-def _load() -> None:
-    """Load model and tokenizer if available."""
+logger = logging.getLogger(__name__)
+
+
+def _load() -> bool:
+    """Load model and tokenizer if available.
+
+    Returns ``True`` if the model is ready for use, otherwise ``False``.
+    """
     global _tokenizer, _model
 
     if _tokenizer is not None and _model is not None:
-        return
+        return True
 
     if not MODEL_PATH or MODEL_PATH == "path/to/social-perception-model":
-        raise RuntimeError(
-            "SOCIAL_PERCEPTION_MODEL environment variable not set or empty"
+        logger.warning(
+            "SOCIAL_PERCEPTION_MODEL not set. Returning neutral perception scores."
         )
+        return False
 
     if not os.path.exists(MODEL_PATH):
-        raise FileNotFoundError(f"Model path not found: {MODEL_PATH}")
+        logger.warning(
+            "Social perception model path not found: %s. Returning neutral perception scores.",
+            MODEL_PATH,
+        )
+        return False
 
-    if _tokenizer is None:
-        _tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
-    if _model is None:
-        _model = AutoModelForSequenceClassification.from_pretrained(MODEL_PATH)
+    try:
+        if _tokenizer is None:
+            _tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+        if _model is None:
+            _model = AutoModelForSequenceClassification.from_pretrained(MODEL_PATH)
+        return True
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Failed to load social perception model: %s", e, exc_info=True)
+        _tokenizer = None
+        _model = None
+        return False
 
 
 def analyze(text: str) -> Dict[str, float]:
     """Return probabilities for flirtation, avoidance and manipulation."""
-    _load()
+    if not _load():
+        neutral = 1.0 / len(LABELS)
+        return {label: neutral for label in LABELS}
+
     assert _tokenizer and _model
     inputs = _tokenizer(text, return_tensors="pt")
     with torch.no_grad():

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -59,7 +59,9 @@ class CognitiveCoreService(BaseService):
                     try:
                         search = OfflineSearch.create_index(db_path, [])
                     except ValueError:
-                        logger.warning("No documents available for search index; disabling offline search")
+                        logger.warning(
+                            "No documents available for search index; disabling offline search"
+                        )
                         search = None
                 else:
                     search = OfflineSearch(db_path)
@@ -131,8 +133,16 @@ class CognitiveCoreService(BaseService):
             self._memory.store_interaction(user_input)
             await self._db.store_memory("user", user_input)
             await self._db.log_interaction("user", None)
-            perception = analyze_social(user_input)
-            await self._db.store_memory("user", json.dumps(perception), topic="social_perception")
+            try:
+                perception = analyze_social(user_input)
+            except Exception as e:  # pragma: no cover - defensive
+                logger.error(
+                    "Failed to analyze social perception: %s", e, exc_info=True
+                )
+                perception = {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0}
+            await self._db.store_memory(
+                "user", json.dumps(perception), topic="social_perception"
+            )
             delta = perception.get("flirtation", 0.0) - (
                 perception.get("avoidance", 0.0) + perception.get("manipulation", 0.0)
             )
@@ -191,7 +201,9 @@ class CognitiveCoreService(BaseService):
         finally:
             duration = time.perf_counter() - start
             INPUTS_TOTAL.labels(service="cognitive_core_service").inc()
-            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(duration)
+            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(
+                duration
+            )
 
     async def start(self, durable_name: str = "cognitive_core_listener") -> bool:
         self._subscriptions.clear()
@@ -203,7 +215,9 @@ class CognitiveCoreService(BaseService):
         )
         started = await super().start()
         if started:
-            logger.info("CognitiveCoreService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            logger.info(
+                "CognitiveCoreService subscribed to %s", EventSubjects.INPUT_RECEIVED
+            )
         return started
 
     async def stop(self) -> None:

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -1,7 +1,8 @@
 import importlib
+import logging
+import os
 import sys
 import types
-import os
 
 import pytest
 
@@ -119,7 +120,7 @@ def test_env_model_path(monkeypatch):
     assert paths["model"] == "/tmp/custom-model"
 
 
-def test_missing_env_var(monkeypatch):
+def test_missing_env_var(monkeypatch, caplog):
     tf_mod = types.ModuleType("transformers")
 
     class DummyTokenizer:
@@ -166,11 +167,15 @@ def test_missing_env_var(monkeypatch):
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
 
-    with pytest.raises(RuntimeError):
-        sp.analyze("hello")
+    with caplog.at_level(logging.WARNING):
+        result = sp.analyze("hello")
+
+    neutral = 1.0 / len(sp.LABELS)
+    assert result == {label: pytest.approx(neutral) for label in sp.LABELS}
+    assert any("SOCIAL_PERCEPTION_MODEL" in r.getMessage() for r in caplog.records)
 
 
-def test_missing_model_path(monkeypatch):
+def test_missing_model_path(monkeypatch, caplog):
     tf_mod = types.ModuleType("transformers")
 
     class DummyTokenizer:
@@ -217,5 +222,9 @@ def test_missing_model_path(monkeypatch):
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
 
-    with pytest.raises(FileNotFoundError):
-        sp.analyze("hello")
+    with caplog.at_level(logging.WARNING):
+        result = sp.analyze("hello")
+
+    neutral = 1.0 / len(sp.LABELS)
+    assert result == {label: pytest.approx(neutral) for label in sp.LABELS}
+    assert any("path not found" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- add graceful fallback to `social_perception.analyze`
- warn instead of error when loading the social model fails
- prevent CognitiveCore from aborting when perception analysis fails
- test that social perception falls back to neutral scores when unset

## Testing
- `black src/deepthought/perception/social_perception.py src/deepthought/services/cognitive_core_service.py tests/unit/perception/test_social_perception.py`
- `isort src/deepthought/perception/social_perception.py src/deepthought/services/cognitive_core_service.py tests/unit/perception/test_social_perception.py`
- `flake8 src/deepthought/perception/social_perception.py src/deepthought/services/cognitive_core_service.py tests/unit/perception/test_social_perception.py`
- `pytest tests/unit/perception/test_social_perception.py::test_missing_env_var tests/unit/perception/test_social_perception.py::test_missing_model_path -q`

------
https://chatgpt.com/codex/tasks/task_e_688acf319df48326b3462d00b1eec73a