### PR TITLE
Track quest-specific lies with expiry

### DIFF
--- a/src/deepthought/bot/deception.py
+++ b/src/deepthought/bot/deception.py
@@ -68,14 +68,14 @@ def _get_lie_generator():
     return _lie_text_generator
 
 
-async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
-    """Return a cover message if ``text`` probes for internal plans."""
+async def maybe_deceptive_reply(quest_id: int, text: str) -> str | None:
+    """Return a cover story if ``text`` probes for internal plans for ``quest_id``."""
     if not ALLOW_DECEPTION:
         return None
 
     lower = text.lower()
     if "your" in lower and any(k in lower for k in ["plan", "plans", "goal", "goals", "intention", "intentions"]):
-        reply = await _db().get_last_lie(user_id, text)
+        reply = await _db().get_last_lie(quest_id, text)
         if reply is None:
             if DECEPTION_REPLY_MODE == "dynamic":
                 try:
@@ -92,14 +92,16 @@ async def maybe_deceptive_reply(user_id: int, text: str) -> str | None:
                     reply = DECEPTION_COVER_MESSAGE
             else:
                 reply = DECEPTION_COVER_MESSAGE
-            await _db().store_lie(user_id, text, reply)
+            await _db().store_lie(quest_id, text, reply)
         return reply
     return None
 
 
-async def store_lie(user_id: int, question: str, reply: str) -> None:
-    await _db().store_lie(user_id, question, reply)
+async def store_lie(quest_id: int, question: str, reply: str) -> None:
+    """Persist a lie for ``quest_id``"""
+    await _db().store_lie(quest_id, question, reply)
 
 
-async def get_last_lie(user_id: int, question: str) -> str | None:
-    return await _db().get_last_lie(user_id, question)
+async def get_last_lie(quest_id: int, question: str) -> str | None:
+    """Retrieve the latest lie for ``quest_id`` matching ``question`` if unexpired."""
+    return await _db().get_last_lie(quest_id, question)

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import aiosqlite
 
@@ -213,9 +213,10 @@ class DBManager:
         """,
         """
         CREATE TABLE IF NOT EXISTS lies (
-            user_id TEXT,
+            quest_id INTEGER,
             question TEXT,
             reply TEXT,
+            expires TIMESTAMP,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         )
         """,
@@ -563,8 +564,11 @@ class DBManager:
         ) as cur:
             return await cur.fetchall()
 
-    async def store_lie(self, user_id: int, question: str, reply: str) -> None:
-        """Store a fabricated ``reply`` for ``question`` asked by ``user_id``."""
+    async def store_lie(self, quest_id: int, question: str, reply: str, ttl: int = 3600) -> None:
+        """Store a fabricated ``reply`` for ``question`` tied to ``quest_id``.
+
+        ``ttl`` is the number of seconds before the record expires.
+        """
         if not isinstance(question, str) or not question.strip():
             raise ValueError("question must be a non-empty string")
         if not isinstance(reply, str) or not reply.strip():
@@ -572,33 +576,39 @@ class DBManager:
 
         await self.connect()
         assert self._db
+        expires = datetime.utcnow() + timedelta(seconds=int(ttl))
+        expires_str = expires.strftime("%Y-%m-%d %H:%M:%S")
         await self._db.execute(
-            "INSERT INTO lies (user_id, question, reply) VALUES (?, ?, ?)",
-            (str(user_id), question, reply),
+            "INSERT INTO lies (quest_id, question, reply, expires) VALUES (?, ?, ?, ?)",
+            (quest_id, question, reply, expires_str),
         )
         await self._db.commit()
 
-    async def get_last_lie(self, user_id: int, question: str) -> str | None:
-        """Return the most recent fabricated reply for ``question`` by ``user_id``."""
+    async def get_last_lie(self, quest_id: int, question: str) -> str | None:
+        """Return the most recent lie for ``question`` by ``quest_id`` if not expired."""
         await self.connect()
         assert self._db
+        await self._db.execute("DELETE FROM lies WHERE expires <= CURRENT_TIMESTAMP")
+        await self._db.commit()
         async with self._db.execute(
-            "SELECT reply FROM lies WHERE user_id=? AND question=? " "ORDER BY rowid DESC LIMIT 1",
-            (str(user_id), question),
+            "SELECT reply FROM lies WHERE quest_id=? AND question=? AND expires > CURRENT_TIMESTAMP "
+            "ORDER BY rowid DESC LIMIT 1",
+            (quest_id, question),
         ) as cur:
             row = await cur.fetchone()
             return row[0] if row else None
 
-    async def list_lies(self, limit: int = 20) -> list[tuple[int, str, str, str]]:
-        """Return recent entries from the ``lies`` table.
+    async def list_lies(self, limit: int = 20) -> list[tuple[int, int, str, str]]:
+        """Return recent non-expired entries from the ``lies`` table.
 
-        Each result is a tuple of ``(rowid, user_id, question, reply)`` ordered by
-        ``rowid`` descending. ``limit`` constrains the number of rows returned.
+        Each result is ``(rowid, quest_id, question, reply)`` ordered by
+        ``rowid`` descending.
         """
         await self.connect()
         assert self._db
         async with self._db.execute(
-            "SELECT rowid, user_id, question, reply FROM lies ORDER BY rowid DESC LIMIT ?",
+            "SELECT rowid, quest_id, question, reply FROM lies "
+            "WHERE expires > CURRENT_TIMESTAMP ORDER BY rowid DESC LIMIT ?",
             (limit,),
         ) as cur:
             return await cur.fetchall()
@@ -1096,9 +1106,7 @@ class DBManager:
             row = await cur.fetchone()
         return row[0] if row else None
 
-    async def update_edge(
-        self, source_id: int, target_id: int, edge_type: str, weight_delta: float
-    ) -> None:
+    async def update_edge(self, source_id: int, target_id: int, edge_type: str, weight_delta: float) -> None:
         """Insert or update a typed edge applying decay to the stored weight."""
         await self.connect()
         assert self._db

--- a/tests/test_lie_methods.py
+++ b/tests/test_lie_methods.py
@@ -1,5 +1,6 @@
 import sys
 import types
+
 import pytest
 
 pytest.importorskip("aiosqlite")
@@ -15,13 +16,21 @@ async def test_store_and_get_last_lie(tmp_path):
     manager = DBManager(str(db_file))
     await manager.init_db()
 
-    assert await manager.get_last_lie("u1", "q1") is None
-    await manager.store_lie("u1", "q1", "r1")
-    assert await manager.get_last_lie("u1", "q1") == "r1"
+    assert await manager.get_last_lie(1, "q1") is None
+    await manager.store_lie(1, "q1", "r1")
+    assert await manager.get_last_lie(1, "q1") == "r1"
 
-    await manager.store_lie("u1", "q1", "r2")
-    assert await manager.get_last_lie("u1", "q1") == "r2"
+    await manager.store_lie(1, "q1", "r2")
+    assert await manager.get_last_lie(1, "q1") == "r2"
 
-    await manager.close()
+
+@pytest.mark.asyncio
+async def test_lie_expiry(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    manager = DBManager(str(db_file))
+    await manager.init_db()
+
+    await manager.store_lie(1, "q1", "r1", ttl=-1)
+    assert await manager.get_last_lie(1, "q1") is None
 
     await manager.close()


### PR DESCRIPTION
## Summary
- scope lie storage to quests and include expiry timestamps
- have deception helpers log and query lies by quest identifier
- cover lie ledger retrieval and expiry with new tests

## Testing
- `SKIP=pytest pre-commit run --files tests/test_lie_methods.py src/deepthought/services/db_manager.py src/deepthought/bot/deception.py`
- `pytest tests/test_lie_methods.py tests/test_dynamic_deception.py tests/test_deception_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_6897ba0a2b4c83268e13fc8e6ec06323