### PR TITLE
Add relationship status inference tests

### DIFF
--- a/tests/test_relationship_inference.py
+++ b/tests/test_relationship_inference.py
@@ -1,0 +1,38 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services import DBManager
+from deepthought.services.social_graph_memory import SocialGraphMemory
+
+
+@pytest.mark.asyncio
+async def test_friendship_status(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+
+    for text in ["You are awesome", "Great job", "I love you"]:
+        await mem.record_message("alice", text, "bob")
+
+    await mem.close()
+
+    mem2 = SocialGraphMemory(DBManager(str(db_path)))
+    status = await mem2.get_relationship_status("alice", "bob")
+    assert status == "friend"
+    await mem2.close()
+
+
+@pytest.mark.asyncio
+async def test_hostility_status(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+
+    for text in ["You are terrible", "Awful job", "I hate you"]:
+        await mem.record_message("alice", text, "bob")
+
+    await mem.close()
+
+    mem2 = SocialGraphMemory(DBManager(str(db_path)))
+    status = await mem2.get_relationship_status("alice", "bob")
+    assert status == "rival"
+    await mem2.close()


### PR DESCRIPTION
## Summary
- test friendship inference after positive messages
- test hostility inference after negative messages

## Testing
- `flake8 tests/test_relationship_inference.py`
- `PYTHONPATH=src pytest tests/test_relationship_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894a7c4c1c88326885b5da2519f996f