### PR TITLE
Use mutual affinity metrics for persona selection

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -208,11 +208,7 @@ class DBManager:
             "INSERT INTO interactions (user_id, target_id) VALUES (?, ?)",
             (str(user_id), str(target_id) if target_id is not None else None),
         )
-        delta = (
-            self._affinity_delta(sentiment_score)
-            if sentiment_score is not None
-            else AFFINITY_POS_DELTA
-        )
+        delta = self._affinity_delta(sentiment_score) if sentiment_score is not None else AFFINITY_POS_DELTA
         if delta:
             await self._db.execute(
                 """
@@ -280,9 +276,7 @@ class DBManager:
             )
         await self._db.commit()
 
-    async def store_theory(
-        self, subject_id: int, theory: str, confidence: float
-    ) -> None:
+    async def store_theory(self, subject_id: int, theory: str, confidence: float) -> None:
         if not isinstance(theory, str) or not theory.strip():
             raise ValueError("theory must be a non-empty string")
         if len(theory) > MAX_THEORY_LENGTH:
@@ -335,8 +329,7 @@ class DBManager:
         await self.connect()
         assert self._db
         async with self._db.execute(
-            "SELECT reply FROM lies WHERE user_id=? AND question=? "
-            "ORDER BY rowid DESC LIMIT 1",
+            "SELECT reply FROM lies WHERE user_id=? AND question=? " "ORDER BY rowid DESC LIMIT 1",
             (str(user_id), question),
         ) as cur:
             row = await cur.fetchone()
@@ -375,9 +368,7 @@ class DBManager:
         ) as cur:
             return await cur.fetchone()
 
-    async def queue_deep_reflection(
-        self, user_id: int, context: dict, prompt: str
-    ) -> int:
+    async def queue_deep_reflection(self, user_id: int, context: dict, prompt: str) -> int:
         if not isinstance(prompt, str) or not prompt.strip():
             raise ValueError("prompt must be a non-empty string")
         if len(prompt) > MAX_PROMPT_LENGTH:
@@ -567,6 +558,12 @@ class DBManager:
         ) as cur:
             row = await cur.fetchone()
             return float(row[0]) if row else 0.0
+
+    async def get_mutual_affinity(self, user_id: int) -> float:
+        """Return a combined score from affinity and trust for ``user_id``."""
+        affinity = await self.get_affinity(user_id)
+        trust = await self.get_trust(user_id)
+        return float(affinity) + float(trust)
 
     async def get_relationship(self, user_id: int, target_id: int):
         await self.connect()

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -39,7 +39,7 @@ class PersonaManager:
         if self._init_task is not None:
             await self._init_task
             self._init_task = None
-        affinity = await self._db.get_affinity(user_id)
+        affinity = await self._db.get_mutual_affinity(user_id)
         if affinity >= self._friendly:
             return "friendly"
         if affinity >= self._playful:

--- a/tests/test_persona_integration.py
+++ b/tests/test_persona_integration.py
@@ -75,6 +75,7 @@ async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, i
     monkeypatch.setattr(asyncio, "sleep", noop)
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
 
@@ -87,7 +88,7 @@ async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, i
     await bot.on_message(msg2)
     assert msg2.channel.sent_messages[-1] == sg.PERSONA_REPLIES["playful"][0]
 
-    await sg.adjust_affinity(msg1.author.id, 2)
+    await sg.db_manager.adjust_trust(msg1.author.id, 2)
     msg3 = DummyMessage("hello friend", author_id=msg1.author.id, message_id=12)
     await bot.on_message(msg3)
     assert msg3.channel.sent_messages[-1] == sg.PERSONA_REPLIES["friendly"][0]

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -18,7 +18,7 @@ async def test_persona_changes_with_affinity(tmp_path):
     await sg.adjust_affinity(user, 2)
     assert await pm.get_persona(user) == "playful"
 
-    await sg.adjust_affinity(user, 3)
+    await sg.db_manager.adjust_trust(user, 3)
     assert await pm.get_persona(user) == "friendly"
 
     await sg.db_manager.close()
@@ -40,7 +40,7 @@ async def test_choose_prompt_uses_persona(tmp_path, monkeypatch):
     await sg.adjust_affinity(user, 1)
     assert await pm.choose_prompt(user, prompts) == "p"
 
-    await sg.adjust_affinity(user, 1)
+    await sg.db_manager.adjust_trust(user, 1)
     assert await pm.choose_prompt(user, prompts) == "f"
 
     # fallback to default when persona key missing

--- a/tests/test_trust_dbmanager.py
+++ b/tests/test_trust_dbmanager.py
@@ -15,5 +15,6 @@ async def test_adjust_get_trust(tmp_path):
     await manager.adjust_trust("u1", -0.2)
 
     assert pytest.approx(await manager.get_trust("u1")) == 0.3
+    assert pytest.approx(await manager.get_mutual_affinity("u1")) == 0.3
 
     await manager.close()


### PR DESCRIPTION
## Summary
- combine trust and affinity into a new `get_mutual_affinity`
- choose personas based on mutual affinity
- adapt persona manager unit and integration tests to use trust
- expose mutual affinity in DB manager tests

## Testing
- `pytest tests/test_persona_manager.py tests/test_persona_integration.py tests/test_trust_dbmanager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdbdbf8d88326ab1f5461ca0cb4c3