### PR TITLE
feat: add reply style selector

### DIFF
--- a/src/deepthought/bot/interaction.py
+++ b/src/deepthought/bot/interaction.py
@@ -29,6 +29,46 @@ async def log_interaction(
     await _db().log_interaction(user_id, target_id, sentiment_score=sentiment_score)
 
 
+STYLE_LEVELS = ["silence", "emoji", "word", "one-liner", "paragraph"]
+
+
+def choose_style(utility: float, tone: str = "neutral") -> str:
+    """Select a reply style based on utility and tone preference.
+
+    Parameters
+    ----------
+    utility:
+        A score in ``[0, 1]`` indicating how useful a response would be.  Higher
+        values correspond to longer replies.
+    tone:
+        User tone preference. ``"concise"`` biases toward shorter replies while
+        ``"verbose"`` biases toward longer replies.
+
+    Returns
+    -------
+    str
+        One of ``"silence"``, ``"emoji"``, ``"word"``, ``"one-liner"``, or
+        ``"paragraph"``.
+    """
+
+    idx = 0
+    if utility >= 0.2:
+        idx = 1
+    if utility >= 0.4:
+        idx = 2
+    if utility >= 0.6:
+        idx = 3
+    if utility >= 0.8:
+        idx = 4
+
+    if tone == "concise":
+        idx = max(0, idx - 1)
+    elif tone == "verbose":
+        idx = min(len(STYLE_LEVELS) - 1, idx + 1)
+
+    return STYLE_LEVELS[idx]
+
+
 def is_bot(user: object) -> bool:
     """Return ``True`` if a user object or name appears bot-like.
 

--- a/tests/unit/test_interaction_heuristics.py
+++ b/tests/unit/test_interaction_heuristics.py
@@ -16,3 +16,16 @@ def test_is_crowded_heuristic():
     participants = ["AlphaBot", "BetaBot", "Charlie"]
     assert interaction.is_crowded(participants)
     assert not interaction.is_crowded(["Alice", "Bob"])
+
+
+def test_choose_style_levels():
+    assert interaction.choose_style(0.1) == "silence"
+    assert interaction.choose_style(0.3) == "emoji"
+    assert interaction.choose_style(0.5) == "word"
+    assert interaction.choose_style(0.7) == "one-liner"
+    assert interaction.choose_style(0.9) == "paragraph"
+
+
+def test_choose_style_tone_adjustment():
+    assert interaction.choose_style(0.5, tone="concise") == "emoji"
+    assert interaction.choose_style(0.5, tone="verbose") == "one-liner"


### PR DESCRIPTION
## Summary
- enable bot to select reply style based on utility and tone preferences
- test style selection outcomes

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/bot/interaction.py tests/unit/test_interaction_heuristics.py`
- `pytest tests/unit/test_interaction_heuristics.py`


------
https://chatgpt.com/codex/tasks/task_e_6897ba0ac01c8326a2a3a633ce5af993