### PR TITLE
Add interaction metrics to social graph

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -572,6 +572,18 @@ async def get_hostility(user_id: int, target_id: int) -> float:
     return await db_manager.get_hostility(user_id, target_id)
 
 
+async def get_interaction_weight(user_id: int, target_id: int) -> float:
+    return await db_manager.get_interaction_weight(user_id, target_id)
+
+
+async def get_last_interaction(user_id: int, target_id: int):
+    return await db_manager.get_last_interaction(user_id, target_id)
+
+
+async def get_pair_mutual_affinity(user_a: int, user_b: int) -> float:
+    return await db_manager.get_pair_mutual_affinity(user_a, user_b)
+
+
 async def set_theme(user_id: int, channel_id: int, theme: str) -> None:
     await db_manager.set_theme(user_id, channel_id, theme)
 

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -67,11 +67,23 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS mutual_affinity (
+            user_a TEXT,
+            user_b TEXT,
+            score INTEGER DEFAULT 0,
+            interaction_weight REAL DEFAULT 0,
+            last_interaction DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(user_a, user_b)
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS relationships (
             source_id TEXT,
             target_id TEXT,
             interaction_count INTEGER DEFAULT 0,
             sentiment_sum REAL DEFAULT 0,
+            interaction_weight REAL DEFAULT 0,
+            last_interaction DATETIME DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY(source_id, target_id)
         )
         """,
@@ -190,6 +202,7 @@ class DBManager:
             if not self._initialized:
                 for query in self.CREATE_TABLE_QUERIES:
                     await self._db.execute(query)
+                await self._ensure_relationship_columns()
                 await self._db.commit()
                 self._initialized = True
 
@@ -197,6 +210,16 @@ class DBManager:
         if self._db is not None:
             await self._db.close()
             self._db = None
+
+    async def _ensure_relationship_columns(self) -> None:
+        """Add new columns to the relationships table if they don't exist."""
+        assert self._db is not None
+        async with self._db.execute("PRAGMA table_info(relationships)") as cur:
+            cols = [row[1] async for row in cur]
+        if "interaction_weight" not in cols:
+            await self._db.execute("ALTER TABLE relationships ADD COLUMN interaction_weight REAL DEFAULT 0")
+        if "last_interaction" not in cols:
+            await self._db.execute("ALTER TABLE relationships ADD COLUMN last_interaction DATETIME")
 
     def _create_table_statements(self) -> list[str]:
         """Return SQL statements for creating required tables."""
@@ -233,15 +256,30 @@ class DBManager:
                 (str(user_id), delta, delta),
             )
         if target_id is not None:
+            weight = 1.0
             await self._db.execute(
                 """
-                INSERT INTO relationships (source_id, target_id, interaction_count, sentiment_sum)
-                VALUES (?, ?, 1, ?)
+                INSERT INTO relationships (source_id, target_id, interaction_count, sentiment_sum, interaction_weight)
+                VALUES (?, ?, 1, ?, ?)
                 ON CONFLICT(source_id, target_id) DO UPDATE SET
                     interaction_count=relationships.interaction_count + 1,
-                    sentiment_sum=relationships.sentiment_sum + excluded.sentiment_sum
+                    sentiment_sum=relationships.sentiment_sum + excluded.sentiment_sum,
+                    interaction_weight=relationships.interaction_weight + excluded.interaction_weight,
+                    last_interaction=CURRENT_TIMESTAMP
                 """,
-                (str(user_id), str(target_id), sentiment_score or 0.0),
+                (str(user_id), str(target_id), sentiment_score or 0.0, weight),
+            )
+            a, b = sorted((str(user_id), str(target_id)))
+            await self._db.execute(
+                """
+                INSERT INTO mutual_affinity (user_a, user_b, score, interaction_weight)
+                VALUES (?, ?, 1, ?)
+                ON CONFLICT(user_a, user_b) DO UPDATE SET
+                    score=mutual_affinity.score + 1,
+                    interaction_weight=mutual_affinity.interaction_weight + excluded.interaction_weight,
+                    last_interaction=CURRENT_TIMESTAMP
+                """,
+                (a, b, weight),
             )
         await self._db.commit()
 
@@ -621,7 +659,7 @@ class DBManager:
         await self.connect()
         assert self._db
         async with self._db.execute(
-            "SELECT interaction_count, sentiment_sum FROM relationships WHERE source_id=? AND target_id=?",
+            "SELECT interaction_count, sentiment_sum, interaction_weight, last_interaction FROM relationships WHERE source_id=? AND target_id=?",
             (str(user_id), str(target_id)),
         ) as cur:
             return await cur.fetchone()
@@ -630,7 +668,7 @@ class DBManager:
         row = await self.get_relationship(user_id, target_id)
         if not row or not row[0]:
             return 0.0
-        count, sentiment_sum = row
+        count, sentiment_sum = row[0], row[1]
         return float(sentiment_sum) / count
 
     async def get_friendliness(self, user_id: int, target_id: int) -> float:
@@ -640,6 +678,25 @@ class DBManager:
     async def get_hostility(self, user_id: int, target_id: int) -> float:
         avg = await self._get_relationship_avg(user_id, target_id)
         return min(0.0, avg)
+
+    async def get_interaction_weight(self, user_id: int, target_id: int) -> float:
+        row = await self.get_relationship(user_id, target_id)
+        return float(row[2]) if row and row[2] is not None else 0.0
+
+    async def get_last_interaction(self, user_id: int, target_id: int):
+        row = await self.get_relationship(user_id, target_id)
+        return row[3] if row else None
+
+    async def get_pair_mutual_affinity(self, user_a: int, user_b: int) -> float:
+        await self.connect()
+        assert self._db
+        a, b = sorted((str(user_a), str(user_b)))
+        async with self._db.execute(
+            "SELECT score FROM mutual_affinity WHERE user_a=? AND user_b=?",
+            (a, b),
+        ) as cur:
+            row = await cur.fetchone()
+            return float(row[0]) if row else 0.0
 
     async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
         if not isinstance(theme, str) or not theme.strip():

--- a/src/deepthought/services/user_graph_dal.py
+++ b/src/deepthought/services/user_graph_dal.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from typing import Optional, Tuple
 
 from .file_graph_dal import FileGraphDAL
@@ -31,26 +32,35 @@ class UserGraphDAL(FileGraphDAL):
         data = self._graph.get_edge_data(source, target, default={})
         count = data.get("interaction_count", 0) + 1
         sentiment_sum = data.get("sentiment_sum", 0.0) + score
+        weight = data.get("interaction_weight", 0.0) + 1.0
         self._graph.add_edge(
             source,
             target,
             interaction_count=count,
             sentiment_sum=sentiment_sum,
+            interaction_weight=weight,
+            last_interaction=time.time(),
         )
 
     def get_affinity(self, user_id: str) -> int:
         """Return how many messages ``user_id`` has sent."""
         return int(self._graph.nodes.get(user_id, {}).get("affinity", 0))
 
-    def get_relationship(self, source: str, target: str) -> Tuple[int, float]:
-        """Return ``(interaction_count, sentiment_sum)`` for the edge."""
+    def get_relationship(self, source: str, target: str) -> Tuple[int, float, float, float]:
+        """Return ``(interaction_count, sentiment_sum, weight, last_interaction)`` for the edge."""
         data = self._graph.get_edge_data(source, target)
         if not data:
-            return 0, 0.0
-        return int(data.get("interaction_count", 0)), float(data.get("sentiment_sum", 0.0))
+            return 0, 0.0, 0.0, 0.0
+        return (
+            int(data.get("interaction_count", 0)),
+            float(data.get("sentiment_sum", 0.0)),
+            float(data.get("interaction_weight", 0.0)),
+            float(data.get("last_interaction", 0.0)),
+        )
 
     def _avg_sentiment(self, source: str, target: str) -> float:
-        count, ssum = self.get_relationship(source, target)
+        rel = self.get_relationship(source, target)
+        count, ssum = rel[0], rel[1]
         if not count:
             return 0.0
         return ssum / count
@@ -67,8 +77,8 @@ class UserGraphDAL(FileGraphDAL):
 
     def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
         """Return how many messages have passed between the pair."""
-        ab_count, _ = self.get_relationship(user_a, user_b)
-        ba_count, _ = self.get_relationship(user_b, user_a)
+        ab_count = self.get_relationship(user_a, user_b)[0]
+        ba_count = self.get_relationship(user_b, user_a)[0]
         # each message updates both directional edges, so average the counts
         return int((ab_count + ba_count) / 2)
 
@@ -82,12 +92,22 @@ class UserGraphDAL(FileGraphDAL):
                 "count": ab[0],
                 "sentiment_sum": ab[1],
                 "avg_sentiment": self._avg_sentiment(user_a, user_b),
+                "interaction_weight": ab[2],
+                "last_interaction": ab[3],
             },
             "b_to_a": {
                 "count": ba[0],
                 "sentiment_sum": ba[1],
                 "avg_sentiment": self._avg_sentiment(user_b, user_a),
+                "interaction_weight": ba[2],
+                "last_interaction": ba[3],
             },
             # average counts because each interaction increments both directions
             "mutual_affinity": int((ab[0] + ba[0]) / 2),
         }
+
+    def get_interaction_weight(self, source: str, target: str) -> float:
+        return self.get_relationship(source, target)[2]
+
+    def get_last_interaction(self, source: str, target: str) -> float:
+        return self.get_relationship(source, target)[3]

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -20,7 +20,10 @@ async def test_relationship_table_and_updates(tmp_path):
     async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
         async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='relationships'") as cur:
             row = await cur.fetchone()
-    assert row is not None, "relationships table should exist"
+        assert row is not None, "relationships table should exist"
+        async with db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='mutual_affinity'") as cur:
+            row = await cur.fetchone()
+        assert row is not None, "mutual_affinity table should exist"
 
     await sg.log_interaction("u1", "u2", sentiment_score=0.3)
     await sg.log_interaction("u1", "u2", sentiment_score=0.2)
@@ -28,11 +31,19 @@ async def test_relationship_table_and_updates(tmp_path):
 
     async with aiosqlite.connect(str(tmp_path / "sg.db")) as db:
         async with db.execute(
-            "SELECT interaction_count, sentiment_sum FROM relationships WHERE source_id=? AND target_id=?",
+            "SELECT interaction_count, sentiment_sum, interaction_weight, last_interaction FROM relationships WHERE source_id=? AND target_id=?",
             ("u1", "u2"),
         ) as cur:
             row = await cur.fetchone()
-    assert row == (2, 0.5)
+        assert row[0] == 2 and row[1] == 0.5 and row[2] == 2
+        assert row[3] is not None
+        a, b = sorted(("u1", "u2"))
+        async with db.execute(
+            "SELECT score, interaction_weight FROM mutual_affinity WHERE user_a=? AND user_b=?",
+            (a, b),
+        ) as cur:
+            mrow = await cur.fetchone()
+        assert mrow == (2, 2.0)
 
     friendliness = await sg.get_friendliness("u1", "u2")
     assert pytest.approx(friendliness) == 0.25
@@ -53,8 +64,10 @@ def test_user_graph_edges_and_stats(tmp_path):
     dal.add_message("b", "a", sentiment_score=-0.2)
 
     # Both directional edges should be updated
-    assert dal.get_relationship("a", "b")[0] == 2
-    assert dal.get_relationship("b", "a")[0] == 2
+    ab = dal.get_relationship("a", "b")
+    ba = dal.get_relationship("b", "a")
+    assert ab[0] == 2 and ab[2] == 2
+    assert ba[0] == 2 and ba[2] == 2
 
     # mutual affinity counts actual messages between the pair
     assert dal.get_mutual_affinity("a", "b") == 2
@@ -63,3 +76,6 @@ def test_user_graph_edges_and_stats(tmp_path):
     assert stats["mutual_affinity"] == 2
     assert stats["a_to_b"]["avg_sentiment"] == pytest.approx(0.15)
     assert stats["b_to_a"]["avg_sentiment"] == pytest.approx(0.15)
+    assert stats["a_to_b"]["interaction_weight"] == 2
+    assert stats["b_to_a"]["interaction_weight"] == 2
+    assert stats["a_to_b"]["last_interaction"] > 0

--- a/tests/unit/services/test_user_graph_dal.py
+++ b/tests/unit/services/test_user_graph_dal.py
@@ -8,9 +8,11 @@ def test_add_message_updates_edges(tmp_path):
     dal.add_message("u1", "u2", sentiment_score=-0.2)
 
     assert dal.get_affinity("u1") == 2
-    count, ssum = dal.get_relationship("u1", "u2")
+    count, ssum, weight, ts = dal.get_relationship("u1", "u2")
     assert count == 2
     assert ssum == 0.3
+    assert weight == 2
+    assert ts > 0
 
 
 def test_friendliness_and_hostility(tmp_path):


### PR DESCRIPTION
## Summary
- add mutual_affinity table and track interaction_weight and last_interaction for relationships
- expose CRUD helpers for interaction metrics in DBManager and social graph DAL
- expand social graph tests for new columns and helpers

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/user_graph_dal.py tests/test_relationships.py tests/unit/services/test_user_graph_dal.py src/deepthought/services/db_manager.py examples/social_graph_bot.py`
- `pytest tests/test_relationships.py tests/unit/services/test_user_graph_dal.py tests/test_trust_dbmanager.py tests/integration/test_social_graph_affinity.py`

------
https://chatgpt.com/codex/tasks/task_e_688e9f697c30832689d85d36ac559fec