### PR TITLE
Implement minimal reply logic for SocialGraphBot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -200,6 +200,9 @@ AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
 USER_REPLY_RATE_SECONDS = float(os.getenv("USER_REPLY_RATE_SECONDS", "3"))
 BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
+MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
+MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
+MINIMAL_REPLIES = ["...", "👍", "No"]
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -918,10 +921,14 @@ class SocialGraphBot(discord.Client):
                 async for recent in message.channel.history(limit=1):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
-            persona = await self.persona_manager.get_persona(message.author.id)
-            reply = random.choice(
-                PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
-            )
+            trust = await db_manager.get_trust(message.author.id)
+            if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
+                reply = random.choice(MINIMAL_REPLIES)
+            else:
+                persona = await self.persona_manager.get_persona(message.author.id)
+                reply = random.choice(
+                    PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+                )
             await message.channel.send(reply)
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()

--- a/tests/test_minimal_reply.py
+++ b/tests/test_minimal_reply.py
@@ -1,0 +1,124 @@
+import asyncio
+import importlib
+import os
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+from deepthought.services import DBManager
+
+
+def reload_sg(monkeypatch, threshold="0", prob="0"):
+    monkeypatch.setitem(os.environ, "MINIMAL_REPLY_THRESHOLD", threshold)
+    monkeypatch.setitem(os.environ, "MINIMAL_REPLY_PROB", prob)
+    import sys
+
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_minimal_reply_by_trust(tmp_path, monkeypatch):
+    sg = reload_sg(monkeypatch, threshold="1", prob="0")
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(random, "random", lambda: 0.5)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("hi")
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages == [sg.MINIMAL_REPLIES[0]]
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_minimal_reply_by_probability(tmp_path, monkeypatch):
+    sg = reload_sg(monkeypatch, threshold="-10", prob="1")
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(random, "random", lambda: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("hi")
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages == [sg.MINIMAL_REPLIES[0]]
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- add minimal reply probability and threshold settings
- reply minimally when trust is low or probability threshold is hit
- test minimal reply behaviour

## Testing
- `flake8 examples/social_graph_bot.py tests/test_minimal_reply.py`
- `pytest tests/test_minimal_reply.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b86fd87988326becb6a13288e6434