### PR TITLE
Add pairwise affinity tracking

### DIFF
--- a/src/deepthought/affinity.py
+++ b/src/deepthought/affinity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Track social affinity scores per persona."""
 
-from typing import Dict
+from typing import Dict, List, Tuple
 
 
 class AffinityTracker:
@@ -10,6 +10,8 @@ class AffinityTracker:
 
     def __init__(self) -> None:
         self._scores: Dict[str, int] = {}
+        self._interactions: Dict[Tuple[str, str], int] = {}
+        self._mutual: Dict[Tuple[str, str], int] = {}
 
     def update(self, persona: str, delta: int = 1) -> None:
         """Increment ``persona`` affinity by ``delta``."""
@@ -18,3 +20,47 @@ class AffinityTracker:
     def get(self, persona: str) -> int:
         """Return current affinity score for ``persona``."""
         return self._scores.get(persona, 0)
+
+    @staticmethod
+    def _pair_key(a: str, b: str) -> Tuple[str, str]:
+        return tuple(sorted((a, b)))
+
+    def update_interaction(self, a: str, b: str, delta: int = 1) -> None:
+        """Increment interaction count between ``a`` and ``b``."""
+        key = self._pair_key(a, b)
+        self._interactions[key] = self._interactions.get(key, 0) + delta
+
+    def interaction_count(self, a: str, b: str) -> int:
+        """Return interaction count between ``a`` and ``b``."""
+        key = self._pair_key(a, b)
+        return self._interactions.get(key, 0)
+
+    def update_mutual_affinity(self, a: str, b: str, delta: int = 1) -> None:
+        """Increment mutual affinity between ``a`` and ``b`` by ``delta``."""
+        key = self._pair_key(a, b)
+        self._mutual[key] = self._mutual.get(key, 0) + delta
+
+    def mutual_affinity(self, a: str, b: str) -> int:
+        """Return mutual affinity between ``a`` and ``b``."""
+        key = self._pair_key(a, b)
+        return self._mutual.get(key, 0)
+
+    def top_friends(self, user: str, n: int = 3) -> List[str]:
+        """Return up to ``n`` users with highest mutual affinity with ``user``."""
+        pairs = [
+            (other, score)
+            for (a, b), score in self._mutual.items()
+            if user in (a, b)
+            for other in ([b] if a == user else [a])
+        ]
+        return [other for other, _ in sorted(pairs, key=lambda x: x[1], reverse=True)[:n]]
+
+    def top_rivals(self, user: str, n: int = 3) -> List[str]:
+        """Return up to ``n`` users with lowest mutual affinity with ``user``."""
+        pairs = [
+            (other, score)
+            for (a, b), score in self._mutual.items()
+            if user in (a, b)
+            for other in ([b] if a == user else [a])
+        ]
+        return [other for other, _ in sorted(pairs, key=lambda x: x[1])[:n]]

--- a/tests/unit/test_persona_goal_affinity.py
+++ b/tests/unit/test_persona_goal_affinity.py
@@ -21,6 +21,20 @@ def test_affinity_updates():
     assert tracker.get("formal") == 1
 
 
+def test_pairwise_affinity_helpers():
+    tracker = AffinityTracker()
+    tracker.update_interaction("alice", "bob")
+    tracker.update_interaction("bob", "alice", 2)
+    tracker.update_mutual_affinity("alice", "bob", 5)
+    tracker.update_mutual_affinity("alice", "charlie", -2)
+    tracker.update_mutual_affinity("alice", "dave", 1)
+
+    assert tracker.interaction_count("alice", "bob") == 3
+    assert tracker.mutual_affinity("alice", "bob") == 5
+    assert tracker.top_friends("alice") == ["bob", "dave", "charlie"]
+    assert tracker.top_rivals("alice")[0] == "charlie"
+
+
 def test_goal_scheduler_order():
     sched = GoalScheduler()
     sched.add_goal("low", priority=1)


### PR DESCRIPTION
## Summary
- extend `AffinityTracker` to maintain interaction counts and mutual affinity for user pairs
- add helpers to surface top friends and rivals
- test pairwise affinity utilities

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/affinity.py tests/unit/test_persona_goal_affinity.py`
- `pytest tests/unit/test_persona_goal_affinity.py`


------
https://chatgpt.com/codex/tasks/task_e_688e9f681c7483268b55704ad4c5178d