### PR TITLE
Add perception embeddings event payload

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -27,6 +27,9 @@ class EventSubjects:
     # LLM events
     RESPONSE_GENERATED = "dtr.llm.response_generated"
 
+    # Perception events
+    PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings"
+
     # Raw chat message events
     CHAT_RAW = "chat.raw"
 
@@ -155,6 +158,18 @@ class PlanGeneratedPayload(EventPayload):
     plan: list[str]
     input_id: Optional[str] = None
     timestamp: Optional[str] = None
+
+
+@dataclass
+class PerceptionEmbeddingsPayload(EventPayload):
+    """Payload containing embeddings produced by perception."""
+
+    message_id: str
+    user_id: str
+    spans: list[tuple[int, int]]
+    embeddings: list[list[float]]
+    encoders: list[str]
+    provenance: Dict[str, Any]
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- introduce `PERCEPTION_EMBEDDINGS` subject for perception events
- add `PerceptionEmbeddingsPayload` dataclass with serialization helpers

## Testing
- `pre-commit run --files src/deepthought/eda/events.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba9044fd88326bb7961b2f3e1f0f7