### PR TITLE
docs: add perception service docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,3 +213,10 @@ Launch the social graph bot with deception enabled:
 export ALLOW_DECEPTION=true
 python examples/social_graph_bot.py
 ```
+
+## Perception Service
+
+The project includes a dedicated service for scoring social cues in user
+messages. The service consumes `dtr.input.received` events and publishes
+its analysis so other components can adjust trust or select personas. See
+[perception_service.md](perception_service.md) for details.

--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -1,0 +1,46 @@
+# Perception Service
+
+The **PerceptionService** evaluates incoming user messages for social cues
+like flirtation, avoidance, manipulation, sarcasm and supportiveness.
+Downstream modules can use the scores to adjust trust levels, choose
+personas or trigger safeguards.
+
+## Event Schema
+
+PerceptionService subscribes to `dtr.input.received` events and publishes
+`dtr.perception.scored` once analysis completes. A published payload
+contains the original `input_id` plus the classifier scores:
+
+```json
+{
+  "input_id": "42",
+  "perception": {
+    "flirtation": 0.2,
+    "avoidance": 0.1,
+    "manipulation": 0.0,
+    "sarcasm": 0.3,
+    "supportiveness": 0.4
+  },
+  "timestamp": "2024-05-01T12:00:00Z"
+}
+```
+
+Consumers can store these events in memory, update trust scores or trigger
+policy checks.
+
+## CLI Usage
+
+The service uses the social perception model specified by
+`SOCIAL_PERCEPTION_MODEL` or the bundled defaults. Start the service after
+configuring a NATS connection:
+
+```bash
+export NATS_URL=nats://localhost:4222
+# optional custom model path
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
+python -m deepthought.services.perception_service
+```
+
+The module listens for new inputs and continuously publishes
+`dtr.perception.scored` events to the bus.
+


### PR DESCRIPTION
## Summary
- document perception service purpose, event schema and CLI usage
- link perception service from architecture overview

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_689ba90527bc8326b4f54a2c03b5e131