### PR TITLE
Load social perception model from config and expand labels

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -23,6 +23,7 @@ def _apply_env_aliases() -> None:
         "NEO4J_PORT": "DT_NEO4J_PORT",
         "NEO4J_USER": "DT_NEO4J_USER",
         "NEO4J_PASSWORD": "DT_NEO4J_PASSWORD",
+        "SOCIAL_PERCEPTION_MODEL": "DT_SOCIAL_PERCEPTION_MODEL",
     }
 
     for old, new in mapping.items():
@@ -70,6 +71,7 @@ class Settings(BaseSettings):
 
     db: DatabaseSettings = DatabaseSettings()
     model_path: str = "distilgpt2"
+    social_perception_model: str | None = Field(None, env="SOCIAL_PERCEPTION_MODEL")
     memory_file: str = "memory.json"
     search_db: str | None = None
     social_graph_db: str = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")

--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -9,8 +9,9 @@ from typing import Dict
 import torch
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
-MODEL_PATH = os.getenv("SOCIAL_PERCEPTION_MODEL", "path/to/social-perception-model")
-LABELS = ["flirtation", "avoidance", "manipulation"]
+from ..config import get_settings
+
+LABELS = ["flirtation", "avoidance", "manipulation", "sarcasm", "supportiveness"]
 
 _tokenizer: AutoTokenizer | None = None
 _model: AutoModelForSequenceClassification | None = None
@@ -29,24 +30,23 @@ def _load() -> bool:
     if _tokenizer is not None and _model is not None:
         return True
 
-    if not MODEL_PATH or MODEL_PATH == "path/to/social-perception-model":
-        logger.warning(
-            "SOCIAL_PERCEPTION_MODEL not set. Returning neutral perception scores."
-        )
+    model_path = get_settings().social_perception_model
+    if not model_path:
+        logger.warning("SOCIAL_PERCEPTION_MODEL not set. Returning neutral perception scores.")
         return False
 
-    if not os.path.exists(MODEL_PATH):
+    if not os.path.exists(model_path):
         logger.warning(
             "Social perception model path not found: %s. Returning neutral perception scores.",
-            MODEL_PATH,
+            model_path,
         )
         return False
 
     try:
         if _tokenizer is None:
-            _tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+            _tokenizer = AutoTokenizer.from_pretrained(model_path)
         if _model is None:
-            _model = AutoModelForSequenceClassification.from_pretrained(MODEL_PATH)
+            _model = AutoModelForSequenceClassification.from_pretrained(model_path)
         return True
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Failed to load social perception model: %s", e, exc_info=True)
@@ -56,12 +56,11 @@ def _load() -> bool:
 
 
 def analyze(text: str) -> Dict[str, float]:
-    """Return probabilities for flirtation, avoidance and manipulation."""
-    if not _load():
+    """Return probabilities for supported social cues."""
+    if not _load() or _tokenizer is None or _model is None:
         neutral = 1.0 / len(LABELS)
         return {label: neutral for label in LABELS}
 
-    assert _tokenizer and _model
     inputs = _tokenizer(text, return_tensors="pt")
     with torch.no_grad():
         logits = _model(**inputs).logits

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -25,7 +25,7 @@ def test_analyze_returns_probs(monkeypatch):
             return cls()
 
         def __call__(self, **kwargs):
-            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0, 4.0, 5.0]])
 
     tf_mod.AutoTokenizer = DummyTokenizer
     tf_mod.AutoModelForSequenceClassification = DummyModel
@@ -46,11 +46,14 @@ def test_analyze_returns_probs(monkeypatch):
         def tolist(self):
             return list(self)
 
-    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.3, 0.15, 0.25])]
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
+    monkeypatch.delenv("DT_SOCIAL_PERCEPTION_MODEL", raising=False)
     monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/model")
     monkeypatch.setattr("os.path.exists", lambda p: True)
+    import deepthought.config as config
+    config._settings_cache = None
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -59,7 +62,9 @@ def test_analyze_returns_probs(monkeypatch):
     assert result == {
         "flirtation": 0.1,
         "avoidance": 0.2,
-        "manipulation": 0.7,
+        "manipulation": 0.3,
+        "sarcasm": 0.15,
+        "supportiveness": 0.25,
     }
 
 
@@ -84,7 +89,7 @@ def test_env_model_path(monkeypatch):
             return cls()
 
         def __call__(self, **kwargs):
-            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
+            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0, 4.0, 5.0]])
 
     tf_mod.AutoTokenizer = DummyTokenizer
     tf_mod.AutoModelForSequenceClassification = DummyModel
@@ -105,11 +110,14 @@ def test_env_model_path(monkeypatch):
         def tolist(self):
             return list(self)
 
-    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
+    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.3, 0.15, 0.25])]
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
+    monkeypatch.delenv("DT_SOCIAL_PERCEPTION_MODEL", raising=False)
     monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/custom-model")
     monkeypatch.setattr("os.path.exists", lambda p: True)
+    import deepthought.config as config
+    config._settings_cache = None
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -162,7 +170,10 @@ def test_missing_env_var(monkeypatch, caplog):
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
     monkeypatch.delenv("SOCIAL_PERCEPTION_MODEL", raising=False)
+    monkeypatch.delenv("DT_SOCIAL_PERCEPTION_MODEL", raising=False)
     monkeypatch.setattr("os.path.exists", lambda p: False)
+    import deepthought.config as config
+    config._settings_cache = None
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -216,8 +227,11 @@ def test_missing_model_path(monkeypatch, caplog):
     torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
     monkeypatch.setitem(sys.modules, "torch", torch_mod)
 
+    monkeypatch.delenv("DT_SOCIAL_PERCEPTION_MODEL", raising=False)
     monkeypatch.setenv("SOCIAL_PERCEPTION_MODEL", "/tmp/missing")
     monkeypatch.setattr("os.path.exists", lambda p: False)
+    import deepthought.config as config
+    config._settings_cache = None
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
@@ -228,3 +242,15 @@ def test_missing_model_path(monkeypatch, caplog):
     neutral = 1.0 / len(sp.LABELS)
     assert result == {label: pytest.approx(neutral) for label in sp.LABELS}
     assert any("path not found" in r.getMessage() for r in caplog.records)
+
+
+def test_analyze_neutral_without_model(monkeypatch):
+    import deepthought.perception.social_perception as sp
+
+    monkeypatch.setattr(sp, "_load", lambda: True)
+    sp._tokenizer = None
+    sp._model = None
+
+    result = sp.analyze("hello")
+    neutral = 1.0 / len(sp.LABELS)
+    assert result == {label: pytest.approx(neutral) for label in sp.LABELS}


### PR DESCRIPTION
## Summary
- load social perception model path from configuration
- classify new cues like sarcasm and supportiveness
- return neutral scores if model artifacts are missing

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/config.py src/deepthought/perception/social_perception.py tests/unit/perception/test_social_perception.py`
- `pytest tests/unit/perception/test_social_perception.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688e9359caec8326aa551a3554dbf4f3