### PR TITLE
feat: track relationship status

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -104,6 +104,14 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS relationship_types (
+            user_a TEXT,
+            user_b TEXT,
+            status TEXT,
+            PRIMARY KEY(user_a, user_b)
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS interaction_decay (
             id INTEGER PRIMARY KEY CHECK(id=1),
             weight_decay REAL DEFAULT 1.0,
@@ -924,6 +932,31 @@ class DBManager:
             elapsed = (datetime.utcnow() - last_dt).total_seconds()
             weight = float(weight) * (w_decay**elapsed)
         return float(weight)
+
+    async def set_relationship_type(self, user_a: int, user_b: int, status: str) -> None:
+        await self.connect()
+        assert self._db
+        a, b = sorted((str(user_a), str(user_b)))
+        await self._db.execute(
+            """
+            INSERT INTO relationship_types (user_a, user_b, status)
+            VALUES (?, ?, ?)
+            ON CONFLICT(user_a, user_b) DO UPDATE SET status=excluded.status
+            """,
+            (a, b, status),
+        )
+        await self._db.commit()
+
+    async def get_relationship_type(self, user_a: int, user_b: int) -> str | None:
+        await self.connect()
+        assert self._db
+        a, b = sorted((str(user_a), str(user_b)))
+        async with self._db.execute(
+            "SELECT status FROM relationship_types WHERE user_a=? AND user_b=?",
+            (a, b),
+        ) as cur:
+            row = await cur.fetchone()
+        return row[0] if row else None
 
     async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
         if not isinstance(theme, str) or not theme.strip():

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -11,6 +11,10 @@ from .db_manager import DBManager
 
 logger = logging.getLogger(__name__)
 
+FRIEND_THRESHOLD = 0.5
+RIVAL_THRESHOLD = -0.5
+MIN_INTERACTIONS = 3
+
 
 class SocialGraphMemory:
     """Record messages and sentiment using a :class:`DBManager` backend."""
@@ -26,6 +30,8 @@ class SocialGraphMemory:
             logger.exception("Sentiment analysis failed")
             score = 0.0
         await self._db.log_interaction(source, target, sentiment_score=score)
+        if target is not None:
+            await self._update_relationship_type(source, target)
 
     async def get_affinity(self, user_id: str) -> int:
         return await self._db.get_affinity(user_id)
@@ -72,6 +78,23 @@ class SocialGraphMemory:
             "b_to_a": stats_b,
             "mutual_affinity": int(mutual),
         }
+
+    async def _update_relationship_type(self, user_a: str, user_b: str) -> None:
+        ab = await self._db.get_relationship(user_a, user_b) or (0, 0.0, 0.0, None)
+        ba = await self._db.get_relationship(user_b, user_a) or (0, 0.0, 0.0, None)
+        total_count = int(ab[0] or 0) + int(ba[0] or 0)
+        total_sentiment = float(ab[1] or 0.0) + float(ba[1] or 0.0)
+        status = "neutral"
+        if total_count >= MIN_INTERACTIONS and total_count:
+            avg = total_sentiment / total_count
+            if avg >= FRIEND_THRESHOLD:
+                status = "friend"
+            elif avg <= RIVAL_THRESHOLD:
+                status = "rival"
+        await self._db.set_relationship_type(user_a, user_b, status)
+
+    async def get_relationship_status(self, user_a: str, user_b: str) -> str | None:
+        return await self._db.get_relationship_type(user_a, user_b)
 
     async def close(self) -> None:
         await self._db.close()

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -75,3 +75,29 @@ async def test_relationship_stats(tmp_path):
     assert stats["a_to_b"]["interaction_weight"] == pytest.approx(1.0)
     assert stats["b_to_a"]["interaction_weight"] == pytest.approx(1.0)
     assert stats["a_to_b"]["last_interaction"] is not None
+
+
+@pytest.mark.asyncio
+async def test_relationship_type_computation(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+
+    for _ in range(3):
+        await mem.record_message("alice", "I love you", "bob")
+
+    status = await mem.get_relationship_status("alice", "bob")
+    assert status == "friend"
+
+    for _ in range(3):
+        await mem.record_message("eve", "I hate you", "mallory")
+
+    status = await mem.get_relationship_status("eve", "mallory")
+    assert status == "rival"
+
+    async with aiosqlite.connect(str(db_path)) as db:
+        async with db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='relationship_types'"
+        ) as cur:
+            assert await cur.fetchone() is not None
+
+    await mem.close()


### PR DESCRIPTION
## Summary
- track high level relationship status
- compute friend or rival from interaction sentiment
- verify relationship type storage and retrieval

## Testing
- `flake8 src/deepthought/services/db_manager.py src/deepthought/services/social_graph_memory.py tests/test_relationships.py`
- `pytest tests/test_relationships.py tests/test_relationship_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689202fb6fd08326929991994852b80f