### PR TITLE
Add full manipulative phrase coverage

### DIFF
--- a/tests/unit/perception/test_manipulative_detection.py
+++ b/tests/unit/perception/test_manipulative_detection.py
@@ -5,6 +5,21 @@ import pytest
 from deepthought.perception import manipulative_detection as md
 
 
+@pytest.mark.parametrize("phrase", md.GUILT_TRIP_PHRASES)
+def test_guilt_trip_phrases(phrase):
+    assert md.detect_manipulation(phrase) == "guilt_tripping"
+
+
+@pytest.mark.parametrize("phrase", md.THREAT_PHRASES)
+def test_threat_phrases(phrase):
+    assert md.detect_manipulation(phrase) == "threat"
+
+
+@pytest.mark.parametrize("phrase", md.FLATTERY_PHRASES)
+def test_flattery_phrases(phrase):
+    assert md.detect_manipulation(phrase) == "excessive_flattery"
+
+
 def test_detect_manipulation_categories():
     assert md.detect_manipulation("After all I've done for you") == "guilt_tripping"
     assert md.detect_manipulation("You'll regret this") == "threat"


### PR DESCRIPTION
## Summary
- test all manipulative phrase lists individually

## Testing
- `flake8`
- `pytest tests/unit/perception/test_manipulative_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688bdb961c608326a354271717cf9f47