### PR TITLE
feat: persist user embeddings

### DIFF
--- a/src/deepthought/modules/fuser.py
+++ b/src/deepthought/modules/fuser.py
@@ -55,9 +55,10 @@ class ModalityFuser(nn.Module):
         Each modality tensor should have shape ``(batch, dim)``. If
         ``user_embedding`` is provided it must have shape ``(batch, user_dim)``.
         When ``embedding_store`` and ``user_id`` are given, the store is queried
-        for a matching embedding which is appended when present. Modality
-        dropout randomly zeroes whole modality vectors during training with
-        probability ``dropout_prob``.
+        for a matching embedding which is appended when present. If a
+        ``user_embedding`` is provided it is persisted back to ``embedding_store``
+        for future calls. Modality dropout randomly zeroes whole modality
+        vectors during training with probability ``dropout_prob``.
         """
 
         if not modalities:
@@ -70,14 +71,17 @@ class ModalityFuser(nn.Module):
                 tensor = tensor * mask
             pieces.append(tensor)
 
-        if user_embedding is None and embedding_store is not None and user_id is not None and self.user_dim > 0:
-            stored = embedding_store.get(user_id)
-            if stored is not None:
-                base = next(iter(modalities.values()))
-                stored = stored.to(base.device)
-                if stored.ndim == 1:
-                    stored = stored.unsqueeze(0)
-                user_embedding = stored.expand(base.size(0), -1)
+        if embedding_store is not None and user_id is not None:
+            if user_embedding is not None:
+                embedding_store.set(user_id, user_embedding.mean(dim=0))
+            elif self.user_dim > 0:
+                stored = embedding_store.get(user_id)
+                if stored is not None:
+                    base = next(iter(modalities.values()))
+                    stored = stored.to(base.device)
+                    if stored.ndim == 1:
+                        stored = stored.unsqueeze(0)
+                    user_embedding = stored.expand(base.size(0), -1)
 
         if user_embedding is not None:
             pieces.append(user_embedding)

--- a/src/deepthought/services/perception/user_embeddings.py
+++ b/src/deepthought/services/perception/user_embeddings.py
@@ -37,6 +37,16 @@ class UserEmbeddings:
 
         return self._store.get(user_id)
 
+    def __contains__(self, user_id: str) -> bool:
+        """Return ``True`` if an embedding for ``user_id`` exists."""
+
+        return user_id in self._store
+
+    def __len__(self) -> int:
+        """Return the number of stored user embeddings."""
+
+        return len(self._store)
+
     def set(self, user_id: str, embedding: Sequence[float] | "torch.Tensor") -> None:
         """Store ``embedding`` for ``user_id`` and persist to disk."""
 

--- a/tests/unit/test_fuser.py
+++ b/tests/unit/test_fuser.py
@@ -38,3 +38,15 @@ def test_fuser_uses_store_when_available(tmp_path):
     mods = {"text": torch.randn(1, 2)}
     out = fuser(mods, user_id="u1", embedding_store=store)
     assert out.shape == (1, 4)
+
+
+def test_fuser_persists_user_embedding(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+    mods = {"text": torch.randn(1, 2)}
+    user_embed = torch.randn(1, 3)
+    fuser(mods, user_embed, user_id="bob", embedding_store=store)
+
+    retrieved = store.get("bob")
+    assert retrieved is not None
+    assert torch.allclose(retrieved, user_embed.squeeze(0))


### PR DESCRIPTION
## Summary
- extend `UserEmbeddings` with utility methods
- allow `ModalityFuser` to fetch and persist user embeddings
- cover persistence behavior with unit tests

## Testing
- `flake8 src tests`
- `pytest tests/unit/test_user_embeddings.py tests/unit/test_fuser.py`

------
https://chatgpt.com/codex/tasks/task_e_689f3bcbc71c8326bccf2d3b29621f3f