### PR TITLE
feat: handle thought channel commands

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -713,6 +713,33 @@ async def process_intentions(bot: "SocialGraphBot") -> None:
             break
 
 
+async def process_thought_commands(bot: "SocialGraphBot") -> None:
+    """Listen for user commands in the thought channel without responding."""
+    if THOUGHT_CHANNEL_ID is None:
+        return
+    await bot.wait_until_ready()
+    check = (
+        lambda m: m.channel.id == THOUGHT_CHANNEL_ID and not getattr(m.author, "bot", False) and m.author != bot.user
+    )
+    while not bot.is_closed():
+        try:
+            message = await bot.wait_for("message", check=check)
+            content = message.content.strip()
+            if content.startswith("/goal"):
+                goal = content.removeprefix("/goal").strip()
+                if goal:
+                    await bot.goal_scheduler.queue_intention(goal, priority=1)
+            elif content.startswith("/memory"):
+                mem = content.removeprefix("/memory").strip()
+                if mem:
+                    await store_memory(message.author.id, mem)
+        except asyncio.CancelledError:
+            logger.info("process_thought_commands cancelled")
+            break
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("Error processing thought command")
+
+
 def evaluate_triggers(message: discord.Message) -> List[Tuple[str, float]]:
     """Return a list of (theory, confidence) pairs inferred from a message."""
     theories: List[Tuple[str, float]] = []
@@ -905,6 +932,8 @@ class SocialGraphBot(discord.Client):
         self._bg_tasks.append(self.loop.create_task(process_deep_reflections(self)))
         self._bg_tasks.append(self.loop.create_task(process_goals(self)))
         self._bg_tasks.append(self.loop.create_task(process_intentions(self)))
+        if THOUGHT_CHANNEL_ID is not None:
+            self._bg_tasks.append(self.loop.create_task(process_thought_commands(self)))
 
     async def on_ready(self) -> None:
         """Log basic information once the bot connects."""
@@ -913,6 +942,9 @@ class SocialGraphBot(discord.Client):
     async def on_message(self, message: discord.Message) -> None:
         global last_bot_reply_time
         if message.author == self.user:
+            return
+
+        if THOUGHT_CHANNEL_ID is not None and message.channel.id == THOUGHT_CHANNEL_ID:
             return
 
         if any(getattr(m, "bot", False) for m in message.mentions) and self.user not in message.mentions:

--- a/tests/unit/test_thought_logging.py
+++ b/tests/unit/test_thought_logging.py
@@ -1,7 +1,6 @@
 import asyncio
-import logging
-
 import importlib
+import logging
 import os
 import sys
 import types
@@ -77,3 +76,78 @@ async def test_send_thought_missing_channel(monkeypatch, caplog):
     monkeypatch.setattr(sg, "THOUGHT_CHANNEL_ID", 999)
     bot = DummyBot(channel=None)
     await sg._send_thought(bot, "hi")
+
+
+@pytest.mark.asyncio
+async def test_process_thought_commands_goal(monkeypatch):
+    monkeypatch.setattr(sg, "THOUGHT_CHANNEL_ID", 42)
+
+    queued: list[tuple[str, int]] = []
+
+    class Bot(DummyBot):
+        def __init__(self):
+            super().__init__()
+            self.goal_scheduler = types.SimpleNamespace(
+                queue_intention=lambda goal, priority: queued.append((goal, priority))
+            )
+            self.user = types.SimpleNamespace(id=1)
+            self._closed = False
+
+        async def wait_until_ready(self):
+            return None
+
+        def is_closed(self):
+            return self._closed
+
+        async def wait_for(self, event, check):
+            msg = types.SimpleNamespace(
+                content="/goal test",
+                channel=types.SimpleNamespace(id=42),
+                author=types.SimpleNamespace(bot=False, id=2),
+            )
+            assert check(msg)
+            self._closed = True
+            return msg
+
+    bot = Bot()
+    await sg.process_thought_commands(bot)
+    assert queued == [("test", 1)]
+
+
+@pytest.mark.asyncio
+async def test_process_thought_commands_memory(monkeypatch):
+    monkeypatch.setattr(sg, "THOUGHT_CHANNEL_ID", 99)
+
+    stored: list[tuple[int, str]] = []
+
+    async def fake_store(uid, mem, *_, **__):
+        stored.append((uid, mem))
+
+    monkeypatch.setattr(sg, "store_memory", fake_store)
+
+    class Bot(DummyBot):
+        def __init__(self):
+            super().__init__()
+            self.goal_scheduler = types.SimpleNamespace(queue_intention=lambda *a, **k: None)
+            self.user = types.SimpleNamespace(id=1)
+            self._closed = False
+
+        async def wait_until_ready(self):
+            return None
+
+        def is_closed(self):
+            return self._closed
+
+        async def wait_for(self, event, check):
+            msg = types.SimpleNamespace(
+                content="/memory remember this",
+                channel=types.SimpleNamespace(id=99),
+                author=types.SimpleNamespace(bot=False, id=5),
+            )
+            assert check(msg)
+            self._closed = True
+            return msg
+
+    bot = Bot()
+    await sg.process_thought_commands(bot)
+    assert stored == [(5, "remember this")]


### PR DESCRIPTION
## Summary
- add background task to process `/goal` and `/memory` commands in thought channel
- ignore thought channel in main message handler
- cover new command handling with unit tests

## Testing
- `SKIP=pytest pre-commit run --files examples/social_graph_bot.py tests/unit/test_thought_logging.py`
- `pytest tests/unit/test_thought_logging.py`


------
https://chatgpt.com/codex/tasks/task_e_689242c867f48326b63164477f0e98ec