### PR TITLE
Add quest sweeper for expired quests

### DIFF
--- a/src/deepthought/quest/fsm.py
+++ b/src/deepthought/quest/fsm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Dict, Iterable, Optional, Set
+from typing import Dict, Optional, Set
 
 
 class QuestState(str, Enum):
@@ -51,9 +51,7 @@ class QuestFSM:
     ttl_seconds: Optional[int] = None
     _last_refresh: datetime = datetime.utcnow()
 
-    def transition(
-        self, new_state: QuestState, *, now: Optional[datetime] = None
-    ) -> None:
+    def transition(self, new_state: QuestState, *, now: Optional[datetime] = None) -> None:
         """Transition to ``new_state`` if allowed.
 
         ``now`` may be provided to override the current time for testing.
@@ -64,9 +62,7 @@ class QuestFSM:
             raise ValueError("Cannot transition from ABANDONED state")
         allowed = ALLOWED_TRANSITIONS[self.state]
         if new_state not in allowed:
-            raise ValueError(
-                f"Invalid transition from {self.state} to {new_state}"
-            )
+            raise ValueError(f"Invalid transition from {self.state} to {new_state}")
         self.state = new_state
         self.refresh(now=now)
 
@@ -90,3 +86,23 @@ class QuestFSM:
             return
         if self.is_expired(now=now):
             self.state = QuestState.ABANDONED
+
+    # ------------------------------------------------------------------
+    def ttl_metadata(self) -> tuple[Optional[int], datetime]:
+        """Return TTL seconds and last refresh timestamp.
+
+        These values are useful for external schedulers that need to reason
+        about when the FSM should expire without mutating it.
+        """
+
+        return self.ttl_seconds, self._last_refresh
+
+    def expires_at(self) -> Optional[datetime]:
+        """Return the absolute expiration time if the FSM has a TTL.
+
+        ``None`` is returned when no TTL is configured.
+        """
+
+        if self.ttl_seconds is None:
+            return None
+        return self._last_refresh + timedelta(seconds=self.ttl_seconds)

--- a/src/deepthought/quest/sweeper.py
+++ b/src/deepthought/quest/sweeper.py
@@ -1,0 +1,62 @@
+"""Utilities for sweeping expired quests.
+
+This module provides an async task that inspects quests stored in a
+``QuestStorage`` instance and moves any whose ``QuestFSM`` has expired to
+``ABANDONED``.  A summary of moved quests is sent through
+``QuestWriter.send_board_update``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, List, Tuple
+
+from .fsm import QuestFSM, QuestState
+from .storage import Quest, QuestStorage
+from .writer import QuestWriter
+
+
+async def sweep_expired_quests(
+    storage: QuestStorage,
+    *,
+    writer: QuestWriter | None = None,
+    now: datetime | None = None,
+) -> List[Quest]:
+    """Transition expired quests and emit a digest of moved quests.
+
+    Parameters
+    ----------
+    storage:
+        Source of quests and their FSM metadata.  It must provide a
+        ``list_quests`` coroutine returning an iterable of ``(Quest,
+        QuestFSM)`` pairs.
+    writer:
+        Optional ``QuestWriter`` used to publish a summary of moved quests.
+    now:
+        Override the current time, primarily for testing.
+
+    Returns
+    -------
+    list[Quest]
+        Quests that were transitioned to ``ABANDONED``.
+    """
+
+    now = now or datetime.utcnow()
+    moved: List[Quest] = []
+    quests: Iterable[Tuple[Quest, QuestFSM]] = await storage.list_quests()
+
+    for quest, fsm in quests:
+        expiration = fsm.expires_at()
+        if expiration and expiration <= now:
+            before = fsm.state
+            fsm.prune(now=now)
+            if before != fsm.state and fsm.state == QuestState.ABANDONED:
+                quest.status = QuestState.ABANDONED.value
+                await storage.update_quest(quest)
+                moved.append(quest)
+
+    if moved and writer is not None:
+        summary = {"abandoned": [q.id for q in moved]}
+        writer.send_board_update(summary, event="sweeper")
+
+    return moved

--- a/tests/test_quest_sweeper.py
+++ b/tests/test_quest_sweeper.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import pytest
+
+from deepthought.quest.fsm import QuestFSM, QuestState
+from deepthought.quest.sweeper import sweep_expired_quests
+
+
+@dataclass
+class Quest:
+    id: int
+    name: str
+    description: str
+    status: str
+
+
+class DummyStorage:
+    def __init__(self, quests):
+        self._quests = quests
+        self.updated = []
+
+    async def list_quests(self):
+        return list(self._quests)
+
+    async def update_quest(self, quest):
+        self.updated.append(quest)
+
+
+class DummyWriter:
+    def __init__(self):
+        self.messages = []
+
+    def send_board_update(self, payload, event="updated"):
+        self.messages.append((payload, event))
+
+
+@pytest.mark.asyncio
+async def test_sweep_expired_moves_and_summarizes():
+    base = datetime(2024, 1, 1)
+    expired_fsm = QuestFSM(ttl_seconds=10, _last_refresh=base)
+    active_fsm = QuestFSM(ttl_seconds=100, _last_refresh=base)
+
+    expired = Quest(1, "old", "", QuestState.TRACKED.value)
+    active = Quest(2, "new", "", QuestState.TRACKED.value)
+
+    storage = DummyStorage([(expired, expired_fsm), (active, active_fsm)])
+    writer = DummyWriter()
+
+    moved = await sweep_expired_quests(storage, writer=writer, now=base + timedelta(seconds=20))
+
+    assert moved == [expired]
+    assert expired.status == QuestState.ABANDONED.value
+    assert writer.messages[0][0] == {"abandoned": [1]}
+    # ensure TTL hook works
+    assert expired_fsm.expires_at() == base + timedelta(seconds=10)


### PR DESCRIPTION
## Summary
- add TTL metadata helpers to `QuestFSM`
- introduce sweeper task that prunes expired quests and reports a digest
- cover sweeper behavior with new tests

## Testing
- `pre-commit run black --files src/deepthought/quest/fsm.py src/deepthought/quest/sweeper.py tests/test_quest_sweeper.py`
- `pre-commit run isort --files src/deepthought/quest/fsm.py src/deepthought/quest/sweeper.py tests/test_quest_sweeper.py`
- `pre-commit run flake8 --files src/deepthought/quest/fsm.py src/deepthought/quest/sweeper.py tests/test_quest_sweeper.py`
- `pytest tests/unit/test_quest_fsm.py tests/test_quest_sweeper.py`

------
https://chatgpt.com/codex/tasks/task_e_689a8a5a0d088326af340c426e14757c