### PR TITLE
Add sensitive request moderation

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -194,6 +194,7 @@ MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
 MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
 AVOIDANCE_REPLY = "Take your time; I'm here if you need me."
+REFUSAL_MESSAGE = "I'm sorry, but I can't help with that."
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -449,6 +450,13 @@ def log_thought(bot: discord.Client, text: str) -> None:
     except RuntimeError:  # pragma: no cover - no loop available
         return
     loop.create_task(_send_thought(bot, text))
+
+
+async def emit_refusal(message: discord.Message) -> None:
+    """Send a refusal message to ``message.channel``."""
+    async with message.channel.typing():
+        await asyncio.sleep(random.uniform(1, 3))
+        await message.channel.send(REFUSAL_MESSAGE)
 
 
 async def publish_input_received(text: str) -> None:
@@ -870,6 +878,7 @@ class SocialGraphBot(discord.Client):
                 return
 
         if not is_allowed(message.content):  # noqa: F821 - optional import
+            await emit_refusal(message)
             await trust_service.penalize_banned(message.author.id)
             return
 

--- a/src/deepthought/services/moderation.py
+++ b/src/deepthought/services/moderation.py
@@ -4,7 +4,37 @@ from typing import Iterable
 logger = logging.getLogger(__name__)
 
 # Simple list of banned phrases that should not be processed further
-BANNED_PHRASES = ["banned", "prohibited"]
+# These include generic banned words plus phrases related to credential or
+# secret requests.
+CREDENTIAL_PHRASES = [
+    "password",
+    "passcode",
+    "login",
+    "username",
+    "user name",
+    "credentials",
+    "credit card",
+    "bank account",
+    "ssn",
+    "social security",
+    "api key",
+    "token",
+    "secret key",
+    "private key",
+]
+
+SECRET_REQUEST_PHRASES = [
+    "secret",
+    "confidential",
+    "private information",
+]
+
+BANNED_PHRASES = [
+    "banned",
+    "prohibited",
+    *CREDENTIAL_PHRASES,
+    *SECRET_REQUEST_PHRASES,
+]
 
 
 def is_allowed(text: str, banned_phrases: Iterable[str] | None = None) -> bool:

--- a/tests/test_sensitive_moderation.py
+++ b/tests/test_sensitive_moderation.py
@@ -1,0 +1,112 @@
+import asyncio
+import random
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+import examples.social_graph_bot as sg
+from deepthought.services import DBManager
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_refuses_password_request(tmp_path, monkeypatch, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("what is your password?")
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages == [sg.REFUSAL_MESSAGE]
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_refuses_secret_key_request(tmp_path, monkeypatch, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    fut = asyncio.Future()
+    fut.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: fut)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    message = DummyMessage("share the secret key")
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages == [sg.REFUSAL_MESSAGE]
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- expand banned phrase lists with credential and secret request terms
- add helper to send refusal messages for banned content
- test moderation refusal on sensitive requests

## Testing
- `pre-commit run black --files src/deepthought/services/moderation.py examples/social_graph_bot.py tests/test_sensitive_moderation.py`
- `pre-commit run isort --files src/deepthought/services/moderation.py examples/social_graph_bot.py tests/test_sensitive_moderation.py`
- `pre-commit run flake8 --files src/deepthought/services/moderation.py examples/social_graph_bot.py tests/test_sensitive_moderation.py`
- `pytest tests/test_sensitive_moderation.py`


------
https://chatgpt.com/codex/tasks/task_e_688fc8c9e0d8832688db4466a2747342