### PR TITLE
feat: persist fused perception embeddings

### DIFF
--- a/src/deepthought/memory/vector_store.py
+++ b/src/deepthought/memory/vector_store.py
@@ -220,17 +220,45 @@ class FaissVectorStore(VectorStore):
         ids: Sequence[str],
         metadatas: Optional[Sequence[dict]] = None,
     ) -> None:
-        self._delete(ids)
         import numpy as np
 
-        ids = list(ids)
-        internal_ids = np.arange(self._next_internal_id, self._next_internal_id + len(ids), dtype="int64")
-        self._index.add_with_ids(np.asarray(list(vectors), dtype="float32"), internal_ids)
-        for _id, iid in zip(ids, internal_ids):
-            self._texts.append(None)
-            self._id_to_internal_id[str(_id)] = int(iid)
-            self._internal_id_to_text_idx[int(iid)] = len(self._texts) - 1
-        self._next_internal_id += len(ids)
+        vectors = list(vectors)
+        ids = [str(i) for i in ids]
+
+        # Separate ids into existing and new to maintain stable internal ids
+        existing_ids: list[int] = []
+        new_ids: list[int] = []
+        new_vectors: list[Sequence[float]] = []
+        existing_vectors: list[Sequence[float]] = []
+
+        for vec, _id in zip(vectors, ids):
+            internal_id = self._id_to_internal_id.get(_id)
+            if internal_id is not None:
+                existing_ids.append(int(internal_id))
+                existing_vectors.append(vec)
+            else:
+                internal_id = self._next_internal_id
+                self._next_internal_id += 1
+                self._id_to_internal_id[_id] = int(internal_id)
+                self._internal_id_to_text_idx[int(internal_id)] = len(self._texts)
+                self._texts.append(None)
+                new_ids.append(int(internal_id))
+                new_vectors.append(vec)
+
+        # Remove and re-add existing ids to update vectors
+        if existing_ids:
+            self._index.remove_ids(np.asarray(existing_ids, dtype="int64"))
+            self._index.add_with_ids(
+                np.asarray(existing_vectors, dtype="float32"),
+                np.asarray(existing_ids, dtype="int64"),
+            )
+
+        # Insert new ids
+        if new_ids:
+            self._index.add_with_ids(
+                np.asarray(new_vectors, dtype="float32"),
+                np.asarray(new_ids, dtype="int64"),
+            )
 
     def query(self, query_texts: Sequence[str], n_results: int = 3):
         import numpy as np

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -206,17 +206,17 @@ class CognitiveCoreService(BaseService):
         """Store fused perception embeddings in the vector store and KG."""
         try:
             payload = PerceptionEmbeddingsPayload.from_json(msg.data.decode())
-            vectors = payload.embeddings
-            if vectors:
-                vector = vectors[0]
+            if payload.embeddings:
+                vector = [float(x) for x in payload.embeddings[0]]
+                message_id = str(payload.message_id)
                 store = getattr(self._memory, "_store", None)
                 if store and hasattr(store, "upsert_vectors"):
-                    store.upsert_vectors([vector], [payload.message_id])
+                    store.upsert_vectors([vector], [message_id])
                 graph = getattr(self._memory, "graph_backend", None)
                 if graph:
                     graph.query_subgraph(
                         "MERGE (m:Message {id: $id}) SET m.embedding = $embedding",
-                        {"id": payload.message_id, "embedding": vector},
+                        {"id": message_id, "embedding": vector},
                     )
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()

--- a/tests/unit/test_vector_store.py
+++ b/tests/unit/test_vector_store.py
@@ -169,6 +169,44 @@ def test_faiss_delete(monkeypatch):
     assert "hello" not in res["documents"][0]
 
 
+def test_faiss_upsert_idempotent(monkeypatch):
+    import types
+
+    class DummyIndex:
+        def __init__(self, dim: int) -> None:
+            self.count = 0
+
+        def add_with_ids(self, vecs, ids):
+            self.count += len(ids)
+
+        def remove_ids(self, ids):
+            self.count -= len(ids)
+
+        def search(self, vecs, k):
+            import numpy as np
+
+            k = min(k, self.count)
+            idx = np.arange(k)
+            return np.zeros((len(vecs), k), dtype="float32"), np.tile(idx, (len(vecs), 1))
+
+    fake_faiss = types.SimpleNamespace(
+        IndexFlatL2=DummyIndex,
+        IndexIDMap=lambda idx: idx,
+        StandardGpuResources=object,
+        index_cpu_to_gpu=lambda res, device, index: index,
+    )
+    vector_store.faiss = fake_faiss
+
+    store = FaissVectorStore(embedding_function=SimpleEmbeddingFunction())
+    store.upsert_vectors([[0.1, 0.2]], ids=["m1"])
+    first_internal = store._id_to_internal_id["m1"]
+    first_next = store._next_internal_id
+    store.upsert_vectors([[0.3, 0.4]], ids=["m1"])
+    assert store._id_to_internal_id["m1"] == first_internal
+    assert store._next_internal_id == first_next
+    assert store._index.count == 1
+
+
 def test_create_vector_store_invalid_backend():
     with pytest.raises(ValueError, match="chroma|faiss"):
         create_vector_store(backend="invalid")


### PR DESCRIPTION
## Summary
- handle PERCEPTION_EMBEDDINGS events by upserting fused vectors keyed by message ID
- make FAISS vector store upserts idempotent and stable
- test idempotent upsert behavior in FAISS store

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/memory/vector_store.py src/deepthought/services/cognitive_core_service.py tests/unit/test_vector_store.py`
- `pytest tests/unit/test_vector_store.py tests/unit/test_faiss_vector_store.py`


------
https://chatgpt.com/codex/tasks/task_e_689f3bcb3340832687b703de437f3bce