### PR TITLE
feat: enrich quest reporting

### DIFF
--- a/src/deepthought/quest/__init__.py
+++ b/src/deepthought/quest/__init__.py
@@ -22,6 +22,7 @@ from .reports import (
     SummaryScheduler,
     case_files,
     compile_narratives,
+    generate_living_report,
     weekly_faction_shifts,
 )
 
@@ -44,6 +45,7 @@ __all__ = [
     "QuestWriter",
     "SummaryScheduler",
     "compile_narratives",
+    "generate_living_report",
     "weekly_faction_shifts",
     "case_files",
 

--- a/src/deepthought/quest/reports.py
+++ b/src/deepthought/quest/reports.py
@@ -33,23 +33,70 @@ from .writer import QuestWriter
 def compile_narratives(quests: Iterable[Quest], writer: QuestWriter | None = None) -> List[str]:
     """Return human readable narratives for each quest.
 
-    The narrative includes the quest description, objectives, epiphanies and
-    notable lies recorded along the way. If ``writer`` is provided, narratives
-    for completed quests are posted via ``QuestWriter.send_quest_story``.
+    The narrative includes the quest description and objectives along with
+    cast lists, evidence summaries, unexpected twists and lessons learned.
+    If ``writer`` is provided, narratives for completed quests are posted via
+    ``QuestWriter.send_quest_story``.
     """
 
     narratives: List[str] = []
     for quest in quests:
         objectives = "; ".join(o.description for o in quest.objectives) or "no objectives"
         narrative = f"{quest.name}: {quest.description}. Objectives: {objectives}."
-        if quest.epiphanies:
-            narrative += " Epiphanies: " + "; ".join(e.insight for e in quest.epiphanies) + "."
+
+        cast = set()
+        evidence_summaries: List[str] = []
+        for obj in quest.objectives:
+            for ev in obj.evidence:
+                evidence_summaries.append(ev.content)
+                if ev.who:
+                    cast.add(ev.who)
+        for epi in quest.epiphanies:
+            if epi.who:
+                cast.add(epi.who)
+        for lie in quest.lies:
+            if lie.who:
+                cast.add(lie.who)
+
+        if cast:
+            narrative += " Cast: " + ", ".join(sorted(cast)) + "."
+        if evidence_summaries:
+            narrative += " Evidence: " + "; ".join(evidence_summaries) + "."
         if quest.lies:
-            narrative += " Lies: " + "; ".join(lie.lie for lie in quest.lies) + "."
+            narrative += " Twists: " + "; ".join(lie.lie for lie in quest.lies) + "."
+        if quest.epiphanies:
+            narrative += " Lessons: " + "; ".join(e.insight for e in quest.epiphanies) + "."
         narratives.append(narrative)
         if writer:
             writer.send_quest_story(quest, narrative)
     return narratives
+
+
+def generate_living_report(
+    quests: Iterable[Quest],
+    channel_activity: Dict[str, int],
+    writer: QuestWriter | None = None,
+) -> Dict[str, Any]:
+    """Return a "living" report of weekly arcs and channel heatmap.
+
+    ``channel_activity`` should map channel names to message counts. When a
+    ``writer`` is supplied the report is dispatched via
+    :meth:`QuestWriter.send_living_report`.
+    """
+
+    arcs: Dict[str, List[str]] = {}
+    for quest in quests:
+        timestamp = quest.updated or quest.created or datetime.utcnow()
+        week_start = (timestamp - timedelta(days=timestamp.weekday())).date().isoformat()
+        arcs.setdefault(week_start, []).append(f"{quest.name}: {quest.status}")
+
+    weekly_arcs = [
+        {"week": week, "summary": "; ".join(entries)} for week, entries in sorted(arcs.items())
+    ]
+    report = {"weekly_arcs": weekly_arcs, "channel_heatmap": channel_activity}
+    if writer:
+        writer.send_living_report(report)
+    return report
 
 
 def weekly_faction_shifts(quests: Iterable[Quest]) -> Dict[str, int]:

--- a/src/deepthought/quest/writer.py
+++ b/src/deepthought/quest/writer.py
@@ -25,6 +25,7 @@ class QuestWriter:
     - ``ALERTS_CHANNEL``: channel for runtime alerts.
     - ``AUTOPSY_CHANNEL``: channel for quest autopsies.
     - ``PARAMETERS_CHANNEL``: channel for parameter dumps.
+    - ``LIVING_REPORT_CHANNEL``: channel for weekly living reports.
     - ``DISCORD_TOKEN``: bot token for authentication.
     """
 
@@ -39,6 +40,7 @@ class QuestWriter:
         alerts_channel: str | None = None,
         autopsy_channel: str | None = None,
         parameters_channel: str | None = None,
+        living_channel: str | None = None,
         token: str | None = None,
     ) -> None:
         self._board_channel = board_channel or os.getenv("QUEST_BOARD_CHANNEL")
@@ -49,6 +51,7 @@ class QuestWriter:
         self._alerts_channel = alerts_channel or os.getenv("ALERTS_CHANNEL")
         self._autopsy_channel = autopsy_channel or os.getenv("AUTOPSY_CHANNEL")
         self._parameters_channel = parameters_channel or os.getenv("PARAMETERS_CHANNEL")
+        self._living_channel = living_channel or os.getenv("LIVING_REPORT_CHANNEL")
         self._token = token or os.getenv("DISCORD_TOKEN")
 
     # ------------------------------------------------------------------
@@ -113,3 +116,8 @@ class QuestWriter:
         if getattr(quest, "status", "") != "completed":
             return
         self._post(self._autopsy_channel, narrative)
+
+    def send_living_report(self, report: dict) -> None:
+        """Publish the weekly living report."""
+
+        self._post(self._living_channel, json.dumps(report))

--- a/tests/test_quest_reports.py
+++ b/tests/test_quest_reports.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from deepthought.quest import (
     Epiphany,
+    Evidence,
     LieRecord,
     Objective,
     Quest,
@@ -11,6 +12,7 @@ from deepthought.quest import (
     SummaryScheduler,
     case_files,
     compile_narratives,
+    generate_living_report,
     weekly_faction_shifts,
 )
 
@@ -23,9 +25,11 @@ def _sample_quest() -> Quest:
         faction="alpha",
         status="completed",
     )
-    quest.objectives = [Objective(id=1, quest_id=1, description="Infiltrate base")]
-    quest.epiphanies = [Epiphany(id=1, quest_id=1, insight="New lead")]
-    quest.lies = [LieRecord(id=1, quest_id=1, lie="Covered tracks")]
+    objective = Objective(id=1, quest_id=1, description="Infiltrate base")
+    objective.evidence = [Evidence(id=1, objective_id=1, content="Photos", who="Agent A")]
+    quest.objectives = [objective]
+    quest.epiphanies = [Epiphany(id=1, quest_id=1, insight="New lead", who="Agent A")]
+    quest.lies = [LieRecord(id=1, quest_id=1, lie="Covered tracks", who="Spy B")]
     return quest
 
 
@@ -33,8 +37,10 @@ def test_compile_narratives_format():
     narrative = compile_narratives([_sample_quest()])[0]
     assert "Secret Mission" in narrative
     assert "Objectives: Infiltrate base" in narrative
-    assert "Epiphanies: New lead" in narrative
-    assert "Lies: Covered tracks" in narrative
+    assert "Cast: Agent A, Spy B" in narrative
+    assert "Evidence: Photos" in narrative
+    assert "Twists: Covered tracks" in narrative
+    assert "Lessons: New lead" in narrative
 
 
 def test_weekly_faction_shifts_counts_status():
@@ -108,3 +114,34 @@ def test_send_quest_story_ignores_incomplete(monkeypatch):
     compile_narratives([quest], writer=writer)
 
     assert called == {}
+
+
+def test_generate_living_report_structure():
+    quest = _sample_quest()
+    report = generate_living_report([quest], {"ops": 3})
+    assert "weekly_arcs" in report
+    assert "channel_heatmap" in report
+    assert report["channel_heatmap"] == {"ops": 3}
+    assert any("Secret Mission" in arc["summary"] for arc in report["weekly_arcs"])
+
+
+def test_send_living_report_posts(monkeypatch):
+    quest = _sample_quest()
+    posted = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        posted.update({"url": url, "json": json})
+
+        class Resp:
+            status_code = 200
+
+        return Resp()
+
+    monkeypatch.setenv("LIVING_REPORT_CHANNEL", "99")
+    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setattr("requests.post", fake_post)
+
+    writer = QuestWriter()
+    generate_living_report([quest], {"ops": 1}, writer=writer)
+
+    assert posted["url"].endswith("/99/messages")


### PR DESCRIPTION
## Summary
- expand quest narratives with cast, evidence, twists, and lessons learned
- add weekly living report generation with channel heatmaps
- support dispatching living reports through `QuestWriter`

## Testing
- `flake8 src/deepthought/quest/reports.py src/deepthought/quest/writer.py src/deepthought/quest/__init__.py tests/test_quest_reports.py`
- `pytest tests/test_quest_reports.py::test_compile_narratives_format tests/test_quest_reports.py::test_weekly_faction_shifts_counts_status tests/test_quest_reports.py::test_case_files_structure tests/test_quest_reports.py::test_scheduler_sends_summary_when_due tests/test_quest_reports.py::test_send_quest_story_posts_to_autopsy tests/test_quest_reports.py::test_send_quest_story_ignores_incomplete tests/test_quest_reports.py::test_generate_living_report_structure tests/test_quest_reports.py::test_send_living_report_posts -q`


------
https://chatgpt.com/codex/tasks/task_e_689b560412a083268aa7633fd45827eb