### PR TITLE
Expand quest storage model with additional fields

### DIFF
--- a/src/deepthought/quest/dsl.py
+++ b/src/deepthought/quest/dsl.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import List
 
-from .storage import Quest, Objective, Evidence, Epiphany, LieRecord
+from .storage import Epiphany, Evidence, LieRecord, Objective, Quest
 
 
 def load_quests(path: str | Path) -> List[Quest]:
@@ -26,12 +26,8 @@ def load_quests(path: str | Path) -> List[Quest]:
             secrecy=q.get("secrecy", ""),
             risk=q.get("risk", ""),
             status=q.get("status", "pending"),
-            created=(
-                datetime.fromisoformat(q["created"]) if q.get("created") else None
-            ),
-            updated=(
-                datetime.fromisoformat(q["updated"]) if q.get("updated") else None
-            ),
+            created=(datetime.fromisoformat(q["created"]) if q.get("created") else None),
+            updated=(datetime.fromisoformat(q["updated"]) if q.get("updated") else None),
         )
         for o in q.get("objectives", []):
             obj = Objective(
@@ -39,14 +35,55 @@ def load_quests(path: str | Path) -> List[Quest]:
                 quest_id=quest.id or 0,
                 description=o["description"],
                 status=o.get("status", "pending"),
+                preconditions=o.get("preconditions", []),
+                success_criteria=o.get("success_criteria", []),
+                fail_criteria=o.get("fail_criteria", []),
+                fallbacks=o.get("fallbacks", []),
+                cooldowns=o.get("cooldowns", []),
             )
             for ev in o.get("evidence", []):
-                obj.evidence.append(Evidence(id=None, objective_id=obj.id or 0, content=ev))
+                if isinstance(ev, dict):
+                    obj.evidence.append(
+                        Evidence(
+                            id=None,
+                            objective_id=obj.id or 0,
+                            content=ev.get("content", ""),
+                            who=ev.get("who", ""),
+                            confidence_delta=ev.get("confidence_delta", 0.0),
+                            expiry=datetime.fromisoformat(ev["expiry"]) if ev.get("expiry") else None,
+                        )
+                    )
+                else:
+                    obj.evidence.append(Evidence(id=None, objective_id=obj.id or 0, content=ev))
             quest.objectives.append(obj)
         for epi in q.get("epiphanies", []):
-            quest.epiphanies.append(Epiphany(id=None, quest_id=quest.id or 0, insight=epi))
+            if isinstance(epi, dict):
+                quest.epiphanies.append(
+                    Epiphany(
+                        id=None,
+                        quest_id=quest.id or 0,
+                        insight=epi.get("insight", ""),
+                        who=epi.get("who", ""),
+                        confidence_delta=epi.get("confidence_delta", 0.0),
+                        expiry=datetime.fromisoformat(epi["expiry"]) if epi.get("expiry") else None,
+                    )
+                )
+            else:
+                quest.epiphanies.append(Epiphany(id=None, quest_id=quest.id or 0, insight=epi))
         for lie in q.get("lies", []):
-            quest.lies.append(LieRecord(id=None, quest_id=quest.id or 0, lie=lie))
+            if isinstance(lie, dict):
+                quest.lies.append(
+                    LieRecord(
+                        id=None,
+                        quest_id=quest.id or 0,
+                        lie=lie.get("lie", ""),
+                        who=lie.get("who", ""),
+                        confidence_delta=lie.get("confidence_delta", 0.0),
+                        expiry=datetime.fromisoformat(lie["expiry"]) if lie.get("expiry") else None,
+                    )
+                )
+            else:
+                quest.lies.append(LieRecord(id=None, quest_id=quest.id or 0, lie=lie))
         quests.append(quest)
     return quests
 
@@ -78,10 +115,39 @@ def quest_to_dict(quest: Quest) -> dict:
                 "id": o.id,
                 "description": o.description,
                 "status": o.status,
-                "evidence": [e.content for e in o.evidence],
+                "preconditions": o.preconditions,
+                "success_criteria": o.success_criteria,
+                "fail_criteria": o.fail_criteria,
+                "fallbacks": o.fallbacks,
+                "cooldowns": o.cooldowns,
+                "evidence": [
+                    {
+                        "content": e.content,
+                        "who": e.who,
+                        "confidence_delta": e.confidence_delta,
+                        "expiry": e.expiry.isoformat() if e.expiry else None,
+                    }
+                    for e in o.evidence
+                ],
             }
             for o in quest.objectives
         ],
-        "epiphanies": [e.insight for e in quest.epiphanies],
-        "lies": [lr.lie for lr in quest.lies],
+        "epiphanies": [
+            {
+                "insight": e.insight,
+                "who": e.who,
+                "confidence_delta": e.confidence_delta,
+                "expiry": e.expiry.isoformat() if e.expiry else None,
+            }
+            for e in quest.epiphanies
+        ],
+        "lies": [
+            {
+                "lie": lr.lie,
+                "who": lr.who,
+                "confidence_delta": lr.confidence_delta,
+                "expiry": lr.expiry.isoformat() if lr.expiry else None,
+            }
+            for lr in quest.lies
+        ],
     }

--- a/src/deepthought/quest/storage.py
+++ b/src/deepthought/quest/storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional
@@ -13,6 +14,9 @@ class Evidence:
     id: Optional[int]
     objective_id: int
     content: str
+    who: str = ""
+    confidence_delta: float = 0.0
+    expiry: Optional[datetime] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
 
@@ -22,6 +26,9 @@ class Epiphany:
     id: Optional[int]
     quest_id: int
     insight: str
+    who: str = ""
+    confidence_delta: float = 0.0
+    expiry: Optional[datetime] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
 
@@ -31,6 +38,9 @@ class LieRecord:
     id: Optional[int]
     quest_id: int
     lie: str
+    who: str = ""
+    confidence_delta: float = 0.0
+    expiry: Optional[datetime] = None
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
 
@@ -41,6 +51,11 @@ class Objective:
     quest_id: int
     description: str
     status: str = "pending"
+    preconditions: List[str] = field(default_factory=list)
+    success_criteria: List[str] = field(default_factory=list)
+    fail_criteria: List[str] = field(default_factory=list)
+    fallbacks: List[str] = field(default_factory=list)
+    cooldowns: List[str] = field(default_factory=list)
     created: Optional[datetime] = None
     updated: Optional[datetime] = None
     evidence: List[Evidence] = field(default_factory=list)
@@ -107,8 +122,22 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         cur = await self.db._db.execute(
-            "INSERT INTO objectives (quest_id, description, status) VALUES (?, ?, ?)",
-            (objective.quest_id, objective.description, objective.status),
+            """
+            INSERT INTO objectives (
+                quest_id, description, status, preconditions, success_criteria,
+                fail_criteria, fallbacks, cooldowns
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                objective.quest_id,
+                objective.description,
+                objective.status,
+                json.dumps(objective.preconditions),
+                json.dumps(objective.success_criteria),
+                json.dumps(objective.fail_criteria),
+                json.dumps(objective.fallbacks),
+                json.dumps(objective.cooldowns),
+            ),
         )
         await self.db._db.commit()
         obj_id = cur.lastrowid
@@ -119,8 +148,18 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         cur = await self.db._db.execute(
-            "INSERT INTO evidence (objective_id, content) VALUES (?, ?)",
-            (evidence.objective_id, evidence.content),
+            """
+            INSERT INTO evidence (
+                objective_id, content, who, confidence_delta, expiry
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                evidence.objective_id,
+                evidence.content,
+                evidence.who,
+                evidence.confidence_delta,
+                evidence.expiry.isoformat() if evidence.expiry else None,
+            ),
         )
         await self.db._db.commit()
         evidence_id = cur.lastrowid
@@ -131,8 +170,18 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         cur = await self.db._db.execute(
-            "INSERT INTO epiphanies (quest_id, insight) VALUES (?, ?)",
-            (epiphany.quest_id, epiphany.insight),
+            """
+            INSERT INTO epiphanies (
+                quest_id, insight, who, confidence_delta, expiry
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                epiphany.quest_id,
+                epiphany.insight,
+                epiphany.who,
+                epiphany.confidence_delta,
+                epiphany.expiry.isoformat() if epiphany.expiry else None,
+            ),
         )
         await self.db._db.commit()
         epiphany_id = cur.lastrowid
@@ -143,8 +192,18 @@ class QuestStorage:
         await self.db.connect()
         assert self.db._db is not None
         cur = await self.db._db.execute(
-            "INSERT INTO lie_ledger (quest_id, lie) VALUES (?, ?)",
-            (lie.quest_id, lie.lie),
+            """
+            INSERT INTO lie_ledger (
+                quest_id, lie, who, confidence_delta, expiry
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                lie.quest_id,
+                lie.lie,
+                lie.who,
+                lie.confidence_delta,
+                lie.expiry.isoformat() if lie.expiry else None,
+            ),
         )
         await self.db._db.commit()
         lie_id = cur.lastrowid
@@ -184,7 +243,11 @@ class QuestStorage:
         )
         # objectives
         async with self.db._db.execute(
-            "SELECT objective_id, description, status, created, updated FROM objectives WHERE quest_id=?",
+            """
+            SELECT objective_id, description, status, preconditions, success_criteria,
+                   fail_criteria, fallbacks, cooldowns, created, updated
+            FROM objectives WHERE quest_id=?
+            """,
             (quest_id,),
         ) as cur:
             obj_rows = await cur.fetchall()
@@ -194,12 +257,20 @@ class QuestStorage:
                 quest_id=quest_id,
                 description=o[1],
                 status=o[2],
-                created=datetime.fromisoformat(o[3]) if o[3] else None,
-                updated=datetime.fromisoformat(o[4]) if o[4] else None,
+                preconditions=json.loads(o[3]) if o[3] else [],
+                success_criteria=json.loads(o[4]) if o[4] else [],
+                fail_criteria=json.loads(o[5]) if o[5] else [],
+                fallbacks=json.loads(o[6]) if o[6] else [],
+                cooldowns=json.loads(o[7]) if o[7] else [],
+                created=datetime.fromisoformat(o[8]) if o[8] else None,
+                updated=datetime.fromisoformat(o[9]) if o[9] else None,
             )
             # evidence for objective
             async with self.db._db.execute(
-                "SELECT evidence_id, content, created, updated FROM evidence WHERE objective_id=?",
+                """
+                SELECT evidence_id, content, who, confidence_delta, expiry, created, updated
+                FROM evidence WHERE objective_id=?
+                """,
                 (obj.id,),
             ) as ecur:
                 e_rows = await ecur.fetchall()
@@ -209,14 +280,20 @@ class QuestStorage:
                         id=e[0],
                         objective_id=obj.id,
                         content=e[1],
-                        created=datetime.fromisoformat(e[2]) if e[2] else None,
-                        updated=datetime.fromisoformat(e[3]) if e[3] else None,
+                        who=e[2] or "",
+                        confidence_delta=e[3] or 0.0,
+                        expiry=datetime.fromisoformat(e[4]) if e[4] else None,
+                        created=datetime.fromisoformat(e[5]) if e[5] else None,
+                        updated=datetime.fromisoformat(e[6]) if e[6] else None,
                     )
                 )
             quest.objectives.append(obj)
         # epiphanies
         async with self.db._db.execute(
-            "SELECT epiphany_id, insight, created, updated FROM epiphanies WHERE quest_id=?",
+            """
+            SELECT epiphany_id, insight, who, confidence_delta, expiry, created, updated
+            FROM epiphanies WHERE quest_id=?
+            """,
             (quest_id,),
         ) as cur:
             epi_rows = await cur.fetchall()
@@ -226,13 +303,19 @@ class QuestStorage:
                     id=e[0],
                     quest_id=quest_id,
                     insight=e[1],
-                    created=datetime.fromisoformat(e[2]) if e[2] else None,
-                    updated=datetime.fromisoformat(e[3]) if e[3] else None,
+                    who=e[2] or "",
+                    confidence_delta=e[3] or 0.0,
+                    expiry=datetime.fromisoformat(e[4]) if e[4] else None,
+                    created=datetime.fromisoformat(e[5]) if e[5] else None,
+                    updated=datetime.fromisoformat(e[6]) if e[6] else None,
                 )
             )
         # lies
         async with self.db._db.execute(
-            "SELECT lie_id, lie, created, updated FROM lie_ledger WHERE quest_id=?",
+            """
+            SELECT lie_id, lie, who, confidence_delta, expiry, created, updated
+            FROM lie_ledger WHERE quest_id=?
+            """,
             (quest_id,),
         ) as cur:
             lie_rows = await cur.fetchall()
@@ -242,8 +325,11 @@ class QuestStorage:
                     id=record[0],
                     quest_id=quest_id,
                     lie=record[1],
-                    created=datetime.fromisoformat(record[2]) if record[2] else None,
-                    updated=datetime.fromisoformat(record[3]) if record[3] else None,
+                    who=record[2] or "",
+                    confidence_delta=record[3] or 0.0,
+                    expiry=datetime.fromisoformat(record[4]) if record[4] else None,
+                    created=datetime.fromisoformat(record[5]) if record[5] else None,
+                    updated=datetime.fromisoformat(record[6]) if record[6] else None,
                 )
             )
         return quest

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -257,6 +257,11 @@ class DBManager:
             quest_id INTEGER REFERENCES quests(quest_id),
             description TEXT NOT NULL,
             status TEXT DEFAULT 'pending',
+            preconditions TEXT,
+            success_criteria TEXT,
+            fail_criteria TEXT,
+            fallbacks TEXT,
+            cooldowns TEXT,
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
@@ -266,6 +271,9 @@ class DBManager:
             evidence_id INTEGER PRIMARY KEY,
             objective_id INTEGER REFERENCES objectives(objective_id),
             content TEXT NOT NULL,
+            who TEXT,
+            confidence_delta REAL DEFAULT 0,
+            expiry TIMESTAMP,
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
@@ -275,6 +283,9 @@ class DBManager:
             epiphany_id INTEGER PRIMARY KEY,
             quest_id INTEGER REFERENCES quests(quest_id),
             insight TEXT NOT NULL,
+            who TEXT,
+            confidence_delta REAL DEFAULT 0,
+            expiry TIMESTAMP,
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
@@ -284,6 +295,9 @@ class DBManager:
             lie_id INTEGER PRIMARY KEY,
             quest_id INTEGER REFERENCES quests(quest_id),
             lie TEXT NOT NULL,
+            who TEXT,
+            confidence_delta REAL DEFAULT 0,
+            expiry TIMESTAMP,
             created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )

--- a/tests/test_quest_dsl.py
+++ b/tests/test_quest_dsl.py
@@ -1,7 +1,7 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
+from deepthought.quest import Epiphany, Evidence, LieRecord, Objective, Quest
 from deepthought.quest.dsl import load_quests, save_quests
-from deepthought.quest import Evidence, Epiphany, LieRecord, Objective, Quest
 
 
 def test_load_and_save_roundtrip(tmp_path):
@@ -17,13 +17,51 @@ def test_load_and_save_roundtrip(tmp_path):
         secrecy="low",
         risk="low",
         status="pending",
-        created=datetime.utcnow(),
+        created=datetime.now(UTC),
     )
-    obj = Objective(id=10, quest_id=1, description="Do thing", status="done")
-    obj.evidence.append(Evidence(id=None, objective_id=10, content="proof"))
+    expiry = datetime.now(UTC).replace(microsecond=0)
+    obj = Objective(
+        id=10,
+        quest_id=1,
+        description="Do thing",
+        status="done",
+        preconditions=["prep"],
+        success_criteria=["success"],
+        fail_criteria=["fail"],
+        fallbacks=["fallback"],
+        cooldowns=["1h"],
+    )
+    obj.evidence.append(
+        Evidence(
+            id=None,
+            objective_id=10,
+            content="proof",
+            who="agent",
+            confidence_delta=0.5,
+            expiry=expiry,
+        )
+    )
     quest.objectives.append(obj)
-    quest.epiphanies.append(Epiphany(id=None, quest_id=1, insight="idea"))
-    quest.lies.append(LieRecord(id=None, quest_id=1, lie="fib"))
+    quest.epiphanies.append(
+        Epiphany(
+            id=None,
+            quest_id=1,
+            insight="idea",
+            who="sage",
+            confidence_delta=0.2,
+            expiry=expiry,
+        )
+    )
+    quest.lies.append(
+        LieRecord(
+            id=None,
+            quest_id=1,
+            lie="fib",
+            who="trickster",
+            confidence_delta=-0.3,
+            expiry=expiry,
+        )
+    )
 
     path = tmp_path / "quests.json"
     save_quests(path, [quest])
@@ -32,6 +70,15 @@ def test_load_and_save_roundtrip(tmp_path):
     assert len(loaded) == 1
     q = loaded[0]
     assert q.name == "Quest"
-    assert q.objectives[0].evidence[0].content == "proof"
-    assert q.epiphanies[0].insight == "idea"
-    assert q.lies[0].lie == "fib"
+    obj_f = q.objectives[0]
+    assert obj_f.preconditions == ["prep"]
+    assert obj_f.success_criteria == ["success"]
+    assert obj_f.fail_criteria == ["fail"]
+    assert obj_f.evidence[0].who == "agent" and obj_f.evidence[0].confidence_delta == 0.5
+    assert obj_f.evidence[0].expiry == expiry
+    epi_f = q.epiphanies[0]
+    assert epi_f.who == "sage" and epi_f.confidence_delta == 0.2
+    assert epi_f.expiry == expiry
+    lie_f = q.lies[0]
+    assert lie_f.who == "trickster" and lie_f.confidence_delta == -0.3
+    assert lie_f.expiry == expiry

--- a/tests/test_quest_storage_crud.py
+++ b/tests/test_quest_storage_crud.py
@@ -1,13 +1,16 @@
+from datetime import UTC, datetime
+
 import pytest
-from deepthought.services import DBManager
+
 from deepthought.quest import (
-    Evidence,
     Epiphany,
+    Evidence,
     LieRecord,
     Objective,
     Quest,
     QuestStorage,
 )
+from deepthought.services import DBManager
 
 pytest.importorskip("aiosqlite")
 
@@ -71,23 +74,66 @@ async def test_nested_entities(tmp_path):
     quest = Quest(id=None, name="Q", description="desc")
     quest_id = await storage.add_quest(quest)
 
-    obj = Objective(id=None, quest_id=quest_id, description="obj")
+    obj = Objective(
+        id=None,
+        quest_id=quest_id,
+        description="obj",
+        preconditions=["prep"],
+        success_criteria=["success"],
+        fail_criteria=["fail"],
+        fallbacks=["fallback"],
+        cooldowns=["1h"],
+    )
     obj_id = await storage.add_objective(obj)
 
-    ev = Evidence(id=None, objective_id=obj_id, content="proof")
+    expiry = datetime.now(UTC).replace(microsecond=0)
+    ev = Evidence(
+        id=None,
+        objective_id=obj_id,
+        content="proof",
+        who="agent",
+        confidence_delta=0.5,
+        expiry=expiry,
+    )
     await storage.add_evidence(ev)
 
-    epi = Epiphany(id=None, quest_id=quest_id, insight="aha")
+    epi = Epiphany(
+        id=None,
+        quest_id=quest_id,
+        insight="aha",
+        who="sage",
+        confidence_delta=0.2,
+        expiry=expiry,
+    )
     await storage.add_epiphany(epi)
 
-    lie = LieRecord(id=None, quest_id=quest_id, lie="fib")
+    lie = LieRecord(
+        id=None,
+        quest_id=quest_id,
+        lie="fib",
+        who="trickster",
+        confidence_delta=-0.3,
+        expiry=expiry,
+    )
     await storage.add_lie(lie)
 
     fetched = await storage.get_quest(quest_id)
     assert fetched is not None
-    assert fetched.objectives and fetched.objectives[0].evidence[0].content == "proof"
-    assert fetched.epiphanies and fetched.epiphanies[0].insight == "aha"
-    assert fetched.lies and fetched.lies[0].lie == "fib"
+    obj_f = fetched.objectives[0]
+    assert obj_f.preconditions == ["prep"]
+    assert obj_f.success_criteria == ["success"]
+    assert obj_f.fail_criteria == ["fail"]
+    assert obj_f.fallbacks == ["fallback"]
+    assert obj_f.cooldowns == ["1h"]
+    ev_f = obj_f.evidence[0]
+    assert ev_f.content == "proof" and ev_f.who == "agent" and ev_f.confidence_delta == 0.5
+    assert ev_f.expiry == expiry
+    epi_f = fetched.epiphanies[0]
+    assert epi_f.insight == "aha" and epi_f.who == "sage" and epi_f.confidence_delta == 0.2
+    assert epi_f.expiry == expiry
+    lie_f = fetched.lies[0]
+    assert lie_f.lie == "fib" and lie_f.who == "trickster" and lie_f.confidence_delta == -0.3
+    assert lie_f.expiry == expiry
 
     await storage.delete_quest(quest_id)
     assert await storage.get_quest(quest_id) is None


### PR DESCRIPTION
## Summary
- extend quest storage models with preconditions and richer evidence/epiphany/lie metadata
- support new columns in SQLite schemas and JSON DSL persistence
- test CRUD and DSL roundtrip for the expanded model

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/quest/storage.py src/deepthought/services/db_manager.py src/deepthought/quest/dsl.py tests/test_quest_storage_crud.py tests/test_quest_dsl.py`
- `pytest tests/test_quest_storage_crud.py tests/test_quest_dsl.py`


------
https://chatgpt.com/codex/tasks/task_e_689a83755bc483268f6aa2737cd5b149