### PR TITLE
Add admin controls for thought logs and lies

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -251,6 +251,13 @@ try:
 except ValueError:
     THOUGHT_CHANNEL_ID = None
 
+# Comma-separated list of developer IDs allowed to run admin commands
+DEVELOPER_IDS = {
+    int(uid)
+    for uid in os.getenv("DEVELOPER_IDS", "").split(",")
+    if uid.strip().isdigit()
+}
+
 # Optional bot-to-bot chatter configuration
 # Accepts values like "true", "1", or "yes" (case-insensitive)
 BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
@@ -576,6 +583,8 @@ async def process_thought_commands(bot: "SocialGraphBot") -> None:
     while not bot.is_closed():
         try:
             message = await bot.wait_for("message", check=check)
+            if message.author.id not in DEVELOPER_IDS:
+                continue
             content = message.content.strip()
             if content.startswith("/goal"):
                 goal = content.removeprefix("/goal").strip()
@@ -585,6 +594,62 @@ async def process_thought_commands(bot: "SocialGraphBot") -> None:
                 mem = content.removeprefix("/memory").strip()
                 if mem:
                     await store_memory(message.author.id, mem)
+            elif content.startswith("/thought"):
+                parts = content.split(maxsplit=3)
+                if len(parts) < 2:
+                    continue
+                cmd = parts[1]
+                if cmd == "list":
+                    limit = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 5
+                    msgs = []
+                    async for msg in message.channel.history(limit=limit):
+                        if msg.author == bot.user:
+                            msgs.append(f"{msg.id}: {msg.content}")
+                    if msgs:
+                        await message.channel.send("\n".join(reversed(msgs)))
+                elif cmd == "delete" and len(parts) > 2:
+                    try:
+                        msg_id = int(parts[2])
+                        target = await message.channel.fetch_message(msg_id)
+                    except Exception:
+                        continue
+                    if target.author == bot.user:
+                        await target.delete()
+                        logger.info("User %s deleted thought %s", message.author.id, msg_id)
+                elif cmd == "edit" and len(parts) > 3:
+                    try:
+                        msg_id = int(parts[2])
+                        new_content = parts[3]
+                        target = await message.channel.fetch_message(msg_id)
+                    except Exception:
+                        continue
+                    if target.author == bot.user:
+                        await target.edit(content=new_content)
+                        logger.info("User %s edited thought %s", message.author.id, msg_id)
+            elif content.startswith("/lies"):
+                parts = content.split(maxsplit=3)
+                if len(parts) < 2:
+                    continue
+                cmd = parts[1]
+                if cmd == "list":
+                    limit = int(parts[2]) if len(parts) > 2 and parts[2].isdigit() else 5
+                    rows = await db_manager.list_lies(limit)
+                    if rows:
+                        lines = [f"{rowid}: {question} -> {reply} (user {uid})" for rowid, uid, question, reply in rows]
+                        await message.channel.send("\n".join(lines))
+                elif cmd == "delete" and len(parts) > 2:
+                    if parts[2].isdigit():
+                        rowid = int(parts[2])
+                        removed = await db_manager.delete_lie(rowid)
+                        if removed:
+                            logger.info("User %s deleted lie %s", message.author.id, rowid)
+                elif cmd == "edit" and len(parts) > 3:
+                    if parts[2].isdigit():
+                        rowid = int(parts[2])
+                        new_reply = parts[3]
+                        updated = await db_manager.update_lie(rowid, new_reply)
+                        if updated:
+                            logger.info("User %s edited lie %s", message.author.id, rowid)
         except asyncio.CancelledError:
             logger.info("process_thought_commands cancelled")
             break

--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import sys
+import types
 
 try:  # Ensure prometheus_client is loaded before tests patch it
     import prometheus_client  # noqa: F401
@@ -13,9 +15,14 @@ __version__ = "0.1.0"
 
 # Re-export modules subpackage for convenient access
 from . import affinity  # noqa: F401
-from . import goal_scheduler  # noqa: F401
-from . import harness  # noqa: F401
-from . import learn  # noqa: F401
+if not os.environ.get("DEEPTHOUGHT_LIGHT_IMPORT"):
+    from . import goal_scheduler  # noqa: F401
+    from . import harness  # noqa: F401
+    from . import learn  # noqa: F401
+else:  # pragma: no cover - skip heavy optional imports
+    goal_scheduler = None  # type: ignore
+    harness = None  # type: ignore
+    learn = None  # type: ignore
 
 # modules depends on optional external packages (e.g. nats). Import it lazily
 if not os.environ.get("DEEPTHOUGHT_LIGHT_IMPORT"):
@@ -30,6 +37,10 @@ else:  # pragma: no cover - skip heavy optional import
     train = None  # type: ignore
 # motivate requires NATS, which may not be installed in test environments
 try:  # pragma: no cover - optional dependency may be missing
+    mod_name = __name__ + ".motivate"
+    stub = sys.modules.get(mod_name)
+    if isinstance(stub, types.ModuleType) and not getattr(stub, "__file__", None):
+        sys.modules.pop(mod_name, None)
     from . import motivate  # type: ignore  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
     motivate = None  # type: ignore

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -519,6 +519,45 @@ class DBManager:
             row = await cur.fetchone()
             return row[0] if row else None
 
+    async def list_lies(self, limit: int = 20) -> list[tuple[int, str, str, str]]:
+        """Return recent entries from the ``lies`` table.
+
+        Each result is a tuple of ``(rowid, user_id, question, reply)`` ordered by
+        ``rowid`` descending. ``limit`` constrains the number of rows returned.
+        """
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT rowid, user_id, question, reply FROM lies ORDER BY rowid DESC LIMIT ?",
+            (limit,),
+        ) as cur:
+            return await cur.fetchall()
+
+    async def delete_lie(self, rowid: int) -> bool:
+        """Delete a lie by its ``rowid``.
+
+        Returns ``True`` if a row was removed.
+        """
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute("DELETE FROM lies WHERE rowid=?", (rowid,))
+        await self._db.commit()
+        return cur.rowcount > 0
+
+    async def update_lie(self, rowid: int, reply: str) -> bool:
+        """Update the ``reply`` field of a lie specified by ``rowid``."""
+        if not reply.strip():
+            raise ValueError("reply must be a non-empty string")
+
+        await self.connect()
+        assert self._db
+        cur = await self._db.execute(
+            "UPDATE lies SET reply=? WHERE rowid=?",
+            (reply, rowid),
+        )
+        await self._db.commit()
+        return cur.rowcount > 0
+
     async def log_manipulation(self, user_id: int, category: str) -> None:
         """Record a manipulation ``category`` associated with ``user_id``."""
         if not isinstance(category, str) or not category.strip():

--- a/src/deepthought/services/trust_service.py
+++ b/src/deepthought/services/trust_service.py
@@ -112,7 +112,7 @@ class TrustService:
         now = datetime.now(UTC)
         severity, last = self._manipulative_state.get(user_id, (0.0, now))
         elapsed = (now - last).total_seconds()
-        if self.manipulative_decay > 0 and elapsed > 0 and severity:
+        if self.manipulative_decay > 0 and elapsed >= 1.0 and severity:
             severity *= math.exp(-self.manipulative_decay * elapsed)
         severity += 1.0
         self._manipulative_state[user_id] = (severity, now)


### PR DESCRIPTION
## Summary
- allow developer IDs to issue admin commands in thought channel
- support listing, deleting, and editing thought messages
- manage lies table entries with list/delete/edit helpers
- avoid stub conflicts when importing optional motivate package
- stabilize manipulative trust cooldown to prevent unintended decay

## Testing
- `flake8 src/deepthought/__init__.py src/deepthought/services/trust_service.py examples/social_graph_bot.py src/deepthought/services/db_manager.py`
- `pytest tests/unit/test_reward_manager_start.py -q`
- `pytest tests/test_manipulative_trust_decay.py::test_manipulative_offense_cooldown -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894bdcb83b8832693353e4da323240b