### PR TITLE
feat: add user embedding store

### DIFF
--- a/src/deepthought/modules/fuser.py
+++ b/src/deepthought/modules/fuser.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 """Utilities for fusing multi-modal embeddings."""
 
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 
 import torch
 from torch import nn
+
+if TYPE_CHECKING:  # pragma: no cover - only for type checkers
+    from deepthought.services.perception.user_embeddings import UserEmbeddings
 
 
 class ModalityFuser(nn.Module):
@@ -40,14 +43,21 @@ class ModalityFuser(nn.Module):
         self.project = nn.Linear(input_dim, fused_dim)
 
     def forward(
-        self, modalities: Dict[str, torch.Tensor], user_embedding: Optional[torch.Tensor] = None
+        self,
+        modalities: Dict[str, torch.Tensor],
+        user_embedding: Optional[torch.Tensor] = None,
+        *,
+        user_id: str | None = None,
+        embedding_store: "UserEmbeddings" | None = None,
     ) -> torch.Tensor:
         """Return a fused embedding from provided modality tensors.
 
         Each modality tensor should have shape ``(batch, dim)``. If
         ``user_embedding`` is provided it must have shape ``(batch, user_dim)``.
-        Modality dropout randomly zeroes whole modality vectors during
-        training with probability ``dropout_prob``.
+        When ``embedding_store`` and ``user_id`` are given, the store is queried
+        for a matching embedding which is appended when present. Modality
+        dropout randomly zeroes whole modality vectors during training with
+        probability ``dropout_prob``.
         """
 
         if not modalities:
@@ -59,6 +69,15 @@ class ModalityFuser(nn.Module):
                 mask = (torch.rand(tensor.size(0), 1, device=tensor.device) > self.dropout_prob).float()
                 tensor = tensor * mask
             pieces.append(tensor)
+
+        if user_embedding is None and embedding_store is not None and user_id is not None and self.user_dim > 0:
+            stored = embedding_store.get(user_id)
+            if stored is not None:
+                base = next(iter(modalities.values()))
+                stored = stored.to(base.device)
+                if stored.ndim == 1:
+                    stored = stored.unsqueeze(0)
+                user_embedding = stored.expand(base.size(0), -1)
 
         if user_embedding is not None:
             pieces.append(user_embedding)

--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -2,6 +2,12 @@
 
 from .publisher import PerceptionPublisher
 from .service import PerceptionService
+from .user_embeddings import UserEmbeddings
 from .worker_text import TextPerceptionWorker
 
-__all__ = ["TextPerceptionWorker", "PerceptionService", "PerceptionPublisher"]
+__all__ = [
+    "TextPerceptionWorker",
+    "PerceptionService",
+    "PerceptionPublisher",
+    "UserEmbeddings",
+]

--- a/src/deepthought/services/perception/user_embeddings.py
+++ b/src/deepthought/services/perception/user_embeddings.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""Utilities for persisting per-user embedding vectors."""
+
+from pathlib import Path
+import json
+from typing import Dict, Optional, Sequence
+
+import torch
+
+
+class UserEmbeddings:
+    """Persist and retrieve embedding vectors keyed by ``user_id``.
+
+    Parameters
+    ----------
+    path:
+        Location on disk where embeddings are stored as JSON. The file is
+        created if it does not already exist.
+    """
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self._store: Dict[str, torch.Tensor]
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as fh:
+                raw = json.load(fh)
+            self._store = {k: torch.tensor(v, dtype=torch.float32) for k, v in raw.items()}
+        else:
+            self._store = {}
+
+    def get(self, user_id: str) -> Optional[torch.Tensor]:
+        """Return the embedding vector for ``user_id`` if present."""
+
+        return self._store.get(user_id)
+
+    def set(self, user_id: str, embedding: Sequence[float] | torch.Tensor) -> None:
+        """Store ``embedding`` for ``user_id`` and persist to disk."""
+
+        if isinstance(embedding, torch.Tensor):
+            tensor = embedding.detach().cpu().float()
+        else:
+            tensor = torch.tensor(list(embedding), dtype=torch.float32)
+        self._store[user_id] = tensor
+        self.save()
+
+    def save(self) -> None:
+        """Persist the current embeddings to the configured path."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        data = {k: v.tolist() for k, v in self._store.items()}
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)

--- a/tests/unit/test_fuser.py
+++ b/tests/unit/test_fuser.py
@@ -1,10 +1,7 @@
-import importlib
-import sys
-
-sys.modules.pop("torch", None)
-torch = importlib.import_module("torch")
+import torch
 
 from deepthought.modules.fuser import ModalityFuser
+from deepthought.services.perception.user_embeddings import UserEmbeddings
 
 
 def test_fuser_shape_with_user_embedding():
@@ -25,3 +22,13 @@ def test_fuser_modality_dropout_bias_only():
     result = fuser(modalities)
     expected = fuser.project.bias.unsqueeze(0)
     assert torch.allclose(result, expected)
+
+
+def test_fuser_uses_store_when_available(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    store.set("u1", torch.ones(3))
+
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+    mods = {"text": torch.randn(1, 2)}
+    out = fuser(mods, user_id="u1", embedding_store=store)
+    assert out.shape == (1, 4)

--- a/tests/unit/test_user_embeddings.py
+++ b/tests/unit/test_user_embeddings.py
@@ -1,0 +1,19 @@
+import importlib
+import sys
+
+sys.modules.pop("torch", None)
+torch = importlib.import_module("torch")
+
+from deepthought.services.perception.user_embeddings import UserEmbeddings
+
+
+def test_user_embeddings_persist_and_retrieve(tmp_path):
+    path = tmp_path / "embeddings.json"
+    store = UserEmbeddings(path)
+    vec = torch.randn(4)
+    store.set("alice", vec)
+
+    reloaded = UserEmbeddings(path)
+    fetched = reloaded.get("alice")
+    assert fetched is not None
+    assert torch.allclose(fetched, vec)


### PR DESCRIPTION
## Summary
- add `UserEmbeddings` utility to save and load per-user vectors
- enhance `ModalityFuser` to incorporate stored user embeddings when available
- cover new behaviour with unit tests

## Testing
- `flake8 src/deepthought/modules/fuser.py src/deepthought/services/perception/__init__.py src/deepthought/services/perception/user_embeddings.py tests/unit/test_fuser.py tests/unit/test_user_embeddings.py`
- `pytest tests/unit/test_user_embeddings.py tests/unit/test_fuser.py`


------
https://chatgpt.com/codex/tasks/task_e_689d0116c8a48326be2c8aedf4d50408