### PR TITLE
Add default social perception model fallback and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,17 +667,16 @@ A minimal notebook demonstrating retrieval-augmented generation is available at 
 ## Social Perception
 
 The classifier produces probabilities for five cues—flirtation, avoidance,
-manipulation, sarcasm, and supportiveness. Download the model weights and set
-the path for `SOCIAL_PERCEPTION_MODEL`:
+manipulation, sarcasm, and supportiveness. A lightweight keyword model is bundled
+with the repository and used automatically when `SOCIAL_PERCEPTION_MODEL` is not
+set. To use a custom transformer model instead, download the weights and point
+the environment variable to the local directory:
 
 ```bash
 pip install huggingface_hub
 huggingface-cli download myorg/social-cue-classifier --local-dir ./models/social_perception
 export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
 ```
-
-If `SOCIAL_PERCEPTION_MODEL` is not set the system returns neutral scores for
-each cue.
 
 ### Manipulation Detection
 

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -171,6 +171,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(level
 
 DB_PATH = get_settings().social_graph_db
 CURRENT_DB_PATH = DB_PATH
+SOCIAL_PERCEPTION_MODEL = get_settings().social_perception_model
 
 
 # Endpoint for forwarding collected data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ reasoning = "deepthought.services.reasoning_service:ReasoningService"
   "reward_service/*",
   "service/*",
 ]
+"deepthought.perception" = ["default_social_perception_model.json"]
 
 [tool.setuptools.dynamic]
 version = {attr = "deepthought.__init__.__version__"}

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -58,6 +58,13 @@ class RewardThresholds(BaseSettings):
     buffer_size: int = 50
 
 
+DEFAULT_SOCIAL_MODEL = (
+    Path(__file__).resolve().parent
+    / "perception"
+    / "default_social_perception_model.json"
+)
+
+
 class Settings(BaseSettings):
     """Application wide settings."""
 
@@ -71,7 +78,9 @@ class Settings(BaseSettings):
 
     db: DatabaseSettings = DatabaseSettings()
     model_path: str = "distilgpt2"
-    social_perception_model: str | None = Field(None, env="SOCIAL_PERCEPTION_MODEL")
+    social_perception_model: str = Field(
+        str(DEFAULT_SOCIAL_MODEL), env="SOCIAL_PERCEPTION_MODEL"
+    )
     memory_file: str = "memory.json"
     search_db: str | None = None
     social_graph_db: str = os.getenv("SOCIAL_GRAPH_DB", "social_graph.db")

--- a/src/deepthought/perception/default_social_perception_model.json
+++ b/src/deepthought/perception/default_social_perception_model.json
@@ -1,0 +1,7 @@
+{
+  "flirtation": ["love", "babe", "date", "kiss"],
+  "avoidance": ["leave", "busy", "later", "away"],
+  "manipulation": ["must", "should", "convince", "persuade"],
+  "sarcasm": ["yeah right", "sure", "as if"],
+  "supportiveness": ["thanks", "thank you", "good job", "proud of you"]
+}

--- a/src/deepthought/perception/social_perception.py
+++ b/src/deepthought/perception/social_perception.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Simple transformer based social cue classifier."""
 
+import json
 import logging
 import os
 from typing import Dict
@@ -15,6 +16,7 @@ LABELS = ["flirtation", "avoidance", "manipulation", "sarcasm", "supportiveness"
 
 _tokenizer: AutoTokenizer | None = None
 _model: AutoModelForSequenceClassification | None = None
+_keyword_model: Dict[str, list[str]] | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -25,39 +27,59 @@ def _load() -> bool:
 
     Returns ``True`` if the model is ready for use, otherwise ``False``.
     """
-    global _tokenizer, _model
+    global _tokenizer, _model, _keyword_model
 
-    if _tokenizer is not None and _model is not None:
+    if (_tokenizer is not None and _model is not None) or _keyword_model is not None:
         return True
 
     model_path = get_settings().social_perception_model
-    if not model_path:
-        logger.warning("SOCIAL_PERCEPTION_MODEL not set. Returning neutral perception scores.")
-        return False
+    if model_path and os.path.exists(model_path):
+        if model_path.endswith(".json"):
+            try:
+                with open(model_path, "r", encoding="utf-8") as f:
+                    _keyword_model = json.load(f)
+                return True
+            except Exception as e:  # pragma: no cover - defensive
+                logger.warning(
+                    "Failed to load default social perception rules: %s", e, exc_info=True
+                )
+                return False
+        try:
+            _tokenizer = AutoTokenizer.from_pretrained(model_path)
+            _model = AutoModelForSequenceClassification.from_pretrained(model_path)
+            return True
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Failed to load social perception model: %s", e, exc_info=True)
+            _tokenizer = None
+            _model = None
+            return False
 
-    if not os.path.exists(model_path):
+    if model_path:
         logger.warning(
             "Social perception model path not found: %s. Returning neutral perception scores.",
             model_path,
         )
-        return False
-
-    try:
-        if _tokenizer is None:
-            _tokenizer = AutoTokenizer.from_pretrained(model_path)
-        if _model is None:
-            _model = AutoModelForSequenceClassification.from_pretrained(model_path)
-        return True
-    except Exception as e:  # pragma: no cover - defensive
-        logger.warning("Failed to load social perception model: %s", e, exc_info=True)
-        _tokenizer = None
-        _model = None
-        return False
+    else:
+        logger.warning("SOCIAL_PERCEPTION_MODEL not set. Returning neutral perception scores.")
+    return False
 
 
 def analyze(text: str) -> Dict[str, float]:
     """Return probabilities for supported social cues."""
-    if not _load() or _tokenizer is None or _model is None:
+    if not _load():
+        neutral = 1.0 / len(LABELS)
+        return {label: neutral for label in LABELS}
+
+    if _keyword_model is not None:
+        lower = text.lower()
+        hits = [label for label, words in _keyword_model.items() if any(w in lower for w in words)]
+        if not hits:
+            neutral = 1.0 / len(LABELS)
+            return {label: neutral for label in LABELS}
+        prob = 1.0 / len(hits)
+        return {label: (prob if label in hits else 0.0) for label in LABELS}
+
+    if _tokenizer is None or _model is None:
         neutral = 1.0 / len(LABELS)
         return {label: neutral for label in LABELS}
 

--- a/tests/test_social_perception_model.py
+++ b/tests/test_social_perception_model.py
@@ -1,0 +1,21 @@
+import importlib
+import deepthought.config as config
+import deepthought.perception.social_perception as sp
+
+
+def test_default_model_detects_cues(monkeypatch):
+    monkeypatch.delenv("SOCIAL_PERCEPTION_MODEL", raising=False)
+    config._settings_cache = None
+    importlib.reload(sp)
+
+    cases = [
+        ("I love you", "flirtation"),
+        ("Please leave me alone", "avoidance"),
+        ("You must obey me", "manipulation"),
+        ("yeah right, that will work", "sarcasm"),
+        ("Thanks for your help", "supportiveness"),
+    ]
+
+    for text, label in cases:
+        scores = sp.analyze(text)
+        assert max(scores, key=scores.get) == label

--- a/tests/unit/perception/test_social_perception.py
+++ b/tests/unit/perception/test_social_perception.py
@@ -128,62 +128,17 @@ def test_env_model_path(monkeypatch):
     assert paths["model"] == "/tmp/custom-model"
 
 
-def test_missing_env_var(monkeypatch, caplog):
-    tf_mod = types.ModuleType("transformers")
-
-    class DummyTokenizer:
-        @classmethod
-        def from_pretrained(cls, path):
-            return cls()
-
-        def __call__(self, text, return_tensors=None):
-            return {"text": text}
-
-    class DummyModel:
-        @classmethod
-        def from_pretrained(cls, path):
-            return cls()
-
-        def __call__(self, **kwargs):
-            return types.SimpleNamespace(logits=[[1.0, 2.0, 3.0]])
-
-    tf_mod.AutoTokenizer = DummyTokenizer
-    tf_mod.AutoModelForSequenceClassification = DummyModel
-    monkeypatch.setitem(sys.modules, "transformers", tf_mod)
-
-    torch_mod = types.ModuleType("torch")
-
-    class _NoGrad:
-        def __enter__(self):
-            pass
-
-        def __exit__(self, exc_type, exc, tb):
-            pass
-
-    torch_mod.no_grad = lambda: _NoGrad()
-
-    class DummyTensor(list):
-        def tolist(self):
-            return list(self)
-
-    torch_mod.softmax = lambda t, dim=0: [DummyTensor([0.1, 0.2, 0.7])]
-    monkeypatch.setitem(sys.modules, "torch", torch_mod)
-
+def test_missing_env_var(monkeypatch):
     monkeypatch.delenv("SOCIAL_PERCEPTION_MODEL", raising=False)
     monkeypatch.delenv("DT_SOCIAL_PERCEPTION_MODEL", raising=False)
-    monkeypatch.setattr("os.path.exists", lambda p: False)
     import deepthought.config as config
     config._settings_cache = None
 
     sp = importlib.import_module("deepthought.perception.social_perception")
     importlib.reload(sp)
 
-    with caplog.at_level(logging.WARNING):
-        result = sp.analyze("hello")
-
-    neutral = 1.0 / len(sp.LABELS)
-    assert result == {label: pytest.approx(neutral) for label in sp.LABELS}
-    assert any("SOCIAL_PERCEPTION_MODEL" in r.getMessage() for r in caplog.records)
+    result = sp.analyze("I love you")
+    assert max(result, key=result.get) == "flirtation"
 
 
 def test_missing_model_path(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- bundle a keyword-based default social perception model
- load bundled model when `SOCIAL_PERCEPTION_MODEL` is unset
- expose `SOCIAL_PERCEPTION_MODEL` path in social graph bot
- test default model cue detection

## Testing
- `flake8 src tests`
- `pytest tests/test_social_perception_model.py tests/unit/perception/test_social_perception.py`


------
https://chatgpt.com/codex/tasks/task_e_688eb93d69dc8326b6e4a403b94eade5