### PR TITLE
Add video perception worker for frame embedding and grid interpolation

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -6,6 +6,7 @@ from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .user_embeddings import UserEmbeddings
 from .worker_text import TextPerceptionWorker
+from .worker_video import VideoPerceptionWorker
 
 __all__ = [
     "TextPerceptionWorker",
@@ -13,5 +14,6 @@ __all__ = [
     "PerceptionPublisher",
     "UserEmbeddings",
     "PerceptionConfig",
+    "VideoPerceptionWorker",
     "main",
 ]

--- a/src/deepthought/services/perception/worker_video.py
+++ b/src/deepthought/services/perception/worker_video.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Video perception worker converting clips into time-aligned features.
+
+This worker leverages the utility functions in
+:mod:`deepthought.perception.worker_video` to decode frames from a video file,
+embed the frames using either SigLIP or OpenCLIP models, and interpolate the
+resulting features onto a uniform time grid.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+
+from deepthought.perception.worker_video import video_to_feature_grid
+
+
+@dataclass
+class VideoPerceptionWorker:
+    """Decode ``path`` and emit features on a uniform time grid.
+
+    Parameters
+    ----------
+    decode_fps:
+        Target frame sampling rate between 1 and 3 frames-per-second.
+    model_type:
+        Embedding model to use, either ``"siglip"`` or ``"openclip"``.
+    grid_fps:
+        Optional output grid sampling rate. Defaults to ``decode_fps``.
+    """
+
+    decode_fps: int = 1
+    model_type: str = "siglip"
+    grid_fps: int | None = None
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple validation
+        if not 1 <= self.decode_fps <= 3:
+            raise ValueError("decode_fps must be between 1 and 3 fps")
+        if self.grid_fps is not None and self.grid_fps <= 0:
+            raise ValueError("grid_fps must be positive")
+
+    def __call__(self, path: str | Path) -> Tuple[np.ndarray, np.ndarray]:
+        """Process ``path`` and return ``(features, times)`` arrays.
+
+        Returns
+        -------
+        features: np.ndarray
+            Grid of frame embeddings with shape ``[T, D]``.
+        times: np.ndarray
+            Uniform timestamps in seconds with shape ``[T]``.
+        """
+
+        return video_to_feature_grid(str(path), self.decode_fps, self.model_type, self.grid_fps)

--- a/tests/unit/services/perception/test_worker_video.py
+++ b/tests/unit/services/perception/test_worker_video.py
@@ -1,0 +1,38 @@
+import os
+import tempfile
+
+import cv2
+import numpy as np
+
+from deepthought.perception import worker_video as util
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+def _make_test_video() -> str:
+    tmp = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+    path = tmp.name
+    tmp.close()
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(path, fourcc, 10, (32, 32))
+    for i in range(20):
+        frame = np.full((32, 32, 3), i, dtype=np.uint8)
+        out.write(frame)
+    out.release()
+    return path
+
+
+def test_video_perception_worker(monkeypatch):
+    path = _make_test_video()
+
+    def fake_embed(frames, model_type="siglip", device=None):
+        return np.arange(len(frames), dtype=float).reshape(-1, 1)
+
+    monkeypatch.setattr(util, "embed_frames", fake_embed)
+
+    worker = VideoPerceptionWorker(decode_fps=2, model_type="siglip", grid_fps=4)
+    features, times = worker(path)
+    os.remove(path)
+
+    assert features.shape == (7, 1)
+    assert np.allclose(times, np.arange(0.0, 1.51, 0.25))
+    assert np.allclose(features[:, 0], [0, 0.5, 1, 1.5, 2, 2.5, 3])


### PR DESCRIPTION
## Summary
- add `VideoPerceptionWorker` to decode clips at 1–3 fps, embed with SigLIP/OpenCLIP, and interpolate features onto a uniform time grid
- expose the video worker through the perception service API and cover it with a unit test

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/services/perception/worker_video.py`
- `pytest tests/unit/services/perception/test_worker_video.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e05a4c7cc8326b3e507c6211abcdd