### PR TITLE
feat(perception): add jetstream publisher

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -1,6 +1,7 @@
 """Perception utilities for DeepThought services."""
 
+from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .worker_text import TextPerceptionWorker
 
-__all__ = ["TextPerceptionWorker", "PerceptionService"]
+__all__ = ["TextPerceptionWorker", "PerceptionService", "PerceptionPublisher"]

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, Sequence
+
+from nats.aio.client import Client as NATS
+from nats.js.client import JetStreamContext
+
+from ...eda.events import EventSubjects, PerceptionEmbeddingsPayload
+from ...eda.publisher import Publisher
+
+logger = logging.getLogger(__name__)
+
+
+class PerceptionPublisher:
+    """Publish perception embedding events via JetStream."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+
+    async def publish(
+        self,
+        message_id: str,
+        user_id: str,
+        *,
+        spans: Sequence[Sequence[int]] | None = None,
+        embeddings: Sequence[Sequence[float]] | None = None,
+        encoders: Sequence[Dict[str, Any]] | None = None,
+        provenance: Dict[str, Any] | None = None,
+        retries: int = 3,
+    ) -> Dict | None:
+        """Publish a :class:`PerceptionEmbeddingsPayload` with retries.
+
+        Parameters
+        ----------
+        message_id:
+            Identifier of the message being processed.
+        user_id:
+            Identifier of the user who produced the message.
+        spans:
+            Span indices for each embedding.
+        embeddings:
+            Vector embeddings.
+        encoders:
+            Metadata describing each encoder.
+        provenance:
+            Provenance information about how the embeddings were generated.
+        retries:
+            Number of times to retry publishing on failure.
+        """
+
+        payload = PerceptionEmbeddingsPayload(
+            message_id=message_id,
+            user_id=user_id,
+            spans=list(spans or []),
+            embeddings=[list(map(float, emb)) for emb in (embeddings or [])],
+            encoders=[dict(meta) for meta in (encoders or [])],
+            provenance=dict(provenance or {}),
+        )
+
+        last_error: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                return await self._publisher.publish(
+                    EventSubjects.PERCEPTION_EMBEDDINGS,
+                    payload,
+                    use_jetstream=True,
+                )
+            except Exception as err:  # pragma: no cover - network issues
+                last_error = err
+                logger.warning("Publish attempt %s failed for message %s: %s", attempt, message_id, err)
+                await asyncio.sleep(min(0.1 * attempt, 1.0))
+        assert last_error is not None
+        logger.error("Failed to publish perception embeddings after %s attempts", retries)
+        raise last_error

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Sequence
 
-from ...eda.events import EventSubjects, PerceptionEmbeddingsPayload
-from ...eda.publisher import Publisher
+from .publisher import PerceptionPublisher
 
 Worker = Callable[..., Any]
 Fuser = Callable[[Sequence[Any]], dict]
@@ -29,7 +28,7 @@ class PerceptionService:
 
     workers: Sequence[Worker]
     fuser: Fuser
-    publisher: Publisher
+    publisher: PerceptionPublisher
 
     async def run(self, message_id: str, user_id: str, *args: Any, **kwargs: Any) -> dict:
         """Execute workers, fuse their outputs and publish the result.
@@ -52,7 +51,7 @@ class PerceptionService:
             results.append(result)
 
         fused = self.fuser(results)
-        payload = PerceptionEmbeddingsPayload(
+        await self.publisher.publish(
             message_id=message_id,
             user_id=user_id,
             spans=fused.get("spans", []),
@@ -60,7 +59,6 @@ class PerceptionService:
             encoders=fused.get("encoders", []),
             provenance=fused.get("provenance", {}),
         )
-        await self.publisher.publish(EventSubjects.PERCEPTION_EMBEDDINGS, payload)
         return fused
 
 

--- a/tests/unit/services/perception/test_publisher.py
+++ b/tests/unit/services/perception/test_publisher.py
@@ -1,0 +1,91 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deepthought.eda.events import (
+    EventSubjects,
+    PerceptionEmbeddingsPayload,
+)
+from deepthought.services.perception import publisher as perception_publisher
+
+
+@pytest.mark.asyncio
+async def test_publish_embeddings(monkeypatch):
+    """Publish a perception event and verify payload formatting."""
+
+    captured: dict = {}
+
+    async def fake_publish(subject, payload, use_jetstream=True):
+        captured["subject"] = subject
+        captured["payload"] = payload
+        captured["use_jetstream"] = use_jetstream
+        return {"seq": 1}
+
+    class FakePublisher:
+        def __init__(self, nats, js):  # pragma: no cover - unused
+            self.publish = AsyncMock(side_effect=fake_publish)
+
+    monkeypatch.setattr(perception_publisher, "Publisher", FakePublisher)
+
+    publisher = perception_publisher.PerceptionPublisher(object(), object())
+    ack = await publisher.publish(
+        message_id="msg1",
+        user_id="user1",
+        spans=[(0, 1)],
+        embeddings=[[0.0, 0.1]],
+        encoders=[{"name": "test", "dim": 2}],
+        provenance={"source": "unit"},
+    )
+
+    assert ack == {"seq": 1}
+    assert captured["subject"] == EventSubjects.PERCEPTION_EMBEDDINGS
+    assert isinstance(captured["payload"], PerceptionEmbeddingsPayload)
+    assert captured["payload"].message_id == "msg1"
+    assert captured["payload"].encoders == [{"name": "test", "dim": 2}]
+    assert captured["payload"].provenance == {"source": "unit"}
+    assert captured["use_jetstream"] is True
+
+
+@pytest.mark.asyncio
+async def test_publish_retries(monkeypatch):
+    """Verify that publish retries on failure."""
+
+    attempts = 0
+
+    async def failing_publish(subject, payload, use_jetstream=True):
+        nonlocal attempts
+        attempts += 1
+        if attempts < 2:
+            raise RuntimeError("fail")
+        return {"seq": 2}
+
+    class FakePublisher:
+        def __init__(self, nats, js):  # pragma: no cover - unused
+            self.publish = AsyncMock(side_effect=failing_publish)
+
+    monkeypatch.setattr(perception_publisher, "Publisher", FakePublisher)
+
+    publisher = perception_publisher.PerceptionPublisher(object(), object())
+    ack = await publisher.publish("msg1", "user1", retries=3)
+
+    assert ack == {"seq": 2}
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_after_retries(monkeypatch):
+    """Ensure publish raises after exhausting retries."""
+
+    async def always_fail(subject, payload, use_jetstream=True):
+        raise RuntimeError("fail")
+
+    class FakePublisher:
+        def __init__(self, nats, js):  # pragma: no cover - unused
+            self.publish = AsyncMock(side_effect=always_fail)
+
+    monkeypatch.setattr(perception_publisher, "Publisher", FakePublisher)
+
+    publisher = perception_publisher.PerceptionPublisher(object(), object())
+
+    with pytest.raises(RuntimeError):
+        await publisher.publish("msg1", "user1", retries=2)


### PR DESCRIPTION
## Summary
- add perception publisher that formats embeddings with encoder metadata and provenance
- use jetstream publish with retries for at-least-once semantics
- expose publisher and add unit test
- mock jetstream in unit tests to remove external NATS dependency and verify retry behavior

## Testing
- `SKIP=pytest pre-commit run --files tests/unit/services/perception/test_publisher.py`
- `pytest tests/unit/services/perception/test_publisher.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd6d1222083268cc7ceb1046bb91d