### PR TITLE
Add video frame embedding worker

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -33,3 +33,7 @@ deepproblog
 rdflib
 httpx==0.28.1
 requests==2.32.4
+
+opencv-python-headless
+torchvision
+open-clip-torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,7 @@ pyperplan>=2.1
 l2p==0.2.2
 UME @ git+https://github.com/d0tTino/UME.git@dev
 rdflib
+
+opencv-python-headless
+torchvision
+open-clip-torch

--- a/src/deepthought/perception/worker_video.py
+++ b/src/deepthought/perception/worker_video.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+"""Utilities for decoding video and embedding frames.
+
+This module provides helper functions to sample frames from a video at a
+controlled rate, embed the frames using either SigLIP or OpenCLIP models,
+and interpolate the resulting features onto a common time grid.
+"""
+
+from typing import Iterable, List, Tuple
+
+import cv2
+import numpy as np
+import torch
+from PIL import Image
+
+try:  # pragma: no cover - optional dependency
+    import open_clip
+except Exception:  # pragma: no cover - optional dependency
+    open_clip = None
+
+
+FrameT = np.ndarray
+
+
+def decode_video(path: str, fps: int = 1) -> Tuple[List[FrameT], np.ndarray]:
+    """Decode ``path`` and return RGB frames and timestamps.
+
+    Parameters
+    ----------
+    path:
+        Path to the input video file.
+    fps:
+        Target frames-per-second rate between 1 and 3. Values outside the
+        range are clamped.
+    """
+    fps = int(np.clip(fps, 1, 3))
+    cap = cv2.VideoCapture(path)
+    video_fps = cap.get(cv2.CAP_PROP_FPS) or fps
+    step = max(int(round(video_fps / fps)), 1)
+    frames: List[FrameT] = []
+    timestamps: List[float] = []
+    idx = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        if idx % step == 0:
+            rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            frames.append(rgb)
+            timestamps.append(idx / video_fps)
+        idx += 1
+    cap.release()
+    return frames, np.asarray(timestamps, dtype=float)
+
+
+def _siglip(device: torch.device):
+    from transformers import SiglipImageProcessor, SiglipModel
+
+    processor = SiglipImageProcessor.from_pretrained("google/siglip-base-patch16-224")
+    model = SiglipModel.from_pretrained("google/siglip-base-patch16-224").to(device)
+    return processor, model
+
+
+def _openclip(device: torch.device):  # pragma: no cover - optional dependency
+    if open_clip is None:
+        raise ImportError("open_clip is not installed")
+    model, _, preprocess = open_clip.create_model_and_transforms("ViT-B-32", pretrained="laion2b_s34b_b79k")
+    model = model.to(device)
+    return preprocess, model
+
+
+def embed_frames(
+    frames: Iterable[FrameT],
+    model_type: str = "siglip",
+    device: torch.device | None = None,
+) -> np.ndarray:
+    """Embed ``frames`` using ``model_type``.
+
+    Parameters
+    ----------
+    frames:
+        Iterable of RGB numpy arrays.
+    model_type:
+        Either ``"siglip"`` or ``"openclip"``.
+    device:
+        Torch device for model inference.
+    """
+    device = device or torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    frames_list = list(frames)
+    if not frames_list:
+        return np.empty((0, 0))
+
+    if model_type.lower() == "siglip":
+        processor, model = _siglip(device)
+        inputs = processor(images=frames_list, return_tensors="pt").to(device)
+        with torch.no_grad():
+            feats = model.get_image_features(**inputs)
+    elif model_type.lower() == "openclip":
+        preprocess, model = _openclip(device)
+        tensor = torch.stack([preprocess(Image.fromarray(f)) for f in frames_list]).to(device)
+        with torch.no_grad():  # pragma: no cover - optional dependency
+            feats = model.encode_image(tensor)
+    else:  # pragma: no cover - defensive programming
+        raise ValueError(f"unknown model_type: {model_type}")
+    return feats.cpu().numpy()
+
+
+def interpolate_features(
+    features: np.ndarray,
+    timestamps: np.ndarray,
+    grid_times: np.ndarray,
+) -> np.ndarray:
+    """Linearly interpolate ``features`` onto ``grid_times``.
+
+    ``features`` must be shaped ``(n_frames, dim)`` with corresponding
+    ``timestamps`` in seconds.
+    """
+    if len(features) == 0:
+        return np.empty((len(grid_times), 0))
+    dim = features.shape[1]
+    grid = np.empty((len(grid_times), dim), dtype=features.dtype)
+    for i in range(dim):
+        grid[:, i] = np.interp(grid_times, timestamps, features[:, i])
+    return grid
+
+
+def video_to_feature_grid(
+    path: str,
+    decode_fps: int = 1,
+    model_type: str = "siglip",
+    grid_fps: int | None = None,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Decode ``path`` and return features on a uniform time grid."""
+    frames, timestamps = decode_video(path, decode_fps)
+    feats = embed_frames(frames, model_type=model_type)
+    if grid_fps is None:
+        grid_fps = decode_fps
+    if len(timestamps) == 0:
+        return np.empty((0, feats.shape[1])), np.empty(0)
+    start, end = timestamps[0], timestamps[-1]
+    step = 1.0 / grid_fps
+    grid_times = np.arange(start, end + step, step)
+    grid_feats = interpolate_features(feats, timestamps, grid_times)
+    return grid_feats, grid_times

--- a/tests/test_worker_video.py
+++ b/tests/test_worker_video.py
@@ -1,0 +1,35 @@
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from deepthought.perception.worker_video import decode_video, interpolate_features
+
+
+def _make_test_video() -> str:
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    path = tmp.name
+    tmp.close()
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(path, fourcc, 10, (32, 32))
+    for i in range(20):
+        frame = np.full((32, 32, 3), i, dtype=np.uint8)
+        out.write(frame)
+    out.release()
+    return path
+
+
+def test_decode_and_interpolate():
+    path = _make_test_video()
+    frames, ts = decode_video(path, fps=2)
+    os.remove(path)
+    assert len(frames) == 4
+    assert np.allclose(ts, [0.0, 0.5, 1.0, 1.5])
+
+    features = np.stack([ts, ts**2], axis=1)
+    grid_times = np.arange(0.0, 1.51, 0.25)
+    grid_feats = interpolate_features(features, ts, grid_times)
+    assert grid_feats.shape == (len(grid_times), 2)
+    # Check interpolation at a midpoint
+    assert np.allclose(grid_feats[2], [0.5, 0.25])


### PR DESCRIPTION
## Summary
- add `worker_video` to decode video, embed frames via SigLIP/OpenCLIP, and interpolate features
- depend on `opencv-python-headless`, `torchvision`, `open-clip-torch`
- test video worker frame sampling and interpolation

## Testing
- `pre-commit run --files src/deepthought/perception/worker_video.py tests/test_worker_video.py requirements.txt requirements-ci.txt`
- `pytest tests/test_worker_video.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccc09ab34832689965e6dc0505c93