### PR TITLE
Integrate Prism analytics with social graph memory

### DIFF
--- a/src/deepthought/services/prism_adapter.py
+++ b/src/deepthought/services/prism_adapter.py
@@ -1,0 +1,46 @@
+"""Adapter for translating Prism analytics into social graph updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .social_graph_memory import SocialGraphMemory
+
+
+@dataclass
+class PrismEvent:
+    """Structured representation of a Prism analytics payload."""
+
+    source: str
+    target: Optional[str]
+    sentiment: float
+    reply_latency: Optional[float] = None
+    emoji_counts: Dict[str, int] | None = None
+
+
+class PrismAdapter:
+    """Convert raw Prism events into calls on :class:`SocialGraphMemory`."""
+
+    def __init__(self, memory: "SocialGraphMemory") -> None:
+        self._memory = memory
+
+    def translate(self, payload: Dict) -> PrismEvent:
+        """Return a :class:`PrismEvent` from a raw payload."""
+
+        latency = payload.get("reply_latency")
+        return PrismEvent(
+            source=str(payload.get("source")),
+            target=payload.get("target"),
+            sentiment=float(payload.get("sentiment", 0.0)),
+            reply_latency=float(latency) if latency is not None else None,
+            emoji_counts=payload.get("emoji_counts") or {},
+        )
+
+    async def ingest(self, payload: Dict) -> None:
+        """Translate and forward a Prism event to the memory backend."""
+
+        event = self.translate(payload)
+        await self._memory.ingest_prism_event(event)
+

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from .prism_adapter import PrismEvent
+
 from textblob import TextBlob
 
 from .db_manager import DBManager
@@ -14,6 +16,10 @@ logger = logging.getLogger(__name__)
 FRIEND_THRESHOLD = 0.5
 RIVAL_THRESHOLD = -0.5
 MIN_INTERACTIONS = 3
+
+POSITIVE_EMOJIS = {"❤️", "👍"}
+NEGATIVE_EMOJIS = {"💔", "👎"}
+LATENCY_THRESHOLD = 5.0
 
 
 class SocialGraphMemory:
@@ -140,6 +146,26 @@ class SocialGraphMemory:
             graph, weight="weight"
         )
         return [sorted(list(c)) for c in communities]
+
+    async def ingest_prism_event(self, event: PrismEvent) -> None:
+        """Update the social graph using a preprocessed Prism event."""
+
+        await self._db.log_interaction(
+            event.source, event.target, sentiment_score=event.sentiment
+        )
+        if event.target is not None:
+            await self._update_relationship_type(event.source, event.target)
+
+        if event.reply_latency is not None:
+            delta = 1 if event.reply_latency <= LATENCY_THRESHOLD else -1
+            await self._db.adjust_affinity(event.source, delta)
+
+        if event.target is not None and event.emoji_counts:
+            for emoji, count in event.emoji_counts.items():
+                if emoji in POSITIVE_EMOJIS:
+                    await self.update_edge(event.source, event.target, "ally", float(count))
+                elif emoji in NEGATIVE_EMOJIS:
+                    await self.update_edge(event.source, event.target, "rival", float(count))
 
     async def close(self) -> None:
         await self._db.close()

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -12,6 +12,8 @@ from ..eda.events import EventSubjects
 from .base import BaseService
 from .db_manager import DBManager
 from .persona_manager import PersonaManager
+from .prism_adapter import PrismAdapter
+from .social_graph_memory import SocialGraphMemory
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +28,7 @@ class SocialGraphService(BaseService):
         db_manager: Optional[DBManager] = None,
         persona_manager: Optional[PersonaManager] = None,
         cognitive_core: CognitiveCoreService | None = None,
+        prism_adapter: Optional[PrismAdapter] = None,
         *,
         nats_url: str | None = None,
         connect_retries: int = 1,
@@ -39,10 +42,12 @@ class SocialGraphService(BaseService):
             connect_timeout=connect_timeout,
         )
         self._db = db_manager or DBManager()
+        self._memory = SocialGraphMemory(self._db)
         self._persona = persona_manager or PersonaManager(self._db)
         if cognitive_core is None:
             raise ValueError("cognitive_core service is required")
         self._core = cognitive_core
+        self._prism = prism_adapter or PrismAdapter(self._memory)
 
     async def _handle_input(self, msg: Msg) -> None:
         """Process an INPUT_RECEIVED message."""

--- a/tests/test_relationship_inference.py
+++ b/tests/test_relationship_inference.py
@@ -4,6 +4,7 @@ pytest.importorskip("aiosqlite")
 
 from deepthought.services import DBManager
 from deepthought.services.social_graph_memory import SocialGraphMemory
+from deepthought.services.prism_adapter import PrismAdapter
 
 
 @pytest.mark.asyncio
@@ -36,3 +37,36 @@ async def test_hostility_status(tmp_path):
     status = await mem2.get_relationship_status("alice", "bob")
     assert status == "rival"
     await mem2.close()
+
+
+@pytest.mark.asyncio
+async def test_prism_event_updates_affinity_and_edges(tmp_path):
+    db_path = tmp_path / "sg.db"
+    mem = SocialGraphMemory(DBManager(str(db_path)))
+    adapter = PrismAdapter(mem)
+
+    await adapter.ingest(
+        {
+            "source": "alice",
+            "target": "bob",
+            "sentiment": 0.7,
+            "reply_latency": 1.0,
+            "emoji_counts": {"❤️": 1},
+        }
+    )
+
+    await adapter.ingest(
+        {
+            "source": "mallory",
+            "target": "trent",
+            "sentiment": -0.6,
+            "reply_latency": 10.0,
+            "emoji_counts": {"💔": 2},
+        }
+    )
+
+    assert await mem.get_affinity("alice") > 0
+    assert await mem.get_affinity("mallory") < 0
+    assert await mem.get_edge_weight("alice", "bob", "ally") > 0
+    assert await mem.get_edge_weight("mallory", "trent", "rival") > 0
+    await mem.close()


### PR DESCRIPTION
## Summary
- add PrismAdapter to translate analytics payloads into memory updates
- expose `ingest_prism_event` in `SocialGraphMemory` and wire adapter in `SocialGraphService`
- test Prism events update affinity scores and social edges

## Testing
- `flake8 src/deepthought/services/prism_adapter.py src/deepthought/services/social_graph_memory.py src/deepthought/services/social_graph_service.py tests/test_relationship_inference.py`
- `pytest tests/test_relationship_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8a5a6e188326bad21ba07587436a