### PR TITLE
Add DSL, cooldown, and auto-spawn tests

### DIFF
--- a/tests/test_auto_spawn_budget.py
+++ b/tests/test_auto_spawn_budget.py
@@ -1,0 +1,26 @@
+import pytest
+
+from deepthought.services import DBManager
+from deepthought.services.social_graph_memory import SocialGraphMemory
+from deepthought.quest.templates import CooldownTracker, auto_spawn_quests
+
+pytest.importorskip("aiosqlite")
+
+
+@pytest.mark.asyncio
+async def test_auto_spawn_respects_budget(tmp_path):
+    db = DBManager(str(tmp_path / "sg.db"))
+    memory = SocialGraphMemory(db)
+    await db.adjust_affinity("u1", 5)
+
+    tracker = CooldownTracker()
+    budget = {"short": 1, "medium": 1, "long": 0}
+
+    quests = await auto_spawn_quests(budget, memory, tracker)
+    names = [q.name for q in quests]
+
+    assert names == ["Investigation", "Side"]
+    assert budget["short"] == 0
+    assert budget["medium"] == 0
+
+    await db.close()

--- a/tests/test_cooldown_tracker.py
+++ b/tests/test_cooldown_tracker.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timedelta
+
+from deepthought.quest.templates import CooldownTracker, QuestTemplate
+
+
+def test_cooldown_tracker_ready_and_mark():
+    tracker = CooldownTracker()
+    tmpl = QuestTemplate("T", "short", cooldown=timedelta(hours=1))
+    now = datetime.utcnow()
+
+    assert tracker.ready("user", tmpl, now=now)
+    tracker.mark("user", tmpl, now=now)
+    assert not tracker.ready("user", tmpl, now=now + timedelta(minutes=30))
+    assert tracker.ready("user", tmpl, now=now + timedelta(hours=1, minutes=1))

--- a/tests/test_quest_dsl.py
+++ b/tests/test_quest_dsl.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+from deepthought.quest.dsl import load_quests, save_quests
+from deepthought.quest import Evidence, Epiphany, LieRecord, Objective, Quest
+
+
+def test_load_and_save_roundtrip(tmp_path):
+    quest = Quest(
+        id=1,
+        name="Quest",
+        description="desc",
+        quest_type="main",
+        priority=1,
+        horizon="short",
+        faction="alpha",
+        cover_story="cover",
+        secrecy="low",
+        risk="low",
+        status="pending",
+        created=datetime.utcnow(),
+    )
+    obj = Objective(id=10, quest_id=1, description="Do thing", status="done")
+    obj.evidence.append(Evidence(id=None, objective_id=10, content="proof"))
+    quest.objectives.append(obj)
+    quest.epiphanies.append(Epiphany(id=None, quest_id=1, insight="idea"))
+    quest.lies.append(LieRecord(id=None, quest_id=1, lie="fib"))
+
+    path = tmp_path / "quests.json"
+    save_quests(path, [quest])
+
+    loaded = load_quests(path)
+    assert len(loaded) == 1
+    q = loaded[0]
+    assert q.name == "Quest"
+    assert q.objectives[0].evidence[0].content == "proof"
+    assert q.epiphanies[0].insight == "idea"
+    assert q.lies[0].lie == "fib"

--- a/tests/test_quest_storage_crud.py
+++ b/tests/test_quest_storage_crud.py
@@ -1,6 +1,13 @@
 import pytest
 from deepthought.services import DBManager
-from deepthought.quest import Quest, QuestStorage
+from deepthought.quest import (
+    Evidence,
+    Epiphany,
+    LieRecord,
+    Objective,
+    Quest,
+    QuestStorage,
+)
 
 pytest.importorskip("aiosqlite")
 
@@ -48,6 +55,39 @@ async def test_quest_crud(tmp_path):
     assert updated.priority == 5
     assert updated.status == "done"
     assert updated.updated is not None
+
+    await storage.delete_quest(quest_id)
+    assert await storage.get_quest(quest_id) is None
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_nested_entities(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    db = DBManager(str(db_file))
+    storage = QuestStorage(db)
+
+    quest = Quest(id=None, name="Q", description="desc")
+    quest_id = await storage.add_quest(quest)
+
+    obj = Objective(id=None, quest_id=quest_id, description="obj")
+    obj_id = await storage.add_objective(obj)
+
+    ev = Evidence(id=None, objective_id=obj_id, content="proof")
+    await storage.add_evidence(ev)
+
+    epi = Epiphany(id=None, quest_id=quest_id, insight="aha")
+    await storage.add_epiphany(epi)
+
+    lie = LieRecord(id=None, quest_id=quest_id, lie="fib")
+    await storage.add_lie(lie)
+
+    fetched = await storage.get_quest(quest_id)
+    assert fetched is not None
+    assert fetched.objectives and fetched.objectives[0].evidence[0].content == "proof"
+    assert fetched.epiphanies and fetched.epiphanies[0].insight == "aha"
+    assert fetched.lies and fetched.lies[0].lie == "fib"
 
     await storage.delete_quest(quest_id)
     assert await storage.get_quest(quest_id) is None


### PR DESCRIPTION
## Summary
- add roundtrip test for quest DSL save/load
- cover nested entity CRUD in QuestStorage
- test CooldownTracker behavior and auto_spawn_quests budget handling

## Testing
- `flake8 tests/test_quest_dsl.py tests/test_cooldown_tracker.py tests/test_auto_spawn_budget.py tests/test_quest_storage_crud.py`
- `pytest tests/test_quest_dsl.py tests/test_cooldown_tracker.py tests/test_auto_spawn_budget.py tests/test_quest_storage_crud.py`


------
https://chatgpt.com/codex/tasks/task_e_689683386904832694bcb3c5c9d3e337