### PR TITLE
Add perception pipeline tests for workers and publisher

### DIFF
--- a/tests/integration/test_perception_event_publish_memory.py
+++ b/tests/integration/test_perception_event_publish_memory.py
@@ -1,0 +1,78 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+import torch
+from scipy.io import wavfile
+
+from deepthought.eda.events import EventSubjects
+from deepthought.modules.fuser import ModalityFuser
+from deepthought.services.perception.publisher import PerceptionPublisher
+from deepthought.services.perception.user_embeddings import UserEmbeddings
+from deepthought.services.perception.worker_audio import AudioPerceptionWorker
+from deepthought.services.perception.worker_text import TextPerceptionWorker
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+class DummySentenceModel:
+    def encode(self, text: str) -> np.ndarray:
+        length = len(text)
+        return np.asarray([length, length + 1], dtype=np.float32)
+
+
+class DummyNats:
+    is_connected = True
+
+
+class DummyJetStream:
+    def __init__(self):
+        self.publish = AsyncMock(return_value=SimpleNamespace(seq=1, stream="s"))
+
+
+@pytest.mark.asyncio
+async def test_perception_event_publishing_and_memory_upsert(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: DummySentenceModel(),
+    )
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (
+            np.asarray([[1.0, 2.0]], dtype=np.float32),
+            np.asarray([0.0], dtype=np.float32),
+        ),
+    )
+
+    sr = 16000
+    audio_path = tmp_path / "a.wav"
+    wavfile.write(audio_path, sr, np.ones(sr // 10, dtype=np.int16))
+
+    audio_worker = AudioPerceptionWorker()
+    audio_feats, _ = audio_worker(audio_path)
+    text_worker = TextPerceptionWorker(hop_seconds=0.05)
+    text_feats = text_worker([("hi", 0.0, 0.05)], tmp_path / "t.dat")
+    video_worker = VideoPerceptionWorker()
+    video_feats, _ = video_worker("v.mp4")
+
+    store = UserEmbeddings(tmp_path / "emb.json")
+    fuser = ModalityFuser({"audio": 1, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
+    modalities = {
+        "audio": torch.from_numpy(audio_feats[:1]).float(),
+        "text": torch.from_numpy(text_feats[:1]).float(),
+        "video": torch.from_numpy(video_feats[:1]).float(),
+    }
+    fused = fuser(modalities, user_embedding=torch.ones((1, 2)), user_id="u1", embedding_store=store)
+    assert "u1" in store
+
+    js = DummyJetStream()
+    pub = PerceptionPublisher(DummyNats(), js)
+    await pub.publish("m1", "u1", spans=[[0, 1]], embeddings=fused.detach().numpy().tolist())
+
+    js.publish.assert_awaited_once()
+    subject, data = js.publish.call_args[0]
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
+    payload = json.loads(data.decode())
+    assert payload["message_id"] == "m1"
+    assert payload["user_id"] == "u1"

--- a/tests/test_perception_publisher.py
+++ b/tests/test_perception_publisher.py
@@ -34,3 +34,21 @@ async def test_perception_publisher(monkeypatch):
     assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
     assert isinstance(payload, PerceptionEmbeddingsPayload)
     assert payload.message_id == "msg1"
+
+
+@pytest.mark.asyncio
+async def test_perception_publisher_defaults(monkeypatch):
+    monkeypatch.setattr(
+        "deepthought.services.perception.publisher.Publisher",
+        DummyPublisher,
+    )
+    pub = PerceptionPublisher(nats_client=object(), js_context=object())
+    result = await pub.publish("m2", "u2")
+    assert result == {"seq": 1}
+    args, kwargs = pub._publisher.publish.call_args
+    subject, payload = args
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
+    assert payload.spans == []
+    assert payload.embeddings == []
+    assert payload.encoders == []
+    assert payload.provenance == {}

--- a/tests/unit/perception/test_worker_text.py
+++ b/tests/unit/perception/test_worker_text.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from deepthought.services.perception.worker_text import TextPerceptionWorker
+
+
+class _DummySentenceModel:
+    def encode(self, text: str) -> np.ndarray:
+        length = len(text)
+        return np.asarray([length, length + 1], dtype=np.float32)
+
+
+def test_text_perception_worker(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: _DummySentenceModel(),
+    )
+    tokens = [("hi", 0.0, 0.05), ("there", 0.05, 0.1)]
+    memmap_path = tmp_path / "tokens.dat"
+
+    worker = TextPerceptionWorker(model_name="dummy", hop_seconds=0.05)
+    feats = worker(tokens, memmap_path)
+
+    assert feats.shape == (2, 2)
+    assert np.allclose(feats[0], [2, 3])
+    assert np.allclose(feats[1], [5, 6])

--- a/tests/unit/perception/test_worker_video.py
+++ b/tests/unit/perception/test_worker_video.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+def test_video_perception_worker(monkeypatch):
+    feats = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    times = np.array([0.0, 1.0], dtype=np.float32)
+
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (feats, times),
+    )
+
+    worker = VideoPerceptionWorker(decode_fps=1, model_type="siglip")
+    out_feats, out_times = worker("dummy.mp4")
+
+    assert np.array_equal(out_feats, feats)
+    assert np.array_equal(out_times, times)

--- a/tests/unit/test_fuser.py
+++ b/tests/unit/test_fuser.py
@@ -50,3 +50,9 @@ def test_fuser_persists_user_embedding(tmp_path):
     retrieved = store.get("bob")
     assert retrieved is not None
     assert torch.allclose(retrieved, user_embed.squeeze(0))
+
+
+def test_fuser_missing_modalities_raises():
+    fuser = ModalityFuser({"text": 2, "audio": 1}, fused_dim=3)
+    with pytest.raises(RuntimeError):
+        fuser({"text": torch.randn(1, 2)})


### PR DESCRIPTION
## Summary
- add unit tests for text and video perception workers
- cover publisher defaults and fuser error handling
- verify end-to-end perception event publishing and memory upsert with mocked JetStream

## Testing
- `SKIP=pytest pre-commit run --files tests/integration/test_perception_event_publish_memory.py tests/test_perception_publisher.py tests/unit/test_fuser.py tests/unit/perception/test_worker_text.py tests/unit/perception/test_worker_video.py`
- `pytest tests/unit/perception/test_worker_text.py tests/unit/perception/test_worker_video.py tests/unit/test_fuser.py tests/test_perception_publisher.py tests/integration/test_perception_event_publish_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc7a22708326bcfcbfce5b9ae1ea