### PR TITLE
Add audio worker with windowed feature extraction and timestamp output

### DIFF
--- a/src/deepthought/perception/worker_audio.py
+++ b/src/deepthought/perception/worker_audio.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Audio worker utilities.
+
+This module extracts simple windowed features from ``.wav`` files and caches
+results using memory-mapped arrays. Each window emits a ``[start, end]``
+ timestamp that aligns with the text worker grid.
+"""
+
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+from scipy.io import wavfile
+
+
+def extract_windowed_features(
+    audio_path: str | Path,
+    window_size: float = 0.02,
+    step_size: float = 0.01,
+    cache_dir: str | Path | None = None,
+) -> Tuple[np.memmap, np.ndarray]:
+    """Return RMS features and per-window timestamps for ``audio_path``.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to a ``.wav`` file.
+    window_size:
+        Size of each analysis window in seconds.
+    step_size:
+        Stride between analysis windows in seconds.
+    cache_dir:
+        Optional directory in which to store the memmap file. Defaults to the
+        parent directory of ``audio_path``.
+    """
+
+    audio_path = Path(audio_path)
+    if cache_dir is None:
+        cache_dir = audio_path.parent
+    cache_dir = Path(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    sr, data = wavfile.read(audio_path)
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    win_samples = int(window_size * sr)
+    step_samples = int(step_size * sr)
+    if win_samples <= 0 or step_samples <= 0:
+        raise ValueError("window_size and step_size must be positive")
+
+    n_samples = len(data)
+    if n_samples < win_samples:
+        num_windows = 0
+    else:
+        num_windows = 1 + (n_samples - win_samples) // step_samples
+
+    memmap_path = cache_dir / f"{audio_path.stem}_ws{window_size}_ss{step_size}.dat"
+    shape = (num_windows, 1)
+
+    if memmap_path.exists():
+        features = np.memmap(memmap_path, dtype=np.float32, mode="r", shape=shape)
+    else:
+        features = np.memmap(memmap_path, dtype=np.float32, mode="w+", shape=shape)
+        for i in range(num_windows):
+            start = i * step_samples
+            end = start + win_samples
+            window = data[start:end]
+            features[i, 0] = np.sqrt(np.mean(window.astype(np.float32) ** 2))
+        features.flush()
+
+    starts = np.arange(num_windows) * step_size
+    ends = starts + window_size
+    timestamps = np.column_stack((starts, ends)).astype(np.float32)
+    return features, timestamps

--- a/tests/unit/perception/test_worker_audio.py
+++ b/tests/unit/perception/test_worker_audio.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy.io import wavfile
+
+from deepthought.perception.worker_audio import extract_windowed_features
+
+
+def test_extract_windowed_features(tmp_path):
+    sr = 16000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    audio_file = tmp_path / "test.wav"
+    wavfile.write(audio_file, sr, data)
+
+    features, timestamps = extract_windowed_features(
+        audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path
+    )
+
+    assert features.shape == (19, 1)
+    assert timestamps.shape == (19, 2)
+    assert np.allclose(timestamps[0], [0.0, 0.1])
+    assert np.allclose(timestamps[1], [0.05, 0.15])
+
+    # Second call should reuse memmap and produce identical results
+    features2, timestamps2 = extract_windowed_features(
+        audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path
+    )
+    assert np.allclose(features, features2)
+    assert np.allclose(timestamps, timestamps2)
+    memmap_path = tmp_path / "test_ws0.1_ss0.05.dat"
+    assert memmap_path.exists()


### PR DESCRIPTION
## Summary
- add `worker_audio` to compute windowed RMS features from WAV files using memmap caching
- emit per-window start/end timestamps matching text worker grid
- add unit test for feature extraction and caching

## Testing
- `flake8 src tests`
- `pytest tests/unit/perception -q`


------
https://chatgpt.com/codex/tasks/task_e_689ccc0a551c83269ee4a09a7529f8d9