### PR TITLE
feat: add wandb hooks to perception service and worker

### DIFF
--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Sequence
 import numpy as np
 import torch
 
+from ...config import get_settings
 from ...modules import ModalityFuser
 from .publisher import PerceptionPublisher
 from .worker_audio import AudioPerceptionWorker
@@ -38,6 +39,18 @@ class PerceptionService:
         audio_path: str | Path | None = None,
     ) -> None:
         """Fuse worker outputs and publish via the ``publisher``."""
+        settings = get_settings()
+        wandb_run = None
+        if settings.wandb_enabled:
+            try:  # pragma: no cover - optional dependency
+                import wandb
+
+                wandb_run = wandb.init(
+                    project=settings.wandb_project,
+                    id=settings.wandb_sweep_id,
+                )
+            except Exception:  # pragma: no cover - wandb may be missing
+                wandb_run = None
 
         if embeddings is None and self.fuser is not None:
             modalities: Dict[str, torch.Tensor] = {}
@@ -65,6 +78,24 @@ class PerceptionService:
             encoders=encoders,
             provenance=provenance,
         )
+
+        if wandb_run is not None:
+            try:  # pragma: no cover - optional dependency
+                import wandb
+
+                wandb.log({"embeddings_published": len(embeddings or [])})
+                if settings.wandb_upload_artifacts and embeddings is not None:
+                    with NamedTemporaryFile(suffix=".npy", delete=False) as tmp:
+                        np.save(tmp.name, np.asarray(embeddings))
+                    art = wandb.Artifact(
+                        name=f"embeddings_{message_id}",
+                        type="checkpoint",
+                    )
+                    art.add_file(tmp.name)
+                    wandb.log_artifact(art)
+                    Path(tmp.name).unlink(missing_ok=True)
+            finally:  # pragma: no cover - wandb may be missing
+                wandb_run.finish()
 
 
 async def run(*args: Any, **kwargs: Any) -> None:

--- a/src/deepthought/services/perception/worker_video.py
+++ b/src/deepthought/services/perception/worker_video.py
@@ -10,10 +10,12 @@ resulting features onto a uniform time grid.
 
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import Tuple
 
 import numpy as np
 
+from deepthought.config import get_settings
 from deepthought.perception.worker_video import video_to_feature_grid
 
 
@@ -51,5 +53,27 @@ class VideoPerceptionWorker:
         times: np.ndarray
             Uniform timestamps in seconds with shape ``[T]``.
         """
+        feats, times = video_to_feature_grid(
+            str(path), self.decode_fps, self.model_type, self.grid_fps
+        )
 
-        return video_to_feature_grid(str(path), self.decode_fps, self.model_type, self.grid_fps)
+        settings = get_settings()
+        if settings.wandb_enabled:
+            try:  # pragma: no cover - optional dependency
+                import wandb
+
+                wandb.log({"video_frames": feats.shape[0]})
+                if settings.wandb_upload_artifacts:
+                    with NamedTemporaryFile(suffix=".npy", delete=False) as tmp:
+                        np.save(tmp.name, feats)
+                    art = wandb.Artifact(
+                        name=f"video_features_{Path(path).stem}",
+                        type="features",
+                    )
+                    art.add_file(tmp.name)
+                    wandb.log_artifact(art)
+                    Path(tmp.name).unlink(missing_ok=True)
+            except Exception:  # pragma: no cover - wandb may be missing
+                pass
+
+        return feats, times


### PR DESCRIPTION
## Summary
- hook Weights & Biases into perception service with sweep and artifact support
- log video worker outputs and upload cached features as artifacts

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f49bdcbf88326ad29675d6817a79b