### PR TITLE
Update docs: local social perception model

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,10 @@ accordingly:
 export THOUGHT_CHANNEL=9876543210
 ```
 
+Create a private channel for the bot and copy its numeric ID from Discord.
+Setting `THOUGHT_CHANNEL` allows the bot to post manipulation scores and
+other notes there.
+
 ```python
 log_thought(bot, "Sentiment looks suspicious")
 ```
@@ -615,10 +619,12 @@ A minimal notebook demonstrating retrieval-augmented generation is available at 
 
 ## Social Perception
 
-Set the path to the social cue classifier with `SOCIAL_PERCEPTION_MODEL`:
+Download the social perception classifier from Hugging Face and set the path for `SOCIAL_PERCEPTION_MODEL`:
 
 ```bash
-export SOCIAL_PERCEPTION_MODEL=/path/to/social-perception-model
+pip install huggingface_hub
+huggingface-cli download myorg/social-cue-classifier --local-dir ./models/social_perception
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
 ```
 
 If unset, the default `path/to/social-perception-model` is used.

--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -69,3 +69,20 @@ Recent iterations introduced several controls to moderate conversations:
 * **Deception memory** – when `ALLOW_DECEPTION=true`, the bot answers probing questions with a predefined message. Each deceptive reply is stored for future reference.
 * **Bot-to-bot cooldown** – to prevent chatter loops, set `PLAYFUL_REPLY_TIMEOUT_MINUTES` and cap active bots with `MAX_BOT_SPEAKERS`.
 
+## Local Social Perception and Thought Logging
+
+Download the social perception classifier and point `SOCIAL_PERCEPTION_MODEL` to the local weights:
+
+```bash
+pip install huggingface_hub
+huggingface-cli download myorg/social-cue-classifier --local-dir ./models/social_perception
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
+```
+
+Enable thought logging by specifying a channel ID:
+
+```bash
+export THOUGHT_CHANNEL=9876543210
+```
+
+When configured, the bot posts manipulation scores and other notes to this private channel.


### PR DESCRIPTION
## Summary
- document THOUGHT_CHANNEL and SOCIAL_PERCEPTION_MODEL in the bot phase report
- document private thought logging in the README and show how to download a local model

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688b86fe93948326839fcb594f8218c9