### PR TITLE
feat: enhance planner arbitration

### DIFF
--- a/src/deepthought/planning/stacked_planner.py
+++ b/src/deepthought/planning/stacked_planner.py
@@ -17,18 +17,14 @@ logger = logging.getLogger(__name__)
 class DiscordThoughtWriter:
     """Send planner summaries to a Discord channel."""
 
-    def __init__(
-        self, channel_id: str | None = None, token: str | None = None
-    ) -> None:
+    def __init__(self, channel_id: str | None = None, token: str | None = None) -> None:
         self._channel_id = channel_id or os.getenv("THOUGHT_CHANNEL")
         self._token = token or os.getenv("DISCORD_TOKEN")
 
     def send(self, summary: dict) -> None:
         if not self._channel_id or not self._token:
             return
-        url = (
-            f"https://discord.com/api/v10/channels/{self._channel_id}/messages"
-        )
+        url = f"https://discord.com/api/v10/channels/{self._channel_id}/messages"
         headers = {"Authorization": f"Bot {self._token}"}
         payload = {"content": json.dumps(summary)}
         try:  # pragma: no cover - network operations
@@ -57,6 +53,14 @@ class StackedPlanner:
         self._desires: List[str] = []
         self._intentions: List[str] = []
         self._last_summary = datetime.utcnow()
+        self._weights = {
+            "info_gain": 1.0,
+            "social_capital": 1.0,
+            "cover_risk": 1.0,
+            "effort": 1.0,
+            "vibes_fit": 1.0,
+        }
+        self._next_action_time = datetime.min
 
     # ------------------------------------------------------------------
     # Beliefs, Desires, Intentions state
@@ -79,8 +83,16 @@ class StackedPlanner:
         social_capital: float = 0.0,
         cover_risk: float = 0.0,
         effort: float = 0.0,
+        vibes_fit: float = 0.0,
     ) -> float:
-        return info_gain + social_capital - cover_risk - effort
+        w = self._weights
+        return (
+            info_gain * w["info_gain"]
+            + social_capital * w["social_capital"]
+            + vibes_fit * w["vibes_fit"]
+            - cover_risk * w["cover_risk"]
+            - effort * w["effort"]
+        )
 
     def should_act(
         self,
@@ -89,16 +101,22 @@ class StackedPlanner:
         social_capital: float = 0.0,
         cover_risk: float = 0.0,
         effort: float = 0.0,
+        vibes_fit: float = 0.0,
+        silence_threshold: float = 0.0,
+        cooldown: float = 0.0,
     ) -> bool:
-        return (
-            self.utility_score(
-                info_gain=info_gain,
-                social_capital=social_capital,
-                cover_risk=cover_risk,
-                effort=effort,
-            )
-            >= 0.0
+        now = datetime.utcnow()
+        if now < self._next_action_time:
+            return False
+        score = self.utility_score(
+            info_gain=info_gain,
+            social_capital=social_capital,
+            cover_risk=cover_risk,
+            effort=effort,
+            vibes_fit=vibes_fit,
         )
+        self._next_action_time = now + timedelta(seconds=cooldown)
+        return score >= silence_threshold
 
     # ------------------------------------------------------------------
     # Layer processing
@@ -159,4 +177,3 @@ class StackedPlanner:
             except Exception:  # pragma: no cover - network errors
                 logger.warning("Failed to publish planner summary", exc_info=True)
             self._last_summary = now
-

--- a/tests/unit/test_stacked_planner_arbitration.py
+++ b/tests/unit/test_stacked_planner_arbitration.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timedelta
+
+from deepthought.planning import StackedPlanner
+
+
+class DummyTranslator:
+    def translate(self, goal: str):
+        return "", ""
+
+
+def dummy_planner(domain: str, problem: str):
+    return []
+
+
+def test_should_act_balances_utilities():
+    planner = StackedPlanner(DummyTranslator(), dummy_planner)
+    assert planner.should_act(info_gain=1.0)
+    assert not planner.should_act(info_gain=0.1, cover_risk=1.0)
+    assert planner.should_act(vibes_fit=1.0)
+
+
+def test_silence_threshold_and_cooldown(monkeypatch):
+    import deepthought.planning.stacked_planner as sp
+
+    fake_now = datetime(2024, 1, 1)
+
+    class FakeDateTime(datetime):
+        @classmethod
+        def utcnow(cls):
+            return fake_now
+
+    monkeypatch.setattr(sp, "datetime", FakeDateTime)
+    planner = sp.StackedPlanner(DummyTranslator(), dummy_planner)
+
+    assert not planner.should_act(info_gain=0.1, silence_threshold=0.5, cooldown=10)
+    assert not planner.should_act(info_gain=1.0, silence_threshold=0.0)
+    fake_now = fake_now + timedelta(seconds=10)
+    assert planner.should_act(info_gain=1.0, silence_threshold=0.0)


### PR DESCRIPTION
## Summary
- expand utility scoring with weighted vibes fit and cost/risk factors
- gate action execution with silence threshold and cooldown
- test planner arbitration across utility weights and cooldown scenarios

## Testing
- `pre-commit run black --files src/deepthought/planning/stacked_planner.py tests/unit/test_stacked_planner_arbitration.py`
- `pre-commit run isort --files src/deepthought/planning/stacked_planner.py tests/unit/test_stacked_planner_arbitration.py`
- `pre-commit run flake8 --files src/deepthought/planning/stacked_planner.py tests/unit/test_stacked_planner_arbitration.py`
- `pytest tests/unit/test_stacked_planner_arbitration.py`

------
https://chatgpt.com/codex/tasks/task_e_6896661ee6348326959b273ae053d8fa