### PR TITLE
Support sub-goal expansion and persistence

### DIFF
--- a/src/deepthought/goal_scheduler.py
+++ b/src/deepthought/goal_scheduler.py
@@ -17,6 +17,7 @@ class ScheduledGoal:
     priority: int
     goal: str = field(compare=False)
     intention_id: Optional[int] = field(default=None, compare=False)
+    sub_goals: List[str] = field(default_factory=list, compare=False)
 
 
 from .services.db_manager import DBManager
@@ -49,17 +50,42 @@ class GoalScheduler:
             await self._load_task
             self._load_task = None
 
-    def add_goal(self, goal: str, priority: int) -> None:
+    def add_goal(self, goal: str, priority: int, sub_goals: Optional[List[str]] = None) -> None:
         """Schedule ``goal`` with ``priority`` (higher runs first)."""
-        heapq.heappush(self._heap, ScheduledGoal(-priority, goal))
+        heapq.heappush(
+            self._heap,
+            ScheduledGoal(-priority, goal, None, list(sub_goals or [])),
+        )
 
-    async def queue_intention(self, goal: str, priority: int) -> int | None:
+    async def queue_intention(self, goal: str, priority: int, sub_goals: Optional[List[str]] = None) -> int | None:
         """Schedule and persist an intention."""
         intention_id: int | None = None
         if self._db_manager is not None:
             intention_id = await self._db_manager.add_intention(goal, priority)
-        heapq.heappush(self._heap, ScheduledGoal(-priority, goal, intention_id))
+        heapq.heappush(
+            self._heap,
+            ScheduledGoal(-priority, goal, intention_id, list(sub_goals or [])),
+        )
         return intention_id
+
+    async def queue_sub_goals(self, sub_goals: List[str], priority: int) -> List[int | None]:
+        """Persist and enqueue each ``sub_goals`` with ``priority``."""
+        ids: List[int | None] = []
+        for sub in sub_goals:
+            ids.append(await self.queue_intention(sub, priority))
+        return ids
+
+    async def expand_goal(self, goal: str, priority: int | None = None) -> List[int | None]:
+        """Expand a queued goal into its sub-goals."""
+        for idx, scheduled in enumerate(self._heap):
+            if scheduled.goal == goal:
+                self._heap.pop(idx)
+                heapq.heapify(self._heap)
+                if self._db_manager is not None and scheduled.intention_id is not None:
+                    await self._db_manager.mark_intention_done(scheduled.intention_id)
+                prio = priority if priority is not None else -scheduled.priority
+                return await self.queue_sub_goals(scheduled.sub_goals, prio)
+        return []
 
     async def load_pending_intentions(self) -> int:
         """Load pending intentions from the database into the queue."""

--- a/src/deepthought/services/planning_service.py
+++ b/src/deepthought/services/planning_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 from typing import List, Optional
 
@@ -15,6 +16,7 @@ from ..eda.events import (
     PlanGeneratedPayload,
     PlanRequestedPayload,
 )
+from ..goal_scheduler import GoalScheduler
 from ..planning import L2PTranslator, plan
 from .base import BaseService
 
@@ -54,15 +56,11 @@ class PlanningService(BaseService):
             ds = data.get("desires", [])
             if isinstance(ds, list):
                 self._desires = [str(d) for d in ds]
-            logger.info(
-                "Loaded %d desires from %s", len(self._desires), self._desires_file
-            )
+            logger.info("Loaded %d desires from %s", len(self._desires), self._desires_file)
         except FileNotFoundError:
             logger.warning("Desires file %s not found", self._desires_file)
         except Exception:  # pragma: no cover - defensive
-            logger.error(
-                "Failed to load desires file %s", self._desires_file, exc_info=True
-            )
+            logger.error("Failed to load desires file %s", self._desires_file, exc_info=True)
 
     async def _handle_memory(self, msg: Msg) -> None:
         try:
@@ -124,6 +122,31 @@ class PlanningService(BaseService):
                 use_jetstream=True,
                 timeout=10.0,
             )
+
+    async def expand_goal(self, goal: str, scheduler: GoalScheduler, priority: int = 1) -> List[str]:
+        """Expand a reflection or directive ``goal`` into sub-goals.
+
+        The ``goal`` text is split on newlines or semi-colons after removing any
+        leading "reflect" or "directive" prefixes. Each resulting sub-goal is
+        queued via ``scheduler`` and persisted using the existing intentions
+        table.
+        """
+        if not goal:
+            return []
+
+        text = goal
+        lower = goal.lower()
+        if lower.startswith("reflect") or lower.startswith("directive"):
+            parts = goal.split(":", 1)
+            if len(parts) == 2:
+                text = parts[1]
+
+        pieces = [p.strip(" -*") for p in re.split(r"[\n;]", text) if p.strip()]
+        if not pieces:
+            return []
+
+        await scheduler.queue_sub_goals(pieces, priority)
+        return pieces
 
     async def start(self, durable_name: str = "planning_service") -> bool:
         self._subscriptions.clear()

--- a/tests/test_goal_scheduler_expand.py
+++ b/tests/test_goal_scheduler_expand.py
@@ -1,0 +1,25 @@
+import pytest
+
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.services.db_manager import DBManager
+
+
+@pytest.mark.asyncio
+async def test_expand_goal_persists_sub_goals(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+
+    sched = GoalScheduler(manager)
+    sched.add_goal("parent", priority=1, sub_goals=["a", "b"])
+    ids = await sched.expand_goal("parent")
+    assert len(ids) == 2
+
+    await manager.close()
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+    sched2 = GoalScheduler(manager)
+    loaded = await sched2.load_pending_intentions()
+    assert loaded == 2
+    assert sched2.next_goal() == "a"
+    assert sched2.next_goal() == "b"

--- a/tests/unit/services/test_planning_service.py
+++ b/tests/unit/services/test_planning_service.py
@@ -71,14 +71,10 @@ torch_mod.no_grad = lambda: types.SimpleNamespace(
 torch_mod.softmax = lambda t, dim=-1: t
 sys.modules.setdefault("torch", torch_mod)
 tb_mod = types.ModuleType("textblob")
-tb_mod.TextBlob = lambda text: types.SimpleNamespace(
-    sentiment=types.SimpleNamespace(polarity=0.0)
-)
+tb_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0))
 sys.modules.setdefault("textblob", tb_mod)
 tf_mod = types.ModuleType("transformers")
-tf_mod.AutoTokenizer = type(
-    "AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())}
-)
+tf_mod.AutoTokenizer = type("AutoTokenizer", (), {"from_pretrained": classmethod(lambda cls, p: cls())})
 tf_mod.AutoModelForSequenceClassification = type(
     "AutoModelForSequenceClassification",
     (),
@@ -119,6 +115,8 @@ from deepthought.eda.events import (
     PlanGeneratedPayload,
     PlanRequestedPayload,
 )
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.services.db_manager import DBManager
 from deepthought.services.planning_service import PlanningService
 
 
@@ -159,9 +157,7 @@ async def test_memory_triggers_plan(tmp_path):
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
-    payload = MemoryRetrievedPayload(
-        retrieved_knowledge={"facts": ["hi"]}, input_id="x"
-    )
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["hi"]}, input_id="x")
     msg = DummyMsg(payload.to_json())
     await service._handle_memory(msg)
 
@@ -232,9 +228,7 @@ async def test_planning_service_event_flow(monkeypatch, tmp_path):
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
-    mem_payload = MemoryRetrievedPayload(
-        retrieved_knowledge={"facts": ["f"]}, input_id="1"
-    )
+    mem_payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f"]}, input_id="1")
     await service._handle_memory(DummyMsg(mem_payload.to_json()))
     assert service._publisher.published
     subj, plan_req = service._publisher.published[-1]
@@ -247,3 +241,27 @@ async def test_planning_service_event_flow(monkeypatch, tmp_path):
     await service._handle_plan(DummyMsg(plan_gen.to_json()))
     subjects = [s for s, _ in service._publisher.published[-2:]]
     assert subjects == [EventSubjects.CHAT_RAW, EventSubjects.CHAT_RAW]
+
+
+@pytest.mark.asyncio
+async def test_expand_goal_persists(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+    scheduler = GoalScheduler(manager)
+    service = PlanningService(None, None)
+
+    goal = "Reflect: do this; do that"
+    parts = await service.expand_goal(goal, scheduler, priority=2)
+    assert parts == ["do this", "do that"]
+
+    await manager.close()
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+    scheduler2 = GoalScheduler(manager)
+    loaded = await scheduler2.load_pending_intentions()
+    assert loaded == 2
+    first = scheduler2.next_intention()
+    second = scheduler2.next_intention()
+    assert {first.goal, second.goal} == {"do this", "do that"}
+    assert first.priority == 2 and second.priority == 2


### PR DESCRIPTION
## Summary
- allow ScheduledGoal to track sub-goals and added helpers to persist and expand them
- planning service can expand reflections/directives into stored sub-goals via the goal scheduler
- add tests for goal expansion and persistence

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/goal_scheduler.py src/deepthought/services/planning_service.py tests/unit/services/test_planning_service.py tests/test_goal_scheduler_expand.py`
- `pre-commit run --files tests/test_goal_scheduler_expand.py`
- `pytest tests/test_goal_scheduler_expand.py tests/unit/services/test_planning_service.py::test_expand_goal_persists -q`


------
https://chatgpt.com/codex/tasks/task_e_68920385e54c8326b94e89779f19af21