### PR TITLE
feat: add layered planning state

### DIFF
--- a/src/deepthought/planning/stacked_planner.py
+++ b/src/deepthought/planning/stacked_planner.py
@@ -103,21 +103,40 @@ class StackedPlanner:
     # ------------------------------------------------------------------
     # Layer processing
     def _reactive_layer(self, actions: List[str]) -> List[str]:
-        return actions
+        """First pass to handle immediate reactions.
+
+        Each action is prefixed with ``"react:"`` so later stages can
+        differentiate work performed at this layer.
+        """
+
+        return [f"react:{act}" for act in actions]
 
     def _investigative_layer(self, actions: List[str]) -> List[str]:
-        return actions
+        """Second pass to gather more information.
+
+        Actions are turned into questions by appending ``"?"``.
+        """
+
+        return [f"{act}?" for act in actions]
 
     def _arc_layer(self, actions: List[str]) -> List[str]:
-        return actions
+        """Final pass to craft a longer term narrative arc.
+
+        Actions are capitalised to represent committed intentions.
+        """
+
+        return [act.upper() for act in actions]
 
     # ------------------------------------------------------------------
     def generate_plan(self, goal: str) -> List[str]:
         domain, problem = self._translator.translate(goal)
         actions = self._planner_fn(domain, problem)
         actions = self._reactive_layer(actions)
+        self._persist_layer_snapshot(goal, actions, "reactive")
         actions = self._investigative_layer(actions)
+        self._persist_layer_snapshot(goal, actions, "investigative")
         actions = self._arc_layer(actions)
+        self._persist_layer_snapshot(goal, actions, "arc")
 
         filtered: List[str] = []
         for act in actions:
@@ -144,6 +163,38 @@ class StackedPlanner:
             path.write_text(json.dumps(snapshot), encoding="utf-8")
         except Exception:  # pragma: no cover - disk errors
             logger.warning("Failed to write planner snapshot", exc_info=True)
+
+    def _persist_layer_snapshot(
+        self, goal: str, actions: List[str], layer: str
+    ) -> None:
+        """Persist the state of a single planning layer.
+
+        Parameters
+        ----------
+        goal:
+            The goal being pursued.
+        actions:
+            The list of actions after the layer transformation.
+        layer:
+            Name of the layer (``reactive``, ``investigative`` or ``arc``).
+        """
+
+        snapshot = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "goal": goal,
+            "layer": layer,
+            "actions": actions,
+        }
+        fname = (
+            datetime.utcnow().strftime("%Y%m%d%H%M%S%f") + f"_{layer}.json"
+        )
+        path = self._snapshot_dir / fname
+        try:
+            path.write_text(json.dumps(snapshot), encoding="utf-8")
+        except Exception:  # pragma: no cover - disk errors
+            logger.warning(
+                "Failed to write %s layer snapshot", layer, exc_info=True
+            )
 
     def _maybe_send_summary(self) -> None:
         now = datetime.utcnow()

--- a/tests/test_stacked_planner_layers.py
+++ b/tests/test_stacked_planner_layers.py
@@ -1,0 +1,40 @@
+import json
+from pathlib import Path
+
+from deepthought.planning.stacked_planner import StackedPlanner
+
+
+class DummyTranslator:
+    def translate(self, goal: str):
+        return "domain", "problem"
+
+
+def dummy_planner(domain: str, problem: str):
+    return ["move", "scan", "report"]
+
+
+def test_layers_modify_actions_and_persist(tmp_path: Path):
+    planner = StackedPlanner(
+        translator=DummyTranslator(),
+        planner_fn=dummy_planner,
+        snapshot_dir=tmp_path,
+    )
+
+    plan = planner.generate_plan("test")
+    assert plan == ["REACT:MOVE?", "REACT:SCAN?", "REACT:REPORT?"]
+
+    reactive_file = next(tmp_path.glob("*_reactive.json"))
+    reactive = json.loads(reactive_file.read_text())
+    assert reactive["actions"] == ["react:move", "react:scan", "react:report"]
+
+    investigative_file = next(tmp_path.glob("*_investigative.json"))
+    investigative = json.loads(investigative_file.read_text())
+    assert investigative["actions"] == [
+        "react:move?",
+        "react:scan?",
+        "react:report?",
+    ]
+
+    arc_file = next(tmp_path.glob("*_arc.json"))
+    arc = json.loads(arc_file.read_text())
+    assert arc["actions"] == plan


### PR DESCRIPTION
## Summary
- make reactive, investigative, and arc layers transform actions differently
- persist per-layer state snapshots during plan generation
- add unit test ensuring layered processing and persistence

## Testing
- `python -m flake8 src/deepthought/planning/stacked_planner.py tests/test_stacked_planner_layers.py`
- `pytest tests/test_stacked_planner_layers.py -q -W ignore`


------
https://chatgpt.com/codex/tasks/task_e_6896661e53f88326a7475f7f1ba44808