### PR TITLE
Add bot message cache and novelty checks

### DIFF
--- a/src/deepthought/bot/interaction.py
+++ b/src/deepthought/bot/interaction.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import deque
+from datetime import datetime, timedelta
 from typing import Callable, Iterable
 
 from deepthought.services.db_manager import DBManager
@@ -83,8 +85,40 @@ def is_bot(user: object) -> bool:
     return "bot" in name.lower()
 
 
-def is_crowded(participants: Iterable[object], bot_threshold: int = 2) -> bool:
-    """Return ``True`` if a conversation has too many bot participants."""
+recent_bot_messages: deque[tuple[datetime, str]] = deque(maxlen=20)
+
+
+def record_bot_message(text: str) -> None:
+    """Record a message sent by a bot for etiquette checks."""
+
+    recent_bot_messages.append((datetime.utcnow(), text))
+
+
+def is_crowded(participants: Iterable[object], bot_threshold: int = 2, *, window: float = 10.0) -> bool:
+    """Return ``True`` if a conversation has too many bot participants or messages."""
 
     bot_count = sum(1 for p in participants if is_bot(p))
-    return bot_count >= bot_threshold
+    if bot_count >= bot_threshold:
+        return True
+
+    cutoff = datetime.utcnow() - timedelta(seconds=window)
+    while recent_bot_messages and recent_bot_messages[0][0] < cutoff:
+        recent_bot_messages.popleft()
+    return len(recent_bot_messages) >= bot_threshold
+
+
+def novel_response(text: str, *, threshold: float = 0.5, window: float = 60.0) -> bool:
+    """Return ``True`` if ``text`` is sufficiently different from recent bot messages."""
+
+    cutoff = datetime.utcnow() - timedelta(seconds=window)
+    tokens = set(text.lower().split())
+    for ts, msg in list(recent_bot_messages):
+        if ts < cutoff:
+            continue
+        other = set(msg.lower().split())
+        if not tokens or not other:
+            continue
+        jaccard = len(tokens & other) / len(tokens | other)
+        if jaccard >= threshold:
+            return False
+    return True

--- a/src/deepthought/planning/stacked_planner.py
+++ b/src/deepthought/planning/stacked_planner.py
@@ -98,12 +98,16 @@ class StackedPlanner:
         cooldown: float = 0.0,
         participants: Iterable[object] | None = None,
         bot_threshold: int = 2,
+        planned_text: str | None = None,
+        novelty_threshold: float = 0.5,
     ) -> bool:
         now = datetime.utcnow()
         if now < self._next_action_time:
             return False
         if participants and bot_interaction.is_crowded(participants, bot_threshold):
             self._next_action_time = now + timedelta(seconds=cooldown)
+            return False
+        if planned_text and not bot_interaction.novel_response(planned_text, threshold=novelty_threshold):
             return False
         score = self.utility_score(conversation or [])
         threshold = self.silence_threshold
@@ -113,6 +117,8 @@ class StackedPlanner:
         self._next_action_time = now + timedelta(seconds=cooldown)
         if score >= threshold:
             self._action_history.append(now)
+            if planned_text:
+                bot_interaction.record_bot_message(planned_text)
             return True
         return False
 

--- a/tests/test_multi_bot_etiquette.py
+++ b/tests/test_multi_bot_etiquette.py
@@ -122,6 +122,24 @@ async def test_silence_on_recent_bot(monkeypatch, tmp_path):
     await sg.db_manager.close()
 
 
+def test_novelty_helper_blocks_redundant():
+    from deepthought.bot import interaction
+    from deepthought.planning.stacked_planner import StackedPlanner
+
+    class DummyTranslator:
+        def translate(self, goal: str):
+            return "domain", "problem"
+
+    def dummy_planner(domain: str, problem: str):
+        return []
+
+    planner = StackedPlanner(DummyTranslator(), dummy_planner)
+    interaction.recent_bot_messages.clear()
+    assert planner.should_act(participants=["Alice"], planned_text="hello world", bot_threshold=5)
+    assert not planner.should_act(participants=["Alice"], planned_text="hello world", bot_threshold=5)
+    interaction.recent_bot_messages.clear()
+
+
 @pytest.mark.asyncio
 async def test_silence_on_message_cap(monkeypatch, tmp_path):
     sg = reload_sg(monkeypatch)

--- a/tests/test_multi_bot_silence.py
+++ b/tests/test_multi_bot_silence.py
@@ -17,9 +17,7 @@ def reload_sg(monkeypatch):
     sys.modules.setdefault("pydantic_settings", types.ModuleType("pydantic_settings"))
     sys.modules.setdefault("prometheus_client", types.ModuleType("prometheus_client"))
     tb_mod = types.ModuleType("textblob")
-    tb_mod.TextBlob = lambda text: types.SimpleNamespace(
-        sentiment=types.SimpleNamespace(polarity=0.0)
-    )
+    tb_mod.TextBlob = lambda text: types.SimpleNamespace(sentiment=types.SimpleNamespace(polarity=0.0))
     sys.modules.setdefault("textblob", tb_mod)
     rdf_mod = types.ModuleType("rdflib")
     rdf_mod.Namespace = lambda *a, **k: None
@@ -119,3 +117,22 @@ async def test_multi_bot_silence(monkeypatch, tmp_path):
 
     assert message.channel.sent_messages == []
     await sg.db_manager.close()
+
+
+def test_silence_when_room_crowded_simple():
+    from deepthought.bot import interaction
+    from deepthought.planning.stacked_planner import StackedPlanner
+
+    class DummyTranslator:
+        def translate(self, goal: str):
+            return "domain", "problem"
+
+    def dummy_planner(domain: str, problem: str):
+        return []
+
+    planner = StackedPlanner(DummyTranslator(), dummy_planner)
+    interaction.recent_bot_messages.clear()
+    interaction.record_bot_message("alpha")
+    interaction.record_bot_message("beta")
+    assert not planner.should_act(participants=["Alice"], planned_text="hello")
+    interaction.recent_bot_messages.clear()


### PR DESCRIPTION
## Summary
- track recent bot messages and extend crowded-room detection and a novel_response helper
- teach StackedPlanner to abstain on repeated or crowded bot chatter
- cover rate limiting and novelty with new multi-bot tests

## Testing
- `pre-commit run black --files src/deepthought/bot/interaction.py src/deepthought/planning/stacked_planner.py tests/test_multi_bot_silence.py tests/test_multi_bot_etiquette.py`
- `pre-commit run isort --files src/deepthought/bot/interaction.py src/deepthought/planning/stacked_planner.py tests/test_multi_bot_silence.py tests/test_multi_bot_etiquette.py`
- `pre-commit run flake8 --files src/deepthought/bot/interaction.py src/deepthought/planning/stacked_planner.py tests/test_multi_bot_silence.py tests/test_multi_bot_etiquette.py`
- `pytest tests/test_multi_bot_silence.py tests/test_multi_bot_etiquette.py`


------
https://chatgpt.com/codex/tasks/task_e_689a8a5b1a088326b1f6cc39bf94d2d5