### PR TITLE
Add text perception worker with time-aligned embeddings

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -1,0 +1,5 @@
+"""Perception workers for DeepThought services."""
+
+from .worker_text import TextPerceptionWorker
+
+__all__ = ["TextPerceptionWorker"]

--- a/src/deepthought/services/perception/worker_text.py
+++ b/src/deepthought/services/perception/worker_text.py
@@ -1,0 +1,71 @@
+"""Text perception worker producing time-aligned embeddings.
+
+This worker uses a BGE/E5 encoder from :mod:`sentence_transformers` to
+transform text tokens into vector representations. Tokens are aligned to a
+fixed temporal hop (between 25 and 50 milliseconds) and the resulting
+features are stored in a NumPy ``memmap`` for efficient downstream
+processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+# A token is represented as ``(text, start_time, end_time)`` where times are in seconds.
+Token = Tuple[str, float, float]
+
+
+@dataclass
+class TextPerceptionWorker:
+    """Convert tokens into hop-aligned embeddings and store in a memmap.
+
+    Parameters
+    ----------
+    model_name:
+        Name of the BGE or E5 model to load via :class:`SentenceTransformer`.
+    hop_seconds:
+        Temporal hop in seconds. Must be between 25 and 50 milliseconds.
+    """
+
+    model_name: str = "intfloat/e5-small-v2"
+    hop_seconds: float = 0.03
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple validation
+        if not 0.025 <= self.hop_seconds <= 0.05:
+            raise ValueError("hop_seconds must be between 0.025 and 0.05 seconds")
+        self._model = SentenceTransformer(self.model_name)
+
+    def __call__(self, tokens: Sequence[Token], memmap_path: str) -> np.memmap:
+        """Process ``tokens`` and write embeddings to ``memmap_path``.
+
+        Each hop is filled with the embedding of the token active during that
+        time frame. Gaps remain zero-filled.
+        """
+
+        if not tokens:
+            raise ValueError("tokens must not be empty")
+
+        # Determine embedding dimension using the first token
+        first_emb = np.asarray(self._model.encode(tokens[0][0]))
+        duration = max(end for _, _, end in tokens)
+        num_steps = int(np.ceil(duration / self.hop_seconds))
+        features = np.memmap(memmap_path, dtype="float32", mode="w+", shape=(num_steps, len(first_emb)))
+        features[:] = 0.0
+
+        # Fill with first token embedding
+        start_idx = int(tokens[0][1] / self.hop_seconds)
+        end_idx = int(np.ceil(tokens[0][2] / self.hop_seconds))
+        features[start_idx:end_idx] = first_emb
+
+        for text, start, end in tokens[1:]:
+            embedding = np.asarray(self._model.encode(text))
+            start_idx = int(start / self.hop_seconds)
+            end_idx = int(np.ceil(end / self.hop_seconds))
+            features[start_idx:end_idx] = embedding
+
+        features.flush()
+        return features

--- a/tests/unit/services/perception/test_worker_text.py
+++ b/tests/unit/services/perception/test_worker_text.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+from deepthought.services.perception import TextPerceptionWorker
+
+
+def test_worker_text_memmap(tmp_path):
+    tokens = [("hi", 0.0, 0.1), ("world", 0.1, 0.2)]
+    worker = TextPerceptionWorker(hop_seconds=0.05)
+    memmap_file = tmp_path / "features.dat"
+    feats = worker(tokens, str(memmap_file))
+
+    assert feats.shape == (4, 1)
+    assert np.allclose(feats[0], feats[1])
+    assert np.allclose(feats[2], feats[3])
+    assert not np.allclose(feats[0], feats[2])


### PR DESCRIPTION
## Summary
- add `TextPerceptionWorker` to generate BGE/E5 token embeddings aligned to a fixed hop and stored in NumPy memmaps
- cover worker behavior with a unit test

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/perception/__init__.py src/deepthought/services/perception/worker_text.py tests/unit/services/perception/test_worker_text.py`
- `pytest tests/unit/services/perception/test_worker_text.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccc0a639083269d4b5373e17aeb61