### PR TITLE
Add modality fuser for multi-modal embeddings

### DIFF
--- a/src/deepthought/modules/__init__.py
+++ b/src/deepthought/modules/__init__.py
@@ -17,9 +17,10 @@ except Exception as exc:  # pragma: no cover - optional dependency may be missin
         """Placeholder that raises if instantiated without nats available."""
 
         def __init__(self, *args: object, **kwargs: object) -> None:
-            raise ImportError(
-                "InputHandler requires the 'nats-py' package"
-            ) from _missing_nats_err
+            raise ImportError("InputHandler requires the 'nats-py' package") from _missing_nats_err
+
+
+from .fuser import ModalityFuser
 from .memory_basic import BasicMemory
 from .memory_graph import GraphMemory
 from .memory_stub import MemoryStub
@@ -82,4 +83,5 @@ __all__ = [
     "BasicLLM",
     "ProductionLLM",
     "RemoteLLM",
+    "ModalityFuser",
 ]

--- a/src/deepthought/modules/fuser.py
+++ b/src/deepthought/modules/fuser.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Utilities for fusing multi-modal embeddings."""
+
+from typing import Dict, Optional
+
+import torch
+from torch import nn
+
+
+class ModalityFuser(nn.Module):
+    """Fuse modality-specific embeddings into a single representation.
+
+    Parameters
+    ----------
+    modality_dims:
+        Mapping of modality name to the size of its embedding vector.
+    fused_dim:
+        Output dimension of the fused embedding.
+    dropout_prob:
+        Probability of dropping an entire modality during training.
+    user_dim:
+        Size of an optional user embedding appended during fusion.
+    """
+
+    def __init__(
+        self,
+        modality_dims: Dict[str, int],
+        fused_dim: int,
+        *,
+        dropout_prob: float = 0.0,
+        user_dim: int = 0,
+    ) -> None:
+        super().__init__()
+        self.modality_dims = modality_dims
+        self.dropout_prob = dropout_prob
+        self.user_dim = user_dim
+
+        input_dim = sum(modality_dims.values()) + user_dim
+        self.project = nn.Linear(input_dim, fused_dim)
+
+    def forward(
+        self, modalities: Dict[str, torch.Tensor], user_embedding: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        """Return a fused embedding from provided modality tensors.
+
+        Each modality tensor should have shape ``(batch, dim)``. If
+        ``user_embedding`` is provided it must have shape ``(batch, user_dim)``.
+        Modality dropout randomly zeroes whole modality vectors during
+        training with probability ``dropout_prob``.
+        """
+
+        if not modalities:
+            raise ValueError("No modalities provided for fusion")
+
+        pieces = []
+        for name, tensor in modalities.items():
+            if self.training and self.dropout_prob > 0.0:
+                mask = (torch.rand(tensor.size(0), 1, device=tensor.device) > self.dropout_prob).float()
+                tensor = tensor * mask
+            pieces.append(tensor)
+
+        if user_embedding is not None:
+            pieces.append(user_embedding)
+
+        combined = torch.cat(pieces, dim=-1)
+        return self.project(combined)
+
+    def fit(self, *args, **kwargs) -> None:  # pragma: no cover - stubbed method
+        """Placeholder for training logic."""
+        raise NotImplementedError("Training is not implemented for ModalityFuser")

--- a/tests/unit/test_fuser.py
+++ b/tests/unit/test_fuser.py
@@ -1,0 +1,27 @@
+import importlib
+import sys
+
+sys.modules.pop("torch", None)
+torch = importlib.import_module("torch")
+
+from deepthought.modules.fuser import ModalityFuser
+
+
+def test_fuser_shape_with_user_embedding():
+    fuser = ModalityFuser({"image": 4, "text": 6}, fused_dim=5, user_dim=3)
+    modalities = {
+        "image": torch.randn(2, 4),
+        "text": torch.randn(2, 6),
+    }
+    user = torch.randn(2, 3)
+    output = fuser(modalities, user)
+    assert output.shape == (2, 5)
+
+
+def test_fuser_modality_dropout_bias_only():
+    fuser = ModalityFuser({"image": 2}, fused_dim=3, dropout_prob=1.0)
+    fuser.train()
+    modalities = {"image": torch.randn(1, 2)}
+    result = fuser(modalities)
+    expected = fuser.project.bias.unsqueeze(0)
+    assert torch.allclose(result, expected)


### PR DESCRIPTION
## Summary
- add `ModalityFuser` to concatenate modality embeddings with dropout
- expose new fuser module via `deepthought.modules`
- test fused output shape and modality dropout behaviour

## Testing
- `python -m isort --profile=black --line-length 120 src/deepthought/modules/fuser.py src/deepthought/modules/__init__.py tests/unit/test_fuser.py`
- `python -m black --line-length 120 src/deepthought/modules/fuser.py src/deepthought/modules/__init__.py tests/unit/test_fuser.py`
- `flake8 src/deepthought/modules/fuser.py src/deepthought/modules/__init__.py tests/unit/test_fuser.py`
- `pytest tests/unit/test_fuser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd6d06be0832687a7f9d49dab967d