### PR TITLE
feat: route quest updates to discord channels

### DIFF
--- a/src/deepthought/planning/stacked_planner.py
+++ b/src/deepthought/planning/stacked_planner.py
@@ -4,33 +4,13 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable, Iterable, List
 
-import requests
+from ..quest.writer import QuestWriter
 
 logger = logging.getLogger(__name__)
-
-
-class DiscordThoughtWriter:
-    """Send planner summaries to a Discord channel."""
-
-    def __init__(self, channel_id: str | None = None, token: str | None = None) -> None:
-        self._channel_id = channel_id or os.getenv("THOUGHT_CHANNEL")
-        self._token = token or os.getenv("DISCORD_TOKEN")
-
-    def send(self, summary: dict) -> None:
-        if not self._channel_id or not self._token:
-            return
-        url = f"https://discord.com/api/v10/channels/{self._channel_id}/messages"
-        headers = {"Authorization": f"Bot {self._token}"}
-        payload = {"content": json.dumps(summary)}
-        try:  # pragma: no cover - network operations
-            requests.post(url, headers=headers, json=payload, timeout=5)
-        except Exception:  # pragma: no cover - failure is non-fatal
-            logger.warning("Failed to send summary to Thought Server", exc_info=True)
 
 
 class StackedPlanner:
@@ -42,13 +22,13 @@ class StackedPlanner:
         planner_fn: Callable[[str, str], List[str]],
         snapshot_dir: str | Path = "planner_snapshots",
         *,
-        thought_writer: DiscordThoughtWriter | None = None,
+        writer: QuestWriter | None = None,
     ) -> None:
         self._translator = translator
         self._planner_fn = planner_fn
         self._snapshot_dir = Path(snapshot_dir)
         self._snapshot_dir.mkdir(parents=True, exist_ok=True)
-        self._writer = thought_writer or DiscordThoughtWriter()
+        self._writer = writer or QuestWriter()
         self._beliefs: List[str] = []
         self._desires: List[str] = []
         self._intentions: List[str] = []
@@ -182,9 +162,7 @@ class StackedPlanner:
         except Exception:  # pragma: no cover - disk errors
             logger.warning("Failed to write planner snapshot", exc_info=True)
 
-    def _persist_layer_snapshot(
-        self, goal: str, actions: List[str], layer: str
-    ) -> None:
+    def _persist_layer_snapshot(self, goal: str, actions: List[str], layer: str) -> None:
         """Persist the state of a single planning layer.
 
         Parameters
@@ -203,16 +181,12 @@ class StackedPlanner:
             "layer": layer,
             "actions": actions,
         }
-        fname = (
-            datetime.utcnow().strftime("%Y%m%d%H%M%S%f") + f"_{layer}.json"
-        )
+        fname = datetime.utcnow().strftime("%Y%m%d%H%M%S%f") + f"_{layer}.json"
         path = self._snapshot_dir / fname
         try:
             path.write_text(json.dumps(snapshot), encoding="utf-8")
         except Exception:  # pragma: no cover - disk errors
-            logger.warning(
-                "Failed to write %s layer snapshot", layer, exc_info=True
-            )
+            logger.warning("Failed to write %s layer snapshot", layer, exc_info=True)
 
     def _maybe_send_summary(self) -> None:
         now = datetime.utcnow()
@@ -224,7 +198,7 @@ class StackedPlanner:
                 "intentions": self._intentions,
             }
             try:
-                self._writer.send(summary)
+                self._writer.send_daily_summary(summary)
             except Exception:  # pragma: no cover - network errors
                 logger.warning("Failed to publish planner summary", exc_info=True)
             self._last_summary = now

--- a/src/deepthought/quest/__init__.py
+++ b/src/deepthought/quest/__init__.py
@@ -1,23 +1,23 @@
 """Quest management utilities."""
 
+from . import dsl
+from .fsm import QuestFSM, QuestState
 from .storage import (
-    Quest,
-    Objective,
-    Evidence,
     Epiphany,
+    Evidence,
     LieRecord,
+    Objective,
+    Quest,
     QuestStorage,
 )
-
-from . import dsl
 from .templates import (
-    QuestTemplate,
-    CooldownTracker,
-    bind_slot,
-    auto_spawn_quests,
     TEMPLATES,
+    CooldownTracker,
+    QuestTemplate,
+    auto_spawn_quests,
+    bind_slot,
 )
-from .fsm import QuestState, QuestFSM
+from .writer import QuestWriter
 
 __all__ = [
     "Quest",
@@ -34,4 +34,5 @@ __all__ = [
     "TEMPLATES",
     "QuestState",
     "QuestFSM",
+    "QuestWriter",
 ]

--- a/src/deepthought/quest/storage.py
+++ b/src/deepthought/quest/storage.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, List
+from typing import List, Optional
 
 from ..services.db_manager import DBManager
+from .writer import QuestWriter
 
 
 @dataclass
@@ -68,8 +69,9 @@ class Quest:
 class QuestStorage:
     """DAO layer for quests and related entities."""
 
-    def __init__(self, db: DBManager) -> None:
+    def __init__(self, db: DBManager, writer: QuestWriter | None = None) -> None:
         self.db = db
+        self.writer = writer
 
     async def add_quest(self, quest: Quest) -> int:
         await self.db.connect()
@@ -97,6 +99,8 @@ class QuestStorage:
         await self.db._db.commit()
         quest_id = cur.lastrowid
         quest.id = quest_id
+        if self.writer:
+            self.writer.send_board_update(quest, event="created")
         return quest_id
 
     async def add_objective(self, objective: Objective) -> int:
@@ -145,6 +149,8 @@ class QuestStorage:
         await self.db._db.commit()
         lie_id = cur.lastrowid
         lie.id = lie_id
+        if self.writer:
+            self.writer.send_lie(lie.quest_id, lie.lie)
         return lie_id
 
     async def get_quest(self, quest_id: int) -> Optional[Quest]:
@@ -271,6 +277,8 @@ class QuestStorage:
             ),
         )
         await self.db._db.commit()
+        if self.writer:
+            self.writer.send_board_update(quest, event="updated")
 
     async def delete_quest(self, quest_id: int) -> None:
         """Delete a quest and its related records."""

--- a/src/deepthought/quest/writer.py
+++ b/src/deepthought/quest/writer.py
@@ -1,0 +1,81 @@
+"""Utilities for routing quest updates to communication channels."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class QuestWriter:
+    """Send quest-related updates to Discord channels.
+
+    Parameters can be provided directly or via environment variables:
+
+    - ``QUEST_BOARD_CHANNEL``: channel for general quest updates.
+    - ``QUEST_JOURNAL_TEMPLATE``: template for per-quest journals, e.g. ``"quest-{id}"``.
+    - ``OPSSEC_LIES_CHANNEL``: channel for lie ledger updates.
+    - ``DAILY_SUMMARY_CHANNEL``: channel for daily planner summaries.
+    - ``DISCORD_TOKEN``: bot token for authentication.
+    """
+
+    def __init__(
+        self,
+        *,
+        board_channel: str | None = None,
+        journal_template: str | None = None,
+        opssec_channel: str | None = None,
+        daily_channel: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self._board_channel = board_channel or os.getenv("QUEST_BOARD_CHANNEL")
+        self._journal_template = journal_template or os.getenv("QUEST_JOURNAL_TEMPLATE")
+        self._opssec_channel = opssec_channel or os.getenv("OPSSEC_LIES_CHANNEL")
+        self._daily_channel = daily_channel or os.getenv("DAILY_SUMMARY_CHANNEL")
+        self._token = token or os.getenv("DISCORD_TOKEN")
+
+    # ------------------------------------------------------------------
+    def _post(self, channel_id: Optional[str], content: str) -> None:
+        if not channel_id or not self._token:
+            return
+        url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+        headers = {"Authorization": f"Bot {self._token}"}
+        payload = {"content": content}
+        try:  # pragma: no cover - network operations
+            requests.post(url, headers=headers, json=payload, timeout=5)
+        except Exception:  # pragma: no cover - failure is non-fatal
+            logger.warning("Failed to send message to channel %s", channel_id, exc_info=True)
+
+    # ------------------------------------------------------------------
+    def send_board_update(self, quest: Any, event: str = "updated") -> None:
+        """Post quest updates to the quest board and journal."""
+
+        message = f"[{event}] {quest.name}: {quest.description}"
+        self._post(self._board_channel, message)
+        if quest.id is not None:
+            self.send_journal_entry(quest.id, message)
+
+    def send_journal_entry(self, quest_id: int, message: str) -> None:
+        """Send a note to the per-quest journal."""
+
+        if not self._journal_template:
+            return
+        channel_id = self._journal_template.format(id=quest_id)
+        self._post(channel_id, message)
+
+    def send_lie(self, quest_id: int, lie: str) -> None:
+        """Record a lie in the opssec ledger and journal."""
+
+        message = f"Lie recorded for quest {quest_id}: {lie}"
+        self._post(self._opssec_channel, message)
+        self.send_journal_entry(quest_id, message)
+
+    def send_daily_summary(self, summary: dict) -> None:
+        """Publish a daily planner summary."""
+
+        self._post(self._daily_channel, json.dumps(summary))

--- a/tests/test_auto_spawn_budget.py
+++ b/tests/test_auto_spawn_budget.py
@@ -1,8 +1,13 @@
 import pytest
 
+from deepthought.quest.templates import (
+    CooldownTracker,
+    HorizonManager,
+    HorizonRule,
+    auto_spawn_quests,
+)
 from deepthought.services import DBManager
 from deepthought.services.social_graph_memory import SocialGraphMemory
-from deepthought.quest.templates import CooldownTracker, auto_spawn_quests
 
 pytest.importorskip("aiosqlite")
 
@@ -14,13 +19,18 @@ async def test_auto_spawn_respects_budget(tmp_path):
     await db.adjust_affinity("u1", 5)
 
     tracker = CooldownTracker()
-    budget = {"short": 1, "medium": 1, "long": 0}
+    rules = {
+        "short": HorizonRule(limit=1),
+        "medium": HorizonRule(limit=1),
+        "long": HorizonRule(limit=0),
+    }
+    manager = HorizonManager(rules)
 
-    quests = await auto_spawn_quests(budget, memory, tracker)
+    quests = await auto_spawn_quests(manager, memory, tracker)
     names = [q.name for q in quests]
 
     assert names == ["Investigation", "Side"]
-    assert budget["short"] == 0
-    assert budget["medium"] == 0
+    assert not manager.can_spawn("short")
+    assert not manager.can_spawn("medium")
 
-    await db.close()
+    await memory.close()


### PR DESCRIPTION
## Summary
- add QuestWriter for routing updates to quest-board, per-quest journals, opssec lies, and daily summaries
- integrate QuestWriter with quest lifecycle storage events
- hook StackedPlanner to QuestWriter for daily summary output
- adapt auto spawn budget test to HorizonManager API

## Testing
- `SKIP=pytest pre-commit run --files tests/test_auto_spawn_budget.py`
- `pytest tests/test_quest_storage_crud.py -q`
- `pytest tests/test_stacked_planner_layers.py -q`
- `pytest tests/unit/test_stacked_planner_arbitration.py -q`
- `pytest tests/test_auto_spawn_budget.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68969a0e11e48326af534fa96163178c