### PR TITLE
Enhance user graph with mutual metrics

### DIFF
--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -14,7 +14,9 @@ class SocialGraphMemory:
     def __init__(self, dal: Optional[UserGraphDAL] = None) -> None:
         self._dal = dal or UserGraphDAL()
 
-    def record_message(self, source: str, text: str, target: Optional[str] = None) -> None:
+    def record_message(
+        self, source: str, text: str, target: Optional[str] = None
+    ) -> None:
         """Analyze sentiment of ``text`` and store the interaction."""
         try:
             score = float(TextBlob(text).sentiment.polarity)
@@ -32,3 +34,9 @@ class SocialGraphMemory:
 
     def get_hostility(self, source: str, target: str) -> float:
         return self._dal.get_hostility(source, target)
+
+    def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
+        return self._dal.get_mutual_affinity(user_a, user_b)
+
+    def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
+        return self._dal.get_relationship_stats(user_a, user_b)

--- a/src/deepthought/services/user_graph_dal.py
+++ b/src/deepthought/services/user_graph_dal.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional, Tuple
 
-
 from .file_graph_dal import FileGraphDAL
 
 logger = logging.getLogger(__name__)
@@ -23,15 +22,18 @@ class UserGraphDAL(FileGraphDAL):
         self._graph.add_node(source, affinity=self.get_affinity(source) + 1)
         if target is not None:
             self._graph.add_node(target, affinity=self.get_affinity(target))
-            data = self._graph.get_edge_data(source, target, default={})
-            count = data.get("interaction_count", 0) + 1
-            sentiment_sum = data.get("sentiment_sum", 0.0) + float(sentiment_score or 0.0)
-            self._graph.add_edge(
-                source,
-                target,
-                interaction_count=count,
-                sentiment_sum=sentiment_sum,
-            )
+            for s, t in ((source, target), (target, source)):
+                data = self._graph.get_edge_data(s, t, default={})
+                count = data.get("interaction_count", 0) + 1
+                sentiment_sum = data.get("sentiment_sum", 0.0) + float(
+                    sentiment_score or 0.0
+                )
+                self._graph.add_edge(
+                    s,
+                    t,
+                    interaction_count=count,
+                    sentiment_sum=sentiment_sum,
+                )
         self._write_graph()
 
     def get_affinity(self, user_id: str) -> int:
@@ -43,7 +45,9 @@ class UserGraphDAL(FileGraphDAL):
         data = self._graph.get_edge_data(source, target)
         if not data:
             return 0, 0.0
-        return int(data.get("interaction_count", 0)), float(data.get("sentiment_sum", 0.0))
+        return int(data.get("interaction_count", 0)), float(
+            data.get("sentiment_sum", 0.0)
+        )
 
     def _avg_sentiment(self, source: str, target: str) -> float:
         count, ssum = self.get_relationship(source, target)
@@ -60,3 +64,28 @@ class UserGraphDAL(FileGraphDAL):
         """Return the average negative sentiment from ``source`` to ``target``."""
         avg = self._avg_sentiment(source, target)
         return min(0.0, avg)
+
+    def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
+        """Return the total interactions between ``user_a`` and ``user_b``."""
+        ab_count, _ = self.get_relationship(user_a, user_b)
+        ba_count, _ = self.get_relationship(user_b, user_a)
+        return ab_count + ba_count
+
+    def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
+        """Return a summary of interactions and sentiment between two users."""
+        ab = self.get_relationship(user_a, user_b)
+        ba = self.get_relationship(user_b, user_a)
+        return {
+            "pair": (user_a, user_b),
+            "a_to_b": {
+                "count": ab[0],
+                "sentiment_sum": ab[1],
+                "avg_sentiment": self._avg_sentiment(user_a, user_b),
+            },
+            "b_to_a": {
+                "count": ba[0],
+                "sentiment_sum": ba[1],
+                "avg_sentiment": self._avg_sentiment(user_b, user_a),
+            },
+            "mutual_affinity": ab[0] + ba[0],
+        }

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -7,6 +7,8 @@ import examples.social_graph_bot as sg
 
 pytest.importorskip("nats")
 from deepthought.services import DBManager
+from deepthought.services.social_graph_memory import SocialGraphMemory
+from deepthought.services.user_graph_dal import UserGraphDAL
 
 
 @pytest.mark.asyncio
@@ -16,7 +18,9 @@ async def test_relationship_table_and_updates(tmp_path):
     await sg.db_manager.init_db()
 
     async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
-        async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='relationships'") as cur:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='relationships'"
+        ) as cur:
             row = await cur.fetchone()
     assert row is not None, "relationships table should exist"
 
@@ -41,3 +45,22 @@ async def test_relationship_table_and_updates(tmp_path):
     assert await sg.get_hostility("u2", "u1") == -1.0
 
     await sg.db_manager.close()
+
+
+def test_user_graph_edges_and_stats(tmp_path):
+    dal = UserGraphDAL(str(tmp_path / "g.json"))
+    mem = SocialGraphMemory(dal)
+
+    dal.add_message("a", "b", sentiment_score=0.5)
+    dal.add_message("b", "a", sentiment_score=-0.2)
+
+    # Both directional edges should be updated
+    assert dal.get_relationship("a", "b")[0] == 2
+    assert dal.get_relationship("b", "a")[0] == 2
+
+    assert dal.get_mutual_affinity("a", "b") == 4
+
+    stats = mem.get_relationship_stats("a", "b")
+    assert stats["mutual_affinity"] == 4
+    assert stats["a_to_b"]["avg_sentiment"] == pytest.approx(0.15)
+    assert stats["b_to_a"]["avg_sentiment"] == pytest.approx(0.15)


### PR DESCRIPTION
## Summary
- update user graph DAL to store bidirectional edges for each message
- add helpers for mutual affinity and relationship stats
- surface the new stats through SocialGraphMemory
- test new relationship metrics and edge updates

## Testing
- `black src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py tests/test_relationships.py`
- `isort src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py tests/test_relationships.py`
- `flake8 src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py tests/test_relationships.py`
- `PYTHONPATH=src pytest tests/test_relationships.py::test_relationship_table_and_updates tests/test_relationships.py::test_user_graph_edges_and_stats -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdbdaf73083269baa1e247c1745ea