### PR TITLE
Add quest reporting utilities and scheduler

### DIFF
--- a/src/deepthought/quest/__init__.py
+++ b/src/deepthought/quest/__init__.py
@@ -1,23 +1,28 @@
 """Quest management utilities."""
 
+from . import dsl
+from .fsm import QuestFSM, QuestState
+from .reports import (
+    SummaryScheduler,
+    case_files,
+    compile_narratives,
+    weekly_faction_shifts,
+)
 from .storage import (
-    Quest,
-    Objective,
-    Evidence,
     Epiphany,
+    Evidence,
     LieRecord,
+    Objective,
+    Quest,
     QuestStorage,
 )
-
-from . import dsl
 from .templates import (
-    QuestTemplate,
-    CooldownTracker,
-    bind_slot,
-    auto_spawn_quests,
     TEMPLATES,
+    CooldownTracker,
+    QuestTemplate,
+    auto_spawn_quests,
+    bind_slot,
 )
-from .fsm import QuestState, QuestFSM
 
 __all__ = [
     "Quest",
@@ -34,4 +39,8 @@ __all__ = [
     "TEMPLATES",
     "QuestState",
     "QuestFSM",
+    "compile_narratives",
+    "weekly_faction_shifts",
+    "case_files",
+    "SummaryScheduler",
 ]

--- a/src/deepthought/quest/reports.py
+++ b/src/deepthought/quest/reports.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+"""Utilities for generating quest progress reports.
+
+This module provides helpers to assemble narrative summaries, track weekly
+faction momentum and produce case file dictionaries suitable for archival or
+transmission.  It also includes a small scheduler that periodically sends the
+compiled summary to the "Thought Server" using the ``DiscordThoughtWriter``
+from :mod:`deepthought.planning.stacked_planner`.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Dict, Iterable, List
+
+from ..planning.stacked_planner import DiscordThoughtWriter
+from .storage import Quest
+
+# ---------------------------------------------------------------------------
+# Report compilation helpers
+
+
+def compile_narratives(quests: Iterable[Quest]) -> List[str]:
+    """Return human readable narratives for each quest.
+
+    The narrative includes the quest description, objectives, epiphanies and
+    notable lies recorded along the way.
+    """
+
+    narratives: List[str] = []
+    for quest in quests:
+        objectives = "; ".join(o.description for o in quest.objectives) or "no objectives"
+        narrative = f"{quest.name}: {quest.description}. Objectives: {objectives}."
+        if quest.epiphanies:
+            narrative += " Epiphanies: " + "; ".join(e.insight for e in quest.epiphanies) + "."
+        if quest.lies:
+            narrative += " Lies: " + "; ".join(lie.lie for lie in quest.lies) + "."
+        narratives.append(narrative)
+    return narratives
+
+
+def weekly_faction_shifts(quests: Iterable[Quest]) -> Dict[str, int]:
+    """Compute weekly faction momentum.
+
+    Completed quests count as +1 for their faction while failed quests count as
+    -1. Other statuses do not influence the shift.
+    """
+
+    shifts: Dict[str, int] = {}
+    for quest in quests:
+        if not quest.faction:
+            continue
+        delta = 1 if quest.status == "completed" else -1 if quest.status == "failed" else 0
+        if delta:
+            shifts[quest.faction] = shifts.get(quest.faction, 0) + delta
+    return shifts
+
+
+def case_files(quests: Iterable[Quest]) -> List[Dict[str, Any]]:
+    """Produce serialisable case file dictionaries for each quest."""
+
+    files: List[Dict[str, Any]] = []
+    for quest in quests:
+        files.append(
+            {
+                "id": quest.id,
+                "name": quest.name,
+                "status": quest.status,
+                "objectives": [o.description for o in quest.objectives],
+                "epiphanies": [e.insight for e in quest.epiphanies],
+                "lies": [lie.lie for lie in quest.lies],
+            }
+        )
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Scheduling logic
+
+
+@dataclass
+class SummaryScheduler:
+    """Send periodic quest summaries to the Thought Server."""
+
+    interval: timedelta = timedelta(days=7)
+    writer: DiscordThoughtWriter | None = None
+    _next_run: datetime = datetime.min
+
+    def maybe_send(self, quests: Iterable[Quest], now: datetime | None = None) -> None:
+        """Send a compiled summary if the scheduled interval has passed."""
+
+        now = now or datetime.utcnow()
+        if now < self._next_run:
+            return
+        summary = {
+            "narratives": compile_narratives(quests),
+            "faction_shifts": weekly_faction_shifts(quests),
+            "case_files": case_files(quests),
+        }
+        writer = self.writer or DiscordThoughtWriter()
+        writer.send(summary)
+        self._next_run = now + self.interval

--- a/tests/test_quest_reports.py
+++ b/tests/test_quest_reports.py
@@ -1,0 +1,68 @@
+"""Tests for quest report generation."""
+
+from datetime import timedelta
+
+from deepthought.quest import (
+    Epiphany,
+    LieRecord,
+    Objective,
+    Quest,
+    SummaryScheduler,
+    case_files,
+    compile_narratives,
+    weekly_faction_shifts,
+)
+
+
+def _sample_quest() -> Quest:
+    quest = Quest(
+        id=1,
+        name="Secret Mission",
+        description="Gather intel",
+        faction="alpha",
+        status="completed",
+    )
+    quest.objectives = [Objective(id=1, quest_id=1, description="Infiltrate base")]
+    quest.epiphanies = [Epiphany(id=1, quest_id=1, insight="New lead")]
+    quest.lies = [LieRecord(id=1, quest_id=1, lie="Covered tracks")]
+    return quest
+
+
+def test_compile_narratives_format():
+    narrative = compile_narratives([_sample_quest()])[0]
+    assert "Secret Mission" in narrative
+    assert "Objectives: Infiltrate base" in narrative
+    assert "Epiphanies: New lead" in narrative
+    assert "Lies: Covered tracks" in narrative
+
+
+def test_weekly_faction_shifts_counts_status():
+    quests = [
+        _sample_quest(),
+        Quest(id=2, name="Failed", description="", faction="alpha", status="failed"),
+        Quest(id=3, name="Beta", description="", faction="beta", status="completed"),
+    ]
+    shifts = weekly_faction_shifts(quests)
+    assert shifts == {"alpha": 0, "beta": 1}
+
+
+def test_case_files_structure():
+    cases = case_files([_sample_quest()])
+    assert cases[0]["name"] == "Secret Mission"
+    assert cases[0]["objectives"] == ["Infiltrate base"]
+    assert cases[0]["epiphanies"] == ["New lead"]
+    assert cases[0]["lies"] == ["Covered tracks"]
+
+
+def test_scheduler_sends_summary_when_due():
+    quest = _sample_quest()
+    sent = {}
+
+    class DummyWriter:
+        def send(self, summary):
+            sent.update(summary)
+
+    scheduler = SummaryScheduler(interval=timedelta(seconds=0), writer=DummyWriter())
+    scheduler.maybe_send([quest])
+    assert set(sent) == {"narratives", "faction_shifts", "case_files"}
+    assert sent["faction_shifts"] == {"alpha": 1}


### PR DESCRIPTION
## Summary
- add quest reporting helpers for narratives, faction shifts, and case files
- schedule periodic quest summaries to Thought Server
- test report formatting and scheduler output

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/quest/reports.py src/deepthought/quest/__init__.py tests/test_quest_reports.py`
- `pytest tests/test_quest_reports.py`


------
https://chatgpt.com/codex/tasks/task_e_68969a0ea9c8832688f352374b43f333