### PR TITLE
Document social cues and relationship tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,9 +627,10 @@ review.
 ### Bidirectional Relationship Tracking
 
 Every logged interaction updates the `relationships` table in **both**
-directions. The `PersonaManager` selects between friendly, playful, and snarky
-personas based on this mutual affinity score. Provide a database path to enable
-tracking:
+directions, storing interaction counts, sentiment, and decay-weighted affinity.
+The `PersonaManager` selects between friendly, playful, and snarky personas
+based on this mutual affinity score. Enable tracking by pointing
+`SOCIAL_GRAPH_DB` to a writable SQLite file:
 
 ```bash
 export SOCIAL_GRAPH_DB=/path/to/social_graph.db
@@ -653,7 +654,9 @@ A minimal notebook demonstrating retrieval-augmented generation is available at 
 
 ## Social Perception
 
-Download the social perception classifier from Hugging Face and set the path for `SOCIAL_PERCEPTION_MODEL`:
+The classifier produces probabilities for five cues—flirtation, avoidance,
+manipulation, sarcasm, and supportiveness. Download the model weights and set
+the path for `SOCIAL_PERCEPTION_MODEL`:
 
 ```bash
 pip install huggingface_hub
@@ -661,7 +664,8 @@ huggingface-cli download myorg/social-cue-classifier --local-dir ./models/social
 export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
 ```
 
-If unset, the default `path/to/social-perception-model` is used.
+If `SOCIAL_PERCEPTION_MODEL` is not set the system returns neutral scores for
+each cue.
 
 ### Manipulation Detection
 

--- a/docs/interaction_trace.md
+++ b/docs/interaction_trace.md
@@ -7,7 +7,7 @@ Each line represents a single event emitted by the system.
 {
   "event": "INPUT_RECEIVED",
   "payload": {"user_input": "hello", "input_id": "abc"},
-  "perception": {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0},
+  "perception": {"flirtation": 0.2, "avoidance": 0.1, "manipulation": 0.0, "sarcasm": 0.3, "supportiveness": 0.4},
   "affinity": 0.1
 }
 ```
@@ -19,7 +19,8 @@ Fields
   either a dictionary or a string for raw chat messages.
 - **perception** – dictionary of social perception label probabilities. When the event contains
   textual user input the recorder runs the social perception classifier and records the resulting
-  probabilities. If no text is available this field is `null`.
+  probabilities for flirtation, avoidance, manipulation, sarcasm, and supportiveness. If no text
+  is available this field is `null`.
 - **affinity** – current affinity score for the user after applying the perception delta. The score is
   incremented when a new input is processed.
 

--- a/docs/social_perception_training.md
+++ b/docs/social_perception_training.md
@@ -12,6 +12,8 @@ Labels are encoded as integers:
 0 -> flirtation
 1 -> avoidance
 2 -> manipulation
+3 -> sarcasm
+4 -> supportiveness
 ```
 
 Any Hugging Face dataset or local JSON/CSV file with these columns can be
@@ -38,3 +40,15 @@ python train/social_perception_train.py \
 
 The fine-tuned model will be saved to `./social_perception_model` by
 default. Adjust `--output-dir` to change the location.
+
+## Enable the classifier
+
+Point the application to the trained weights by setting
+`SOCIAL_PERCEPTION_MODEL` to the model directory:
+
+```bash
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/social_perception_model
+```
+
+When this variable is unset the system falls back to neutral perception
+scores.

--- a/train/social_perception_train.py
+++ b/train/social_perception_train.py
@@ -14,7 +14,13 @@ from transformers import (
     TrainingArguments,
 )
 
-LABELS: Dict[int, str] = {0: "flirtation", 1: "avoidance", 2: "manipulation"}
+LABELS: Dict[int, str] = {
+    0: "flirtation",
+    1: "avoidance",
+    2: "manipulation",
+    3: "sarcasm",
+    4: "supportiveness",
+}
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- document bidirectional relationship tracking and how to enable it with `SOCIAL_GRAPH_DB`
- expand social perception docs and code for new labels and `SOCIAL_PERCEPTION_MODEL`
- update interaction trace example to include new social perception cues

## Testing
- `pre-commit run --files train/social_perception_train.py docs/social_perception_training.md docs/interaction_trace.md README.md`
- `pytest tests/unit/perception/test_social_perception.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688eb0f7e0388326bd3c18ef4b581d09