### PR TITLE
Add text-generation deception mode

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -12,7 +12,9 @@ import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.services import PersonaManager
-from deepthought.services.db_manager import MAX_MEMORY_LENGTH, MAX_PROMPT_LENGTH, MAX_THEORY_LENGTH, DBManager
+from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
+                                             MAX_PROMPT_LENGTH,
+                                             MAX_THEORY_LENGTH, DBManager)
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -99,7 +101,9 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import BDIIntentionPayload, EventSubjects, InputReceivedPayload, PlanRequestedPayload
+    from deepthought.eda.events import (BDIIntentionPayload, EventSubjects,
+                                        InputReceivedPayload,
+                                        PlanRequestedPayload)
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -160,7 +164,9 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -283,7 +289,9 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+        gen_prompt = prompt or os.getenv(
+            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
+        )
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -319,13 +327,23 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
         return None
 
     lower = text.lower()
-    if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
+    if "your" in lower and any(
+        k in lower
+        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
+    ):
         reply = await db_manager.get_last_lie(user_id, text)
         if reply is None:
-            if DECEPTION_REPLY_MODE.lower() == "dynamic":
-                reply = random.choice(DYNAMIC_COVER_REPLIES)
-            else:
-
+            try:
+                generator = _get_lie_generator()
+                outputs = await asyncio.to_thread(
+                    generator,
+                    text,
+                    max_new_tokens=20,
+                    num_return_sequences=1,
+                )
+                reply = outputs[0]["generated_text"].strip()
+            except Exception:  # pragma: no cover - optional dependency or runtime error
+                logger.exception("Dynamic deception failed")
                 reply = DECEPTION_COVER_MESSAGE
             await db_manager.store_lie(user_id, text, reply)
         return reply
@@ -348,7 +366,11 @@ async def init_db(db_path: str | None = None) -> None:
     target_path = (
         db_path
         if db_path is not None
-        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
+        else (
+            DB_PATH
+            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
+            else db_manager.db_path
+        )
     )
 
     if db_manager.db_path != target_path:
@@ -366,7 +388,9 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+    await db_manager.log_interaction(
+        user_id, target_id, sentiment_score=sentiment_score
+    )
 
 
 async def recall_user(user_id: int):
@@ -379,7 +403,9 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
+    await db_manager.store_memory(
+        user_id, memory, topic=topic, sentiment_score=sentiment_score
+    )
 
 
 async def send_to_prism(data: dict) -> None:
@@ -444,7 +470,9 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
+        )
 
         return
     payload = InputReceivedPayload(
@@ -467,7 +495,9 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
+        logger.warning(
+            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
+        )
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -644,8 +674,12 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                    when = discord.utils.utcnow().replace(
+                        tzinfo=timezone.utc
+                    ) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(
+                        message, when, str(uuid.uuid4())
+                    )
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -709,7 +743,9 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
+            return (
+                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
+            ).total_seconds() / 60
     return None
 
 
@@ -734,9 +770,15 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
+            if (
+                last_message
+                and last_message.author.bot
+                and prev_message
+                and not prev_message.author.bot
+            ):
                 age = (
-                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -747,7 +789,8 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow()
+                    - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -788,7 +831,9 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
+        self.scheduler_service: SchedulerService | None = (
+            None  # noqa: F821 - optional feature
+        )
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -817,7 +862,9 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
+        self._bg_tasks.append(
+            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
+        )
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -831,16 +878,26 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+        if (
+            any(getattr(m, "bot", False) for m in message.mentions)
+            and self.user not in message.mentions
+        ):
             return
 
         now = discord.utils.utcnow()
         if message.author.bot:
             last = bot_last_messages.get(message.author.id)
-            if last and last[0] == message.content and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS:
+            if (
+                last
+                and last[0] == message.content
+                and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
                 return
             bot_last_messages[message.author.id] = (message.content, now)
-            if last_bot_reply_time and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS:
+            if (
+                last_bot_reply_time
+                and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS
+            ):
                 return
 
         cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
@@ -870,7 +927,9 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        await update_sentiment_trend(
+            message.author.id, message.channel.id, sentiment_score
+        )
 
         manip_category = manipulation_score(message.content)
         if manip_category:
@@ -909,7 +968,9 @@ class SocialGraphBot(discord.Client):
                 reply = random.choice(MINIMAL_REPLIES)
             else:
                 persona = await self.persona_manager.get_persona(message.author.id)
-                reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+                reply = random.choice(
+                    PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
+                )
             await message.channel.send(reply)
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()

--- a/tests/test_deception_memory.py
+++ b/tests/test_deception_memory.py
@@ -2,6 +2,8 @@ import asyncio
 import importlib
 import os
 import random
+import sys
+import types
 
 import pytest
 
@@ -120,15 +122,33 @@ async def test_deception_memory_dynamic(monkeypatch, tmp_path):
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
 
+    call_count = {"n": 0}
+
+    def fake_pipeline(task, model=None):
+        assert task == "text-generation"
+
+        def gen(prompt, **kwargs):
+            call_count["n"] += 1
+            return [{"generated_text": f"lie{call_count['n']}"}]
+
+        return gen
+
+    if "transformers" not in sys.modules:
+        sys.modules["transformers"] = types.ModuleType("transformers")
+    monkeypatch.setattr(
+        sys.modules["transformers"], "pipeline", fake_pipeline, raising=False
+    )
+
     bot = sg.SocialGraphBot(monitor_channel_id=1)
     message = DummyMessage("Tell me your plan")
     await bot.on_message(message)
 
     dynamic_reply = message.channel.sent_messages[-1]
-    assert dynamic_reply in sg.DYNAMIC_COVER_REPLIES
+    assert dynamic_reply == "lie1"
 
     message2 = DummyMessage("Tell me your plan", message_id=11)
     await bot.on_message(message2)
 
     assert message2.channel.sent_messages[-1] == dynamic_reply
+    assert call_count["n"] == 1
     await sg.db_manager.close()

--- a/tests/test_dynamic_deception.py
+++ b/tests/test_dynamic_deception.py
@@ -36,7 +36,9 @@ async def test_dynamic_deceptive_reply(monkeypatch, tmp_path):
 
     if "transformers" not in sys.modules:
         sys.modules["transformers"] = types.ModuleType("transformers")
-    monkeypatch.setattr(sys.modules["transformers"], "pipeline", fake_pipeline, raising=False)
+    monkeypatch.setattr(
+        sys.modules["transformers"], "pipeline", fake_pipeline, raising=False
+    )
 
     r1 = await sg.maybe_deceptive_reply(1, "what are your plans?")
     r2 = await sg.maybe_deceptive_reply(1, "what are your goals?")


### PR DESCRIPTION
## Summary
- generate cover replies with a HuggingFace `text-generation` pipeline
- record generated lies for reuse
- mock text-generation in tests

## Testing
- `black examples/social_graph_bot.py tests/test_deception_memory.py tests/test_dynamic_deception.py`
- `isort examples/social_graph_bot.py tests/test_deception_memory.py tests/test_dynamic_deception.py`
- `flake8 examples/social_graph_bot.py tests/test_deception_memory.py tests/test_dynamic_deception.py`
- `pytest tests/test_deception_memory.py::test_deception_memory_dynamic tests/test_dynamic_deception.py::test_dynamic_deceptive_reply`

------
https://chatgpt.com/codex/tasks/task_e_688d1b57ac30832681ad4a611b1a979b