### PR TITLE
Add QuestWriter and planner policy tests

### DIFF
--- a/tests/test_quest_sweeper.py
+++ b/tests/test_quest_sweeper.py
@@ -53,6 +53,6 @@ async def test_sweep_expired_moves_and_summarizes():
 
     assert moved == [expired]
     assert expired.status == QuestState.ABANDONED.value
-    assert writer.messages[0][0] == {"abandoned": [1]}
+    assert writer.messages == [({"abandoned": [1]}, "sweeper")]
     # ensure TTL hook works
     assert expired_fsm.expires_at() == base + timedelta(seconds=10)

--- a/tests/test_quest_writer.py
+++ b/tests/test_quest_writer.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import deepthought.quest.writer as writer_module
+from deepthought.quest.writer import QuestWriter
+
+
+@dataclass
+class Quest:
+    id: int
+    name: str
+    description: str
+
+
+def test_send_board_update_success(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):  # pragma: no cover - mocked
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+
+    monkeypatch.setattr(writer_module.requests, "post", fake_post)
+
+    quest = Quest(1, "quest", "desc")
+    writer = QuestWriter(board_channel="123", token="tok")
+
+    writer.send_board_update(quest, event="start")
+
+    assert "channels/123/messages" in captured["url"]
+    assert captured["headers"]["Authorization"] == "Bot tok"
+    assert captured["json"]["content"].startswith("[start] quest")
+
+
+def test_send_board_update_missing_token(monkeypatch):
+    called = False
+
+    def fake_post(*args, **kwargs):  # pragma: no cover - mocked
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(writer_module.requests, "post", fake_post)
+
+    quest = Quest(1, "quest", "desc")
+    writer = QuestWriter(board_channel="123", token=None)
+
+    writer.send_board_update(quest)
+
+    assert not called
+
+
+def test_send_board_update_network_failure(monkeypatch):
+    def fake_post(*args, **kwargs):  # pragma: no cover - mocked
+        raise RuntimeError("boom")
+
+    warnings: list[str] = []
+
+    def fake_warning(msg, *args, **kwargs):  # pragma: no cover - mocked
+        warnings.append(msg)
+
+    monkeypatch.setattr(writer_module.requests, "post", fake_post)
+    monkeypatch.setattr(writer_module.logger, "warning", fake_warning)
+
+    quest = Quest(1, "quest", "desc")
+    writer = QuestWriter(board_channel="123", token="tok")
+
+    writer.send_board_update(quest)
+
+    assert warnings, "network failure should trigger warning log"

--- a/tests/test_stacked_planner_policy.py
+++ b/tests/test_stacked_planner_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import deepthought.planning.stacked_planner as sp
+from deepthought.planning.stacked_planner import StackedPlanner
+
+
+class DummyTranslator:
+    def translate(self, goal: str):  # pragma: no cover - dummy
+        return "", ""
+
+
+def dummy_planner(domain: str, problem: str):  # pragma: no cover - dummy
+    return []
+
+
+def test_should_act_obeys_silence_heuristic(monkeypatch, tmp_path):
+    planner = StackedPlanner(DummyTranslator(), dummy_planner, snapshot_dir=tmp_path)
+    planner.silence_rate = 2
+    planner.silence_threshold = 0.0
+
+    now = datetime(2024, 1, 1)
+
+    class FakeDatetime(datetime):
+        @classmethod
+        def utcnow(cls):  # pragma: no cover - mocked
+            return now
+
+    monkeypatch.setattr(sp, "datetime", FakeDatetime)
+
+    assert planner.should_act(["hi"])
+    assert planner.should_act(["hi"])
+    assert not planner.should_act(["hi"])
+
+
+def test_should_act_checks_novelty(monkeypatch, tmp_path):
+    planner = StackedPlanner(DummyTranslator(), dummy_planner, snapshot_dir=tmp_path)
+
+    monkeypatch.setattr(sp.bot_interaction, "novel_response", lambda text, threshold: False)
+    called = []
+    monkeypatch.setattr(sp.bot_interaction, "record_bot_message", lambda text: called.append(text))
+
+    assert not planner.should_act(planned_text="hello", conversation=["hi"])
+    assert called == []


### PR DESCRIPTION
## Summary
- add QuestWriter tests for success, missing token, and network errors
- test StackedPlanner policy for silence heuristic and novelty gating
- verify quest sweeper emits digest when expiring quests

## Testing
- `python -m flake8 tests/test_quest_writer.py tests/test_stacked_planner_policy.py tests/test_quest_sweeper.py`
- `pytest tests/test_quest_writer.py tests/test_stacked_planner_policy.py tests/test_quest_sweeper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b560555408326897d7f05221af5a9