### PR TITLE
Improve manipulation detection categories

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -889,10 +889,10 @@ class SocialGraphBot(discord.Client):
             message.author.id, message.channel.id, sentiment_score
         )
 
-        manip_score = manipulation_score(message.content)
-        if manip_score > 0:
-            await db_manager.adjust_trust(message.author.id, -manip_score)
-            log_thought(self, f"Manipulation score: {manip_score:+.2f}")
+        manip_category = manipulation_score(message.content)
+        if manip_category:
+            await db_manager.adjust_trust(message.author.id, -1.0)
+            log_thought(self, f"Manipulation detected: {manip_category}")
 
         result = await who_is_active(message.channel)
         if len(result) == 3:

--- a/src/deepthought/services/manipulative_detection.py
+++ b/src/deepthought/services/manipulative_detection.py
@@ -1,23 +1,62 @@
 """Simple heuristic-based manipulation detector."""
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Iterable, Optional
 
-MANIPULATIVE_PHRASES: Dict[str, float] = {
-    "trust me": 0.8,
-    "for your own good": 0.7,
-    "if you": 0.5,
-    "only": 0.3,
+
+# Phrase lists grouped by manipulation category
+GUILT_TRIP_PHRASES: Iterable[str] = [
+    "after all i've done for you",
+    "you owe me",
+    "i thought you cared",
+    "if you really loved me",
+    "how could you do this",
+    "don't you care",
+    "think of everything i've sacrificed",
+]
+
+THREAT_PHRASES: Iterable[str] = [
+    "or else",
+    "you'll regret",
+    "i'll make you",
+    "i will hurt",
+    "i will harm",
+    "i'm going to report",
+    "you will be sorry",
+    "i'll ruin you",
+]
+
+FLATTERY_PHRASES: Iterable[str] = [
+    "you're the best",
+    "no one is as",
+    "you're amazing",
+    "you're incredible",
+    "you're perfect",
+    "trust me",
+    "you're so talented",
+    "i admire you so much",
+]
+
+# Mapping of category names to their phrases
+CATEGORY_PHRASES: Dict[str, Iterable[str]] = {
+    "guilt_tripping": GUILT_TRIP_PHRASES,
+    "threat": THREAT_PHRASES,
+    "excessive_flattery": FLATTERY_PHRASES,
 }
 
 
-def manipulation_score(text: str, phrases: Dict[str, float] | None = None) -> float:
-    """Return a manipulation score between 0 and 1 based on keyword matches."""
+def manipulation_score(
+    text: str, phrases: Dict[str, Iterable[str]] | None = None
+) -> Optional[str]:
+    """Return the detected manipulation category if any phrase matches."""
     if not isinstance(text, str):
-        return 0.0
+        return None
+
     lowered = text.lower()
-    scores = phrases or MANIPULATIVE_PHRASES
-    for phrase, score in scores.items():
-        if phrase in lowered:
-            return score
-    return 0.0
+    categories = phrases or CATEGORY_PHRASES
+    for category, plist in categories.items():
+        for phrase in plist:
+            if phrase in lowered:
+                return category
+
+    return None

--- a/tests/test_manipulative_detection.py
+++ b/tests/test_manipulative_detection.py
@@ -123,9 +123,10 @@ class DummyMessage:
 
 
 def test_manipulation_score_heuristics():
-    assert manipulation_score("trust me on this") == pytest.approx(0.8)
-    assert manipulation_score("this is for your own good") == pytest.approx(0.7)
-    assert manipulation_score("hello") == 0.0
+    assert manipulation_score("After all I've done for you") == "guilt_tripping"
+    assert manipulation_score("You'll regret this") == "threat"
+    assert manipulation_score("You're the best!") == "excessive_flattery"
+    assert manipulation_score("hello") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- expand phrase lists and return manipulation categories
- log detected manipulation type in social graph bot
- update tests for new detection behavior

## Testing
- `flake8 src tests`
- `PYTHONPATH=src pytest tests/test_manipulative_detection.py tests/unit/perception/test_manipulative_detection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdb9663c08326b84e8435701df216