### PR TITLE
feat: track emotions and manipulation

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -160,6 +160,20 @@ class DBManager:
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         )
         """,
+        """
+        CREATE TABLE IF NOT EXISTS emotions (
+            user_id TEXT,
+            emotion_json TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS manipulations (
+            user_id TEXT,
+            manipulation_type TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
     ]
 
     def __init__(self, db_path: str = DB_PATH) -> None:
@@ -276,6 +290,23 @@ class DBManager:
             )
         await self._db.commit()
 
+    async def store_emotion(self, user_id: int, emotions: dict | list) -> None:
+        """Store a JSON-serializable emotion payload for ``user_id``."""
+        if not isinstance(emotions, (dict, list)):
+            raise ValueError("emotions must be a dictionary or list")
+        try:
+            emotion_json = json.dumps(emotions)
+        except (TypeError, ValueError) as exc:  # pragma: no cover - json failure
+            raise ValueError("emotions must be JSON serializable") from exc
+
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO emotions (user_id, emotion_json) VALUES (?, ?)",
+            (str(user_id), emotion_json),
+        )
+        await self._db.commit()
+
     async def store_theory(self, subject_id: int, theory: str, confidence: float) -> None:
         if not isinstance(theory, str) or not theory.strip():
             raise ValueError("theory must be a non-empty string")
@@ -334,6 +365,19 @@ class DBManager:
         ) as cur:
             row = await cur.fetchone()
             return row[0] if row else None
+
+    async def log_manipulation(self, user_id: int, category: str) -> None:
+        """Record a manipulation ``category`` associated with ``user_id``."""
+        if not isinstance(category, str) or not category.strip():
+            raise ValueError("category must be a non-empty string")
+
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "INSERT INTO manipulations (user_id, manipulation_type) VALUES (?, ?)",
+            (str(user_id), category),
+        )
+        await self._db.commit()
 
     async def update_sentiment_trend(
         self,

--- a/tests/test_db_manager_init.py
+++ b/tests/test_db_manager_init.py
@@ -22,6 +22,8 @@ TABLES = [
     "themes",
     "user_flags",
     "recent_topics",
+    "emotions",
+    "manipulations",
 ]
 
 

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import random
 
@@ -62,6 +63,7 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
+    sg.reply_limiter.clear("2")
 
     async def noop(*args, **kwargs):
         return None
@@ -97,10 +99,11 @@ async def test_on_message_stores_memory(tmp_path, monkeypatch, input_events):
 
 
 @pytest.mark.asyncio
-async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls, input_events):
+async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
+    sg.reply_limiter.clear("2")
 
     async def noop(*args, **kwargs):
         return None
@@ -111,6 +114,13 @@ async def test_on_message_calls_send_to_prism(tmp_path, monkeypatch, prism_calls
     monkeypatch.setattr(sg, "store_theory", noop)
     monkeypatch.setattr(sg, "queue_deep_reflection", noop)
     monkeypatch.setattr(asyncio, "sleep", noop)
+
+    prism_calls = []
+
+    async def fake_send(data):
+        prism_calls.append(data)
+
+    monkeypatch.setattr(sg, "send_to_prism", fake_send)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
     assert bot.intents.members
@@ -263,6 +273,7 @@ async def test_on_message_ignores_other_bot_mentions(tmp_path, monkeypatch):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
+    sg.reply_limiter.clear("2")
 
     async def noop(*args, **kwargs):
         return None
@@ -356,4 +367,40 @@ async def test_on_message_classifier_manipulation(tmp_path, monkeypatch, input_e
 
     trust = await sg.db_manager.get_trust(message.author.id)
     assert trust < 0
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_store_emotion(tmp_path):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    await sg.db_manager.store_emotion(1, {"happy": 0.8})
+
+    async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
+        async with db.execute(
+            "SELECT emotion_json FROM emotions WHERE user_id=?",
+            ("1",),
+        ) as cur:
+            row = await cur.fetchone()
+    assert json.loads(row[0]) == {"happy": 0.8}
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_log_manipulation(tmp_path):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    await sg.db_manager.log_manipulation(2, "coercion")
+
+    async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
+        async with db.execute(
+            "SELECT manipulation_type FROM manipulations WHERE user_id=?",
+            ("2",),
+        ) as cur:
+            row = await cur.fetchone()
+    assert row[0] == "coercion"
     await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- extend `DBManager` with tables for emotions and manipulations
- add helpers to persist emotion payloads and manipulation categories
- cover DB initialization and new behaviors in tests

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/db_manager.py tests/test_db_manager_init.py tests/test_on_message_memory.py`
- `pytest tests/test_db_manager_init.py tests/test_on_message_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_688e565386f883268124a0fee8cf4d7c