### PR TITLE
feat: add audio perception worker

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -5,10 +5,12 @@ from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .user_embeddings import UserEmbeddings
+from .worker_audio import AudioPerceptionWorker
 from .worker_text import TextPerceptionWorker
 
 __all__ = [
     "TextPerceptionWorker",
+    "AudioPerceptionWorker",
     "PerceptionService",
     "PerceptionPublisher",
     "UserEmbeddings",

--- a/src/deepthought/services/perception/worker_audio.py
+++ b/src/deepthought/services/perception/worker_audio.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Audio perception worker producing windowed RMS features."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from deepthought.perception.worker_audio import extract_windowed_features
+
+
+@dataclass
+class AudioPerceptionWorker:
+    """Extract windowed RMS features from an audio file.
+
+    Parameters
+    ----------
+    window_size:
+        Size of each analysis window in seconds.
+    step_size:
+        Step between windows in seconds.
+    """
+
+    window_size: float = 0.02
+    step_size: float = 0.01
+
+    def __call__(self, audio_path: str | Path, cache_dir: str | Path | None = None) -> Tuple[np.memmap, np.ndarray]:
+        """Return features and per-window timestamps for ``audio_path``.
+
+        Parameters
+        ----------
+        audio_path:
+            Path to a ``.wav`` file.
+        cache_dir:
+            Optional directory in which to store the memmap file. Defaults to the
+            parent directory of ``audio_path``.
+        """
+
+        return extract_windowed_features(
+            audio_path,
+            window_size=self.window_size,
+            step_size=self.step_size,
+            cache_dir=cache_dir,
+        )

--- a/tests/unit/services/perception/test_worker_audio.py
+++ b/tests/unit/services/perception/test_worker_audio.py
@@ -1,0 +1,26 @@
+import numpy as np
+from scipy.io import wavfile
+
+from deepthought.services.perception import AudioPerceptionWorker
+
+
+def test_worker_audio_memmap(tmp_path):
+    sr = 16000
+    t = np.linspace(0, 1, sr, endpoint=False)
+    data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    audio_file = tmp_path / "test.wav"
+    wavfile.write(audio_file, sr, data)
+
+    worker = AudioPerceptionWorker(window_size=0.1, step_size=0.05)
+    features, timestamps = worker(audio_file, cache_dir=tmp_path)
+
+    assert features.shape == (19, 1)
+    assert timestamps.shape == (19, 2)
+    assert np.allclose(timestamps[0], [0.0, 0.1])
+    assert np.allclose(timestamps[1], [0.05, 0.15])
+
+    features2, timestamps2 = worker(audio_file, cache_dir=tmp_path)
+    assert np.allclose(features, features2)
+    assert np.allclose(timestamps, timestamps2)
+    memmap_path = tmp_path / "test_ws0.1_ss0.05.dat"
+    assert memmap_path.exists()


### PR DESCRIPTION
## Summary
- add AudioPerceptionWorker that caches windowed RMS features and timestamps
- expose AudioPerceptionWorker via perception service package
- test audio worker memmap caching and timestamp alignment

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/perception/worker_audio.py src/deepthought/services/perception/__init__.py tests/unit/services/perception/test_worker_audio.py`
- `pytest tests/unit/perception/test_worker_audio.py -q`
- `pytest tests/unit/services/perception/test_worker_audio.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689e05a3ea84832684a7f8b568889589