### PR TITLE
Add dynamic deception replies

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -12,9 +12,7 @@ import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.services import PersonaManager
-from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
-                                             MAX_PROMPT_LENGTH,
-                                             MAX_THEORY_LENGTH, DBManager)
+from deepthought.services.db_manager import MAX_MEMORY_LENGTH, MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH, DBManager
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -101,9 +99,7 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import (BDIIntentionPayload, EventSubjects,
-                                        InputReceivedPayload,
-                                        PlanRequestedPayload)
+    from deepthought.eda.events import BDIIntentionPayload, EventSubjects, InputReceivedPayload, PlanRequestedPayload
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -164,9 +160,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -243,6 +237,7 @@ PERSONA_REPLIES = {
 # Idle text generation helpers
 # -----------------------------
 _idle_text_generator = None
+_lie_text_generator = None
 
 
 def _get_idle_generator():
@@ -256,6 +251,17 @@ def _get_idle_generator():
     return _idle_text_generator
 
 
+def _get_lie_generator():
+    """Return a cached HuggingFace text-generation pipeline for lies."""
+    global _lie_text_generator
+    if _lie_text_generator is None:
+        from transformers import pipeline
+
+        model_name = os.getenv("LIE_MODEL_NAME", "distilgpt2")
+        _lie_text_generator = pipeline("text-generation", model=model_name)
+    return _lie_text_generator
+
+
 async def generate_idle_response(prompt: str | None = None) -> str | None:
     """Generate a prompt to send when the channel has been idle.
 
@@ -264,9 +270,7 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv(
-            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
-        )
+        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -302,13 +306,21 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
         return None
 
     lower = text.lower()
-    if "your" in lower and any(
-        k in lower
-        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
-    ):
+    if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
         reply = await db_manager.get_last_lie(user_id, text)
         if reply is None:
-            reply = DECEPTION_COVER_MESSAGE
+            try:
+                generator = _get_lie_generator()
+                outputs = await asyncio.to_thread(
+                    generator,
+                    text,
+                    max_new_tokens=20,
+                    num_return_sequences=1,
+                )
+                reply = outputs[0]["generated_text"].strip()
+            except Exception:  # pragma: no cover - optional dependency or runtime error
+                logger.exception("Dynamic deception failed")
+                reply = DECEPTION_COVER_MESSAGE
             await db_manager.store_lie(user_id, text, reply)
         return reply
 
@@ -330,11 +342,7 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (
-            DB_PATH
-            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
-            else db_manager.db_path
-        )
+        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
     )
 
     if db_manager.db_path != target_path:
@@ -352,9 +360,7 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(
-        user_id, target_id, sentiment_score=sentiment_score
-    )
+    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
 
 
 async def recall_user(user_id: int):
@@ -367,9 +373,7 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(
-        user_id, memory, topic=topic, sentiment_score=sentiment_score
-    )
+    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
 
 
 async def send_to_prism(data: dict) -> None:
@@ -434,9 +438,7 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
 
         return
     payload = InputReceivedPayload(
@@ -459,9 +461,7 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -638,12 +638,8 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(
-                        tzinfo=timezone.utc
-                    ) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(
-                        message, when, str(uuid.uuid4())
-                    )
+                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -707,9 +703,7 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (
-                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
-            ).total_seconds() / 60
+            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
     return None
 
 
@@ -734,15 +728,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if (
-                last_message
-                and last_message.author.bot
-                and prev_message
-                and not prev_message.author.bot
-            ):
+            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
                 age = (
-                    discord.utils.utcnow()
-                    - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -753,8 +741,7 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow()
-                    - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -795,9 +782,7 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = (
-            None  # noqa: F821 - optional feature
-        )
+        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -826,9 +811,7 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(
-            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
-        )
+        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -842,26 +825,16 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if (
-            any(getattr(m, "bot", False) for m in message.mentions)
-            and self.user not in message.mentions
-        ):
+        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
             return
 
         now = discord.utils.utcnow()
         if message.author.bot:
             last = bot_last_messages.get(message.author.id)
-            if (
-                last
-                and last[0] == message.content
-                and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS
-            ):
+            if last and last[0] == message.content and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS:
                 return
             bot_last_messages[message.author.id] = (message.content, now)
-            if (
-                last_bot_reply_time
-                and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS
-            ):
+            if last_bot_reply_time and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS:
                 return
 
         cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
@@ -891,9 +864,7 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(
-            message.author.id, message.channel.id, sentiment_score
-        )
+        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
 
         manip_category = manipulation_score(message.content)
         if manip_category:
@@ -932,9 +903,7 @@ class SocialGraphBot(discord.Client):
                 reply = random.choice(MINIMAL_REPLIES)
             else:
                 persona = await self.persona_manager.get_persona(message.author.id)
-                reply = random.choice(
-                    PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
-                )
+                reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             await message.channel.send(reply)
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()

--- a/tests/test_dynamic_deception.py
+++ b/tests/test_dynamic_deception.py
@@ -1,0 +1,52 @@
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("discord")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "ALLOW_DECEPTION", "1")
+    import tests.test_deceptive_reply as base
+
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot"), base.DummyMessage
+
+
+@pytest.mark.asyncio
+async def test_dynamic_deceptive_reply(monkeypatch, tmp_path):
+    sg, DummyMessage = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    call_count = {"n": 0}
+
+    def fake_pipeline(task, model=None):
+        assert task == "text-generation"
+
+        def gen(prompt, **kwargs):
+            call_count["n"] += 1
+            return [{"generated_text": f"lie{call_count['n']}"}]
+
+        return gen
+
+    if "transformers" not in sys.modules:
+        sys.modules["transformers"] = types.ModuleType("transformers")
+    monkeypatch.setattr(sys.modules["transformers"], "pipeline", fake_pipeline, raising=False)
+
+    r1 = await sg.maybe_deceptive_reply(1, "what are your plans?")
+    r2 = await sg.maybe_deceptive_reply(1, "what are your goals?")
+
+    assert r1 != r2
+    assert await sg.db_manager.get_last_lie(1, "what are your plans?") == r1
+    assert await sg.db_manager.get_last_lie(1, "what are your goals?") == r2
+
+    r1b = await sg.maybe_deceptive_reply(1, "what are your plans?")
+    assert r1b == r1
+    assert call_count["n"] == 2
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- add optional text-generation pipeline for lies
- store generated lies
- test dynamic deception via mocked pipeline

## Testing
- `pre-commit run black --files examples/social_graph_bot.py tests/test_dynamic_deception.py`
- `pre-commit run isort --files examples/social_graph_bot.py tests/test_dynamic_deception.py`
- `pre-commit run flake8 --files examples/social_graph_bot.py tests/test_dynamic_deception.py`
- `pytest tests/test_dynamic_deception.py`

------
https://chatgpt.com/codex/tasks/task_e_688cd3b850c083269878e9bff1c8352d