### PR TITLE
Handle perception embeddings in cognitive core

### DIFF
--- a/src/deepthought/memory/vector_store.py
+++ b/src/deepthought/memory/vector_store.py
@@ -16,11 +16,15 @@ except Exception:  # pragma: no cover - chromadb not installed
 
     class _DummyCollection:
         def __init__(self) -> None:
-            self.docs: dict[str, str] = {}
+            self.docs: dict[str, Any] = {}
 
         def add(self, documents, ids, metadatas=None):  # type: ignore[override]
             for i, doc in zip(ids, documents):
                 self.docs[str(i)] = doc
+
+        def upsert(self, embeddings, ids, metadatas=None):  # type: ignore[override]
+            for i, emb in zip(ids, embeddings):
+                self.docs[str(i)] = emb
 
         def query(self, query_texts, n_results=3):  # type: ignore[override]
             docs = [list(self.docs.values())[:n_results] for _ in query_texts]
@@ -76,6 +80,15 @@ class VectorStore(ABC):
     def query(self, query_texts: Sequence[str], n_results: int = 3):
         """Query the vector store for matching texts."""
 
+    @abstractmethod
+    def upsert_vectors(
+        self,
+        vectors: Sequence[Sequence[float]],
+        ids: Sequence[str],
+        metadatas: Optional[Sequence[dict]] = None,
+    ) -> None:
+        """Upsert pre-computed vectors keyed by ``ids``."""
+
 
 class ChromaVectorStore(VectorStore):
     """Thin wrapper around a Chroma collection."""
@@ -114,6 +127,18 @@ class ChromaVectorStore(VectorStore):
 
     def query(self, query_texts: Sequence[str], n_results: int = 3):
         return self._collection.query(query_texts=list(query_texts), n_results=n_results)
+
+    def upsert_vectors(
+        self,
+        vectors: Sequence[Sequence[float]],
+        ids: Sequence[str],
+        metadatas: Optional[Sequence[dict]] = None,
+    ) -> None:
+        self._collection.upsert(
+            embeddings=[list(map(float, v)) for v in vectors],
+            ids=list(ids),
+            metadatas=list(metadatas) if metadatas else None,
+        )
 
 
 try:  # pragma: no cover - optional dependency
@@ -188,6 +213,24 @@ class FaissVectorStore(VectorStore):
             self._id_to_internal_id[str(_id)] = int(iid)
             self._internal_id_to_text_idx[int(iid)] = len(self._texts) - 1
         self._next_internal_id += len(texts)
+
+    def upsert_vectors(
+        self,
+        vectors: Sequence[Sequence[float]],
+        ids: Sequence[str],
+        metadatas: Optional[Sequence[dict]] = None,
+    ) -> None:
+        self._delete(ids)
+        import numpy as np
+
+        ids = list(ids)
+        internal_ids = np.arange(self._next_internal_id, self._next_internal_id + len(ids), dtype="int64")
+        self._index.add_with_ids(np.asarray(list(vectors), dtype="float32"), internal_ids)
+        for _id, iid in zip(ids, internal_ids):
+            self._texts.append(None)
+            self._id_to_internal_id[str(_id)] = int(iid)
+            self._internal_id_to_text_idx[int(iid)] = len(self._texts) - 1
+        self._next_internal_id += len(ids)
 
     def query(self, query_texts: Sequence[str], n_results: int = 3):
         import numpy as np

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -12,7 +12,12 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from ..config import Settings, get_settings
-from ..eda.events import BDIIntentionPayload, EventSubjects, MemoryRetrievedPayload
+from ..eda.events import (
+    BDIIntentionPayload,
+    EventSubjects,
+    MemoryRetrievedPayload,
+    PerceptionEmbeddingsPayload,
+)
 from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
@@ -197,6 +202,37 @@ class CognitiveCoreService(BaseService):
             INPUTS_TOTAL.labels(service="cognitive_core_service").inc()
             INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(duration)
 
+    async def _handle_embeddings(self, msg: Msg) -> None:
+        """Store fused perception embeddings in the vector store and KG."""
+        try:
+            payload = PerceptionEmbeddingsPayload.from_json(msg.data.decode())
+            vectors = payload.embeddings
+            if vectors:
+                vector = vectors[0]
+                store = getattr(self._memory, "_store", None)
+                if store and hasattr(store, "upsert_vectors"):
+                    store.upsert_vectors([vector], [payload.message_id])
+                graph = getattr(self._memory, "graph_backend", None)
+                if graph:
+                    graph.query_subgraph(
+                        "MERGE (m:Message {id: $id}) SET m.embedding = $embedding",
+                        {"id": payload.message_id, "embedding": vector},
+                    )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("Failed to handle PERCEPTION_EMBEDDINGS", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                try:
+                    await msg.nak()
+                except Exception:
+                    logger.error("Failed to NAK message", exc_info=True)
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                try:
+                    await msg.ack()
+                except Exception:
+                    logger.error("Failed to ack message after error", exc_info=True)
+
     async def _handle_intention(self, msg: Msg) -> None:
         """React to BDI_INTENTION events by logging the goal."""
         try:
@@ -224,6 +260,12 @@ class CognitiveCoreService(BaseService):
             handler=self._handle_input,
             use_jetstream=True,
             durable=durable_name,
+        )
+        self.add_subscription(
+            subject=EventSubjects.PERCEPTION_EMBEDDINGS,
+            handler=self._handle_embeddings,
+            use_jetstream=True,
+            durable=f"{durable_name}_perception",
         )
         self.add_subscription(
             subject=EventSubjects.BDI_INTENTION,

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -102,7 +102,11 @@ import pytest
 
 import deepthought.services.cognitive_core_service as cognitive_core_service
 from deepthought.config import Settings
-from deepthought.eda.events import EventSubjects, InputReceivedPayload
+from deepthought.eda.events import (
+    EventSubjects,
+    InputReceivedPayload,
+    PerceptionEmbeddingsPayload,
+)
 from deepthought.services.cognitive_core_service import CognitiveCoreService
 
 
@@ -212,3 +216,50 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"
     assert "hello" in sent_payload.retrieved_knowledge["facts"]
+
+
+class DummyStore:
+    def __init__(self) -> None:
+        self.upserts: list = []
+
+    def upsert_vectors(self, vectors, ids, metadatas=None):
+        self.upserts.append((list(vectors), list(ids)))
+
+
+class DummyGraph:
+    def __init__(self) -> None:
+        self.queries: list = []
+
+    def query_subgraph(self, query, params):
+        self.queries.append((query, params))
+
+    def merge_entity(self, name):
+        pass
+
+
+class DummyMem2:
+    def __init__(self):
+        self._store = DummyStore()
+        self.graph_backend = DummyGraph()
+
+
+@pytest.mark.asyncio
+async def test_handle_embeddings_upserts(monkeypatch):
+    memory = DummyMem2()
+    db = DummyDB()
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+    payload = PerceptionEmbeddingsPayload(
+        message_id="m1",
+        user_id="u",
+        spans=[],
+        embeddings=[[0.1, 0.2]],
+        encoders=[],
+        provenance={},
+    )
+    msg = DummyMsg(payload.to_json())
+    await service._handle_embeddings(msg)
+    assert msg.acked
+    assert memory._store.upserts == [([[0.1, 0.2]], ["m1"])]
+    assert memory.graph_backend.queries[0][1]["id"] == "m1"

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -49,6 +49,13 @@ def test_add_twice_without_ids():
     assert store.collection.count() == 2
 
 
+def test_upsert_vectors_chroma():
+    store = ChromaVectorStore(collection_name="test_vs4", embedding_function=SimpleEmbeddingFunction())
+    store.upsert_vectors([[0.1, 0.2]], ids=["m1"])
+    store.upsert_vectors([[0.2, 0.3]], ids=["m1"])
+    assert store.collection.count() == 1
+
+
 def test_faiss_store():
     import types
 


### PR DESCRIPTION
## Summary
- support upserting pre-computed vectors in vector store backends
- handle perception embedding events in CognitiveCoreService
- test perception embedding upserts

## Testing
- `flake8 src/deepthought/memory/vector_store.py src/deepthought/services/cognitive_core_service.py tests/unit/services/test_cognitive_core_service.py tests/unit/test_vector_store.py`
- `pytest tests/unit/test_vector_store.py tests/unit/services/test_cognitive_core_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01161e9883268d650f2ab2b32525