### PR TITLE
feat: add jittered scheduler ticks

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -32,6 +32,9 @@ class EventSubjects:
 
     # Scheduler events
     REMINDER_TRIGGERED = "dtr.scheduler.reminder_triggered"
+    MICRO_TICK = "dtr.scheduler.micro_tick"
+    DAILY_STANDUP = "dtr.scheduler.daily_standup"
+    WEEKLY_PLANNING = "dtr.scheduler.weekly_planning"
 
     # Code generation events
     CODE_TEMPLATE_REQUEST = "dtr.codegen.template_request"
@@ -107,6 +110,13 @@ class ReminderTriggeredPayload(EventPayload):
     message: str
     reminder_id: Optional[str] = None
     timestamp: Optional[str] = None
+
+
+@dataclass
+class TickPayload(EventPayload):
+    """Payload for periodic scheduler ticks."""
+
+    timestamp: str
 
 
 @dataclass

--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import random
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Awaitable, Callable, List, Optional
 
-from ..eda.events import EventSubjects, ReminderTriggeredPayload
+from ..eda.events import EventSubjects, ReminderTriggeredPayload, TickPayload
 from ..eda.publisher import Publisher
 from ..graph.dal import GraphDAL
 from ..motivate.caption import summarise_message
@@ -38,6 +40,11 @@ class SchedulerService:
         summary_db=None,
         now_func: Callable[[], datetime] | None = None,
         sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        micro_tick_range: tuple[float, float] | None = None,
+        daily_standup_interval: float | None = None,
+        weekly_planning_interval: float | None = None,
+        state_file: str | None = None,
+        jitter_fraction: float = 0.1,
     ) -> None:
         self._publisher = publisher
         self._memory_dal = memory_dal
@@ -48,6 +55,29 @@ class SchedulerService:
         self._sleep = sleep_func
         self._summary_db = summary_db
         self._chat_summary_interval = chat_summary_interval
+        self._micro_tick_range = micro_tick_range
+        self._standup_interval = daily_standup_interval
+        self._weekly_planning_interval = weekly_planning_interval
+        self._jitter_fraction = jitter_fraction
+        self._state_file = state_file
+        self._next_runs = self._load_state()
+        now = self._now()
+        if self._micro_tick_range is not None:
+            self._next_runs.setdefault(
+                "micro_tick", now + timedelta(seconds=self._next_micro_interval())
+            )
+        if self._standup_interval is not None:
+            self._next_runs.setdefault(
+                "daily_standup",
+                now + timedelta(seconds=self._jittered(self._standup_interval)),
+            )
+        if self._weekly_planning_interval is not None:
+            self._next_runs.setdefault(
+                "weekly_planning",
+                now + timedelta(seconds=self._jittered(self._weekly_planning_interval)),
+            )
+        if self._next_runs:
+            self._persist_state()
         self._reminders: List[ScheduledReminder] = []
         self._running = False
         self._summary_task: Optional[asyncio.Task] = None
@@ -55,6 +85,9 @@ class SchedulerService:
         self._daily_summary_task: Optional[asyncio.Task] = None
         self._chat_summary_task: Optional[asyncio.Task] = None
         self._goal_task: Optional[asyncio.Task] = None
+        self._micro_tick_task: Optional[asyncio.Task] = None
+        self._standup_task: Optional[asyncio.Task] = None
+        self._planning_task: Optional[asyncio.Task] = None
 
     def schedule_reminder(self, message: str, when: datetime, reminder_id: str) -> None:
         """Schedule a reminder message for the future."""
@@ -68,6 +101,12 @@ class SchedulerService:
         self._reminder_task = asyncio.create_task(self._reminder_loop())
         self._chat_summary_task = asyncio.create_task(self._chat_summary_loop())
         self._goal_task = asyncio.create_task(self._goal_loop())
+        if self._micro_tick_range is not None:
+            self._micro_tick_task = asyncio.create_task(self._micro_tick_loop())
+        if self._standup_interval is not None:
+            self._standup_task = asyncio.create_task(self._standup_loop())
+        if self._weekly_planning_interval is not None:
+            self._planning_task = asyncio.create_task(self._planning_loop())
         return True
 
     async def stop(self) -> None:
@@ -80,6 +119,9 @@ class SchedulerService:
                 self._reminder_task,
                 self._chat_summary_task,
                 self._goal_task,
+                self._micro_tick_task,
+                self._standup_task,
+                self._planning_task,
             ]
             if t
         ]
@@ -97,6 +139,30 @@ class SchedulerService:
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         await self.stop()
+
+    def _next_micro_interval(self) -> float:
+        return random.uniform(*self._micro_tick_range)
+
+    def _jittered(self, base: float) -> float:
+        span = base * self._jitter_fraction
+        return base + random.uniform(-span, span)
+
+    def _load_state(self) -> dict:
+        if not self._state_file or not os.path.exists(self._state_file):
+            return {}
+        try:
+            with open(self._state_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return {k: datetime.fromisoformat(v) for k, v in data.items()}
+        except Exception:
+            return {}
+
+    def _persist_state(self) -> None:
+        if not self._state_file:
+            return
+        data = {k: v.isoformat() for k, v in self._next_runs.items()}
+        with open(self._state_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
 
     async def _summary_loop(self) -> None:
         while self._running:
@@ -166,6 +232,60 @@ class SchedulerService:
         while self._running:
             await self._sleep(self._chat_summary_interval)
             await self._generate_chat_summary()
+
+    async def _micro_tick_loop(self) -> None:
+        while self._running:
+            wait = (self._next_runs["micro_tick"] - self._now()).total_seconds()
+            if wait > 0:
+                await self._sleep(wait)
+            now = self._now()
+            payload = TickPayload(timestamp=now.isoformat())
+            await self._publisher.publish(
+                EventSubjects.MICRO_TICK,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            self._next_runs["micro_tick"] = self._now() + timedelta(
+                seconds=self._next_micro_interval()
+            )
+            self._persist_state()
+
+    async def _standup_loop(self) -> None:
+        while self._running:
+            wait = (self._next_runs["daily_standup"] - self._now()).total_seconds()
+            if wait > 0:
+                await self._sleep(wait)
+            now = self._now()
+            payload = TickPayload(timestamp=now.isoformat())
+            await self._publisher.publish(
+                EventSubjects.DAILY_STANDUP,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            self._next_runs["daily_standup"] = self._now() + timedelta(
+                seconds=self._jittered(self._standup_interval)
+            )
+            self._persist_state()
+
+    async def _planning_loop(self) -> None:
+        while self._running:
+            wait = (self._next_runs["weekly_planning"] - self._now()).total_seconds()
+            if wait > 0:
+                await self._sleep(wait)
+            now = self._now()
+            payload = TickPayload(timestamp=now.isoformat())
+            await self._publisher.publish(
+                EventSubjects.WEEKLY_PLANNING,
+                payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            self._next_runs["weekly_planning"] = self._now() + timedelta(
+                seconds=self._jittered(self._weekly_planning_interval)
+            )
+            self._persist_state()
 
     async def _goal_loop(self) -> None:
         if self._summary_db is None:

--- a/tests/test_goal_scheduler.py
+++ b/tests/test_goal_scheduler.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -7,7 +9,9 @@ pytest.importorskip("nats")
 from deepthought.eda.events import BDIIntentionPayload, EventSubjects
 from deepthought.eda.publisher import connect
 from deepthought.goal_scheduler import GoalScheduler
+from deepthought.services.scheduler import SchedulerService
 
+pytest_plugins = ["tests.helpers"]
 pytestmark = pytest.mark.nats
 
 
@@ -37,3 +41,142 @@ async def test_goals_persist_and_publish(nats_server):
     assert count == 3
     assert [p.goal for p in received] == ["high", "mid", "low"]
     assert sched.next_goal() is None
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+class DummyMemoryDAL:
+    def __init__(self, interactions=None):
+        self.interactions = interactions or []
+
+    def get_recent_facts(self, count=3):
+        return self.interactions[-count:]
+
+
+class DummyGraphDAL:
+    def add_entity(self, label, props):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_scheduler_loops_and_jitter(tmp_path):
+    current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def now():
+        return current
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds):
+        nonlocal current
+        if seconds < 1:
+            current += timedelta(seconds=seconds)
+        await real_sleep(0)
+
+    state_file = tmp_path / "state.json"
+    pub = DummyPublisher()
+    service = SchedulerService(
+        pub,
+        DummyMemoryDAL([]),
+        DummyGraphDAL(),
+        summary_interval=1000.0,
+        daily_summary_interval=1000.0,
+        chat_summary_interval=1000.0,
+        now_func=now,
+        sleep_func=fake_sleep,
+        micro_tick_range=(0.01, 0.02),
+        daily_standup_interval=0.03,
+        weekly_planning_interval=0.04,
+        state_file=str(state_file),
+        jitter_fraction=0.0,
+    )
+    await service.start()
+    await fake_sleep(0)
+    await fake_sleep(0.1)
+    await service.stop()
+
+    micro_times = [
+        datetime.fromisoformat(p.timestamp)
+        for s, p in pub.published
+        if s == EventSubjects.MICRO_TICK
+    ]
+    assert micro_times
+    with open(state_file, "r", encoding="utf-8") as f:
+        state = json.load(f)
+    next_run = datetime.fromisoformat(state["micro_tick"])
+    diff = (next_run - micro_times[-1]).total_seconds()
+    assert 0.01 <= diff <= 0.02
+    subjects = [s for s, _ in pub.published]
+    assert EventSubjects.DAILY_STANDUP in subjects
+    assert EventSubjects.WEEKLY_PLANNING in subjects
+
+
+@pytest.mark.asyncio
+async def test_scheduler_persists_next_run(tmp_path):
+    current = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    def now():
+        return current
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds):
+        nonlocal current
+        if seconds < 1:
+            current += timedelta(seconds=seconds)
+        await real_sleep(0)
+
+    state_file = tmp_path / "state.json"
+    pub = DummyPublisher()
+    service = SchedulerService(
+        pub,
+        DummyMemoryDAL([]),
+        DummyGraphDAL(),
+        summary_interval=1000.0,
+        daily_summary_interval=1000.0,
+        chat_summary_interval=1000.0,
+        now_func=now,
+        sleep_func=fake_sleep,
+        micro_tick_range=(0.05, 0.05),
+        daily_standup_interval=1000.0,
+        weekly_planning_interval=1000.0,
+        state_file=str(state_file),
+        jitter_fraction=0.0,
+    )
+    await service.start()
+    await fake_sleep(0)
+    await fake_sleep(0.06)
+    await service.stop()
+
+    with open(state_file, "r", encoding="utf-8") as f:
+        state = json.load(f)
+    next_run = datetime.fromisoformat(state["micro_tick"])
+
+    pub2 = DummyPublisher()
+    service2 = SchedulerService(
+        pub2,
+        DummyMemoryDAL([]),
+        DummyGraphDAL(),
+        summary_interval=1000.0,
+        daily_summary_interval=1000.0,
+        chat_summary_interval=1000.0,
+        now_func=now,
+        sleep_func=fake_sleep,
+        micro_tick_range=(0.05, 0.05),
+        daily_standup_interval=1000.0,
+        weekly_planning_interval=1000.0,
+        state_file=str(state_file),
+        jitter_fraction=0.0,
+    )
+    await service2.start()
+    await fake_sleep((next_run - current).total_seconds() - 0.01)
+    assert not [s for s, _ in pub2.published if s == EventSubjects.MICRO_TICK]
+    await fake_sleep(0.02)
+    await service2.stop()
+    assert [s for s, _ in pub2.published if s == EventSubjects.MICRO_TICK]


### PR DESCRIPTION
## Summary
- add micro-tick, daily standup, and weekly planning events
- persist next-run timestamps with jittered scheduling
- test scheduler loop intervals and persistence

## Testing
- `flake8 src/deepthought/eda/events.py src/deepthought/services/scheduler.py tests/test_goal_scheduler.py`
- `pytest tests/test_goal_scheduler.py tests/unit/services/test_scheduler.py tests/unit/services/test_scheduler_reminders.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689b560325ac83269a56f546fa4a2787