### PR TITLE
Add trust service with decay and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,19 @@ await db_manager.adjust_trust("u1", 0.5)
 score = await db_manager.get_trust("u1")
 ```
 
+A ``TrustService`` wraps these helpers and can optionally decay trust scores
+over time. It also exposes an ``is_trusted`` method for simple threshold
+checks:
+
+```python
+from deepthought.services import TrustService
+
+svc = TrustService(decay=0.01)
+await svc.adjust_trust("u1", 1.0)
+if await svc.is_trusted("u1", 0.5):
+    print("trusted user")
+```
+
 Manipulation attempts are flagged by the social perception classifier. The bot
 records its internal assessments in a private channel when
 `THOUGHT_CHANNEL` is set. Messages are scored with

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -3,17 +3,19 @@
 from .cognitive_core_service import CognitiveCoreService
 from .db_manager import DBManager
 from .file_graph_dal import FileGraphDAL
+from .manipulative_detection import manipulation_score
 from .persona_manager import PersonaManager
 from .planning_service import PlanningService
 from .reasoning_service import ReasoningService
 from .social_graph_service import SocialGraphService
-from .manipulative_detection import manipulation_score
+from .trust_service import TrustService
 
 __all__ = [
     "FileGraphDAL",
     "CognitiveCoreService",
     "PersonaManager",
     "DBManager",
+    "TrustService",
     "SocialGraphService",
     "PlanningService",
     "ReasoningService",

--- a/src/deepthought/services/trust_service.py
+++ b/src/deepthought/services/trust_service.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime
+from typing import Dict
+
+from .db_manager import DBManager
+
+
+class TrustService:
+    """Manage per-user trust scores with optional exponential decay.
+
+    Parameters
+    ----------
+    db_manager:
+        Instance of :class:`DBManager` used for persistence. If not provided, a
+        new :class:`DBManager` is created.
+    decay:
+        Exponential decay rate per second. A value of ``0`` disables decay.
+    """
+
+    def __init__(self, db_manager: DBManager | None = None, *, decay: float = 0.0) -> None:
+        self._db = db_manager or DBManager()
+        self.decay = max(decay, 0.0)
+        self._last_update: Dict[str | int, datetime] = {}
+
+    async def _apply_decay(self, user_id: str | int) -> float:
+        """Return the current trust score after applying decay.
+
+        The decayed value is written back to the database so that future calls
+        operate on the updated value.
+        """
+
+        now = datetime.now(UTC)
+        score = await self._db.get_trust(user_id)
+        last = self._last_update.get(user_id, now)
+        elapsed = (now - last).total_seconds()
+        if self.decay > 0 and elapsed > 0 and score:
+            factor = math.exp(-self.decay * elapsed)
+            decayed = score * factor
+            await self._db.adjust_trust(user_id, decayed - score)
+            score = decayed
+        self._last_update[user_id] = now
+        return float(score)
+
+    async def adjust_trust(self, user_id: str | int, delta: float) -> float:
+        """Adjust ``user_id``'s trust score by ``delta`` and return the new score."""
+
+        score = await self._apply_decay(user_id)
+        await self._db.adjust_trust(user_id, float(delta))
+        return score + float(delta)
+
+    async def get_trust(self, user_id: str | int) -> float:
+        """Retrieve ``user_id``'s trust score with decay applied."""
+
+        return await self._apply_decay(user_id)
+
+    async def is_trusted(self, user_id: str | int, threshold: float) -> bool:
+        """Return ``True`` if ``user_id``'s trust meets or exceeds ``threshold``."""
+
+        return (await self.get_trust(user_id)) >= float(threshold)

--- a/tests/unit/services/test_trust_service.py
+++ b/tests/unit/services/test_trust_service.py
@@ -1,0 +1,27 @@
+import math
+from datetime import timedelta
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services.db_manager import DBManager
+from deepthought.services.trust_service import TrustService
+
+
+@pytest.mark.asyncio
+async def test_trust_decay_and_threshold(tmp_path):
+    db = DBManager(str(tmp_path / "db.sqlite"))
+    await db.init_db()
+    service = TrustService(db_manager=db, decay=0.1)
+
+    assert pytest.approx(await service.adjust_trust("u1", 1.0)) == 1.0
+    assert await service.is_trusted("u1", 0.5)
+
+    service._last_update["u1"] -= timedelta(seconds=10)
+    decayed = await service.get_trust("u1")
+    expected = math.exp(-0.1 * 10)
+    assert pytest.approx(decayed, rel=1e-3) == expected
+    assert not await service.is_trusted("u1", 1.0)
+
+    await db.close()


### PR DESCRIPTION
## Summary
- add TrustService for adjusting, retrieving and checking trust with optional decay
- expose TrustService in services package and document trust-based controls
- cover TrustService with unit tests

## Testing
- `pre-commit run --files src/deepthought/services/trust_service.py`
- `SKIP=pytest pre-commit run --files tests/unit/services/test_trust_service.py`
- `pytest tests/unit/services/test_trust_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e5654b34c8326863d61a04f30d93a