### PR TITLE
Add deflection and gaslighting manipulation detection

### DIFF
--- a/src/deepthought/perception/manipulative_detection.py
+++ b/src/deepthought/perception/manipulative_detection.py
@@ -40,6 +40,20 @@ FLATTERY_PHRASES = [
     "trust me",
 ]
 
+DEFLECTION_PHRASES = [
+    "you're overreacting",
+    "you're taking this too seriously",
+    "let's not dwell on",
+    "that's not important",
+]
+
+GASLIGHTING_PHRASES = [
+    "that never happened",
+    "you're imagining things",
+    "you're making things up",
+    "i never said that",
+]
+
 
 def _get_classifier():
     """Return a text classification pipeline if available."""
@@ -84,4 +98,10 @@ def detect_manipulation(text: str) -> Optional[str]:
     for phrase in FLATTERY_PHRASES:
         if phrase in lower:
             return "excessive_flattery"
+    for phrase in DEFLECTION_PHRASES:
+        if phrase in lower:
+            return "deflection"
+    for phrase in GASLIGHTING_PHRASES:
+        if phrase in lower:
+            return "gaslighting"
     return None

--- a/src/deepthought/services/manipulative_detection.py
+++ b/src/deepthought/services/manipulative_detection.py
@@ -39,17 +39,31 @@ FLATTERY_PHRASES: Iterable[str] = [
     "i admire you so much",
 ]
 
+DEFLECTION_PHRASES: Iterable[str] = [
+    "you're overreacting",
+    "you're taking this too seriously",
+    "let's not dwell on",
+    "that's not important",
+]
+
+GASLIGHTING_PHRASES: Iterable[str] = [
+    "that never happened",
+    "you're imagining things",
+    "you're making things up",
+    "i never said that",
+]
+
 # Mapping of category names to their phrases
 CATEGORY_PHRASES: Dict[str, Iterable[str]] = {
     "guilt_tripping": GUILT_TRIP_PHRASES,
     "threat": THREAT_PHRASES,
     "excessive_flattery": FLATTERY_PHRASES,
+    "deflection": DEFLECTION_PHRASES,
+    "gaslighting": GASLIGHTING_PHRASES,
 }
 
 
-def manipulation_score(
-    text: str, phrases: Dict[str, Iterable[str]] | None = None
-) -> Optional[str]:
+def manipulation_score(text: str, phrases: Dict[str, Iterable[str]] | None = None) -> Optional[str]:
     """Return the detected manipulation category."""
     if not isinstance(text, str):
         return None

--- a/tests/test_manipulative_detection.py
+++ b/tests/test_manipulative_detection.py
@@ -13,16 +13,19 @@ sys.modules.setdefault("pydantic", fake_pyd)
 
 fake_ps = types.ModuleType("pydantic_settings")
 
+
 class DummyBase:
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
+
 
 fake_ps.BaseSettings = DummyBase
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 
 fake_prom = types.ModuleType("prometheus_client")
+
 
 class _Metric:
     def labels(self, **kwargs):
@@ -33,6 +36,7 @@ class _Metric:
 
     def observe(self, *a, **k):
         pass
+
 
 fake_prom.Counter = lambda *a, **k: _Metric()
 fake_prom.Histogram = lambda *a, **k: _Metric()
@@ -64,12 +68,14 @@ rdf_mod.URIRef = str
 sys.modules.setdefault("rdflib", rdf_mod)
 sys.modules.setdefault("rdflib.namespace", ns_mod)
 
+
 def reload_sg(monkeypatch):
     import importlib
     import sys as _sys
 
     _sys.modules.pop("examples.social_graph_bot", None)
     return importlib.import_module("examples.social_graph_bot")
+
 
 pytest.importorskip("discord")
 pytest.importorskip("nats")
@@ -126,6 +132,8 @@ def test_manipulation_score_heuristics():
     assert manipulation_score("After all I've done for you") == "guilt_tripping"
     assert manipulation_score("You'll regret this") == "threat"
     assert manipulation_score("You're the best!") == "excessive_flattery"
+    assert manipulation_score("You're overreacting") == "deflection"
+    assert manipulation_score("That never happened") == "gaslighting"
     assert manipulation_score("hello") is None
 
 


### PR DESCRIPTION
## Summary
- expand manipulative phrase heuristics to detect deflection and gaslighting
- wire new categories through services and tests

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/perception/manipulative_detection.py src/deepthought/services/manipulative_detection.py tests/test_manipulative_detection.py`
- `pytest tests/test_manipulative_detection.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2e6c087c8326a1237cb018b9f9d2