### PR TITLE
feat: add quest storage and DSL utilities

### DIFF
--- a/src/deepthought/quest/__init__.py
+++ b/src/deepthought/quest/__init__.py
@@ -1,0 +1,22 @@
+"""Quest management utilities."""
+
+from .storage import (
+    Quest,
+    Objective,
+    Evidence,
+    Epiphany,
+    LieRecord,
+    QuestStorage,
+)
+
+from . import dsl
+
+__all__ = [
+    "Quest",
+    "Objective",
+    "Evidence",
+    "Epiphany",
+    "LieRecord",
+    "QuestStorage",
+    "dsl",
+]

--- a/src/deepthought/quest/dsl.py
+++ b/src/deepthought/quest/dsl.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from .storage import Quest, Objective, Evidence, Epiphany, LieRecord
+
+
+def load_quests(path: str | Path) -> List[Quest]:
+    """Load quests from a JSON DSL file."""
+    with Path(path).open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    quests: List[Quest] = []
+    for q in data.get("quests", []):
+        quest = Quest(
+            id=q.get("id"),
+            name=q["name"],
+            description=q.get("description", ""),
+            status=q.get("status", "pending"),
+        )
+        for o in q.get("objectives", []):
+            obj = Objective(
+                id=o.get("id"),
+                quest_id=quest.id or 0,
+                description=o["description"],
+                status=o.get("status", "pending"),
+            )
+            for ev in o.get("evidence", []):
+                obj.evidence.append(Evidence(id=None, objective_id=obj.id or 0, content=ev))
+            quest.objectives.append(obj)
+        for epi in q.get("epiphanies", []):
+            quest.epiphanies.append(Epiphany(id=None, quest_id=quest.id or 0, insight=epi))
+        for lie in q.get("lies", []):
+            quest.lies.append(LieRecord(id=None, quest_id=quest.id or 0, lie=lie))
+        quests.append(quest)
+    return quests
+
+
+def save_quests(path: str | Path, quests: List[Quest]) -> None:
+    """Save quests to a JSON DSL file."""
+    data = {"quests": [quest_to_dict(q) for q in quests]}
+    with Path(path).open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def quest_to_dict(quest: Quest) -> dict:
+    return {
+        "id": quest.id,
+        "name": quest.name,
+        "description": quest.description,
+        "status": quest.status,
+        "objectives": [
+            {
+                "id": o.id,
+                "description": o.description,
+                "status": o.status,
+                "evidence": [e.content for e in o.evidence],
+            }
+            for o in quest.objectives
+        ],
+        "epiphanies": [e.insight for e in quest.epiphanies],
+        "lies": [lr.lie for lr in quest.lies],
+    }

--- a/src/deepthought/quest/storage.py
+++ b/src/deepthought/quest/storage.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional, List
+
+from ..services.db_manager import DBManager
+
+
+@dataclass
+class Evidence:
+    id: Optional[int]
+    objective_id: int
+    content: str
+    created: Optional[datetime] = None
+
+
+@dataclass
+class Epiphany:
+    id: Optional[int]
+    quest_id: int
+    insight: str
+    created: Optional[datetime] = None
+
+
+@dataclass
+class LieRecord:
+    id: Optional[int]
+    quest_id: int
+    lie: str
+    created: Optional[datetime] = None
+
+
+@dataclass
+class Objective:
+    id: Optional[int]
+    quest_id: int
+    description: str
+    status: str = "pending"
+    created: Optional[datetime] = None
+    evidence: List[Evidence] = field(default_factory=list)
+
+
+@dataclass
+class Quest:
+    id: Optional[int]
+    name: str
+    description: str
+    status: str = "pending"
+    created: Optional[datetime] = None
+    objectives: List[Objective] = field(default_factory=list)
+    epiphanies: List[Epiphany] = field(default_factory=list)
+    lies: List[LieRecord] = field(default_factory=list)
+
+
+class QuestStorage:
+    """DAO layer for quests and related entities."""
+
+    def __init__(self, db: DBManager) -> None:
+        self.db = db
+
+    async def add_quest(self, quest: Quest) -> int:
+        await self.db.connect()
+        assert self.db._db is not None
+        cur = await self.db._db.execute(
+            "INSERT INTO quests (name, description, status) VALUES (?, ?, ?)",
+            (quest.name, quest.description, quest.status),
+        )
+        await self.db._db.commit()
+        quest_id = cur.lastrowid
+        quest.id = quest_id
+        return quest_id
+
+    async def add_objective(self, objective: Objective) -> int:
+        await self.db.connect()
+        assert self.db._db is not None
+        cur = await self.db._db.execute(
+            "INSERT INTO objectives (quest_id, description, status) VALUES (?, ?, ?)",
+            (objective.quest_id, objective.description, objective.status),
+        )
+        await self.db._db.commit()
+        obj_id = cur.lastrowid
+        objective.id = obj_id
+        return obj_id
+
+    async def add_evidence(self, evidence: Evidence) -> int:
+        await self.db.connect()
+        assert self.db._db is not None
+        cur = await self.db._db.execute(
+            "INSERT INTO evidence (objective_id, content) VALUES (?, ?)",
+            (evidence.objective_id, evidence.content),
+        )
+        await self.db._db.commit()
+        evidence_id = cur.lastrowid
+        evidence.id = evidence_id
+        return evidence_id
+
+    async def add_epiphany(self, epiphany: Epiphany) -> int:
+        await self.db.connect()
+        assert self.db._db is not None
+        cur = await self.db._db.execute(
+            "INSERT INTO epiphanies (quest_id, insight) VALUES (?, ?)",
+            (epiphany.quest_id, epiphany.insight),
+        )
+        await self.db._db.commit()
+        epiphany_id = cur.lastrowid
+        epiphany.id = epiphany_id
+        return epiphany_id
+
+    async def add_lie(self, lie: LieRecord) -> int:
+        await self.db.connect()
+        assert self.db._db is not None
+        cur = await self.db._db.execute(
+            "INSERT INTO lie_ledger (quest_id, lie) VALUES (?, ?)",
+            (lie.quest_id, lie.lie),
+        )
+        await self.db._db.commit()
+        lie_id = cur.lastrowid
+        lie.id = lie_id
+        return lie_id
+
+    async def get_quest(self, quest_id: int) -> Optional[Quest]:
+        await self.db.connect()
+        assert self.db._db is not None
+        async with self.db._db.execute(
+            "SELECT quest_id, name, description, status, created FROM quests WHERE quest_id=?",
+            (quest_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        quest = Quest(
+            id=row[0],
+            name=row[1],
+            description=row[2],
+            status=row[3],
+            created=datetime.fromisoformat(row[4]) if row[4] else None,
+        )
+        # objectives
+        async with self.db._db.execute(
+            "SELECT objective_id, description, status, created FROM objectives WHERE quest_id=?",
+            (quest_id,),
+        ) as cur:
+            obj_rows = await cur.fetchall()
+        for o in obj_rows:
+            obj = Objective(
+                id=o[0],
+                quest_id=quest_id,
+                description=o[1],
+                status=o[2],
+                created=datetime.fromisoformat(o[3]) if o[3] else None,
+            )
+            # evidence for objective
+            async with self.db._db.execute(
+                "SELECT evidence_id, content, created FROM evidence WHERE objective_id=?",
+                (obj.id,),
+            ) as ecur:
+                e_rows = await ecur.fetchall()
+            for e in e_rows:
+                obj.evidence.append(
+                    Evidence(
+                        id=e[0],
+                        objective_id=obj.id,
+                        content=e[1],
+                        created=datetime.fromisoformat(e[2]) if e[2] else None,
+                    )
+                )
+            quest.objectives.append(obj)
+        # epiphanies
+        async with self.db._db.execute(
+            "SELECT epiphany_id, insight, created FROM epiphanies WHERE quest_id=?",
+            (quest_id,),
+        ) as cur:
+            epi_rows = await cur.fetchall()
+        for e in epi_rows:
+            quest.epiphanies.append(
+                Epiphany(
+                    id=e[0],
+                    quest_id=quest_id,
+                    insight=e[1],
+                    created=datetime.fromisoformat(e[2]) if e[2] else None,
+                )
+            )
+        # lies
+        async with self.db._db.execute(
+            "SELECT lie_id, lie, created FROM lie_ledger WHERE quest_id=?",
+            (quest_id,),
+        ) as cur:
+            lie_rows = await cur.fetchall()
+        for record in lie_rows:
+            quest.lies.append(
+                LieRecord(
+                    id=record[0],
+                    quest_id=quest_id,
+                    lie=record[1],
+                    created=datetime.fromisoformat(record[2]) if record[2] else None,
+                )
+            )
+        return quest

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -223,6 +223,48 @@ class DBManager:
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         )
         """,
+        """
+        CREATE TABLE IF NOT EXISTS quests (
+            quest_id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'pending',
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS objectives (
+            objective_id INTEGER PRIMARY KEY,
+            quest_id INTEGER REFERENCES quests(quest_id),
+            description TEXT NOT NULL,
+            status TEXT DEFAULT 'pending',
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS evidence (
+            evidence_id INTEGER PRIMARY KEY,
+            objective_id INTEGER REFERENCES objectives(objective_id),
+            content TEXT NOT NULL,
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS epiphanies (
+            epiphany_id INTEGER PRIMARY KEY,
+            quest_id INTEGER REFERENCES quests(quest_id),
+            insight TEXT NOT NULL,
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS lie_ledger (
+            lie_id INTEGER PRIMARY KEY,
+            quest_id INTEGER REFERENCES quests(quest_id),
+            lie TEXT NOT NULL,
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
     ]
 
     def __init__(self, db_path: str = DB_PATH) -> None:


### PR DESCRIPTION
## Summary
- add quest-related tables to DB manager
- implement DAO layer for quest entities
- provide JSON DSL loader and saver for quests

## Testing
- `flake8 src/deepthought/services/db_manager.py src/deepthought/quest`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689543847ebc8326ae7ce2f38f3c7d71