### PR TITLE
Add bot handshake and cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,9 +536,11 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 
 Set the `IDLE_TIMEOUT_MINUTES` environment variable to control the inactivity
 threshold. By default the bot waits five minutes before sending a prompt.
-Enable bot-to-bot chatter by setting `BOT_CHAT_ENABLED=true`. Set
-`PLAYFUL_REPLY_TIMEOUT_MINUTES` to enforce a cooldown before responding to other
-bots and `MAX_BOT_SPEAKERS` to cap the number of active bots.
+Enable bot-to-bot chatter by setting `BOT_CHAT_ENABLED=true`. Bots exchange the
+literal `BOT_HANDSHAKE` message before chatting and respect
+`BOT_COOLDOWN_SECONDS` between replies. Set `PLAYFUL_REPLY_TIMEOUT_MINUTES` to
+enforce a cooldown before responding to other bots and `MAX_BOT_SPEAKERS` to cap
+the number of active bots.
 
 ### Rate Limiting
 

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -214,6 +214,9 @@ BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
     "yes",
 }
 
+# Literal handshake message exchanged between bots before chatting.
+HANDSHAKE_MESSAGE = "BOT_HANDSHAKE"
+
 # When ``ALLOW_DECEPTION`` is true, the bot may hide its real intentions.
 ALLOW_DECEPTION = os.getenv("ALLOW_DECEPTION", "false").lower() in {
     "true",
@@ -358,6 +361,10 @@ bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
 last_bot_reply_time: datetime.datetime | None = None
 bot_message_times: dict[int, deque[datetime.datetime]] = {}
 our_message_times: deque[datetime.datetime] = deque()
+
+# Track handshake completions and per-bot cooldowns
+bot_handshakes: dict[int, datetime.datetime] = {}
+bot_reply_times: dict[int, datetime.datetime] = {}
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -752,6 +759,44 @@ async def last_human_message_age(channel: discord.TextChannel, limit: int = 50):
     return None
 
 
+async def handle_bot_handshake(message: discord.Message) -> bool:
+    """Handle bot handshakes and cooldowns.
+
+    Returns ``True`` when normal processing should continue. When a handshake
+    message is received the bot echoes ``HANDSHAKE_MESSAGE`` and returns
+    ``False`` to stop further processing. Messages from bots that have not
+    completed the handshake or are still in their cooldown period are ignored.
+    """
+
+    if not BOT_CHAT_ENABLED or not message.author.bot:
+        return True
+
+    global last_bot_reply_time
+    now = discord.utils.utcnow()
+    content = message.content.strip()
+
+    if content == HANDSHAKE_MESSAGE:
+        ts = bot_handshakes.get(message.author.id)
+        if ts is None or (now - ts).total_seconds() > BOT_COOLDOWN_SECONDS:
+            bot_handshakes[message.author.id] = now
+            async with message.channel.typing():
+                await asyncio.sleep(random.uniform(1, 3))
+                await message.channel.send(HANDSHAKE_MESSAGE)
+            bot_reply_times[message.author.id] = now
+            last_bot_reply_time = now
+        return False
+
+    if message.author.id not in bot_handshakes:
+        return False
+
+    last = bot_reply_times.get(message.author.id)
+    if last and (now - last).total_seconds() < BOT_COOLDOWN_SECONDS:
+        return False
+
+    bot_reply_times[message.author.id] = now
+    return True
+
+
 async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
     """Monitor a channel and occasionally speak during idle periods."""
     await bot.wait_until_ready()
@@ -871,6 +916,9 @@ class SocialGraphBot(discord.Client):
             return
 
         if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:
+            return
+
+        if not await handle_bot_handshake(message):
             return
 
         now = discord.utils.utcnow()

--- a/tests/test_multi_bot_handshake.py
+++ b/tests/test_multi_bot_handshake.py
@@ -1,0 +1,71 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import examples.social_graph_bot as sg
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, content, *, reference=None, **kwargs):
+        self.sent.append(content)
+
+    def typing(self):
+        class DummyCtx:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyCtx()
+
+
+@pytest.mark.asyncio
+async def test_multi_bot_handshake(monkeypatch):
+    channel = DummyChannel()
+
+    sg.BOT_CHAT_ENABLED = True
+    sg.bot_handshakes.clear()
+    sg.bot_reply_times.clear()
+    sg.last_bot_reply_time = None
+
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def fake_now():
+        return now
+
+    monkeypatch.setattr(sg.discord.utils, "utcnow", fake_now)
+
+    async def fake_sleep(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(sg.random, "uniform", lambda a, b: 0)
+
+    author1 = SimpleNamespace(id=1, bot=True)
+    author2 = SimpleNamespace(id=2, bot=True)
+
+    msg = SimpleNamespace(channel=channel)
+
+    msg.author = author1
+    msg.content = sg.HANDSHAKE_MESSAGE
+    assert await sg.handle_bot_handshake(msg) is False
+
+    msg.author = author2
+    msg.content = sg.HANDSHAKE_MESSAGE
+    assert await sg.handle_bot_handshake(msg) is False
+
+    assert channel.sent == [sg.HANDSHAKE_MESSAGE, sg.HANDSHAKE_MESSAGE]
+
+    msg.author = author1
+    msg.content = "hello"
+    assert await sg.handle_bot_handshake(msg) is False
+
+    now += timedelta(seconds=sg.BOT_COOLDOWN_SECONDS + 1)
+
+    assert await sg.handle_bot_handshake(msg) is True


### PR DESCRIPTION
## Summary
- recognize `BOT_HANDSHAKE` messages and wait before responding to bots
- document bot handshake behavior in the README
- test multi-bot handshake interaction

## Testing
- `SKIP=pytest pre-commit run --files README.md examples/social_graph_bot.py tests/test_multi_bot_handshake.py`
- `pytest tests/test_multi_bot_handshake.py`


------
https://chatgpt.com/codex/tasks/task_e_6891393cbf7c8326b5ba420bb936e0f7