### PR TITLE
Add quest metadata and timestamps to quest storage

### DIFF
--- a/src/deepthought/quest/dsl.py
+++ b/src/deepthought/quest/dsl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
@@ -17,7 +18,20 @@ def load_quests(path: str | Path) -> List[Quest]:
             id=q.get("id"),
             name=q["name"],
             description=q.get("description", ""),
+            quest_type=q.get("quest_type", ""),
+            priority=q.get("priority", 0),
+            horizon=q.get("horizon", ""),
+            faction=q.get("faction", ""),
+            cover_story=q.get("cover_story", ""),
+            secrecy=q.get("secrecy", ""),
+            risk=q.get("risk", ""),
             status=q.get("status", "pending"),
+            created=(
+                datetime.fromisoformat(q["created"]) if q.get("created") else None
+            ),
+            updated=(
+                datetime.fromisoformat(q["updated"]) if q.get("updated") else None
+            ),
         )
         for o in q.get("objectives", []):
             obj = Objective(
@@ -49,7 +63,16 @@ def quest_to_dict(quest: Quest) -> dict:
         "id": quest.id,
         "name": quest.name,
         "description": quest.description,
+        "quest_type": quest.quest_type,
+        "priority": quest.priority,
+        "horizon": quest.horizon,
+        "faction": quest.faction,
+        "cover_story": quest.cover_story,
+        "secrecy": quest.secrecy,
+        "risk": quest.risk,
         "status": quest.status,
+        "created": quest.created.isoformat() if quest.created else None,
+        "updated": quest.updated.isoformat() if quest.updated else None,
         "objectives": [
             {
                 "id": o.id,

--- a/src/deepthought/quest/storage.py
+++ b/src/deepthought/quest/storage.py
@@ -13,6 +13,7 @@ class Evidence:
     objective_id: int
     content: str
     created: Optional[datetime] = None
+    updated: Optional[datetime] = None
 
 
 @dataclass
@@ -21,6 +22,7 @@ class Epiphany:
     quest_id: int
     insight: str
     created: Optional[datetime] = None
+    updated: Optional[datetime] = None
 
 
 @dataclass
@@ -29,6 +31,7 @@ class LieRecord:
     quest_id: int
     lie: str
     created: Optional[datetime] = None
+    updated: Optional[datetime] = None
 
 
 @dataclass
@@ -38,6 +41,7 @@ class Objective:
     description: str
     status: str = "pending"
     created: Optional[datetime] = None
+    updated: Optional[datetime] = None
     evidence: List[Evidence] = field(default_factory=list)
 
 
@@ -46,8 +50,16 @@ class Quest:
     id: Optional[int]
     name: str
     description: str
+    quest_type: str = ""
+    priority: int = 0
+    horizon: str = ""
+    faction: str = ""
+    cover_story: str = ""
+    secrecy: str = ""
+    risk: str = ""
     status: str = "pending"
     created: Optional[datetime] = None
+    updated: Optional[datetime] = None
     objectives: List[Objective] = field(default_factory=list)
     epiphanies: List[Epiphany] = field(default_factory=list)
     lies: List[LieRecord] = field(default_factory=list)
@@ -63,8 +75,24 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         cur = await self.db._db.execute(
-            "INSERT INTO quests (name, description, status) VALUES (?, ?, ?)",
-            (quest.name, quest.description, quest.status),
+            """
+            INSERT INTO quests (
+                name, description, quest_type, priority, horizon, faction,
+                cover_story, secrecy, risk, status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                quest.name,
+                quest.description,
+                quest.quest_type,
+                quest.priority,
+                quest.horizon,
+                quest.faction,
+                quest.cover_story,
+                quest.secrecy,
+                quest.risk,
+                quest.status,
+            ),
         )
         await self.db._db.commit()
         quest_id = cur.lastrowid
@@ -123,7 +151,11 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         async with self.db._db.execute(
-            "SELECT quest_id, name, description, status, created FROM quests WHERE quest_id=?",
+            """
+            SELECT quest_id, name, description, quest_type, priority, horizon,
+                   faction, cover_story, secrecy, risk, status, created, updated
+            FROM quests WHERE quest_id=?
+            """,
             (quest_id,),
         ) as cur:
             row = await cur.fetchone()
@@ -133,12 +165,20 @@ class QuestStorage:
             id=row[0],
             name=row[1],
             description=row[2],
-            status=row[3],
-            created=datetime.fromisoformat(row[4]) if row[4] else None,
+            quest_type=row[3] or "",
+            priority=row[4] or 0,
+            horizon=row[5] or "",
+            faction=row[6] or "",
+            cover_story=row[7] or "",
+            secrecy=row[8] or "",
+            risk=row[9] or "",
+            status=row[10],
+            created=datetime.fromisoformat(row[11]) if row[11] else None,
+            updated=datetime.fromisoformat(row[12]) if row[12] else None,
         )
         # objectives
         async with self.db._db.execute(
-            "SELECT objective_id, description, status, created FROM objectives WHERE quest_id=?",
+            "SELECT objective_id, description, status, created, updated FROM objectives WHERE quest_id=?",
             (quest_id,),
         ) as cur:
             obj_rows = await cur.fetchall()
@@ -149,10 +189,11 @@ class QuestStorage:
                 description=o[1],
                 status=o[2],
                 created=datetime.fromisoformat(o[3]) if o[3] else None,
+                updated=datetime.fromisoformat(o[4]) if o[4] else None,
             )
             # evidence for objective
             async with self.db._db.execute(
-                "SELECT evidence_id, content, created FROM evidence WHERE objective_id=?",
+                "SELECT evidence_id, content, created, updated FROM evidence WHERE objective_id=?",
                 (obj.id,),
             ) as ecur:
                 e_rows = await ecur.fetchall()
@@ -163,12 +204,13 @@ class QuestStorage:
                         objective_id=obj.id,
                         content=e[1],
                         created=datetime.fromisoformat(e[2]) if e[2] else None,
+                        updated=datetime.fromisoformat(e[3]) if e[3] else None,
                     )
                 )
             quest.objectives.append(obj)
         # epiphanies
         async with self.db._db.execute(
-            "SELECT epiphany_id, insight, created FROM epiphanies WHERE quest_id=?",
+            "SELECT epiphany_id, insight, created, updated FROM epiphanies WHERE quest_id=?",
             (quest_id,),
         ) as cur:
             epi_rows = await cur.fetchall()
@@ -179,11 +221,12 @@ class QuestStorage:
                     quest_id=quest_id,
                     insight=e[1],
                     created=datetime.fromisoformat(e[2]) if e[2] else None,
+                    updated=datetime.fromisoformat(e[3]) if e[3] else None,
                 )
             )
         # lies
         async with self.db._db.execute(
-            "SELECT lie_id, lie, created FROM lie_ledger WHERE quest_id=?",
+            "SELECT lie_id, lie, created, updated FROM lie_ledger WHERE quest_id=?",
             (quest_id,),
         ) as cur:
             lie_rows = await cur.fetchall()
@@ -194,6 +237,48 @@ class QuestStorage:
                     quest_id=quest_id,
                     lie=record[1],
                     created=datetime.fromisoformat(record[2]) if record[2] else None,
+                    updated=datetime.fromisoformat(record[3]) if record[3] else None,
                 )
             )
         return quest
+
+    async def update_quest(self, quest: Quest) -> None:
+        """Persist changes to a quest and update the timestamp."""
+        if quest.id is None:
+            raise ValueError("quest.id is required for update")
+        await self.db.connect()
+        assert self.db._db is not None
+        await self.db._db.execute(
+            """
+            UPDATE quests SET
+                name=?, description=?, quest_type=?, priority=?, horizon=?,
+                faction=?, cover_story=?, secrecy=?, risk=?, status=?,
+                updated=CURRENT_TIMESTAMP
+            WHERE quest_id=?
+            """,
+            (
+                quest.name,
+                quest.description,
+                quest.quest_type,
+                quest.priority,
+                quest.horizon,
+                quest.faction,
+                quest.cover_story,
+                quest.secrecy,
+                quest.risk,
+                quest.status,
+                quest.id,
+            ),
+        )
+        await self.db._db.commit()
+
+    async def delete_quest(self, quest_id: int) -> None:
+        """Delete a quest and its related records."""
+        await self.db.connect()
+        assert self.db._db is not None
+        # Delete child records first to maintain integrity
+        await self.db._db.execute("DELETE FROM objectives WHERE quest_id=?", (quest_id,))
+        await self.db._db.execute("DELETE FROM epiphanies WHERE quest_id=?", (quest_id,))
+        await self.db._db.execute("DELETE FROM lie_ledger WHERE quest_id=?", (quest_id,))
+        await self.db._db.execute("DELETE FROM quests WHERE quest_id=?", (quest_id,))
+        await self.db._db.commit()

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -228,8 +228,16 @@ class DBManager:
             quest_id INTEGER PRIMARY KEY,
             name TEXT NOT NULL,
             description TEXT,
+            quest_type TEXT,
+            priority INTEGER DEFAULT 0,
+            horizon TEXT,
+            faction TEXT,
+            cover_story TEXT,
+            secrecy TEXT,
+            risk TEXT,
             status TEXT DEFAULT 'pending',
-            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
         """
@@ -238,7 +246,8 @@ class DBManager:
             quest_id INTEGER REFERENCES quests(quest_id),
             description TEXT NOT NULL,
             status TEXT DEFAULT 'pending',
-            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
         """
@@ -246,7 +255,8 @@ class DBManager:
             evidence_id INTEGER PRIMARY KEY,
             objective_id INTEGER REFERENCES objectives(objective_id),
             content TEXT NOT NULL,
-            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
         """
@@ -254,7 +264,8 @@ class DBManager:
             epiphany_id INTEGER PRIMARY KEY,
             quest_id INTEGER REFERENCES quests(quest_id),
             insight TEXT NOT NULL,
-            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
         """
@@ -262,7 +273,8 @@ class DBManager:
             lie_id INTEGER PRIMARY KEY,
             quest_id INTEGER REFERENCES quests(quest_id),
             lie TEXT NOT NULL,
-            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
         """,
     ]

--- a/tests/test_quest_storage_crud.py
+++ b/tests/test_quest_storage_crud.py
@@ -1,0 +1,55 @@
+import pytest
+from deepthought.services import DBManager
+from deepthought.quest import Quest, QuestStorage
+
+pytest.importorskip("aiosqlite")
+
+
+@pytest.mark.asyncio
+async def test_quest_crud(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    db = DBManager(str(db_file))
+    storage = QuestStorage(db)
+
+    quest = Quest(
+        id=None,
+        name="Test Quest",
+        description="desc",
+        quest_type="main",
+        priority=1,
+        horizon="short",
+        faction="alpha",
+        cover_story="cover",
+        secrecy="low",
+        risk="minimal",
+        status="pending",
+    )
+
+    quest_id = await storage.add_quest(quest)
+    assert quest_id
+
+    fetched = await storage.get_quest(quest_id)
+    assert fetched is not None
+    assert fetched.quest_type == "main"
+    assert fetched.priority == 1
+    assert fetched.horizon == "short"
+    assert fetched.faction == "alpha"
+    assert fetched.cover_story == "cover"
+    assert fetched.secrecy == "low"
+    assert fetched.risk == "minimal"
+    assert fetched.created is not None
+    assert fetched.updated is not None
+
+    fetched.priority = 5
+    fetched.status = "done"
+    await storage.update_quest(fetched)
+
+    updated = await storage.get_quest(quest_id)
+    assert updated.priority == 5
+    assert updated.status == "done"
+    assert updated.updated is not None
+
+    await storage.delete_quest(quest_id)
+    assert await storage.get_quest(quest_id) is None
+
+    await db.close()


### PR DESCRIPTION
## Summary
- expand quest dataclasses with quest_type, priority, horizon, faction, cover_story, secrecy, risk, and created/updated timestamps
- migrate DB schema and QuestStorage CRUD to handle new metadata
- update DSL serialization and add CRUD tests for quest metadata

## Testing
- `flake8 src/deepthought/quest/storage.py src/deepthought/quest/dsl.py src/deepthought/services/db_manager.py tests/test_quest_storage_crud.py`
- `pytest tests/test_quest_storage_crud.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68965a5692748326ad42e2cc904d5bab