### PR TITLE
Add perception pipeline tests

### DIFF
--- a/tests/integration/test_perception_integration.py
+++ b/tests/integration/test_perception_integration.py
@@ -1,0 +1,73 @@
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+import torch
+from scipy.io import wavfile
+
+from deepthought.eda.events import EventSubjects, PerceptionEmbeddingsPayload
+from deepthought.modules.fuser import ModalityFuser
+from deepthought.services.perception.publisher import PerceptionPublisher
+from deepthought.services.perception.user_embeddings import UserEmbeddings
+from deepthought.services.perception.worker_audio import AudioPerceptionWorker
+from deepthought.services.perception.worker_text import TextPerceptionWorker
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+class DummySentenceModel:
+    def encode(self, text: str) -> np.ndarray:
+        length = len(text)
+        return np.asarray([length, length + 1], dtype=np.float32)
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.publish = AsyncMock(return_value={"seq": 1})
+
+
+@pytest.mark.asyncio
+async def test_perception_pipeline_end_to_end(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: DummySentenceModel(),
+    )
+    dummy_feats = np.array([[1.0, 2.0]], dtype=np.float32)
+    dummy_times = np.array([0.0], dtype=np.float32)
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (dummy_feats, dummy_times),
+    )
+    monkeypatch.setattr(
+        "deepthought.services.perception.publisher.Publisher",
+        DummyPublisher,
+    )
+
+    sr = 16000
+    audio_path = tmp_path / "a.wav"
+    wavfile.write(audio_path, sr, np.ones(sr // 10, dtype=np.int16))
+    audio_worker = AudioPerceptionWorker()
+    audio_feats, _ = audio_worker(audio_path)
+
+    text_worker = TextPerceptionWorker(hop_seconds=0.05)
+    text_feats = text_worker([("hi", 0.0, 0.05)], tmp_path / "t.dat")
+
+    video_worker = VideoPerceptionWorker()
+    video_feats, _ = video_worker("v.mp4")
+
+    store = UserEmbeddings(tmp_path / "emb.json")
+    fuser = ModalityFuser({"audio": 1, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
+    modalities = {
+        "audio": torch.from_numpy(np.asarray(audio_feats[:1])).float(),
+        "text": torch.from_numpy(np.asarray(text_feats[:1])).float(),
+        "video": torch.from_numpy(np.asarray(video_feats[:1])).float(),
+    }
+    fused = fuser(modalities, user_embedding=torch.ones((1, 2)), user_id="u1", embedding_store=store)
+    assert "u1" in store
+
+    pub = PerceptionPublisher(nats_client=object(), js_context=object())
+    await pub.publish("m1", "u1", spans=[[0, 1]], embeddings=fused.detach().numpy().tolist())
+    pub._publisher.publish.assert_awaited_once()
+    args, kwargs = pub._publisher.publish.call_args
+    subject, payload = args
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
+    assert isinstance(payload, PerceptionEmbeddingsPayload)

--- a/tests/test_modality_fuser.py
+++ b/tests/test_modality_fuser.py
@@ -1,0 +1,35 @@
+import pytest
+import torch
+
+from deepthought.modules.fuser import ModalityFuser
+
+
+def test_modality_fuser_basic():
+    fuser = ModalityFuser({"text": 3, "audio": 1}, fused_dim=5)
+    text = torch.ones((2, 3))
+    audio = torch.ones((2, 1))
+    out = fuser({"text": text, "audio": audio})
+    assert out.shape == (2, 5)
+
+
+def test_modality_fuser_dropout(monkeypatch):
+    fuser = ModalityFuser({"text": 2}, fused_dim=2, dropout_prob=1.0)
+    fuser.train()
+    captured = {}
+    original_forward = fuser.project.forward
+
+    def capture(x):
+        captured["input"] = x.detach().clone()
+        return original_forward(x)
+
+    monkeypatch.setattr(fuser.project, "forward", capture)
+    text = torch.ones((3, 2))
+    fuser({"text": text})
+    assert torch.count_nonzero(captured["input"]) == 0
+
+
+def test_modality_fuser_missing_modalities():
+    fuser = ModalityFuser({"text": 2, "audio": 1}, fused_dim=3)
+    text = torch.ones((1, 2))
+    with pytest.raises(RuntimeError):
+        fuser({"text": text})

--- a/tests/test_perception_publisher.py
+++ b/tests/test_perception_publisher.py
@@ -1,0 +1,36 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deepthought.eda.events import EventSubjects, PerceptionEmbeddingsPayload
+from deepthought.services.perception.publisher import PerceptionPublisher
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.publish = AsyncMock(return_value={"seq": 1})
+
+
+@pytest.mark.asyncio
+async def test_perception_publisher(monkeypatch):
+    monkeypatch.setattr(
+        "deepthought.services.perception.publisher.Publisher",
+        DummyPublisher,
+    )
+    pub = PerceptionPublisher(nats_client=object(), js_context=object())
+    result = await pub.publish(
+        "msg1",
+        "user1",
+        spans=[[0, 1]],
+        embeddings=[[0.1, 0.2]],
+        encoders=[{"name": "enc"}],
+        provenance={"p": 1},
+    )
+    assert result == {"seq": 1}
+    pub._publisher.publish.assert_awaited_once()
+    args, kwargs = pub._publisher.publish.call_args
+    subject, payload = args
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
+    assert isinstance(payload, PerceptionEmbeddingsPayload)
+    assert payload.message_id == "msg1"

--- a/tests/test_perception_workers.py
+++ b/tests/test_perception_workers.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+from deepthought.services.perception.worker_audio import AudioPerceptionWorker
+from deepthought.services.perception.worker_text import TextPerceptionWorker
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+class _DummySentenceModel:
+    def encode(self, text: str) -> np.ndarray:
+        length = len(text)
+        return np.asarray([length, length + 1], dtype=np.float32)
+
+
+def test_audio_perception_worker(tmp_path):
+    sr = 16000
+    data = np.ones(int(0.05 * sr), dtype=np.int16)
+    path = tmp_path / "test.wav"
+    wavfile.write(path, sr, data)
+
+    worker = AudioPerceptionWorker(window_size=0.02, step_size=0.01)
+    features, times = worker(path)
+
+    assert features.shape == (4, 1)
+    assert times.shape == (4, 2)
+
+
+def test_text_perception_worker(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: _DummySentenceModel(),
+    )
+    tokens = [("hi", 0.0, 0.05), ("there", 0.05, 0.1)]
+    memmap_path = tmp_path / "tokens.dat"
+
+    worker = TextPerceptionWorker(model_name="dummy", hop_seconds=0.05)
+    feats = worker(tokens, memmap_path)
+
+    assert feats.shape == (2, 2)
+    assert np.allclose(feats[0], [2, 3])
+    assert np.allclose(feats[1], [5, 6])
+
+
+def test_video_perception_worker(monkeypatch):
+    dummy_feats = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    dummy_times = np.array([0.0, 1.0], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (dummy_feats, dummy_times),
+    )
+
+    worker = VideoPerceptionWorker(decode_fps=1, model_type="siglip")
+    feats, times = worker("dummy.mp4")
+
+    assert np.array_equal(feats, dummy_feats)
+    assert np.array_equal(times, dummy_times)


### PR DESCRIPTION
## Summary
- add unit tests for audio, text and video perception workers
- cover modality fusion including dropout and missing modalities
- test perception publisher and end-to-end pipeline with user embeddings

## Testing
- `SKIP=pytest pre-commit run --files tests/test_perception_workers.py tests/test_modality_fuser.py tests/test_perception_publisher.py tests/integration/test_perception_integration.py`
- `pytest tests/test_perception_workers.py tests/test_modality_fuser.py tests/test_perception_publisher.py tests/integration/test_perception_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_689f55c9a0808326833865574c9687d1