### PR TITLE
Add personality trait weighting to persona manager

### DIFF
--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -20,6 +20,7 @@ class PersonaManager:
         self._friendly = friendly
         self._playful = playful
         self._descriptions = descriptions or {}
+        self._personality: dict[str, dict[str, float]] = {}
 
         # Initialize the database once. If an event loop is running we
         # schedule the task and await it on first use. Otherwise we
@@ -35,14 +36,26 @@ class PersonaManager:
             asyncio.run(self._db.init_db())
             self._init_task = None
 
+    def update_personality(self, user_id: int, traits: dict[str, float]) -> None:
+        """Update stored personality ``traits`` for ``user_id``.
+
+        The provided ``traits`` mapping is merged with any existing traits for
+        the user, overwriting values for matching keys.
+        """
+
+        uid = str(user_id)
+        current = self._personality.setdefault(uid, {})
+        current.update(traits)
+
     async def get_persona(self, user_id: int) -> str:
         if self._init_task is not None:
             await self._init_task
             self._init_task = None
         score = await self._db.get_mutual_affinity(user_id)
-        if score >= self._friendly:
+        traits = self._personality.get(str(user_id), {})
+        if score + traits.get("friendly", 0) >= self._friendly:
             return "friendly"
-        if score >= self._playful:
+        if score + traits.get("playful", 0) >= self._playful:
             return "playful"
         return "snarky"
 

--- a/tests/test_persona_manager_personality.py
+++ b/tests/test_persona_manager_personality.py
@@ -1,0 +1,41 @@
+import pytest
+
+import examples.social_graph_bot as sg
+from deepthought.services import DBManager, PersonaManager
+
+pytest.importorskip("nats")
+
+
+@pytest.mark.asyncio
+async def test_personality_traits_override_affinity(tmp_path):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    pm = PersonaManager(sg.db_manager, friendly=5, playful=2)
+    user = "u1"
+
+    # Default persona is snarky when score is low
+    assert await pm.get_persona(user) == "snarky"
+
+    # Personality can push persona to friendly
+    pm.update_personality(user, {"friendly": 5})
+    assert await pm.get_persona(user) == "friendly"
+
+    # Updating traits can shift persona again
+    pm.update_personality(user, {"friendly": 0, "playful": 2})
+    assert await pm.get_persona(user) == "playful"
+
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_personality_combines_with_affinity(tmp_path):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    pm = PersonaManager(sg.db_manager, friendly=5, playful=2)
+    user = "u2"
+
+    await sg.adjust_affinity(user, 1)
+    assert await pm.get_persona(user) == "snarky"
+
+    pm.update_personality(user, {"playful": 1})
+    assert await pm.get_persona(user) == "playful"
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- extend PersonaManager with per-user personality traits and an `update_personality` method
- weigh stored personality traits along with affinity when choosing personas
- test that personality traits alter persona selection

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/persona_manager.py tests/test_persona_manager_personality.py`
- `pytest tests/test_persona_manager_personality.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd3f53db483269a4ee987ac12cef2