### PR TITLE
Add perception service scaffolding

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -1,5 +1,7 @@
 """Perception utilities for DeepThought services."""
 
+from .cli import main
+from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .user_embeddings import UserEmbeddings
@@ -10,4 +12,6 @@ __all__ = [
     "PerceptionService",
     "PerceptionPublisher",
     "UserEmbeddings",
+    "PerceptionConfig",
+    "main",
 ]

--- a/src/deepthought/services/perception/cli.py
+++ b/src/deepthought/services/perception/cli.py
@@ -1,0 +1,44 @@
+"""Command-line interface for the perception service."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+
+from nats.aio.client import Client as NATS
+
+from .config import PerceptionConfig
+from .publisher import PerceptionPublisher
+from .service import PerceptionService
+from .service import run as run_service
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser(description="Run the perception service")
+    parser.add_argument("--nats-url", default=PerceptionConfig().nats_url)
+    parser.add_argument("--message-id", required=True)
+    parser.add_argument("--user-id", required=True)
+    args = parser.parse_args()
+
+    nc = NATS()
+    await nc.connect(args.nats_url)
+    js = nc.jetstream()
+
+    publisher = PerceptionPublisher(nc, js)
+    service = PerceptionService(publisher)
+    await run_service(
+        message_id=args.message_id,
+        user_id=args.user_id,
+        service=service,
+    )
+    await nc.drain()
+
+
+def main() -> None:
+    """Synchronous entry point for ``python -m`` execution."""
+
+    asyncio.run(_main())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -1,0 +1,15 @@
+"""Configuration for the perception service."""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class PerceptionConfig(BaseSettings):
+    """Settings controlling the perception service."""
+
+    nats_url: str = Field("nats://localhost:4222", env="DT_NATS_URL")
+
+    class Config:
+        env_prefix = "DT_PERCEPTION_"

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -1,102 +1,50 @@
+"""Minimal perception service leveraging a NATS publisher stub."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Sequence
-
-from deepthought.config import get_settings
+from typing import Any, Dict, Sequence
 
 from .publisher import PerceptionPublisher
-
-Worker = Callable[..., Any]
-Fuser = Callable[[Sequence[Any]], dict]
 
 
 @dataclass
 class PerceptionService:
-    """Orchestrate perception workers and publish fused embeddings.
+    """Thin wrapper around :class:`PerceptionPublisher`.
 
     Parameters
     ----------
-    workers:
-        Sequence of callables that produce intermediate perception outputs. Each
-        worker can be synchronous or asynchronous and is invoked with the same
-        positional and keyword arguments provided to :meth:`run`.
-    fuser:
-        Callable that merges the list of worker outputs into a dictionary with
-        ``spans``, ``embeddings``, ``encoders`` and ``provenance`` entries.
     publisher:
-        Event publisher used to emit :class:`~deepthought.eda.events.PerceptionEmbeddingsPayload`.
+        Event publisher used to emit
+        :class:`~deepthought.eda.events.PerceptionEmbeddingsPayload`.
     """
 
-    workers: Sequence[Worker]
-    fuser: Fuser
     publisher: PerceptionPublisher
 
-    async def run(self, message_id: str, user_id: str, *args: Any, **kwargs: Any) -> dict:
-        """Execute workers, fuse their outputs and publish the result.
+    async def run(
+        self,
+        message_id: str,
+        user_id: str,
+        *,
+        spans: Sequence[Sequence[int]] | None = None,
+        embeddings: Sequence[Sequence[float]] | None = None,
+        encoders: Sequence[Dict[str, Any]] | None = None,
+        provenance: Dict[str, Any] | None = None,
+    ) -> None:
+        """Publish a perception payload."""
 
-        Parameters
-        ----------
-        message_id:
-            Identifier of the message being processed.
-        user_id:
-            Identifier of the user that produced the message.
-        *args, **kwargs:
-            Additional arguments forwarded to each worker.
-        """
-
-        settings = get_settings()
-        if settings.wandb_enabled:
-            try:  # pragma: no cover - optional dependency
-                import wandb
-
-                if wandb.run is None:
-                    wandb.init(
-                        project=settings.wandb_project,
-                        sweep_id=settings.wandb_sweep_id,
-                    )
-                wandb.log({"perception_workers": len(self.workers)})
-            except Exception:  # pragma: no cover - wandb may be missing
-                pass
-
-        results: list[Any] = []
-        for worker in self.workers:
-            result = worker(*args, **kwargs)
-            if isinstance(result, Awaitable):
-                result = await result
-            results.append(result)
-
-        fused = self.fuser(results)
-        if settings.wandb_enabled:
-            try:  # pragma: no cover - optional dependency
-                import wandb
-
-                wandb.log({"num_embeddings": len(fused.get("embeddings", []))})
-            except Exception:  # pragma: no cover - wandb may be missing
-                pass
         await self.publisher.publish(
             message_id=message_id,
             user_id=user_id,
-            spans=fused.get("spans", []),
-            embeddings=fused.get("embeddings", []),
-            encoders=fused.get("encoders", []),
-            provenance=fused.get("provenance", {}),
+            spans=spans,
+            embeddings=embeddings,
+            encoders=encoders,
+            provenance=provenance,
         )
-        return fused
 
 
 async def run(*args: Any, **kwargs: Any) -> None:
-    """Entry point for ``dtrt perception run``.
-
-    Parameters
-    ----------
-    service:
-        Optional :class:`PerceptionService` instance. If provided, the service's
-        :meth:`run` method is invoked with any additional ``args`` and
-        ``kwargs``. When omitted, the function returns immediately. This loose
-        contract allows the CLI to expose the entry point without imposing a
-        specific wiring of workers or publisher.
-    """
+    """Entry point for ``dtrt perception run``."""
 
     service: PerceptionService | None = kwargs.pop("service", None)
     if service is not None:


### PR DESCRIPTION
## Summary
- stub out minimal PerceptionService that publishes embedding payloads
- add PerceptionConfig and CLI wiring a NATS/JetStream publisher
- expose new entry points from perception package

## Testing
- `pre-commit run --files src/deepthought/services/perception/config.py src/deepthought/services/perception/cli.py src/deepthought/services/perception/service.py src/deepthought/services/perception/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfb3b87188326ac0b83d637bdab41