### PR TITLE
Add quest state machine with TTL pruning

### DIFF
--- a/src/deepthought/quest/__init__.py
+++ b/src/deepthought/quest/__init__.py
@@ -17,6 +17,7 @@ from .templates import (
     auto_spawn_quests,
     TEMPLATES,
 )
+from .fsm import QuestState, QuestFSM
 
 __all__ = [
     "Quest",
@@ -31,4 +32,6 @@ __all__ = [
     "bind_slot",
     "auto_spawn_quests",
     "TEMPLATES",
+    "QuestState",
+    "QuestFSM",
 ]

--- a/src/deepthought/quest/fsm.py
+++ b/src/deepthought/quest/fsm.py
@@ -1,0 +1,92 @@
+"""Finite state machine for quest lifecycle management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import Enum
+from typing import Dict, Iterable, Optional, Set
+
+
+class QuestState(str, Enum):
+    """Enumeration of quest lifecycle states."""
+
+    PROPOSED = "Proposed"
+    TRACKED = "Tracked"
+    ACTIVE = "Active"
+    PAUSED = "Paused"
+    BLOCKED = "Blocked"
+    SHELVED = "Shelved"
+    COMPLETED = "Completed"
+    ABANDONED = "Abandoned"
+
+
+# Mapping of allowed state transitions
+ALLOWED_TRANSITIONS: Dict[QuestState, Set[QuestState]] = {
+    QuestState.PROPOSED: {QuestState.TRACKED, QuestState.ABANDONED},
+    QuestState.TRACKED: {
+        QuestState.ACTIVE,
+        QuestState.SHELVED,
+        QuestState.ABANDONED,
+    },
+    QuestState.ACTIVE: {
+        QuestState.PAUSED,
+        QuestState.BLOCKED,
+        QuestState.COMPLETED,
+        QuestState.ABANDONED,
+    },
+    QuestState.PAUSED: {QuestState.ACTIVE, QuestState.ABANDONED},
+    QuestState.BLOCKED: {QuestState.ACTIVE, QuestState.ABANDONED},
+    QuestState.SHELVED: {QuestState.TRACKED, QuestState.ABANDONED},
+    QuestState.COMPLETED: set(),  # terminal
+    QuestState.ABANDONED: set(),  # terminal
+}
+
+
+@dataclass
+class QuestFSM:
+    """State machine with TTL-based auto-pruning."""
+
+    state: QuestState = QuestState.PROPOSED
+    ttl_seconds: Optional[int] = None
+    _last_refresh: datetime = datetime.utcnow()
+
+    def transition(
+        self, new_state: QuestState, *, now: Optional[datetime] = None
+    ) -> None:
+        """Transition to ``new_state`` if allowed.
+
+        ``now`` may be provided to override the current time for testing.
+        """
+
+        self.prune(now=now)
+        if self.state == QuestState.ABANDONED:
+            raise ValueError("Cannot transition from ABANDONED state")
+        allowed = ALLOWED_TRANSITIONS[self.state]
+        if new_state not in allowed:
+            raise ValueError(
+                f"Invalid transition from {self.state} to {new_state}"
+            )
+        self.state = new_state
+        self.refresh(now=now)
+
+    def refresh(self, *, now: Optional[datetime] = None) -> None:
+        """Refresh the TTL timer."""
+
+        self._last_refresh = now or datetime.utcnow()
+
+    def is_expired(self, *, now: Optional[datetime] = None) -> bool:
+        """Return ``True`` if the FSM has exceeded its TTL."""
+
+        if self.ttl_seconds is None:
+            return False
+        now = now or datetime.utcnow()
+        return now - self._last_refresh > timedelta(seconds=self.ttl_seconds)
+
+    def prune(self, *, now: Optional[datetime] = None) -> None:
+        """Auto-transition to ``ABANDONED`` if the TTL has expired."""
+
+        if self.state in {QuestState.COMPLETED, QuestState.ABANDONED}:
+            return
+        if self.is_expired(now=now):
+            self.state = QuestState.ABANDONED

--- a/tests/unit/test_quest_fsm.py
+++ b/tests/unit/test_quest_fsm.py
@@ -1,0 +1,46 @@
+"""Tests for the quest FSM."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from deepthought.quest import QuestFSM, QuestState
+
+
+# Helper to make deterministic times
+BASE_TIME = datetime(2024, 1, 1, 0, 0, 0)
+
+
+def test_valid_transition_sequence():
+    fsm = QuestFSM(ttl_seconds=100, _last_refresh=BASE_TIME)
+    fsm.transition(QuestState.TRACKED, now=BASE_TIME)
+    fsm.transition(QuestState.ACTIVE, now=BASE_TIME)
+    fsm.transition(QuestState.COMPLETED, now=BASE_TIME)
+    assert fsm.state is QuestState.COMPLETED
+
+
+def test_invalid_transition_raises():
+    fsm = QuestFSM(ttl_seconds=100, _last_refresh=BASE_TIME)
+    with pytest.raises(ValueError):
+        fsm.transition(QuestState.ACTIVE, now=BASE_TIME)
+
+
+def test_ttl_auto_prune():
+    fsm = QuestFSM(ttl_seconds=10, _last_refresh=BASE_TIME)
+    # move time forward beyond TTL
+    later = BASE_TIME + timedelta(seconds=11)
+    fsm.prune(now=later)
+    assert fsm.state is QuestState.ABANDONED
+
+
+def test_refresh_extends_ttl():
+    fsm = QuestFSM(ttl_seconds=10, _last_refresh=BASE_TIME)
+    half_time = BASE_TIME + timedelta(seconds=5)
+    fsm.refresh(now=half_time)
+    near_expiry = half_time + timedelta(seconds=9)
+    fsm.prune(now=near_expiry)
+    assert fsm.state is QuestState.PROPOSED
+    # now exceed TTL after refresh
+    expired = half_time + timedelta(seconds=11)
+    fsm.prune(now=expired)
+    assert fsm.state is QuestState.ABANDONED


### PR DESCRIPTION
## Summary
- introduce QuestState enum and QuestFSM with TTL-based auto pruning
- expose QuestState and QuestFSM in quest package
- test quest FSM transitions and TTL handling

## Testing
- `flake8 src/deepthought/quest tests/unit/test_quest_fsm.py`
- `pytest tests/unit/test_quest_fsm.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68965a573d84832681252adabc105af7