### PR TITLE
feat: persist social relationships in db

### DIFF
--- a/scripts/migrate_social_graph.py
+++ b/scripts/migrate_social_graph.py
@@ -1,0 +1,81 @@
+"""Utility to migrate legacy JSON user graphs to the SQLite database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Dict, Tuple
+
+from deepthought.services.db_manager import DBManager
+from deepthought.services.user_graph_dal import UserGraphDAL
+
+
+async def migrate(json_path: str, db_path: str) -> None:
+    dal = UserGraphDAL(json_path)
+    db = DBManager(db_path)
+    await db.connect()
+    await db.init_db()
+
+    # Migrate node affinities
+    assert dal._graph  # for type checkers
+    for node, data in dal._graph.nodes(data=True):
+        affinity = int(data.get("affinity", 0))
+        if affinity:
+            await db._db.execute(
+                """
+                INSERT INTO affinity (user_id, score)
+                VALUES (?, ?)
+                ON CONFLICT(user_id) DO UPDATE SET score=excluded.score
+                """,
+                (str(node), affinity),
+            )
+
+    # Prepare mutual affinity data
+    pairs: Dict[Tuple[str, str], Dict[str, float]] = {}
+
+    for source, target, data in dal._graph.edges(data=True):
+        await db.set_relationship(
+            source,
+            target,
+            int(data.get("interaction_count", 0)),
+            float(data.get("sentiment_sum", 0.0)),
+            float(data.get("interaction_weight", 0.0)),
+            data.get("last_interaction"),
+        )
+        a, b = sorted((source, target))
+        info = pairs.setdefault((a, b), {"score": 0, "weight": 0.0, "last": 0.0})
+        info["score"] += int(data.get("interaction_count", 0))
+        info["weight"] += float(data.get("interaction_weight", 0.0))
+        info["last"] = max(info["last"], float(data.get("last_interaction", 0.0)))
+
+    for (a, b), info in pairs.items():
+        score = info["score"] // 2
+        weight = info["weight"] / 2
+        last = info["last"] if info["last"] else None
+        await db._db.execute(
+            """
+            INSERT INTO mutual_affinity (user_a, user_b, score, interaction_weight, last_interaction)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(user_a, user_b) DO UPDATE SET
+                score=excluded.score,
+                interaction_weight=excluded.interaction_weight,
+                last_interaction=excluded.last_interaction
+            """,
+            (a, b, score, weight, last),
+        )
+
+    await db._db.commit()
+    await db.close()
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("json_graph", help="Path to the legacy user_graph.json file")
+    parser.add_argument("database", help="Destination SQLite database path")
+    args = parser.parse_args()
+    asyncio.run(migrate(args.json_graph, args.database))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    _main()
+

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -299,6 +299,60 @@ class DBManager:
             )
         await self._db.commit()
 
+    async def set_relationship(
+        self,
+        source_id: int,
+        target_id: int,
+        interaction_count: int,
+        sentiment_sum: float,
+        interaction_weight: float = 0.0,
+        last_interaction: float | str | None = None,
+    ) -> None:
+        """Insert or update a relationship row with explicit values.
+
+        This is primarily used for migrating data from legacy stores where
+        interaction statistics were persisted in JSON files.
+        """
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO relationships (
+                source_id,
+                target_id,
+                interaction_count,
+                sentiment_sum,
+                interaction_weight,
+                last_interaction
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(source_id, target_id) DO UPDATE SET
+                interaction_count=excluded.interaction_count,
+                sentiment_sum=excluded.sentiment_sum,
+                interaction_weight=excluded.interaction_weight,
+                last_interaction=excluded.last_interaction
+            """,
+            (
+                str(source_id),
+                str(target_id),
+                int(interaction_count),
+                float(sentiment_sum),
+                float(interaction_weight),
+                last_interaction,
+            ),
+        )
+        await self._db.commit()
+
+    async def delete_relationship(self, source_id: int, target_id: int) -> None:
+        """Remove a relationship between ``source_id`` and ``target_id``."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "DELETE FROM relationships WHERE source_id=? AND target_id=?",
+            (str(source_id), str(target_id)),
+        )
+        await self._db.commit()
+
     async def recall_user(self, user_id: int):
         await self.connect()
         assert self._db

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -1,40 +1,78 @@
+"""High level helpers for recording and querying social interactions."""
+
+from __future__ import annotations
+
 import logging
 from typing import Optional
 
 from textblob import TextBlob
 
-from .user_graph_dal import UserGraphDAL
+from .db_manager import DBManager
 
 logger = logging.getLogger(__name__)
 
 
 class SocialGraphMemory:
-    """Record messages and sentiment in a :class:`UserGraphDAL`."""
+    """Record messages and sentiment using a :class:`DBManager` backend."""
 
-    def __init__(self, dal: Optional[UserGraphDAL] = None) -> None:
-        self._dal = dal or UserGraphDAL()
+    def __init__(self, db_manager: Optional[DBManager] = None) -> None:
+        self._db = db_manager or DBManager()
 
-    def record_message(self, source: str, text: str, target: Optional[str] = None) -> None:
+    async def record_message(self, source: str, text: str, target: Optional[str] = None) -> None:
         """Analyze sentiment of ``text`` and store the interaction."""
         try:
             score = float(TextBlob(text).sentiment.polarity)
         except Exception:  # pragma: no cover - TextBlob failure
             logger.exception("Sentiment analysis failed")
             score = 0.0
-        self._dal.add_message(source, target, sentiment_score=score)
+        await self._db.log_interaction(source, target, sentiment_score=score)
 
-    # Expose some helper methods from the DAL
-    def get_affinity(self, user_id: str) -> int:
-        return self._dal.get_affinity(user_id)
+    async def get_affinity(self, user_id: str) -> int:
+        return await self._db.get_affinity(user_id)
 
-    def get_friendliness(self, source: str, target: str) -> float:
-        return self._dal.get_friendliness(source, target)
+    async def get_friendliness(self, source: str, target: str) -> float:
+        return await self._db.get_friendliness(source, target)
 
-    def get_hostility(self, source: str, target: str) -> float:
-        return self._dal.get_hostility(source, target)
+    async def get_hostility(self, source: str, target: str) -> float:
+        return await self._db.get_hostility(source, target)
 
-    def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
-        return self._dal.get_mutual_affinity(user_a, user_b)
+    async def get_mutual_affinity(self, user_a: str, user_b: str) -> float:
+        return await self._db.get_pair_mutual_affinity(user_a, user_b)
 
-    def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
-        return self._dal.get_relationship_stats(user_a, user_b)
+    async def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
+        """Return a summary of interactions and sentiment between two users."""
+        ab = await self._db.get_relationship(user_a, user_b)
+        ba = await self._db.get_relationship(user_b, user_a)
+
+        def _stats(row: tuple | None) -> dict:
+            if not row:
+                return {
+                    "count": 0,
+                    "sentiment_sum": 0.0,
+                    "avg_sentiment": 0.0,
+                    "interaction_weight": 0.0,
+                    "last_interaction": None,
+                }
+            count, sentiment_sum, weight, last = row
+            avg = float(sentiment_sum) / count if count else 0.0
+            return {
+                "count": int(count),
+                "sentiment_sum": float(sentiment_sum),
+                "avg_sentiment": avg,
+                "interaction_weight": float(weight),
+                "last_interaction": last,
+            }
+
+        stats_a = _stats(ab)
+        stats_b = _stats(ba)
+        mutual = await self._db.get_pair_mutual_affinity(user_a, user_b)
+        return {
+            "pair": (user_a, user_b),
+            "a_to_b": stats_a,
+            "b_to_a": stats_b,
+            "mutual_affinity": int(mutual),
+        }
+
+    async def close(self) -> None:
+        await self._db.close()
+

--- a/tests/test_relationship_persistence.py
+++ b/tests/test_relationship_persistence.py
@@ -1,0 +1,24 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services import DBManager
+from deepthought.services.social_graph_memory import SocialGraphMemory
+
+
+@pytest.mark.asyncio
+async def test_relationship_persistence(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+
+    await mem.record_message("alice", "hi", "bob")
+    await mem.record_message("bob", "hi", "alice")
+    await mem.close()
+
+    mem2 = SocialGraphMemory(DBManager(str(db_path)))
+    stats = await mem2.get_relationship_stats("alice", "bob")
+    assert stats["mutual_affinity"] == 2
+    assert stats["a_to_b"]["count"] == 1
+    assert stats["b_to_a"]["count"] == 1
+    await mem2.close()
+

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -8,7 +8,6 @@ import examples.social_graph_bot as sg
 pytest.importorskip("nats")
 from deepthought.services import DBManager
 from deepthought.services.social_graph_memory import SocialGraphMemory
-from deepthought.services.user_graph_dal import UserGraphDAL
 
 
 @pytest.mark.asyncio
@@ -56,26 +55,23 @@ async def test_relationship_table_and_updates(tmp_path):
     await sg.db_manager.close()
 
 
-def test_user_graph_edges_and_stats(tmp_path):
-    dal = UserGraphDAL(str(tmp_path / "g.json"))
-    mem = SocialGraphMemory(dal)
+@pytest.mark.asyncio
+async def test_relationship_stats(tmp_path):
+    db = DBManager(str(tmp_path / "sg.db"))
+    mem = SocialGraphMemory(db)
 
-    dal.add_message("a", "b", sentiment_score=0.5)
-    dal.add_message("b", "a", sentiment_score=-0.2)
+    await db.log_interaction("a", "b", sentiment_score=0.5)
+    await db.log_interaction("b", "a", sentiment_score=-0.2)
 
-    # Both directional edges should be updated
-    ab = dal.get_relationship("a", "b")
-    ba = dal.get_relationship("b", "a")
-    assert ab[0] == 2 and ab[2] == 2
-    assert ba[0] == 2 and ba[2] == 2
+    ab = await db.get_relationship("a", "b")
+    ba = await db.get_relationship("b", "a")
+    assert ab[0] == 1 and ab[2] == 1
+    assert ba[0] == 1 and ba[2] == 1
 
-    # mutual affinity counts actual messages between the pair
-    assert dal.get_mutual_affinity("a", "b") == 2
-
-    stats = mem.get_relationship_stats("a", "b")
+    stats = await mem.get_relationship_stats("a", "b")
     assert stats["mutual_affinity"] == 2
-    assert stats["a_to_b"]["avg_sentiment"] == pytest.approx(0.15)
-    assert stats["b_to_a"]["avg_sentiment"] == pytest.approx(0.15)
-    assert stats["a_to_b"]["interaction_weight"] == 2
-    assert stats["b_to_a"]["interaction_weight"] == 2
-    assert stats["a_to_b"]["last_interaction"] > 0
+    assert stats["a_to_b"]["avg_sentiment"] == pytest.approx(0.5)
+    assert stats["b_to_a"]["avg_sentiment"] == pytest.approx(-0.2)
+    assert stats["a_to_b"]["interaction_weight"] == pytest.approx(1.0)
+    assert stats["b_to_a"]["interaction_weight"] == pytest.approx(1.0)
+    assert stats["a_to_b"]["last_interaction"] is not None


### PR DESCRIPTION
## Summary
- add CRUD helpers for relationships in DBManager
- switch SocialGraphMemory to DBManager and provide relationship stats
- script to migrate legacy JSON social graphs to SQLite
- tests for relationship stats and persistence

## Testing
- `flake8 src/deepthought/services/db_manager.py src/deepthought/services/social_graph_memory.py scripts/migrate_social_graph.py tests/test_relationships.py tests/test_relationship_persistence.py`
- `pytest tests/test_relationships.py tests/test_relationship_persistence.py`

------
https://chatgpt.com/codex/tasks/task_e_688f89b6b7248326a0794c5728a4e538