### PR TITLE
feat: publish intentions and log in core service

### DIFF
--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -84,14 +84,20 @@ class GoalScheduler:
         if self._db_manager is not None and scheduled.intention_id is not None:
             try:
                 loop = asyncio.get_running_loop()
-                loop.create_task(
-                    self._db_manager.mark_intention_done(scheduled.intention_id)
-                )
+                loop.create_task(self._db_manager.mark_intention_done(scheduled.intention_id))
             except RuntimeError:
-                asyncio.run(
-                    self._db_manager.mark_intention_done(scheduled.intention_id)
-                )
+                asyncio.run(self._db_manager.mark_intention_done(scheduled.intention_id))
         return BDIIntentionPayload(goal=scheduled.goal, priority=-scheduled.priority)
+
+    async def emit_next_intention(self, publisher: Publisher) -> bool:
+        """Publish the next intention using ``publisher``.
+
+        Returns ``True`` if an intention was published."""
+        intention = self.next_intention()
+        if intention is None:
+            return False
+        await publisher.publish(EventSubjects.BDI_INTENTION, intention, use_jetstream=True)
+        return True
 
     async def publish_intentions(self, publisher: Publisher) -> int:
         """Publish all queued goals as BDI intentions.
@@ -99,13 +105,7 @@ class GoalScheduler:
         Returns the number of published intentions.
         """
         count = 0
-        while self._heap:
-            intention = self.next_intention()
-            if intention is None:
-                break
-            await publisher.publish(
-                EventSubjects.BDI_INTENTION, intention, use_jetstream=True
-            )
+        while await self.emit_next_intention(publisher):
             count += 1
         return count
 

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -12,7 +12,7 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from ..config import Settings, get_settings
-from ..eda.events import EventSubjects, MemoryRetrievedPayload
+from ..eda.events import BDIIntentionPayload, EventSubjects, MemoryRetrievedPayload
 from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
@@ -59,9 +59,7 @@ class CognitiveCoreService(BaseService):
                     try:
                         search = OfflineSearch.create_index(db_path, [])
                     except ValueError:
-                        logger.warning(
-                            "No documents available for search index; disabling offline search"
-                        )
+                        logger.warning("No documents available for search index; disabling offline search")
                         search = None
                 else:
                     search = OfflineSearch(db_path)
@@ -136,13 +134,9 @@ class CognitiveCoreService(BaseService):
             try:
                 perception = analyze_social(user_input)
             except Exception as e:  # pragma: no cover - defensive
-                logger.error(
-                    "Failed to analyze social perception: %s", e, exc_info=True
-                )
+                logger.error("Failed to analyze social perception: %s", e, exc_info=True)
                 perception = {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0}
-            await self._db.store_memory(
-                "user", json.dumps(perception), topic="social_perception"
-            )
+            await self._db.store_memory("user", json.dumps(perception), topic="social_perception")
             delta = perception.get("flirtation", 0.0) - (
                 perception.get("avoidance", 0.0) + perception.get("manipulation", 0.0)
             )
@@ -201,9 +195,27 @@ class CognitiveCoreService(BaseService):
         finally:
             duration = time.perf_counter() - start
             INPUTS_TOTAL.labels(service="cognitive_core_service").inc()
-            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(
-                duration
-            )
+            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(duration)
+
+    async def _handle_intention(self, msg: Msg) -> None:
+        """React to BDI_INTENTION events by logging the goal."""
+        try:
+            payload = BDIIntentionPayload.from_json(msg.data.decode())
+            logger.info("CognitiveCoreService received intention goal: %s", payload.goal)
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("Failed to handle BDI_INTENTION", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
 
     async def start(self, durable_name: str = "cognitive_core_listener") -> bool:
         self._subscriptions.clear()
@@ -213,11 +225,15 @@ class CognitiveCoreService(BaseService):
             use_jetstream=True,
             durable=durable_name,
         )
+        self.add_subscription(
+            subject=EventSubjects.BDI_INTENTION,
+            handler=self._handle_intention,
+            use_jetstream=True,
+            durable=f"{durable_name}_bdi",
+        )
         started = await super().start()
         if started:
-            logger.info(
-                "CognitiveCoreService subscribed to %s", EventSubjects.INPUT_RECEIVED
-            )
+            logger.info("CognitiveCoreService subscribed to %s", EventSubjects.INPUT_RECEIVED)
         return started
 
     async def stop(self) -> None:

--- a/tests/integration/test_intention_to_core.py
+++ b/tests/integration/test_intention_to_core.py
@@ -1,0 +1,66 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("nats")
+
+pytest_plugins = ["tests.helpers"]
+
+from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+
+from deepthought.eda.publisher import connect
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.services.cognitive_core_service import CognitiveCoreService
+
+pytestmark = pytest.mark.nats
+
+STREAM_NAME = "deepthought_events"
+
+
+class _DummyDB:
+    async def close(self) -> None:  # pragma: no cover - simple stub
+        return None
+
+
+@pytest.mark.asyncio
+async def test_intention_reaches_cognitive_core(nats_server, caplog):
+    publisher = await connect(nats_server)
+    nc = publisher._nc
+    js = publisher._js
+
+    try:
+        await js.stream_info(STREAM_NAME)
+    except Exception:
+        config = StreamConfig(
+            name=STREAM_NAME,
+            subjects=["dtr.>"],
+            retention=RetentionPolicy.LIMITS,
+            storage=StorageType.MEMORY,
+            max_msgs_per_subject=100,
+            discard=DiscardPolicy.OLD,
+        )
+        await js.add_stream(config)
+
+    service = CognitiveCoreService(
+        nats_client=nc,
+        js_context=js,
+        memory=SimpleNamespace(),
+        db=_DummyDB(),
+        search=None,
+    )
+    await service.start()
+
+    sched = GoalScheduler()
+    sched.add_goal("integration-goal", priority=1)
+
+    with caplog.at_level(logging.INFO):
+        await sched.publish_intentions(publisher)
+        await asyncio.sleep(0.5)
+
+    await service.stop()
+    if nc.is_connected:
+        await nc.close()
+
+    assert any("integration-goal" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- allow `GoalScheduler` to emit individual BDI intention events
- log BDI_INTENTION goals in `CognitiveCoreService`
- add integration test ensuring intentions reach cognitive core

## Testing
- `SKIP=pytest pre-commit run --all-files`
- `SKIP=pytest pre-commit run --files src/deepthought/goal_scheduler.py src/deepthought/services/cognitive_core_service.py tests/integration/test_intention_to_core.py`
- `pytest tests/integration/test_intention_to_core.py`

------
https://chatgpt.com/codex/tasks/task_e_6891393e0ac88326bfcd6158b1f2981e