### PR TITLE
Use mutual affinity in persona selection

### DIFF
--- a/src/deepthought/perception/manipulative_detection.py
+++ b/src/deepthought/perception/manipulative_detection.py
@@ -37,6 +37,7 @@ FLATTERY_PHRASES = [
     "you're amazing",
     "you're incredible",
     "you're perfect",
+    "trust me",
 ]
 
 

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -39,10 +39,10 @@ class PersonaManager:
         if self._init_task is not None:
             await self._init_task
             self._init_task = None
-        affinity = await self._db.get_mutual_affinity(user_id)
-        if affinity >= self._friendly:
+        score = await self._db.get_mutual_affinity(user_id)
+        if score >= self._friendly:
             return "friendly"
-        if affinity >= self._playful:
+        if score >= self._playful:
             return "playful"
         return "snarky"
 

--- a/tests/test_persona_manager.py
+++ b/tests/test_persona_manager.py
@@ -47,3 +47,23 @@ async def test_choose_prompt_uses_persona(tmp_path, monkeypatch):
     assert await pm.choose_prompt(user, {"default": ["x"]}) == "x"
 
     await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_persona_uses_mutual_affinity(tmp_path, monkeypatch):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+
+    pm = PersonaManager(sg.db_manager, friendly=2, playful=1)
+    called = False
+
+    async def fake_get_mutual_affinity(_user_id):
+        nonlocal called
+        called = True
+        return 3
+
+    monkeypatch.setattr(sg.db_manager, "get_mutual_affinity", fake_get_mutual_affinity)
+
+    assert await pm.get_persona("u1") == "friendly"
+    assert called
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- score personas with `get_mutual_affinity`
- ensure manipulative detection catches "trust me" phrases
- test PersonaManager's call to mutual affinity metric

## Testing
- `flake8 src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2b94d2c08326966bcc348dcd8426