### PR TITLE
feat: add jetstream publisher with retries

### DIFF
--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -1,4 +1,5 @@
 # File: src/deepthought/eda/publisher.py
+import asyncio
 import logging
 import ssl
 
@@ -31,8 +32,12 @@ class Publisher:
         payload: Union[str, Dict, Any],
         use_jetstream: bool = True,
         timeout: float = 10.0,
+        retries: int = 3,
     ) -> Optional[Dict]:
-        """Publish message, using JetStream if requested."""
+        """Publish message, retrying for at-least-once semantics."""
+        if retries < 1:
+            raise ValueError("retries must be at least 1")
+
         # Convert payload
         if isinstance(payload, bytes):
             data = payload
@@ -51,25 +56,34 @@ class Publisher:
         if len(payload_summary) > 100:
             payload_summary = payload_summary[:97] + "..."
 
-        try:
-            if use_jetstream:
-                # Use JetStream publish with timeout
-                ack = await self._js.publish(subject, data, timeout=timeout)  # Use timeout
-                logger.debug(f"Published to '{subject}' via JetStream: seq={ack.seq}")
-                return {"seq": ack.seq, "stream": ack.stream}
-            else:
+        last_error: Exception | None = None
+        for attempt in range(1, retries + 1):
+            try:
+                if use_jetstream:
+                    ack = await self._js.publish(subject, data, timeout=timeout)
+                    logger.debug("Published to '%s' via JetStream: seq=%s", subject, ack.seq)
+                    return {"seq": ack.seq, "stream": ack.stream}
                 # Use regular NATS publish
                 await self._nc.publish(subject, data)
-                logger.debug(f"Published basic NATS message to '{subject}'")
+                logger.debug("Published basic NATS message to '%s'", subject)
                 return None
-        except nats.errors.TimeoutError as e:
-            message = f"Publish timeout for '{subject}' with payload {payload_summary}: {e}"
-            logger.error(message, exc_info=True)
-            raise type(e)(message) from e
-        except Exception as e:
-            message = f"Failed to publish to '{subject}' with payload {payload_summary}: {e}"
-            logger.error(message, exc_info=True)  # Log traceback
-            raise type(e)(message) from e
+            except nats.errors.TimeoutError as err:
+                last_error = err
+                logger.warning("Publish timeout for '%s' with payload %s: %s", subject, payload_summary, err)
+            except Exception as err:
+                last_error = err
+                logger.warning(
+                    "Failed to publish to '%s' with payload %s: %s",
+                    subject,
+                    payload_summary,
+                    err,
+                )
+            if attempt < retries:
+                await asyncio.sleep(min(0.1 * attempt, 1.0))
+
+        assert last_error is not None
+        logger.error("Failed to publish to '%s' after %s attempts", subject, retries)
+        raise last_error
 
 
 async def connect(

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Dict, Sequence
 
@@ -59,18 +58,9 @@ class PerceptionPublisher:
             provenance=dict(provenance or {}),
         )
 
-        last_error: Exception | None = None
-        for attempt in range(1, retries + 1):
-            try:
-                return await self._publisher.publish(
-                    EventSubjects.PERCEPTION_EMBEDDINGS,
-                    payload,
-                    use_jetstream=True,
-                )
-            except Exception as err:  # pragma: no cover - network issues
-                last_error = err
-                logger.warning("Publish attempt %s failed for message %s: %s", attempt, message_id, err)
-                await asyncio.sleep(min(0.1 * attempt, 1.0))
-        assert last_error is not None
-        logger.error("Failed to publish perception embeddings after %s attempts", retries)
-        raise last_error
+        return await self._publisher.publish(
+            EventSubjects.PERCEPTION_EMBEDDINGS,
+            payload,
+            use_jetstream=True,
+            retries=retries,
+        )

--- a/tests/unit/eda/test_publisher.py
+++ b/tests/unit/eda/test_publisher.py
@@ -1,0 +1,74 @@
+"""Tests for the generic JetStream publisher."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock
+
+import pytest
+
+# Stub out nats modules if not installed
+fake_nats = types.ModuleType("nats")
+fake_nats.errors = types.SimpleNamespace(TimeoutError=Exception)
+aio_mod = types.ModuleType("nats.aio")
+client_mod = types.ModuleType("nats.aio.client")
+client_mod.Client = object
+aio_mod.client = client_mod
+js_client_mod = types.ModuleType("nats.js.client")
+js_client_mod.JetStreamContext = object
+sys.modules.setdefault("nats", fake_nats)
+sys.modules.setdefault("nats.aio", aio_mod)
+sys.modules.setdefault("nats.aio.client", client_mod)
+sys.modules.setdefault("nats.js.client", js_client_mod)
+
+from deepthought.eda.publisher import Publisher
+
+
+class StubNATS:
+    """Simple stub NATS client."""
+
+    def __init__(self) -> None:
+        self.is_connected = True
+
+
+class StubJS:
+    """JetStream stub that fails once before succeeding."""
+
+    def __init__(self) -> None:
+        self.attempts = 0
+
+    async def publish(self, subject, data, timeout=10.0):  # pragma: no cover - signature
+        self.attempts += 1
+        if self.attempts < 2:
+            raise RuntimeError("fail")
+
+        class Ack:
+            def __init__(self) -> None:
+                self.seq = 1
+                self.stream = "test"
+
+        return Ack()
+
+
+@pytest.mark.asyncio
+async def test_publish_retries_until_success():
+    nc = StubNATS()
+    js = StubJS()
+    pub = Publisher(nc, js)
+
+    ack = await pub.publish("sub", {"a": 1}, retries=3)
+
+    assert ack == {"seq": 1, "stream": "test"}
+    assert js.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_after_exhausting_retries():
+    nc = StubNATS()
+    js = StubJS()
+    js.publish = AsyncMock(side_effect=RuntimeError("fail"))
+    pub = Publisher(nc, js)
+
+    with pytest.raises(RuntimeError):
+        await pub.publish("sub", b"data", retries=2)

--- a/tests/unit/services/perception/test_perception_publisher.py
+++ b/tests/unit/services/perception/test_perception_publisher.py
@@ -15,10 +15,11 @@ async def test_publish_embeddings(monkeypatch):
 
     captured: dict = {}
 
-    async def fake_publish(subject, payload, use_jetstream=True):
+    async def fake_publish(subject, payload, use_jetstream=True, retries=3):
         captured["subject"] = subject
         captured["payload"] = payload
         captured["use_jetstream"] = use_jetstream
+        captured["retries"] = retries
         return {"seq": 1}
 
     class FakePublisher:
@@ -44,39 +45,36 @@ async def test_publish_embeddings(monkeypatch):
     assert captured["payload"].encoders == [{"name": "test", "dim": 2}]
     assert captured["payload"].provenance == {"source": "unit"}
     assert captured["use_jetstream"] is True
+    assert captured["retries"] == 3
 
 
 @pytest.mark.asyncio
-async def test_publish_retries(monkeypatch):
-    """Verify that publish retries on failure."""
+async def test_publish_forwards_retries(monkeypatch):
+    """Ensure PerceptionPublisher forwards retry count to Publisher."""
 
-    attempts = 0
+    captured: dict = {}
 
-    async def failing_publish(subject, payload, use_jetstream=True):
-        nonlocal attempts
-        attempts += 1
-        if attempts < 2:
-            raise RuntimeError("fail")
+    async def fake_publish(subject, payload, use_jetstream=True, retries=3):
+        captured["retries"] = retries
         return {"seq": 2}
 
     class FakePublisher:
         def __init__(self, nats, js):  # pragma: no cover - unused
-            self.publish = AsyncMock(side_effect=failing_publish)
+            self.publish = AsyncMock(side_effect=fake_publish)
 
     monkeypatch.setattr(perception_publisher, "Publisher", FakePublisher)
 
     publisher = perception_publisher.PerceptionPublisher(object(), object())
-    ack = await publisher.publish("msg1", "user1", retries=3)
+    await publisher.publish("msg1", "user1", retries=5)
 
-    assert ack == {"seq": 2}
-    assert attempts == 2
+    assert captured["retries"] == 5
 
 
 @pytest.mark.asyncio
 async def test_publish_raises_after_retries(monkeypatch):
-    """Ensure publish raises after exhausting retries."""
+    """Ensure publish raises if underlying Publisher fails."""
 
-    async def always_fail(subject, payload, use_jetstream=True):
+    async def always_fail(subject, payload, use_jetstream=True, retries=1):
         raise RuntimeError("fail")
 
     class FakePublisher:


### PR DESCRIPTION
## Summary
- add retry logic for JetStream Publisher
- format perception events with encoder metadata and provenance
- test publisher retry semantics

## Testing
- `python -m pytest tests/unit/services/perception/test_perception_publisher.py tests/unit/eda/test_publisher.py -q`
- `SKIP=pytest pre-commit run --files src/deepthought/eda/publisher.py src/deepthought/services/perception/publisher.py tests/unit/services/perception/test_perception_publisher.py tests/unit/eda/test_publisher.py`


------
https://chatgpt.com/codex/tasks/task_e_689e0c197fe083268abbf6c4d7fd7053