### PR TITLE
Add mutual affinity helpers to social graph

### DIFF
--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -14,9 +14,7 @@ class SocialGraphMemory:
     def __init__(self, dal: Optional[UserGraphDAL] = None) -> None:
         self._dal = dal or UserGraphDAL()
 
-    def record_message(
-        self, source: str, text: str, target: Optional[str] = None
-    ) -> None:
+    def record_message(self, source: str, text: str, target: Optional[str] = None) -> None:
         """Analyze sentiment of ``text`` and store the interaction."""
         try:
             score = float(TextBlob(text).sentiment.polarity)

--- a/src/deepthought/services/user_graph_dal.py
+++ b/src/deepthought/services/user_graph_dal.py
@@ -22,19 +22,21 @@ class UserGraphDAL(FileGraphDAL):
         self._graph.add_node(source, affinity=self.get_affinity(source) + 1)
         if target is not None:
             self._graph.add_node(target, affinity=self.get_affinity(target))
+            score = float(sentiment_score or 0.0)
             for s, t in ((source, target), (target, source)):
-                data = self._graph.get_edge_data(s, t, default={})
-                count = data.get("interaction_count", 0) + 1
-                sentiment_sum = data.get("sentiment_sum", 0.0) + float(
-                    sentiment_score or 0.0
-                )
-                self._graph.add_edge(
-                    s,
-                    t,
-                    interaction_count=count,
-                    sentiment_sum=sentiment_sum,
-                )
+                self._update_edge(s, t, score)
         self._write_graph()
+
+    def _update_edge(self, source: str, target: str, score: float) -> None:
+        data = self._graph.get_edge_data(source, target, default={})
+        count = data.get("interaction_count", 0) + 1
+        sentiment_sum = data.get("sentiment_sum", 0.0) + score
+        self._graph.add_edge(
+            source,
+            target,
+            interaction_count=count,
+            sentiment_sum=sentiment_sum,
+        )
 
     def get_affinity(self, user_id: str) -> int:
         """Return how many messages ``user_id`` has sent."""
@@ -45,9 +47,7 @@ class UserGraphDAL(FileGraphDAL):
         data = self._graph.get_edge_data(source, target)
         if not data:
             return 0, 0.0
-        return int(data.get("interaction_count", 0)), float(
-            data.get("sentiment_sum", 0.0)
-        )
+        return int(data.get("interaction_count", 0)), float(data.get("sentiment_sum", 0.0))
 
     def _avg_sentiment(self, source: str, target: str) -> float:
         count, ssum = self.get_relationship(source, target)
@@ -66,10 +66,11 @@ class UserGraphDAL(FileGraphDAL):
         return min(0.0, avg)
 
     def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
-        """Return the total interactions between ``user_a`` and ``user_b``."""
+        """Return how many messages have passed between the pair."""
         ab_count, _ = self.get_relationship(user_a, user_b)
         ba_count, _ = self.get_relationship(user_b, user_a)
-        return ab_count + ba_count
+        # each message updates both directional edges, so average the counts
+        return int((ab_count + ba_count) / 2)
 
     def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
         """Return a summary of interactions and sentiment between two users."""
@@ -87,5 +88,6 @@ class UserGraphDAL(FileGraphDAL):
                 "sentiment_sum": ba[1],
                 "avg_sentiment": self._avg_sentiment(user_b, user_a),
             },
-            "mutual_affinity": ab[0] + ba[0],
+            # average counts because each interaction increments both directions
+            "mutual_affinity": int((ab[0] + ba[0]) / 2),
         }

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -18,9 +18,7 @@ async def test_relationship_table_and_updates(tmp_path):
     await sg.db_manager.init_db()
 
     async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
-        async with db.execute(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name='relationships'"
-        ) as cur:
+        async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='relationships'") as cur:
             row = await cur.fetchone()
     assert row is not None, "relationships table should exist"
 
@@ -58,9 +56,10 @@ def test_user_graph_edges_and_stats(tmp_path):
     assert dal.get_relationship("a", "b")[0] == 2
     assert dal.get_relationship("b", "a")[0] == 2
 
-    assert dal.get_mutual_affinity("a", "b") == 4
+    # mutual affinity counts actual messages between the pair
+    assert dal.get_mutual_affinity("a", "b") == 2
 
     stats = mem.get_relationship_stats("a", "b")
-    assert stats["mutual_affinity"] == 4
+    assert stats["mutual_affinity"] == 2
     assert stats["a_to_b"]["avg_sentiment"] == pytest.approx(0.15)
     assert stats["b_to_a"]["avg_sentiment"] == pytest.approx(0.15)


### PR DESCRIPTION
## Summary
- refactor `add_message` to update edges via new helper
- expose stats helpers in social graph memory
- clarify mutual affinity counts and fix calculation

## Testing
- `flake8 src/deepthought/services/user_graph_dal.py src/deepthought/services/social_graph_memory.py tests/test_relationships.py`
- `pytest -q tests/test_relationships.py`


------
https://chatgpt.com/codex/tasks/task_e_688d2b94366883268b3e5f1230565588