### PR TITLE
feat: track multi-bot chatter

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -5,6 +5,7 @@ import logging
 import os
 import random
 import uuid
+from collections import deque
 from datetime import timedelta, timezone
 from typing import List, Tuple
 
@@ -190,6 +191,8 @@ AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
 USER_REPLY_RATE_SECONDS = float(os.getenv("USER_REPLY_RATE_SECONDS", "3"))
 BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
+BOT_MESSAGE_INTERVAL_SECONDS = int(os.getenv("BOT_MESSAGE_INTERVAL_SECONDS", "60"))
+MAX_BOT_MESSAGES_PER_INTERVAL = int(os.getenv("MAX_BOT_MESSAGES_PER_INTERVAL", "5"))
 MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
 MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
@@ -352,6 +355,8 @@ trust_service = TrustService(db_manager)
 reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
 bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
 last_bot_reply_time: datetime.datetime | None = None
+bot_message_times: dict[int, deque[datetime.datetime]] = {}
+our_message_times: deque[datetime.datetime] = deque()
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -862,6 +867,12 @@ class SocialGraphBot(discord.Client):
 
         now = discord.utils.utcnow()
         if message.author.bot:
+            q = bot_message_times.setdefault(message.author.id, deque())
+            q.append(now)
+            while q and (now - q[0]).total_seconds() > BOT_MESSAGE_INTERVAL_SECONDS:
+                q.popleft()
+            if len(q) >= MAX_BOT_MESSAGES_PER_INTERVAL:
+                return
             last = bot_last_messages.get(message.author.id)
             if last and last[0] == message.content and (now - last[1]).total_seconds() < BOT_COOLDOWN_SECONDS:
                 return
@@ -942,6 +953,16 @@ class SocialGraphBot(discord.Client):
         if len(bots) > MAX_BOT_SPEAKERS and self.user not in message.mentions:
             # Too many bots talking and we're not addressed directly
             return
+        for bot_id, times in bot_message_times.items():
+            while times and (now - times[0]).total_seconds() > BOT_MESSAGE_INTERVAL_SECONDS:
+                times.popleft()
+            if (
+                self.user not in message.mentions
+                and (user_id is None or bot_id != user_id)
+                and times
+                and (now - times[-1]).total_seconds() < BOT_MESSAGE_INTERVAL_SECONDS
+            ):
+                return
 
         if not reply_limiter.allow(str(message.author.id)):
             return
@@ -965,7 +986,13 @@ class SocialGraphBot(discord.Client):
                 else:
                     persona = await self.persona_manager.get_persona(message.author.id)
                     reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+            now = discord.utils.utcnow()
+            while our_message_times and (now - our_message_times[0]).total_seconds() > BOT_MESSAGE_INTERVAL_SECONDS:
+                our_message_times.popleft()
+            if len(our_message_times) >= MAX_BOT_MESSAGES_PER_INTERVAL:
+                return
             await message.channel.send(reply)
+            our_message_times.append(discord.utils.utcnow())
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()
 

--- a/tests/test_multi_bot_etiquette.py
+++ b/tests/test_multi_bot_etiquette.py
@@ -1,0 +1,154 @@
+import asyncio
+import importlib
+import os
+import random
+import sys
+import types
+from collections import deque
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "PLAYFUL_REPLY_TIMEOUT_MINUTES", "5")
+    sys.modules.setdefault("pydantic", types.ModuleType("pydantic"))
+    sys.modules.setdefault("pydantic_settings", types.ModuleType("pydantic_settings"))
+    sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
+    tb_mod = types.ModuleType("textblob")
+    tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+        sentiment=types.SimpleNamespace(polarity=0.0),
+    )
+    sys.modules.setdefault("textblob", tb_mod)
+    rdf_mod = types.ModuleType("rdflib")
+    rdf_mod.Namespace = lambda *a, **k: None
+    rdf_mod.Graph = object
+    rdf_mod.URIRef = str
+    ns_mod = types.ModuleType("rdflib.namespace")
+    ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+    sys.modules.setdefault("rdflib", rdf_mod)
+    sys.modules.setdefault("rdflib.namespace", ns_mod)
+    py_mod = types.ModuleType("pyperplan")
+    py_mod.pddl = types.ModuleType("pyperplan.pddl")
+    parser_mod = types.ModuleType("pyperplan.pddl.parser")
+    parser_mod.Parser = object
+    py_mod.planner = types.ModuleType("pyperplan.planner")
+    py_mod.planner._ground = lambda p: p
+    py_mod.search = types.ModuleType("pyperplan.search")
+    py_mod.search.breadth_first_search = lambda t: []
+    py_mod.pddl.parser = parser_mod
+    sys.modules.setdefault("pyperplan", py_mod)
+    sys.modules.setdefault("pyperplan.pddl", py_mod.pddl)
+    sys.modules.setdefault("pyperplan.pddl.parser", parser_mod)
+    sys.modules.setdefault("pyperplan.planner", py_mod.planner)
+    sys.modules.setdefault("pyperplan.search", py_mod.search)
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_silence_on_recent_bot(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    now = sg.discord.utils.utcnow()
+    sg.bot_message_times[99] = deque([now])
+    message = DummyMessage("hi")
+    await bot.on_message(message)
+    assert message.channel.sent_messages == []
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_silence_on_message_cap(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    now = sg.discord.utils.utcnow()
+    for _ in range(sg.MAX_BOT_MESSAGES_PER_INTERVAL):
+        sg.our_message_times.append(now)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("hi")
+    await bot.on_message(message)
+    assert message.channel.sent_messages == []
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- track individual bot message frequency and ignore routine posts
- silence replies when another bot spoke recently
- cap how many messages the bot sends per interval
- test etiquette around multi-bot silence scenarios

## Testing
- `SKIP=pytest pre-commit run --files examples/social_graph_bot.py tests/test_multi_bot_etiquette.py`
- `pytest tests/test_multi_bot_etiquette.py tests/test_multi_bot_silence.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc8c938e083269e6bfaf7fd1031ee