### PR TITLE
Add decayed user graph metrics

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -14,12 +14,7 @@ from deepthought.goal_scheduler import GoalScheduler
 from deepthought.perception.emotion_detection import detect_emotions
 from deepthought.perception.social_perception import analyze as analyze_social
 from deepthought.services import PersonaManager, TrustService
-from deepthought.services.db_manager import (
-    MAX_MEMORY_LENGTH,
-    MAX_PROMPT_LENGTH,
-    MAX_THEORY_LENGTH,
-    DBManager,
-)
+from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import is_allowed
 from deepthought.services.scheduler import SchedulerService
@@ -927,7 +922,7 @@ class SocialGraphBot(discord.Client):
             return
 
         trust = await trust_service.get_trust(message.author.id)
-        if trust < trust_service.lower_limit:
+        if trust <= trust_service.lower_limit:
             return
 
         result = await who_is_active(message.channel)

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime
 
 import aiosqlite
+
+from ..config import get_settings
 
 SENTIMENT_BACKEND = os.getenv("SENTIMENT_BACKEND", "textblob").lower()
 if SENTIMENT_BACKEND == "vader":
@@ -28,9 +31,6 @@ else:
 
     def analyze_sentiment(text: str) -> float:
         return TextBlob(text).sentiment.polarity
-
-
-from ..config import get_settings
 
 # Default database path used when none is provided.
 DB_PATH = get_settings().social_graph_db
@@ -100,6 +100,13 @@ class DBManager:
             interaction_weight REAL DEFAULT 0,
             last_interaction DATETIME DEFAULT CURRENT_TIMESTAMP,
             PRIMARY KEY(source_id, target_id)
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS interaction_decay (
+            id INTEGER PRIMARY KEY CHECK(id=1),
+            weight_decay REAL DEFAULT 1.0,
+            sentiment_decay REAL DEFAULT 1.0
         )
         """,
         """
@@ -219,6 +226,9 @@ class DBManager:
                     await self._db.execute(query)
                 await self._ensure_relationship_columns()
                 await self._db.execute("INSERT OR IGNORE INTO trust_config (id) VALUES (1)")
+                await self._db.execute(
+                    "INSERT OR IGNORE INTO interaction_decay (id) VALUES (1)"
+                )
                 await self._db.commit()
                 self._initialized = True
 
@@ -273,30 +283,58 @@ class DBManager:
             )
         if target_id is not None:
             weight = 1.0
-            await self._db.execute(
-                """
-                INSERT INTO relationships (source_id, target_id, interaction_count, sentiment_sum, interaction_weight)
-                VALUES (?, ?, 1, ?, ?)
-                ON CONFLICT(source_id, target_id) DO UPDATE SET
-                    interaction_count=relationships.interaction_count + 1,
-                    sentiment_sum=relationships.sentiment_sum + excluded.sentiment_sum,
-                    interaction_weight=relationships.interaction_weight + excluded.interaction_weight,
-                    last_interaction=CURRENT_TIMESTAMP
-                """,
-                (str(user_id), str(target_id), sentiment_score or 0.0, weight),
-            )
+            w_decay, s_decay = await self.get_decay_params()
+            now = datetime.utcnow()
+            # Update directional relationship with decay
+            async with self._db.execute(
+                "SELECT interaction_count, sentiment_sum, interaction_weight, last_interaction FROM relationships WHERE source_id=? AND target_id=?",
+                (str(user_id), str(target_id)),
+            ) as cur:
+                row = await cur.fetchone()
+            if row:
+                count, ssum, w, last_ts = row
+                if last_ts:
+                    last_dt = datetime.fromisoformat(str(last_ts))
+                    elapsed = (now - last_dt).total_seconds()
+                    ssum = float(ssum) * (s_decay ** elapsed)
+                    w = float(w) * (w_decay ** elapsed)
+                count = int(count) + 1
+                ssum += sentiment_score or 0.0
+                w += weight
+                await self._db.execute(
+                    "UPDATE relationships SET interaction_count=?, sentiment_sum=?, interaction_weight=?, last_interaction=CURRENT_TIMESTAMP WHERE source_id=? AND target_id=?",
+                    (count, ssum, w, str(user_id), str(target_id)),
+                )
+            else:
+                await self._db.execute(
+                    "INSERT INTO relationships (source_id, target_id, interaction_count, sentiment_sum, interaction_weight, last_interaction) VALUES (?, ?, 1, ?, ?, CURRENT_TIMESTAMP)",
+                    (str(user_id), str(target_id), sentiment_score or 0.0, weight),
+                )
+
+            # Update mutual affinity with decay
             a, b = sorted((str(user_id), str(target_id)))
-            await self._db.execute(
-                """
-                INSERT INTO mutual_affinity (user_a, user_b, score, interaction_weight)
-                VALUES (?, ?, 1, ?)
-                ON CONFLICT(user_a, user_b) DO UPDATE SET
-                    score=mutual_affinity.score + 1,
-                    interaction_weight=mutual_affinity.interaction_weight + excluded.interaction_weight,
-                    last_interaction=CURRENT_TIMESTAMP
-                """,
-                (a, b, weight),
-            )
+            async with self._db.execute(
+                "SELECT score, interaction_weight, last_interaction FROM mutual_affinity WHERE user_a=? AND user_b=?",
+                (a, b),
+            ) as cur:
+                mrow = await cur.fetchone()
+            if mrow:
+                score, w, last_ts = mrow
+                if last_ts:
+                    last_dt = datetime.fromisoformat(str(last_ts))
+                    elapsed = (now - last_dt).total_seconds()
+                    w = float(w) * (w_decay ** elapsed)
+                score = int(score) + 1
+                w += weight
+                await self._db.execute(
+                    "UPDATE mutual_affinity SET score=?, interaction_weight=?, last_interaction=CURRENT_TIMESTAMP WHERE user_a=? AND user_b=?",
+                    (score, w, a, b),
+                )
+            else:
+                await self._db.execute(
+                    "INSERT INTO mutual_affinity (user_a, user_b, score, interaction_weight, last_interaction) VALUES (?, ?, 1, ?, CURRENT_TIMESTAMP)",
+                    (a, b, weight),
+                )
         await self._db.commit()
 
     async def recall_user(self, user_id: int):
@@ -687,6 +725,27 @@ class DBManager:
         )
         await self._db.commit()
 
+    async def get_decay_params(self) -> tuple[float, float]:
+        """Return stored decay factors for weights and sentiment."""
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT weight_decay, sentiment_decay FROM interaction_decay WHERE id=1"
+        ) as cur:
+            row = await cur.fetchone()
+            if row:
+                return float(row[0]), float(row[1])
+            return 1.0, 1.0
+
+    async def set_decay_params(self, weight_decay: float, sentiment_decay: float) -> None:
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            "UPDATE interaction_decay SET weight_decay=?, sentiment_decay=? WHERE id=1",
+            (float(weight_decay), float(sentiment_decay)),
+        )
+        await self._db.commit()
+
     async def increment_offense(self, user_id: int, offense: str) -> int:
         column = "manipulative_count" if offense == "manipulative" else "banned_count"
         await self.connect()
@@ -720,7 +779,17 @@ class DBManager:
             "SELECT interaction_count, sentiment_sum, interaction_weight, last_interaction FROM relationships WHERE source_id=? AND target_id=?",
             (str(user_id), str(target_id)),
         ) as cur:
-            return await cur.fetchone()
+            row = await cur.fetchone()
+        if not row:
+            return None
+        count, sentiment_sum, weight, last_ts = row
+        w_decay, s_decay = await self.get_decay_params()
+        if last_ts:
+            last_dt = datetime.fromisoformat(str(last_ts))
+            elapsed = (datetime.utcnow() - last_dt).total_seconds()
+            sentiment_sum = float(sentiment_sum) * (s_decay ** elapsed)
+            weight = float(weight) * (w_decay ** elapsed)
+        return count, sentiment_sum, weight, last_ts
 
     async def _get_relationship_avg(self, user_id: int, target_id: int) -> float:
         row = await self.get_relationship(user_id, target_id)
@@ -748,13 +817,21 @@ class DBManager:
     async def get_pair_mutual_affinity(self, user_a: int, user_b: int) -> float:
         await self.connect()
         assert self._db
+        w_decay, _ = await self.get_decay_params()
         a, b = sorted((str(user_a), str(user_b)))
         async with self._db.execute(
-            "SELECT score FROM mutual_affinity WHERE user_a=? AND user_b=?",
+            "SELECT interaction_weight, last_interaction FROM mutual_affinity WHERE user_a=? AND user_b=?",
             (a, b),
         ) as cur:
             row = await cur.fetchone()
-            return float(row[0]) if row else 0.0
+        if not row:
+            return 0.0
+        weight, last_ts = row
+        if last_ts:
+            last_dt = datetime.fromisoformat(str(last_ts))
+            elapsed = (datetime.utcnow() - last_dt).total_seconds()
+            weight = float(weight) * (w_decay ** elapsed)
+        return float(weight)
 
     async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
         if not isinstance(theme, str) or not theme.strip():

--- a/src/deepthought/services/user_graph_dal.py
+++ b/src/deepthought/services/user_graph_dal.py
@@ -8,10 +8,34 @@ logger = logging.getLogger(__name__)
 
 
 class UserGraphDAL(FileGraphDAL):
-    """File-backed graph tracking interactions between users."""
+    """File-backed graph tracking interactions between users.
 
-    def __init__(self, graph_file: str = "user_graph.json") -> None:
+    The graph stores additional parameters ``weight_decay`` and
+    ``sentiment_decay`` which are applied exponentially based on the time
+    elapsed between interactions. These parameters are persisted in the graph
+    metadata so that decay behaviour is reproducible across runs.
+    """
+
+    def __init__(
+        self,
+        graph_file: str = "user_graph.json",
+        weight_decay: float = 1.0,
+        sentiment_decay: float = 1.0,
+    ) -> None:
+        self._weight_decay = float(weight_decay)
+        self._sentiment_decay = float(sentiment_decay)
         super().__init__(graph_file)
+        # Persist decay parameters for reproducibility
+        g = self._graph.graph
+        if "weight_decay" in g:
+            self._weight_decay = float(g["weight_decay"])
+        else:
+            g["weight_decay"] = self._weight_decay
+        if "sentiment_decay" in g:
+            self._sentiment_decay = float(g["sentiment_decay"])
+        else:
+            g["sentiment_decay"] = self._sentiment_decay
+        self._write_graph()
 
     def add_message(
         self,
@@ -30,16 +54,24 @@ class UserGraphDAL(FileGraphDAL):
 
     def _update_edge(self, source: str, target: str, score: float) -> None:
         data = self._graph.get_edge_data(source, target, default={})
-        count = data.get("interaction_count", 0) + 1
-        sentiment_sum = data.get("sentiment_sum", 0.0) + score
-        weight = data.get("interaction_weight", 0.0) + 1.0
+        now = time.time()
+        last = float(data.get("last_interaction", now))
+        elapsed = max(0.0, now - last)
+        # Apply decay to existing values before updating
+        sentiment_sum = float(data.get("sentiment_sum", 0.0)) * (
+            self._sentiment_decay ** elapsed
+        ) + score
+        weight = float(data.get("interaction_weight", 0.0)) * (
+            self._weight_decay ** elapsed
+        ) + 1.0
+        count = int(data.get("interaction_count", 0)) + 1
         self._graph.add_edge(
             source,
             target,
             interaction_count=count,
             sentiment_sum=sentiment_sum,
             interaction_weight=weight,
-            last_interaction=time.time(),
+            last_interaction=now,
         )
 
     def get_affinity(self, user_id: str) -> int:
@@ -51,11 +83,20 @@ class UserGraphDAL(FileGraphDAL):
         data = self._graph.get_edge_data(source, target)
         if not data:
             return 0, 0.0, 0.0, 0.0
+        now = time.time()
+        last = float(data.get("last_interaction", now))
+        elapsed = max(0.0, now - last)
+        sentiment_sum = float(data.get("sentiment_sum", 0.0)) * (
+            self._sentiment_decay ** elapsed
+        )
+        weight = float(data.get("interaction_weight", 0.0)) * (
+            self._weight_decay ** elapsed
+        )
         return (
             int(data.get("interaction_count", 0)),
-            float(data.get("sentiment_sum", 0.0)),
-            float(data.get("interaction_weight", 0.0)),
-            float(data.get("last_interaction", 0.0)),
+            sentiment_sum,
+            weight,
+            last,
         )
 
     def _avg_sentiment(self, source: str, target: str) -> float:
@@ -75,12 +116,11 @@ class UserGraphDAL(FileGraphDAL):
         avg = self._avg_sentiment(source, target)
         return min(0.0, avg)
 
-    def get_mutual_affinity(self, user_a: str, user_b: str) -> int:
-        """Return how many messages have passed between the pair."""
-        ab_count = self.get_relationship(user_a, user_b)[0]
-        ba_count = self.get_relationship(user_b, user_a)[0]
-        # each message updates both directional edges, so average the counts
-        return int((ab_count + ba_count) / 2)
+    def get_mutual_affinity(self, user_a: str, user_b: str) -> float:
+        """Return decayed interaction weight between the pair."""
+        ab_weight = self.get_relationship(user_a, user_b)[2]
+        ba_weight = self.get_relationship(user_b, user_a)[2]
+        return (ab_weight + ba_weight) / 2
 
     def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
         """Return a summary of interactions and sentiment between two users."""
@@ -102,8 +142,8 @@ class UserGraphDAL(FileGraphDAL):
                 "interaction_weight": ba[2],
                 "last_interaction": ba[3],
             },
-            # average counts because each interaction increments both directions
-            "mutual_affinity": int((ab[0] + ba[0]) / 2),
+            # average weights because each message updates both directions
+            "mutual_affinity": (ab[2] + ba[2]) / 2,
         }
 
     def get_interaction_weight(self, source: str, target: str) -> float:

--- a/tests/test_user_graph_decay.py
+++ b/tests/test_user_graph_decay.py
@@ -1,0 +1,24 @@
+import pytest
+
+from deepthought.services.user_graph_dal import UserGraphDAL
+
+
+@pytest.mark.parametrize("decay", [0.5])
+def test_edge_decay(tmp_path, decay):
+    dal = UserGraphDAL(str(tmp_path / "g.json"), weight_decay=decay, sentiment_decay=decay)
+    dal.add_message("a", "b", sentiment_score=1.0)
+    # Simulate time passing
+    edge = dal._graph.get_edge_data("a", "b")
+    edge["last_interaction"] -= 1
+    edge = dal._graph.get_edge_data("b", "a")
+    edge["last_interaction"] -= 1
+    rel = dal.get_relationship("a", "b")
+    assert rel[1] == pytest.approx(decay)
+    assert rel[2] == pytest.approx(decay)
+    dal.add_message("a", "b", sentiment_score=1.0)
+    rel2 = dal.get_relationship("a", "b")
+    # Previous values should have decayed before adding new interaction
+    expected = decay + 1.0
+    assert rel2[1] == pytest.approx(expected)
+    assert rel2[2] == pytest.approx(expected)
+    assert dal.get_mutual_affinity("a", "b") == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- support exponential decay for interaction weight and sentiment in user graph DAL
- persist decay parameters and apply them when computing mutual affinity
- add test ensuring decayed interaction metrics are handled correctly
- enforce trust floor when deciding whether to respond, fixing low-trust refusal tests

## Testing
- `ruff check examples/social_graph_bot.py`
- `pytest tests/test_autonomy_refusal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f89b63c4c83269528072a37bcc6b5