### PR TITLE
Add quest story channel support

### DIFF
--- a/src/deepthought/quest/reports.py
+++ b/src/deepthought/quest/reports.py
@@ -16,22 +16,26 @@ from typing import Any, Dict, Iterable, List
 try:  # pragma: no cover - optional dependency
     from ..planning.stacked_planner import DiscordThoughtWriter
 except Exception:  # pragma: no cover
+
     class DiscordThoughtWriter:  # type: ignore[no-redef]
         def send(self, summary: dict) -> None:  # pragma: no cover - placeholder
             """Fallback writer used when planner module is unavailable."""
             pass
 
+
 from .storage import Quest
+from .writer import QuestWriter
 
 # ---------------------------------------------------------------------------
 # Report compilation helpers
 
 
-def compile_narratives(quests: Iterable[Quest]) -> List[str]:
+def compile_narratives(quests: Iterable[Quest], writer: QuestWriter | None = None) -> List[str]:
     """Return human readable narratives for each quest.
 
     The narrative includes the quest description, objectives, epiphanies and
-    notable lies recorded along the way.
+    notable lies recorded along the way. If ``writer`` is provided, narratives
+    for completed quests are posted via ``QuestWriter.send_quest_story``.
     """
 
     narratives: List[str] = []
@@ -43,6 +47,8 @@ def compile_narratives(quests: Iterable[Quest]) -> List[str]:
         if quest.lies:
             narrative += " Lies: " + "; ".join(lie.lie for lie in quest.lies) + "."
         narratives.append(narrative)
+        if writer:
+            writer.send_quest_story(quest, narrative)
     return narratives
 
 

--- a/src/deepthought/quest/writer.py
+++ b/src/deepthought/quest/writer.py
@@ -21,6 +21,10 @@ class QuestWriter:
     - ``QUEST_JOURNAL_TEMPLATE``: template for per-quest journals, e.g. ``"quest-{id}"``.
     - ``OPSSEC_LIES_CHANNEL``: channel for lie ledger updates.
     - ``DAILY_SUMMARY_CHANNEL``: channel for daily planner summaries.
+    - ``WHISPERS_DAILY_CHANNEL``: channel for daily whisper summaries.
+    - ``ALERTS_CHANNEL``: channel for runtime alerts.
+    - ``AUTOPSY_CHANNEL``: channel for quest autopsies.
+    - ``PARAMETERS_CHANNEL``: channel for parameter dumps.
     - ``DISCORD_TOKEN``: bot token for authentication.
     """
 
@@ -31,12 +35,20 @@ class QuestWriter:
         journal_template: str | None = None,
         opssec_channel: str | None = None,
         daily_channel: str | None = None,
+        whispers_daily_channel: str | None = None,
+        alerts_channel: str | None = None,
+        autopsy_channel: str | None = None,
+        parameters_channel: str | None = None,
         token: str | None = None,
     ) -> None:
         self._board_channel = board_channel or os.getenv("QUEST_BOARD_CHANNEL")
         self._journal_template = journal_template or os.getenv("QUEST_JOURNAL_TEMPLATE")
         self._opssec_channel = opssec_channel or os.getenv("OPSSEC_LIES_CHANNEL")
         self._daily_channel = daily_channel or os.getenv("DAILY_SUMMARY_CHANNEL")
+        self._whispers_daily_channel = whispers_daily_channel or os.getenv("WHISPERS_DAILY_CHANNEL")
+        self._alerts_channel = alerts_channel or os.getenv("ALERTS_CHANNEL")
+        self._autopsy_channel = autopsy_channel or os.getenv("AUTOPSY_CHANNEL")
+        self._parameters_channel = parameters_channel or os.getenv("PARAMETERS_CHANNEL")
         self._token = token or os.getenv("DISCORD_TOKEN")
 
     # ------------------------------------------------------------------
@@ -79,3 +91,25 @@ class QuestWriter:
         """Publish a daily planner summary."""
 
         self._post(self._daily_channel, json.dumps(summary))
+
+    def send_whispers_daily(self, message: str) -> None:
+        """Publish the daily whispers summary."""
+
+        self._post(self._whispers_daily_channel, message)
+
+    def send_alert(self, message: str) -> None:
+        """Send an alert message."""
+
+        self._post(self._alerts_channel, message)
+
+    def send_parameters(self, params: dict) -> None:
+        """Dump parameter information."""
+
+        self._post(self._parameters_channel, json.dumps(params))
+
+    def send_quest_story(self, quest: Any, narrative: str) -> None:
+        """Publish a quest narrative to the autopsy channel when completed."""
+
+        if getattr(quest, "status", "") != "completed":
+            return
+        self._post(self._autopsy_channel, narrative)

--- a/tests/test_quest_reports.py
+++ b/tests/test_quest_reports.py
@@ -7,6 +7,7 @@ from deepthought.quest import (
     LieRecord,
     Objective,
     Quest,
+    QuestWriter,
     SummaryScheduler,
     case_files,
     compile_narratives,
@@ -66,3 +67,44 @@ def test_scheduler_sends_summary_when_due():
     scheduler.maybe_send([quest])
     assert set(sent) == {"narratives", "faction_shifts", "case_files"}
     assert sent["faction_shifts"] == {"alpha": 1}
+
+
+def test_send_quest_story_posts_to_autopsy(monkeypatch):
+    quest = _sample_quest()
+    posted = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        posted.update({"url": url, "json": json})
+
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
+    monkeypatch.setenv("AUTOPSY_CHANNEL", "42")
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    writer = QuestWriter()
+    compile_narratives([quest], writer=writer)
+
+    assert posted["url"].endswith("/42/messages")
+    assert "Secret Mission" in posted["json"]["content"]
+
+
+def test_send_quest_story_ignores_incomplete(monkeypatch):
+    quest = _sample_quest()
+    quest.status = "pending"
+    called = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        called["called"] = True
+
+    monkeypatch.setenv("AUTOPSY_CHANNEL", "42")
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    writer = QuestWriter()
+    compile_narratives([quest], writer=writer)
+
+    assert called == {}


### PR DESCRIPTION
## Summary
- support new Discord channels via env vars (#whispers-daily, #alerts, #autopsy, #parameters)
- send quest stories to autopsy channel when quests complete
- test channel selection logic for quest stories

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/quest/writer.py src/deepthought/quest/reports.py tests/test_quest_reports.py`
- `pytest tests/test_quest_reports.py`

------
https://chatgpt.com/codex/tasks/task_e_689a837673808326b1351abb96797f71