### PR TITLE
Add optional transformer-based manipulative detection

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -11,14 +11,10 @@ from typing import List, Tuple
 import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
-from deepthought.perception.manipulative_detection import detect_manipulation
 from deepthought.services import PersonaManager
-from deepthought.services.db_manager import (
-    MAX_MEMORY_LENGTH,
-    MAX_PROMPT_LENGTH,
-    MAX_THEORY_LENGTH,
-    DBManager,
-)
+from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
+                                             MAX_PROMPT_LENGTH,
+                                             MAX_THEORY_LENGTH, DBManager)
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -105,12 +101,9 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import (
-        BDIIntentionPayload,
-        EventSubjects,
-        InputReceivedPayload,
-        PlanRequestedPayload,
-    )
+    from deepthought.eda.events import (BDIIntentionPayload, EventSubjects,
+                                        InputReceivedPayload,
+                                        PlanRequestedPayload)
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -171,7 +164,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -269,7 +264,9 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -305,7 +302,10 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
         return None
 
     lower = text.lower()
-    if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
+    if "your" in lower and any(
+        k in lower
+        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
+    ):
         reply = await db_manager.get_last_lie(user_id, text)
         if reply is None:
             reply = DECEPTION_COVER_MESSAGE
@@ -330,7 +330,11 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
     )
 
     if db_manager.db_path != target_path:
@@ -348,7 +352,9 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+    await db_manager.log_interaction(
+        user_id, target_id, sentiment_score=sentiment_score
+    )
 
 
 async def recall_user(user_id: int):
@@ -361,7 +367,9 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
 
 
 async def send_to_prism(data: dict) -> None:
@@ -426,7 +434,9 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -449,7 +459,9 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
+        )
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -626,8 +638,12 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                    when = discord.utils.utcnow().replace(
+                        tzinfo=timezone.utc
+                    ) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(
+                        message, when, str(uuid.uuid4())
+                    )
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -691,7 +707,9 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+            return (
+                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds() / 60
     return None
 
 
@@ -716,9 +734,15 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+            if (
+                last_message
+                and last_message.author.bot
+                and prev_message
+                and not prev_message.author.bot
+            ):
                 age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -729,7 +753,8 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -770,7 +795,9 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
+        self.scheduler_service: SchedulerService | None = (
+            None  # noqa: F821 - optional feature
+        )
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -799,7 +826,9 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
+        self._bg_tasks.append(
+            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -813,16 +842,26 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+        if (
+            any(getattr(m, "bot", False) for m in message.mentions)
+            and self.user not in message.mentions
+        ):
             return
 
         now = discord.utils.utcnow()
         if message.author.bot:
             last = bot_last_messages.get(message.author.id)
-            if last and last[0] == message.content and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS:
+            if (
+                last
+                and last[0] == message.content
+                and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
                 return
             bot_last_messages[message.author.id] = (message.content, now)
-            if last_bot_reply_time and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS:
+            if (
+                last_bot_reply_time
+                and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
                 return
 
         cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
@@ -852,7 +891,9 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
         manip_category = manipulation_score(message.content)
         if manip_category:
@@ -891,7 +932,9 @@ class SocialGraphBot(discord.Client):
                 reply = random.choice(MINIMAL_REPLIES)
             else:
                 persona = await self.persona_manager.get_persona(message.author.id)
-                reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+                reply = random.choice(
+                    PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+                )
             await message.channel.send(reply)
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()

--- a/src/deepthought/perception/manipulative_detection.py
+++ b/src/deepthought/perception/manipulative_detection.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 """Heuristic detection of manipulative language in text."""
 
+import os
 from typing import Optional
+
+_classifier = None
+_model_checked = False
 
 # Simple lists of phrases for each manipulation tactic
 GUILT_TRIP_PHRASES = [
@@ -31,8 +35,39 @@ FLATTERY_PHRASES = [
 ]
 
 
+def _get_classifier():
+    """Return a text classification pipeline if available."""
+    global _classifier, _model_checked
+    if _model_checked:
+        return _classifier
+    _model_checked = True
+    model_path = os.getenv("MANIP_MODEL_PATH")
+    if not model_path:
+        return None
+    try:  # pragma: no cover - optional dependency
+        from transformers import pipeline
+    except Exception:
+        return None
+    try:  # pragma: no cover - optional dependency
+        _classifier = pipeline("text-classification", model=model_path)
+    except Exception:
+        _classifier = None
+    return _classifier
+
+
 def detect_manipulation(text: str) -> Optional[str]:
-    """Return the manipulation category if any heuristic matches."""
+    """Return the manipulation category using a model or heuristics."""
+    classifier = _get_classifier()
+    if classifier is not None:
+        try:
+            result = classifier(text, truncation=True)
+            if isinstance(result, list) and result:
+                label = str(result[0].get("label", "")).lower()
+                if label and label != "none":
+                    return label
+        except Exception:  # pragma: no cover - model inference failure
+            pass
+
     lower = text.lower()
     for phrase in GUILT_TRIP_PHRASES:
         if phrase in lower:

--- a/src/deepthought/services/manipulative_detection.py
+++ b/src/deepthought/services/manipulative_detection.py
@@ -1,8 +1,10 @@
 """Simple heuristic-based manipulation detector."""
+
 from __future__ import annotations
 
 from typing import Dict, Iterable, Optional
 
+from deepthought.perception.manipulative_detection import detect_manipulation
 
 # Phrase lists grouped by manipulation category
 GUILT_TRIP_PHRASES: Iterable[str] = [
@@ -48,13 +50,15 @@ CATEGORY_PHRASES: Dict[str, Iterable[str]] = {
 def manipulation_score(
     text: str, phrases: Dict[str, Iterable[str]] | None = None
 ) -> Optional[str]:
-    """Return the detected manipulation category if any phrase matches."""
+    """Return the detected manipulation category."""
     if not isinstance(text, str):
         return None
 
+    if phrases is None:
+        return detect_manipulation(text)
+
     lowered = text.lower()
-    categories = phrases or CATEGORY_PHRASES
-    for category, plist in categories.items():
+    for category, plist in phrases.items():
         for phrase in plist:
             if phrase in lowered:
                 return category

--- a/tests/unit/perception/test_manipulative_detection.py
+++ b/tests/unit/perception/test_manipulative_detection.py
@@ -25,3 +25,24 @@ def test_detect_manipulation_categories():
     assert md.detect_manipulation("You'll regret this") == "threat"
     assert md.detect_manipulation("You're the best!") == "excessive_flattery"
     assert md.detect_manipulation("Just a normal message") is None
+
+
+def test_model_path_used(monkeypatch):
+    class DummyClassifier:
+        def __call__(self, text, truncation=True):
+            return [{"label": "threat"}]
+
+    monkeypatch.setenv("MANIP_MODEL_PATH", "dummy")
+    import importlib
+
+    tf = importlib.import_module("transformers")
+    monkeypatch.setattr(
+        tf, "pipeline", lambda *a, **k: DummyClassifier(), raising=False
+    )
+
+    md_reloaded = importlib.reload(md)
+    try:
+        assert md_reloaded.detect_manipulation("hello") == "threat"
+    finally:
+        monkeypatch.delenv("MANIP_MODEL_PATH", raising=False)
+        importlib.reload(md)


### PR DESCRIPTION
## Summary
- support a transformer classifier in `detect_manipulation`
- use new logic from the service layer
- update social graph example to import the unified function
- extend tests for classifier path

## Testing
- `flake8 src/deepthought/perception/manipulative_detection.py src/deepthought/services/manipulative_detection.py examples/social_graph_bot.py tests/unit/perception/test_manipulative_detection.py`
- `pytest tests/unit/perception/test_manipulative_detection.py::test_model_path_used tests/unit/perception/test_manipulative_detection.py::test_detect_manipulation_categories`

------
https://chatgpt.com/codex/tasks/task_e_688cc2c9f1488326b12ae01eb07556b6