### PR TITLE
docs: add license overview and privacy controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ DeepThought-ReThought is an experimental Artificial Intelligence (AI) project fo
 
 The project is hosted on GitHub: [https://github.com/d0tTino/DeepThought-ReThought](https://github.com/d0tTino/DeepThought-ReThought)
 
+See [docs/licenses.md](docs/licenses.md) for a list of bundled models and
+libraries along with their permissive licenses.
+
 ## Installation
 
 Install the package from PyPI:
@@ -785,6 +788,17 @@ uvicorn deepthought.api.server:app
   The response includes the generated `input_id`.
 * `GET /memory/query?input_id=<id>` – retrieve the latest `MEMORY_RETRIEVED` payload.
 
+## Privacy Controls
+
+DeepThought-ReThought offers switches to manage user data handling:
+
+- **Consent toggle:** set `PERCEPTION_REQUIRE_CONSENT=1` to require an explicit
+  consent flag on incoming messages. Events without consent are ignored.
+- **Retention policy:** the JetStream setup uses `limits` retention by default.
+  Override `PERCEPTION_RETENTION_POLICY` with `limits`, `interest`, or
+  `workqueue` when provisioning streams to control how long perception events
+  persist.
+
 ## Testing
 
 Tests are implemented using the `pytest` framework. To run the tests:
@@ -894,6 +908,12 @@ published. You can also trigger it manually thanks to the
 select the **Release** workflow, click **Run workflow**, and confirm to
 start a manual release. This is useful for verifying the packaging steps
 without creating a new tag.
+
+## License
+
+DeepThought-ReThought is released under the MIT License. See
+[LICENSE](LICENSE) for the full text and [docs/licenses.md](docs/licenses.md)
+for third-party models and libraries and their permissive licenses.
 
 ## Contributing
 

--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -1,0 +1,42 @@
+# Third-Party Licenses
+
+This project relies on several open-source models and libraries. The table below
+summarizes each component and its permissive license.
+
+| Component | License | Notes |
+| --- | --- | --- |
+| PyTorch | BSD-3-Clause | Deep learning framework |
+| Transformers | Apache-2.0 | Hugging Face model/optimizer library |
+| Datasets | Apache-2.0 | Hugging Face dataset utilities |
+| PEFT | Apache-2.0 | Parameter-Efficient Fine-Tuning |
+| TRL | Apache-2.0 | Reinforcement learning helpers |
+| Accelerate | Apache-2.0 | Hardware abstraction for transformers |
+| bitsandbytes | MIT | 8-bit optimizers |
+| SentencePiece | Apache-2.0 | Tokenizer library |
+| Protobuf | BSD-3-Clause | Protocol buffers |
+| SciPy | BSD-3-Clause | Scientific computing |
+| Evaluate | Apache-2.0 | Model evaluation tools |
+| nats-py | Apache-2.0 | NATS client |
+| aiohttp | Apache-2.0 | Async HTTP client/server |
+| FastAPI | MIT | Web framework |
+| pydantic | MIT | Data validation |
+| sentence-transformers | Apache-2.0 | Sentence embedding models |
+| Uvicorn | BSD-3-Clause | ASGI server |
+| PyYAML | MIT | YAML parser |
+| FAISS | MIT | Vector similarity search |
+| prometheus-client | Apache-2.0 | Metrics exporter |
+| discord.py | MIT | Discord API client |
+| NetworkX | BSD-3-Clause | Graph algorithms |
+| TextBlob | MIT | NLP utilities |
+| aiosqlite | MIT | Async SQLite interface |
+| pytest-asyncio | Apache-2.0 | Async pytest support |
+| VaderSentiment | MIT | Sentiment analysis |
+| pyperplan | MIT | Automated planning |
+| l2p | MIT | Learning to plan library |
+| UME | MIT | Micro-embedding utilities |
+| OpenCLIP (open-clip-torch) | MIT | CLIP implementation |
+| torchvision | BSD-3-Clause | Computer vision models |
+| opencv-python-headless | Apache-2.0 | Computer vision toolkit |
+| Default social perception model | MIT | Bundled classifier weights |
+
+All of these licenses permit commercial and derivative use with attribution.

--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -65,3 +65,19 @@ nats consumer next PERCEPTION analytics-perception-consumer --count=10 --json
 These commands help inspect past perception embeddings for debugging or
 analysis.
 
+## Privacy Controls
+
+The perception service provides basic controls over user consent and data
+retention:
+
+- **Consent toggle:** set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming
+  messages to include a `"consent": true` flag. Events without consent are
+  ignored.
+- **Retention policy:** the `PERCEPTION` stream defaults to the JetStream
+  `limits` retention policy. Override `PERCEPTION_RETENTION_POLICY` with
+  `limits`, `interest`, or `workqueue` when provisioning streams to control how
+  long scored events are stored.
+
+These options allow deployments to honor user preferences and organizational
+data policies.
+


### PR DESCRIPTION
## Summary
- document third-party models and libraries with permissive licenses
- explain consent toggle and JetStream retention options for perception data
- link license list and privacy controls from README

## Testing
- no tests run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_689f55ca63b483269d40279d8a354424