### PR TITLE
Add personality detection heuristics

### DIFF
--- a/src/deepthought/perception/personality_detection.py
+++ b/src/deepthought/perception/personality_detection.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Infer Big Five personality traits from chat messages.
+
+This module uses simple keyword heuristics to approximate the Big Five
+personality traits: openness, conscientiousness, extraversion, agreeableness
+and neuroticism. If no indicative keywords are present, a neutral score of
+``0.5`` is returned for each trait.
+"""
+
+from collections import Counter
+from typing import Dict, Iterable
+
+# Basic keywords loosely associated with each trait.
+TRAIT_KEYWORDS = {
+    "openness": {
+        "curious",
+        "imaginative",
+        "creative",
+        "adventurous",
+        "inventive",
+        "artistic",
+    },
+    "conscientiousness": {
+        "organized",
+        "prepared",
+        "responsible",
+        "efficient",
+        "plan",
+        "orderly",
+    },
+    "extraversion": {
+        "outgoing",
+        "energetic",
+        "talkative",
+        "social",
+        "assertive",
+        "party",
+    },
+    "agreeableness": {
+        "kind",
+        "trusting",
+        "generous",
+        "cooperative",
+        "helpful",
+        "warm",
+    },
+    "neuroticism": {
+        "anxious",
+        "moody",
+        "nervous",
+        "worry",
+        "insecure",
+        "fearful",
+    },
+}
+
+NEUTRAL_SCORE = 0.5
+
+
+def _heuristic_scores(text: str) -> Dict[str, float]:
+    """Return normalized trait scores using keyword counts."""
+    counts = Counter({trait: 0 for trait in TRAIT_KEYWORDS})
+    for trait, words in TRAIT_KEYWORDS.items():
+        counts[trait] = sum(1 for word in words if word in text)
+    total = sum(counts.values())
+    if total == 0:
+        return {trait: NEUTRAL_SCORE for trait in TRAIT_KEYWORDS}
+    return {trait: counts[trait] / total for trait in TRAIT_KEYWORDS}
+
+
+def infer_personality(messages: Iterable[str]) -> Dict[str, float]:
+    """Infer Big Five trait scores from a sequence of ``messages``."""
+    if not messages:
+        return {trait: NEUTRAL_SCORE for trait in TRAIT_KEYWORDS}
+    text = " ".join(messages).lower()
+    return _heuristic_scores(text)

--- a/tests/unit/perception/test_personality_detection.py
+++ b/tests/unit/perception/test_personality_detection.py
@@ -1,0 +1,17 @@
+from deepthought.perception.personality_detection import infer_personality
+
+
+def test_keyword_scoring():
+    messages = [
+        "I am very organized and always plan ahead.",
+        "People say I'm helpful and cooperative.",
+    ]
+    scores = infer_personality(messages)
+    assert scores["conscientiousness"] == 0.5
+    assert scores["agreeableness"] == 0.5
+    assert scores["extraversion"] == 0.0
+
+
+def test_neutral_fallback():
+    scores = infer_personality([])
+    assert all(score == 0.5 for score in scores.values())


### PR DESCRIPTION
## Summary
- implement Big Five personality detection using keyword heuristics with neutral fallback
- test personality detection for keyword scoring and neutral behavior

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/perception/personality_detection.py tests/unit/perception/test_personality_detection.py`
- `pytest tests/unit/perception/test_personality_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd3f481f0832689e063075af37542