### PR TITLE
Handle bullying detection and trust-based replies

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -315,6 +315,7 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
 
 # Simple list of phrases considered bullying
 BULLYING_PHRASES = ["idiot", "stupid", "loser", "dumb", "ugly"]
+BULLYING_RESPONSE = "I'm not here to be disrespected. Let's keep things civil."
 
 
 async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
@@ -906,12 +907,16 @@ class SocialGraphBot(discord.Client):
         await db_manager.record_emotion(message.author.id, emotions)
 
         social_scores = analyze_social(message.content)
+        bullying = manipulation_score(message.content, {"bullying": BULLYING_PHRASES})
         manip_category = manipulation_score(message.content)
-        category_to_log = manip_category or max(social_scores, key=social_scores.get)
+        category_to_log = manip_category or bullying or max(social_scores, key=social_scores.get)
         await db_manager.record_manipulation(message.author.id, category_to_log)
-        if manip_category or social_scores.get("manipulation", 0) > 0.5:
+        if (manip_category and manip_category != "bullying") or (
+            social_scores.get("manipulation", 0) > 0.5 and not bullying
+        ):
             await trust_service.adjust_trust(message.author.id, -1.0)
             log_thought(self, f"Manipulation detected: {category_to_log}")
+            return
 
         if not await trust_service.is_trusted(message.author.id, 0.0):
             return
@@ -943,7 +948,9 @@ class SocialGraphBot(discord.Client):
                 async for recent in message.channel.history(limit=1):
                     if recent.id != message.id and getattr(recent.author, "bot", False):
                         return
-            if social_scores.get("flirtation", 0) > 0.5:
+            if bullying and not await is_do_not_mock(message.author.id):
+                reply = BULLYING_RESPONSE
+            elif social_scores.get("flirtation", 0) > 0.5:
                 reply = random.choice(PERSONA_REPLIES["playful"])
             elif social_scores.get("avoidance", 0) > 0.5:
                 reply = AVOIDANCE_REPLY
@@ -971,20 +978,6 @@ class SocialGraphBot(discord.Client):
                 "content": message.content,
             }
         )
-
-        bullying = manipulation_score(message.content, {"bullying": BULLYING_PHRASES})
-        if bullying:
-            if not await is_do_not_mock(message.author.id):
-                sarcastic = random.choice(
-                    [
-                        "Oh, how original.",
-                        "Wow, such eloquence.",
-                        "Tell us how you really feel!",
-                    ]
-                )
-                async with message.channel.typing():
-                    await asyncio.sleep(random.uniform(1, 2))
-                    await message.channel.send(sarcastic)
 
         memories = await recall_user(message.author.id)
         if memories:

--- a/tests/test_autonomy_refusal.py
+++ b/tests/test_autonomy_refusal.py
@@ -4,10 +4,9 @@ import random
 import pytest
 
 pytest.importorskip("discord")
+pytest.importorskip("nats")
 
 import examples.social_graph_bot as sg
-
-pytest.importorskip("nats")
 from deepthought.services import DBManager
 
 
@@ -28,7 +27,7 @@ class DummyChannel:
     def history(self, limit=1):
         async def _gen():
             if False:
-                yield  # pragma: no cover
+                yield
 
         return _gen()
 
@@ -56,17 +55,18 @@ class DummyMessage:
 
 
 @pytest.mark.asyncio
-async def test_bullying_triggers_firm_message(tmp_path, monkeypatch, input_events):
+async def test_refuses_low_trust(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
 
     async def noop(*args, **kwargs):
         return None
 
-    f = asyncio.Future()
-    f.set_result((set(), set(), {}))
-    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)
     monkeypatch.setattr(sg, "queue_deep_reflection", noop)
@@ -74,36 +74,30 @@ async def test_bullying_triggers_firm_message(tmp_path, monkeypatch, input_event
     monkeypatch.setattr(asyncio, "sleep", noop)
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
-    monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
 
-    async def allow_mock(user_id):
-        return False
-
-    monkeypatch.setattr(sg, "is_do_not_mock", allow_mock)
+    await sg.trust_service.adjust_trust(2, -10)
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
-    assert bot.intents.members
-    assert bot.intents.presences
-
-    message = DummyMessage("You are an idiot")
+    message = DummyMessage("hi")
     await bot.on_message(message)
 
-    assert sg.BULLYING_RESPONSE in message.channel.sent_messages
+    assert message.channel.sent_messages == []
     await sg.db_manager.close()
 
 
 @pytest.mark.asyncio
-async def test_do_not_mock_blocks_firm_message(tmp_path, monkeypatch, input_events):
+async def test_minimal_reply_low_trust(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
     await sg.db_manager.connect()
     await sg.db_manager.init_db()
 
     async def noop(*args, **kwargs):
         return None
 
-    f = asyncio.Future()
-    f.set_result((set(), set(), {}))
-    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
     monkeypatch.setattr(sg, "send_to_prism", noop)
     monkeypatch.setattr(sg, "store_theory", noop)
     monkeypatch.setattr(sg, "queue_deep_reflection", noop)
@@ -111,19 +105,14 @@ async def test_do_not_mock_blocks_firm_message(tmp_path, monkeypatch, input_even
     monkeypatch.setattr(asyncio, "sleep", noop)
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
     monkeypatch.setattr(random, "uniform", lambda a, b: 0)
-    monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
+    monkeypatch.setattr(random, "random", lambda: 0.5)
 
-    async def prevent_mock(user_id):
-        return True
-
-    monkeypatch.setattr(sg, "is_do_not_mock", prevent_mock)
+    sg.MINIMAL_REPLY_THRESHOLD = 1
+    sg.MINIMAL_REPLY_PROB = 0
 
     bot = sg.SocialGraphBot(monitor_channel_id=1)
-    assert bot.intents.members
-    assert bot.intents.presences
-
-    message = DummyMessage("You are an idiot")
+    message = DummyMessage("hello")
     await bot.on_message(message)
 
-    assert sg.BULLYING_RESPONSE not in message.channel.sent_messages
+    assert message.channel.sent_messages == [sg.MINIMAL_REPLIES[0]]
     await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- Respond firmly to bullying phrases and skip replies for manipulation or low trust
- Add tests covering autonomy refusal and minimal replies
- Update bullying tests for new firm response

## Testing
- `pytest tests/test_autonomy_refusal.py tests/test_bullying_mock.py tests/test_manipulation_trust.py tests/test_minimal_reply.py -q`
- `flake8 examples/social_graph_bot.py tests/test_bullying_mock.py tests/test_autonomy_refusal.py`


------
https://chatgpt.com/codex/tasks/task_e_688ec031fbdc832686b4060af55f62c5