### PR TITLE
Add engagement policy service for reply mode decisions

### DIFF
--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -2,6 +2,7 @@
 
 from .cognitive_core_service import CognitiveCoreService
 from .db_manager import DBManager
+from .engagement_policy import EngagementPolicy, should_reply
 from .file_graph_dal import FileGraphDAL
 from .manipulative_detection import manipulation_score
 from .persona_manager import PersonaManager
@@ -16,6 +17,8 @@ __all__ = [
     "PersonaManager",
     "DBManager",
     "TrustService",
+    "EngagementPolicy",
+    "should_reply",
     "SocialGraphService",
     "PlanningService",
     "ReasoningService",

--- a/src/deepthought/services/engagement_policy.py
+++ b/src/deepthought/services/engagement_policy.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Dict, Optional
+
+from .trust_service import TrustService
+
+
+class EngagementPolicy:
+    """Determine reply strategy based on trust and activity signals.
+
+    The policy examines a user's trust score, recent reply history and recent
+    bot activity to choose between three response modes: ``"silent"`` (no
+    reply), ``"minimal"`` (acknowledgement only) and ``"full"`` (complete
+    response).
+
+    Configuration options
+    ---------------------
+    full_threshold:
+        Minimum trust score required for a full response.
+    minimal_threshold:
+        Minimum trust score required for any response. Scores below this value
+        result in ``"silent"``.
+    cooldown_seconds:
+        Number of seconds that must elapse between replies to the same user.
+    bot_cooldown:
+        Seconds to wait after detecting a message from another bot before
+        responding. Helps prevent bot-to-bot chatter.
+    """
+
+    def __init__(
+        self,
+        trust_service: TrustService | None = None,
+        *,
+        full_threshold: float = 0.0,
+        minimal_threshold: float = -5.0,
+        cooldown_seconds: float = 0.0,
+        bot_cooldown: float = 0.0,
+    ) -> None:
+        self._trust_service = trust_service
+        self.full_threshold = float(full_threshold)
+        self.minimal_threshold = float(minimal_threshold)
+        self.cooldown = max(float(cooldown_seconds), 0.0)
+        self.bot_cooldown = max(float(bot_cooldown), 0.0)
+        self._last_reply: Dict[str | int, datetime] = {}
+        self._last_bot_message: Optional[datetime] = None
+
+    async def response_mode(self, message) -> str:
+        """Return the appropriate response mode for ``message``."""
+
+        now = datetime.now(UTC)
+        author = getattr(message, "author", None)
+        user_id = getattr(author, "id", None)
+        is_bot = bool(getattr(author, "bot", False))
+
+        if is_bot:
+            self._last_bot_message = now
+            return "silent"
+
+        if self._last_bot_message and (now - self._last_bot_message).total_seconds() < self.bot_cooldown:
+            return "silent"
+
+        if user_id is not None and self.cooldown > 0:
+            last = self._last_reply.get(user_id)
+            if last and (now - last).total_seconds() < self.cooldown:
+                return "silent"
+
+        trust = 0.0
+        if self._trust_service and user_id is not None:
+            try:
+                trust = await self._trust_service.get_trust(user_id)
+            except Exception:
+                trust = 0.0
+
+        if trust < self.minimal_threshold:
+            mode = "silent"
+        elif trust < self.full_threshold:
+            mode = "minimal"
+        else:
+            mode = "full"
+
+        if mode != "silent" and user_id is not None:
+            self._last_reply[user_id] = now
+        return mode
+
+    async def should_reply(self, message) -> bool:
+        """Return ``True`` if ``message`` warrants a reply."""
+
+        return (await self.response_mode(message)) != "silent"
+
+
+_default_policy: EngagementPolicy | None = None
+
+
+async def should_reply(message) -> bool:
+    """Convenience wrapper using a default :class:`EngagementPolicy`."""
+
+    global _default_policy
+    if _default_policy is None:
+        _default_policy = EngagementPolicy()
+    return await _default_policy.should_reply(message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,7 @@ if "l2p" not in sys.modules:
     def _parse_problem(*args, **kwargs):
         return {}
 
-    l2p_stub.utils = types.SimpleNamespace(
-        parse_domain=_parse_domain, parse_problem=_parse_problem
-    )
+    l2p_stub.utils = types.SimpleNamespace(parse_domain=_parse_domain, parse_problem=_parse_problem)
     sys.modules["l2p"] = l2p_stub
     sys.modules["l2p.utils"] = l2p_stub.utils
 
@@ -200,7 +198,9 @@ if "sentence_transformers" not in sys.modules:
 # ``sys.modules.setdefault`` which can break imports that expect the real
 # submodules. Registering this stub early ensures those imports succeed even when
 # the optional package is missing.
-if "deepthought.motivate" not in sys.modules:
+import importlib.util
+
+if importlib.util.find_spec("deepthought.motivate") is None:
     motivate = types.ModuleType("motivate")
 
     caption = types.ModuleType("caption")


### PR DESCRIPTION
## Summary
- add EngagementPolicy to determine reply modes using trust, rate limits, and bot cooldowns
- expose should_reply helper and export via services package
- ensure test suite detects real motivate package instead of stub

## Testing
- `SKIP=pytest pre-commit run --files tests/conftest.py`
- `pytest tests/unit/test_reward_manager_start.py tests/unit/test_reward_manager.py tests/unit/services/test_reward_manager_service.py`
- `pytest tests/test_minimal_reply.py tests/test_reply_rate_limit.py tests/test_bot_cooldown.py`


------
https://chatgpt.com/codex/tasks/task_e_6894bdc973ec83268f68a79c740dd8a4