### PR TITLE
feat: add social cues and trust gating

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -11,10 +11,15 @@ from typing import List, Tuple
 import aiohttp
 
 from deepthought.goal_scheduler import GoalScheduler
-from deepthought.services import PersonaManager
-from deepthought.services.db_manager import (MAX_MEMORY_LENGTH,
-                                             MAX_PROMPT_LENGTH,
-                                             MAX_THEORY_LENGTH, DBManager)
+from deepthought.perception.emotion_detection import detect_emotions
+from deepthought.perception.social_perception import analyze as analyze_social
+from deepthought.services import PersonaManager, TrustService
+from deepthought.services.db_manager import (
+    MAX_MEMORY_LENGTH,
+    MAX_PROMPT_LENGTH,
+    MAX_THEORY_LENGTH,
+    DBManager,
+)
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -101,9 +106,7 @@ else:
 
 try:
     from deepthought.config import get_settings
-    from deepthought.eda.events import (BDIIntentionPayload, EventSubjects,
-                                        InputReceivedPayload,
-                                        PlanRequestedPayload)
+    from deepthought.eda.events import BDIIntentionPayload, EventSubjects, InputReceivedPayload, PlanRequestedPayload
     from deepthought.eda.publisher import Publisher
     from deepthought.eda.subscriber import Subscriber
 except Exception:  # pragma: no cover - optional dependency
@@ -164,9 +167,7 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
@@ -196,6 +197,7 @@ BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
 MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
 MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
+AVOIDANCE_REPLY = "Take your time; I'm here if you need me."
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -289,9 +291,7 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     reason.
     """
     try:
-        gen_prompt = prompt or os.getenv(
-            "IDLE_GENERATOR_PROMPT", "Say something to spark conversation."
-        )
+        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
         if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
             topics = await get_recent_topics(3)
             if topics:
@@ -327,10 +327,7 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
         return None
 
     lower = text.lower()
-    if "your" in lower and any(
-        k in lower
-        for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]
-    ):
+    if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
         reply = await db_manager.get_last_lie(user_id, text)
         if reply is None:
             try:
@@ -354,6 +351,7 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
 DEFAULT_DB_PATH = DB_PATH
 db_manager = DBManager()
 persona_manager = PersonaManager(db_manager)
+trust_service = TrustService(db_manager)
 reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
 bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
 last_bot_reply_time: datetime.datetime | None = None
@@ -361,16 +359,12 @@ last_bot_reply_time: datetime.datetime | None = None
 
 async def init_db(db_path: str | None = None) -> None:
     """Initialize the database, recreating the manager when the path changes."""
-    global db_manager, persona_manager, CURRENT_DB_PATH
+    global db_manager, persona_manager, trust_service, CURRENT_DB_PATH
 
     target_path = (
         db_path
         if db_path is not None
-        else (
-            DB_PATH
-            if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH
-            else db_manager.db_path
-        )
+        else (DB_PATH if DB_PATH != CURRENT_DB_PATH and db_manager.db_path == CURRENT_DB_PATH else db_manager.db_path)
     )
 
     if db_manager.db_path != target_path:
@@ -380,6 +374,7 @@ async def init_db(db_path: str | None = None) -> None:
 
     await db_manager.init_db()
     persona_manager = PersonaManager(db_manager)
+    trust_service = TrustService(db_manager)
     CURRENT_DB_PATH = db_manager.db_path
 
 
@@ -388,9 +383,7 @@ async def log_interaction(
     target_id: int | None = None,
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.log_interaction(
-        user_id, target_id, sentiment_score=sentiment_score
-    )
+    await db_manager.log_interaction(user_id, target_id, sentiment_score=sentiment_score)
 
 
 async def recall_user(user_id: int):
@@ -403,9 +396,7 @@ async def store_memory(
     topic: str = "",
     sentiment_score: float | None = None,
 ) -> None:
-    await db_manager.store_memory(
-        user_id, memory, topic=topic, sentiment_score=sentiment_score
-    )
+    await db_manager.store_memory(user_id, memory, topic=topic, sentiment_score=sentiment_score)
 
 
 async def send_to_prism(data: dict) -> None:
@@ -470,9 +461,7 @@ async def publish_input_received(text: str) -> None:
         return
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping INPUT_RECEIVED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping INPUT_RECEIVED event because NATS publisher is unavailable")
 
         return
     payload = InputReceivedPayload(
@@ -495,9 +484,7 @@ async def publish_plan_requested(goal: str, input_id: str | None = None) -> None
     """Publish a PLAN_REQUESTED event for ``goal``."""
     await _ensure_nats()
     if _input_publisher is None:
-        logger.warning(
-            "Dropping PLAN_REQUESTED event because NATS publisher is unavailable"
-        )
+        logger.warning("Dropping PLAN_REQUESTED event because NATS publisher is unavailable")
         return
     payload = PlanRequestedPayload(goal=goal, input_id=input_id)
     try:
@@ -674,12 +661,8 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(
-                        tzinfo=timezone.utc
-                    ) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(
-                        message, when, str(uuid.uuid4())
-                    )
+                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
+                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
                     await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -743,9 +726,7 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     """Return minutes since the most recent human message or ``None`` if none."""
     async for msg in channel.history(limit=limit):
         if not msg.author.bot:
-            return (
-                discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)
-            ).total_seconds() / 60
+            return (discord.utils.utcnow() - msg.created_at.replace(tzinfo=timezone.utc)).total_seconds() / 60
     return None
 
 
@@ -770,15 +751,9 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
             respond_to = None
             send_prompt = False
-            if (
-                last_message
-                and last_message.author.bot
-                and prev_message
-                and not prev_message.author.bot
-            ):
+            if last_message and last_message.author.bot and prev_message and not prev_message.author.bot:
                 age = (
-                    discord.utils.utcnow()
-                    - prev_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - prev_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if age < PLAYFUL_REPLY_TIMEOUT_MINUTES:
                     await asyncio.sleep(60)
@@ -789,8 +764,7 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 send_prompt = True
             else:
                 idle_minutes = (
-                    discord.utils.utcnow()
-                    - last_message.created_at.replace(tzinfo=timezone.utc)
+                    discord.utils.utcnow() - last_message.created_at.replace(tzinfo=timezone.utc)
                 ).total_seconds() / 60
                 if idle_minutes >= IDLE_TIMEOUT_MINUTES:
                     send_prompt = True
@@ -831,9 +805,7 @@ class SocialGraphBot(discord.Client):
         self.monitor_channel_id = monitor_channel_id
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
-        self.scheduler_service: SchedulerService | None = (
-            None  # noqa: F821 - optional feature
-        )
+        self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
 
@@ -862,9 +834,7 @@ class SocialGraphBot(discord.Client):
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
 
-        self._bg_tasks.append(
-            self.loop.create_task(monitor_channels(self, self.monitor_channel_id))
-        )
+        self._bg_tasks.append(self.loop.create_task(monitor_channels(self, self.monitor_channel_id)))
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
@@ -878,26 +848,16 @@ class SocialGraphBot(discord.Client):
         if message.author == self.user:
             return
 
-        if (
-            any(getattr(m, "bot", False) for m in message.mentions)
-            and self.user not in message.mentions
-        ):
+        if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
             return
 
         now = discord.utils.utcnow()
         if message.author.bot:
             last = bot_last_messages.get(message.author.id)
-            if (
-                last
-                and last[0] == message.content
-                and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS
-            ):
+            if last and last[0] == message.content and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS:
                 return
             bot_last_messages[message.author.id] = (message.content, now)
-            if (
-                last_bot_reply_time
-                and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS
-            ):
+            if last_bot_reply_time and (now - last_bot_reply_time).total_seconds() < BOT_COOLDOWN_SECONDS:
                 return
 
         cover_reply = await maybe_deceptive_reply(message.author.id, message.content)
@@ -927,14 +887,21 @@ class SocialGraphBot(discord.Client):
             topic=topic,
             sentiment_score=sentiment_score,
         )
-        await update_sentiment_trend(
-            message.author.id, message.channel.id, sentiment_score
-        )
+        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
 
+        emotions = detect_emotions(message.content)
+        await db_manager.record_emotion(message.author.id, emotions)
+
+        social_scores = analyze_social(message.content)
         manip_category = manipulation_score(message.content)
-        if manip_category:
-            await db_manager.adjust_trust(message.author.id, -1.0)
-            log_thought(self, f"Manipulation detected: {manip_category}")
+        category_to_log = manip_category or max(social_scores, key=social_scores.get)
+        await db_manager.record_manipulation(message.author.id, category_to_log)
+        if manip_category or social_scores.get("manipulation", 0) > 0.5:
+            await trust_service.adjust_trust(message.author.id, -1.0)
+            log_thought(self, f"Manipulation detected: {category_to_log}")
+
+        if not await trust_service.is_trusted(message.author.id, 0.0):
+            return
 
         result = await who_is_active(message.channel)
         if len(result) == 3:
@@ -963,14 +930,17 @@ class SocialGraphBot(discord.Client):
                 async for recent in message.channel.history(limit=1):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
-            trust = await db_manager.get_trust(message.author.id)
-            if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
-                reply = random.choice(MINIMAL_REPLIES)
+            if social_scores.get("flirtation", 0) > 0.5:
+                reply = random.choice(PERSONA_REPLIES["playful"])
+            elif social_scores.get("avoidance", 0) > 0.5:
+                reply = AVOIDANCE_REPLY
             else:
-                persona = await self.persona_manager.get_persona(message.author.id)
-                reply = random.choice(
-                    PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"])
-                )
+                trust = await trust_service.get_trust(message.author.id)
+                if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
+                    reply = random.choice(MINIMAL_REPLIES)
+                else:
+                    persona = await self.persona_manager.get_persona(message.author.id)
+                    reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             await message.channel.send(reply)
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -379,6 +379,14 @@ class DBManager:
         )
         await self._db.commit()
 
+    async def record_emotion(self, user_id: int, emotions: dict | list) -> None:
+        """Alias for :meth:`store_emotion` for backward compatibility."""
+        await self.store_emotion(user_id, emotions)
+
+    async def record_manipulation(self, user_id: int, category: str) -> None:
+        """Alias for :meth:`log_manipulation` for backward compatibility."""
+        await self.log_manipulation(user_id, category)
+
     async def update_sentiment_trend(
         self,
         user_id: int,

--- a/tests/test_manipulation_trust.py
+++ b/tests/test_manipulation_trust.py
@@ -58,6 +58,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_manipulative_message_adjusts_trust(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
 
@@ -74,6 +75,12 @@ async def test_manipulative_message_adjusts_trust(tmp_path, monkeypatch, input_e
     monkeypatch.setattr(asyncio, "sleep", noop)
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(sg, "detect_emotions", lambda _t: {})
+    monkeypatch.setattr(
+        sg,
+        "analyze_social",
+        lambda _t: {"flirtation": 0, "avoidance": 0, "manipulation": 0},
+    )
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
     message = DummyMessage("After all I've done for you")
@@ -81,4 +88,5 @@ async def test_manipulative_message_adjusts_trust(tmp_path, monkeypatch, input_e
 
     trust = await sg.db_manager.get_trust(message.author.id)
     assert trust < 0
+    assert message.channel.sent_messages == []
     await sg.db_manager.close()

--- a/tests/test_persona_integration.py
+++ b/tests/test_persona_integration.py
@@ -59,6 +59,7 @@ class DummyMessage:
 @pytest.mark.asyncio
 async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
 
     # Use lower thresholds for easier testing
     sg.persona_manager = PersonaManager(sg.db_manager, friendly=3, playful=1)
@@ -76,6 +77,12 @@ async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, i
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
     monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
+    monkeypatch.setattr(sg, "detect_emotions", lambda _t: {})
+    monkeypatch.setattr(
+        sg,
+        "analyze_social",
+        lambda _t: {"flirtation": 0, "avoidance": 0, "manipulation": 0},
+    )
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
 
@@ -92,5 +99,48 @@ async def test_on_message_persona_changes_with_affinity(tmp_path, monkeypatch, i
     msg3 = DummyMessage("hello friend", author_id=msg1.author.id, message_id=12)
     await bot.on_message(msg3)
     assert msg3.channel.sent_messages[-1] == sg.PERSONA_REPLIES["friendly"][0]
+
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_social_analysis_adjusts_tone(tmp_path, monkeypatch, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
+    monkeypatch.setattr(sg, "detect_emotions", lambda _t: {})
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+
+    monkeypatch.setattr(
+        sg,
+        "analyze_social",
+        lambda _t: {"flirtation": 0.9, "avoidance": 0.05, "manipulation": 0.05},
+    )
+    msg1 = DummyMessage("hey there")
+    await bot.on_message(msg1)
+    assert msg1.channel.sent_messages[-1] == sg.PERSONA_REPLIES["playful"][0]
+
+    monkeypatch.setattr(
+        sg,
+        "analyze_social",
+        lambda _t: {"flirtation": 0.1, "avoidance": 0.8, "manipulation": 0.1},
+    )
+    msg2 = DummyMessage("leave me alone", author_id=msg1.author.id, message_id=11)
+    await bot.on_message(msg2)
+    assert msg2.channel.sent_messages[-1] == sg.AVOIDANCE_REPLY
 
     await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- react to flirtation or avoidance cues and store emotion/perception data
- gate responses behind trust checks using TrustService
- test persona adaptation and untrusted refusal

## Testing
- `SKIP=pytest pre-commit run --files examples/social_graph_bot.py src/deepthought/services/db_manager.py tests/test_persona_integration.py tests/test_manipulation_trust.py`
- `pytest tests/test_persona_integration.py tests/test_manipulation_trust.py`

------
https://chatgpt.com/codex/tasks/task_e_688e60b5a16883269d874b800df77b16