### PR TITLE
feat: honor other bot cooldown

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -236,6 +236,7 @@ AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
 USER_REPLY_RATE_SECONDS = float(os.getenv("USER_REPLY_RATE_SECONDS", "3"))
 BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
+OTHER_BOT_COOLDOWN_SECONDS = int(os.getenv("OTHER_BOT_COOLDOWN_SECONDS", "10"))
 BOT_MESSAGE_INTERVAL_SECONDS = int(os.getenv("BOT_MESSAGE_INTERVAL_SECONDS", "60"))
 MAX_BOT_MESSAGES_PER_INTERVAL = int(os.getenv("MAX_BOT_MESSAGES_PER_INTERVAL", "5"))
 MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
@@ -345,6 +346,7 @@ bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
 last_bot_reply_time: datetime.datetime | None = None
 bot_message_times: dict[int, deque[datetime.datetime]] = {}
 our_message_times: deque[datetime.datetime] = deque()
+last_other_bot_message_time: datetime.datetime | None = None
 
 # Track handshake completions and per-bot cooldowns
 bot_handshakes: dict[int, datetime.datetime] = {}
@@ -792,9 +794,12 @@ class SocialGraphBot(discord.Client):
         logger.info("Logged in as %s (%s)", self.user.name, self.user.id)
 
     async def on_message(self, message: discord.Message) -> None:
-        global last_bot_reply_time
+        global last_bot_reply_time, last_other_bot_message_time
         if message.author == self.user:
             return
+
+        if getattr(message.author, "bot", False):
+            last_other_bot_message_time = message.created_at.replace(tzinfo=timezone.utc)
 
         if THOUGHT_CHANNEL_ID is not None and message.channel.id == THOUGHT_CHANNEL_ID:
             return
@@ -806,6 +811,13 @@ class SocialGraphBot(discord.Client):
             return
 
         now = discord.utils.utcnow()
+        if not message.author.bot:
+            if (
+                last_other_bot_message_time
+                and (now - last_other_bot_message_time).total_seconds() < OTHER_BOT_COOLDOWN_SECONDS
+            ):
+                return
+
         if message.author.bot:
             q = bot_message_times.setdefault(message.author.id, deque())
             q.append(now)
@@ -910,11 +922,10 @@ class SocialGraphBot(discord.Client):
             return
 
         async with message.channel.typing():
+            start_time = discord.utils.utcnow()
             await asyncio.sleep(random.uniform(1, 3))
-            if hasattr(message.channel, "history"):
-                async for recent in message.channel.history(limit=1):
-                    if recent.id != message.id and getattr(recent.author, "bot", False):
-                        return
+            if last_other_bot_message_time and last_other_bot_message_time > start_time:
+                return
             if bullying and not await is_do_not_mock(message.author.id):
                 reply = BULLYING_RESPONSE
             elif social_scores.get("flirtation", 0) > 0.5:

--- a/tests/test_other_bot_cooldown.py
+++ b/tests/test_other_bot_cooldown.py
@@ -1,0 +1,123 @@
+import asyncio
+import importlib
+import os
+import random
+import sys
+import types
+
+import pytest
+
+pytest.importorskip("discord")
+pytest.importorskip("nats")
+
+
+def reload_sg(monkeypatch):
+    monkeypatch.setitem(os.environ, "OTHER_BOT_COOLDOWN_SECONDS", "60")
+    sys.modules.setdefault("pydantic", types.ModuleType("pydantic"))
+    sys.modules.setdefault("pydantic_settings", types.ModuleType("pydantic_settings"))
+    sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
+    tb_mod = types.ModuleType("textblob")
+    tb_mod.TextBlob = lambda text: types.SimpleNamespace(
+        sentiment=types.SimpleNamespace(polarity=0.0),
+    )
+    sys.modules.setdefault("textblob", tb_mod)
+    rdf_mod = types.ModuleType("rdflib")
+    rdf_mod.Namespace = lambda *a, **k: None
+    rdf_mod.Graph = object
+    rdf_mod.URIRef = str
+    ns_mod = types.ModuleType("rdflib.namespace")
+    ns_mod.RDF = types.SimpleNamespace(type="rdf:type")
+    sys.modules.setdefault("rdflib", rdf_mod)
+    sys.modules.setdefault("rdflib.namespace", ns_mod)
+    py_mod = types.ModuleType("pyperplan")
+    py_mod.pddl = types.ModuleType("pyperplan.pddl")
+    parser_mod = types.ModuleType("pyperplan.pddl.parser")
+    parser_mod.Parser = object
+    py_mod.planner = types.ModuleType("pyperplan.planner")
+    py_mod.planner._ground = lambda p: p
+    py_mod.search = types.ModuleType("pyperplan.search")
+    py_mod.search.breadth_first_search = lambda t: []
+    py_mod.pddl.parser = parser_mod
+    sys.modules.setdefault("pyperplan", py_mod)
+    sys.modules.setdefault("pyperplan.pddl", py_mod.pddl)
+    sys.modules.setdefault("pyperplan.pddl.parser", parser_mod)
+    sys.modules.setdefault("pyperplan.planner", py_mod.planner)
+    sys.modules.setdefault("pyperplan.search", py_mod.search)
+    sys.modules.pop("examples.social_graph_bot", None)
+    return importlib.import_module("examples.social_graph_bot")
+
+
+class DummyAuthor:
+    def __init__(self, user_id, bot=False):
+        self.id = user_id
+        self.bot = bot
+
+
+class DummyChannel:
+    def __init__(self, channel_id=1):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content, reference=None):
+        self.sent_messages.append(content)
+
+    def history(self, limit=1):
+        async def _gen():
+            if False:
+                yield
+
+        return _gen()
+
+    def typing(self):
+        class DummyContext:
+            async def __aenter__(self):
+                return None
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return DummyContext()
+
+
+class DummyMessage:
+    def __init__(self, content, author_id=2, message_id=10, is_bot=False):
+        from discord.utils import utcnow
+
+        self.content = content
+        self.author = DummyAuthor(author_id, bot=is_bot)
+        self.channel = DummyChannel()
+        self.id = message_id
+        self.created_at = utcnow()
+        self.mentions = []
+
+
+@pytest.mark.asyncio
+async def test_other_bot_cooldown(monkeypatch, tmp_path):
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    sg.last_other_bot_message_time = sg.discord.utils.utcnow()
+
+    message = DummyMessage("hi", author_id=5, is_bot=False)
+    await bot.on_message(message)
+
+    assert message.channel.sent_messages == []
+    await sg.db_manager.close()
+


### PR DESCRIPTION
## Summary
- avoid manual history scans by tracking other bot timestamps
- add configurable cooldown before replying after another bot
- test that bot remains silent when another bot spoke recently

## Testing
- `flake8 examples/social_graph_bot.py tests/test_other_bot_cooldown.py`
- `pytest tests/test_other_bot_cooldown.py tests/test_multi_bot_etiquette.py tests/test_multi_bot_silence.py tests/test_bot_cooldown.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6894bdcc75548326be4fc4eae68749ce