### PR TITLE
Add user profiles for personality traits

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -181,6 +181,12 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS user_profiles (
+            user_id TEXT PRIMARY KEY,
+            traits TEXT
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS recent_topics (
             topic TEXT PRIMARY KEY,
             last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -750,6 +756,35 @@ class DBManager:
         ) as cur:
             row = await cur.fetchone()
             return bool(row[0]) if row else False
+
+    async def set_user_profile(self, user_id: int, traits: dict | list | str) -> None:
+        await self.connect()
+        assert self._db
+        data = json.dumps(traits) if not isinstance(traits, str) else traits
+        await self._db.execute(
+            """
+            INSERT INTO user_profiles (user_id, traits)
+            VALUES (?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET traits=excluded.traits
+            """,
+            (str(user_id), data),
+        )
+        await self._db.commit()
+
+    async def get_user_profile(self, user_id: int) -> dict | list | str | None:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT traits FROM user_profiles WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        try:
+            return json.loads(row[0])
+        except Exception:
+            return row[0]
 
     def _affinity_delta(self, value: float) -> int:
         if -1 <= float(value) <= 1:

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -45,6 +45,12 @@ class SocialGraphMemory:
     async def get_mutual_affinity(self, user_a: str, user_b: str) -> float:
         return await self._db.get_pair_mutual_affinity(user_a, user_b)
 
+    async def set_personality(self, user_id: str, traits) -> None:
+        await self._db.set_user_profile(user_id, traits)
+
+    async def get_personality(self, user_id: str):
+        return await self._db.get_user_profile(user_id)
+
     async def get_relationship_stats(self, user_a: str, user_b: str) -> dict:
         """Return a summary of interactions and sentiment between two users."""
         ab = await self._db.get_relationship(user_a, user_b)
@@ -98,4 +104,3 @@ class SocialGraphMemory:
 
     async def close(self) -> None:
         await self._db.close()
-

--- a/tests/test_db_manager_init.py
+++ b/tests/test_db_manager_init.py
@@ -21,6 +21,7 @@ TABLES = [
     "sentiment_trends",
     "themes",
     "user_flags",
+    "user_profiles",
     "recent_topics",
     "emotions",
     "manipulations",

--- a/tests/test_user_profiles.py
+++ b/tests/test_user_profiles.py
@@ -1,0 +1,22 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services import DBManager
+from deepthought.services.social_graph_memory import SocialGraphMemory
+
+
+@pytest.mark.asyncio
+async def test_user_profile_persistence(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+
+    traits = {"openness": 0.7, "tags": ["curious", "analytical"]}
+    await mem.set_personality("alice", traits)
+
+    # Ensure data persists after reopening the database
+    await mem.close()
+    mem2 = SocialGraphMemory(DBManager(str(db_path)))
+    stored = await mem2.get_personality("alice")
+    assert stored == traits
+    await mem2.close()


### PR DESCRIPTION
## Summary
- add `user_profiles` table for storing personality tags
- support persisting and retrieving personality via `SocialGraphMemory`
- test user profile persistence and DB initialization

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/db_manager.py src/deepthought/services/social_graph_memory.py tests/test_db_manager_init.py tests/test_user_profiles.py`
- `pytest tests/test_relationship_inference.py tests/test_relationship_persistence.py tests/test_db_manager_init.py tests/test_user_profiles.py`


------
https://chatgpt.com/codex/tasks/task_e_6894bdcae68c832694d1f4ba44b9ae58