### PR TITLE
Add periodic goal publishing with lifecycle hooks

### DIFF
--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -60,6 +60,19 @@ The `examples/social_graph_bot.py` script logs user interactions in a SQLite dat
 
 The knowledge graph memory uses GraphDAL to persist data in Memgraph. Start Memgraph with `docker run --rm -p 7687:7687 memgraph/memgraph` and see [docs/graphdal.md](graphdal.md) for a full example service.
 
+### Goal Scheduler
+
+Run the goal scheduler in the background to publish queued intentions automatically:
+
+```python
+from deepthought.goal_scheduler import GoalScheduler
+
+sched = GoalScheduler()
+sched.start(publisher, interval=5.0)  # seconds
+# ... queue goals with sched.add_goal or sched.queue_intention ...
+await sched.stop()
+```
+
 ## Additional Safety Features
 
 Recent iterations introduced several controls to moderate conversations:

--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Simple priority-based goal scheduler."""
 
 import asyncio
+import contextlib
 import heapq
 from dataclasses import dataclass, field
 from typing import List, Optional
@@ -28,6 +29,9 @@ class GoalScheduler:
         self._heap: List[ScheduledGoal] = []
         self._db_manager = db_manager
         self._load_task: asyncio.Task | None = None
+        self._publish_task: asyncio.Task | None = None
+        self._publisher: Publisher | None = None
+        self._interval = 1.0
         if self._db_manager is not None:
             try:
                 loop = asyncio.get_running_loop()
@@ -104,3 +108,32 @@ class GoalScheduler:
             )
             count += 1
         return count
+
+    def start(self, publisher: Publisher, interval: float = 1.0) -> None:
+        """Start background task to periodically publish intentions."""
+        if self._publish_task is not None:
+            return
+        self._publisher = publisher
+        self._interval = interval
+        loop = asyncio.get_running_loop()
+        self._publish_task = loop.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Stop the background publishing task."""
+        if self._publish_task is None:
+            return
+        self._publish_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._publish_task
+        self._publish_task = None
+        self._publisher = None
+
+    async def _run(self) -> None:
+        if self._publisher is None:
+            return
+        try:
+            while True:
+                await self.publish_intentions(self._publisher)
+                await asyncio.sleep(self._interval)
+        except asyncio.CancelledError:
+            pass

--- a/tests/test_goal_scheduler_periodic.py
+++ b/tests/test_goal_scheduler_periodic.py
@@ -1,0 +1,48 @@
+import asyncio
+import sys
+import types
+
+import pytest
+
+# Stub nats modules required by Publisher import in GoalScheduler
+fake_nats = types.ModuleType("nats")
+fake_nats.aio = types.ModuleType("aio")
+fake_nats.aio.client = types.ModuleType("client")
+fake_nats.js = types.ModuleType("js")
+fake_nats.js.client = types.ModuleType("client")
+fake_nats.errors = types.ModuleType("errors")
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", fake_nats.aio)
+sys.modules.setdefault("nats.aio.client", fake_nats.aio.client)
+sys.modules.setdefault("nats.js", fake_nats.js)
+sys.modules.setdefault("nats.js.client", fake_nats.js.client)
+sys.modules.setdefault("nats.errors", fake_nats.errors)
+
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.eda.events import EventSubjects
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+@pytest.mark.asyncio
+async def test_goals_emitted_periodically():
+    sched = GoalScheduler()
+    pub = DummyPublisher()
+    sched.start(pub, interval=0.05)
+    try:
+        sched.add_goal("first", priority=1)
+        await asyncio.sleep(0.1)
+        assert [p.goal for _, p in pub.published] == ["first"]
+
+        sched.add_goal("second", priority=2)
+        await asyncio.sleep(0.1)
+        assert [p.goal for _, p in pub.published] == ["first", "second"]
+        assert all(s == EventSubjects.BDI_INTENTION for s, _ in pub.published)
+    finally:
+        await sched.stop()


### PR DESCRIPTION
## Summary
- run goal scheduler in a background task with start()/stop() lifecycle hooks
- document how to launch the scheduler in the Discord bot guide
- test that queued goals are published over time

## Testing
- `flake8 src/deepthought/goal_scheduler.py tests/test_goal_scheduler_periodic.py`
- `pytest tests/test_goal_scheduler_periodic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e60b6ca7c832699d93e78dff23db3