### PR TITLE
feat: add bot crowding heuristics

### DIFF
--- a/src/deepthought/bot/interaction.py
+++ b/src/deepthought/bot/interaction.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Iterable
 
 from deepthought.services.db_manager import DBManager
 
@@ -27,3 +27,24 @@ async def log_interaction(
     sentiment_score: float | None = None,
 ) -> None:
     await _db().log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+
+
+def is_bot(user: object) -> bool:
+    """Return ``True`` if a user object or name appears bot-like.
+
+    The heuristic checks for a truthy ``bot`` attribute or the substring
+    ``"bot"`` in the user's name.  It operates on minimal information to avoid
+    depending on any specific chat platform.
+    """
+
+    if hasattr(user, "bot") and bool(getattr(user, "bot")):
+        return True
+    name = getattr(user, "name", str(user))
+    return "bot" in name.lower()
+
+
+def is_crowded(participants: Iterable[object], bot_threshold: int = 2) -> bool:
+    """Return ``True`` if a conversation has too many bot participants."""
+
+    bot_count = sum(1 for p in participants if is_bot(p))
+    return bot_count >= bot_threshold

--- a/src/deepthought/planning/stacked_planner.py
+++ b/src/deepthought/planning/stacked_planner.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable, Iterable, List
 
+from ..bot import interaction as bot_interaction
 from ..quest.writer import QuestWriter
 
 logger = logging.getLogger(__name__)
@@ -84,9 +85,14 @@ class StackedPlanner:
         vibes_fit: float = 0.0,
         silence_threshold: float = 0.0,
         cooldown: float = 0.0,
+        participants: Iterable[object] | None = None,
+        bot_threshold: int = 2,
     ) -> bool:
         now = datetime.utcnow()
         if now < self._next_action_time:
+            return False
+        if participants and bot_interaction.is_crowded(participants, bot_threshold):
+            self._next_action_time = now + timedelta(seconds=cooldown)
             return False
         score = self.utility_score(
             info_gain=info_gain,

--- a/tests/unit/test_interaction_heuristics.py
+++ b/tests/unit/test_interaction_heuristics.py
@@ -1,0 +1,18 @@
+from deepthought.bot import interaction
+
+
+def test_is_bot_heuristic():
+    class User:
+        def __init__(self, name, bot=False):
+            self.name = name
+            self.bot = bot
+
+    assert interaction.is_bot(User("HelperBot"))
+    assert interaction.is_bot(User("Alice", bot=True))
+    assert not interaction.is_bot(User("Alice"))
+
+
+def test_is_crowded_heuristic():
+    participants = ["AlphaBot", "BetaBot", "Charlie"]
+    assert interaction.is_crowded(participants)
+    assert not interaction.is_crowded(["Alice", "Bob"])

--- a/tests/unit/test_stacked_planner_arbitration.py
+++ b/tests/unit/test_stacked_planner_arbitration.py
@@ -36,3 +36,9 @@ def test_silence_threshold_and_cooldown(monkeypatch):
     assert not planner.should_act(info_gain=1.0, silence_threshold=0.0)
     fake_now = fake_now + timedelta(seconds=10)
     assert planner.should_act(info_gain=1.0, silence_threshold=0.0)
+
+
+def test_should_act_silent_when_crowded_bots():
+    planner = StackedPlanner(DummyTranslator(), dummy_planner)
+    participants = ["AlphaBot", "BetaBot", "Charlie"]
+    assert not planner.should_act(info_gain=1.0, participants=participants)


### PR DESCRIPTION
## Summary
- detect bots and crowded conversations in interaction helpers
- gate StackedPlanner actions when bots crowd
- test bot detection and planner silence with many bots

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/bot/interaction.py src/deepthought/planning/stacked_planner.py tests/unit/test_stacked_planner_arbitration.py tests/unit/test_interaction_heuristics.py`
- `pytest tests/unit/test_interaction_heuristics.py tests/unit/test_stacked_planner_arbitration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896b9d7a0b88326aadec634484f579a