### PR TITLE
Document thought channel permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,18 @@ other notes there.
 ```python
 log_thought(bot, "Sentiment looks suspicious")
 ```
+#### THOUGHT_CHANNEL usage and permissions
+
+The `THOUGHT_CHANNEL` environment variable should point to a private Discord
+channel used only for internal logs. Configure the channel so that only the bot
+and trusted maintainers can view it.
+
+* Grant the bot permission to read and send messages.
+* Remove access for regular members to keep internal assessments hidden.
+* Avoid cross-posting thought logs to public channels.
+
+Keeping the channel private ensures the bot's inner thoughts remain isolated
+from public conversations.
 
 When `ALLOW_DECEPTION=true`, the bot may conceal its plans by sending a preset
 message instead of the real intention. The chosen reply is stored so repeated

--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -101,6 +101,15 @@ export THOUGHT_CHANNEL=9876543210
 
 When configured, the bot posts manipulation scores and other notes to this private channel.
 
+### THOUGHT_CHANNEL usage and permissions
+
+Set the variable to the numeric ID of a Discord channel that only the bot and
+trusted maintainers can access.
+
+* Grant the bot permission to send messages.
+* Deny read access to regular members to keep internal assessments hidden.
+* Avoid referencing thought logs in public channels.
+
 ## Manipulation Detection Flow
 
 Set ``MANIP_MODEL_PATH`` to load a Hugging Face classifier used to categorize


### PR DESCRIPTION
## Summary
- document THOUGHT_CHANNEL usage and required permissions
- outline best practices to keep thought logs private

## Testing
- no tests run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_688eb0f87ce8832680e4e85006a9df19