### PR TITLE
docs: add privacy controls and license reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ DeepThought-ReThought is an experimental Artificial Intelligence (AI) project fo
 
 The project is hosted on GitHub: [https://github.com/d0tTino/DeepThought-ReThought](https://github.com/d0tTino/DeepThought-ReThought)
 
-See [docs/licenses.md](docs/licenses.md) for a list of bundled models and
-libraries along with their permissive licenses.
+See the [licenses guide](docs/licenses.md) for a list of bundled models and
+libraries and their permissive licenses.
 
 ## Installation
 
@@ -725,6 +725,16 @@ scores = detect_emotions("I'm feeling thrilled today!")
 print(scores["Happy"])
 ```
 
+### Privacy Controls
+
+Set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming messages include a
+`"consent": true` flag before they are scored. Configure JetStream retention with
+`PERCEPTION_RETENTION_POLICY`, choosing `limits`, `interest`, or `workqueue` to
+control how long perception events are stored.
+
+See [docs/perception_service.md](docs/perception_service.md#privacy-controls) for
+details.
+
 ## Discord Bot Roadmap
 
 For a detailed overview of the Discord bot progress, see [docs/discord_bot_roadmap.md](docs/discord_bot_roadmap.md).
@@ -912,8 +922,9 @@ without creating a new tag.
 ## License
 
 DeepThought-ReThought is released under the MIT License. See
-[LICENSE](LICENSE) for the full text and [docs/licenses.md](docs/licenses.md)
-for third-party models and libraries and their permissive licenses.
+[LICENSE](LICENSE) for the full text and the
+[third-party licenses](docs/licenses.md) for bundled models and libraries with
+permissive terms.
 
 ## Contributing
 

--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -1,7 +1,10 @@
 # Third-Party Licenses
 
 This project relies on several open-source models and libraries. The table below
-summarizes each component and its permissive license.
+summarizes each component and its permissive license. All entries use
+OSI-approved terms that allow commercial and derivative use with attribution.
+The list reflects the components bundled with DeepThought-ReThought; consult the
+upstream projects for the most current license information.
 
 | Component | License | Notes |
 | --- | --- | --- |
@@ -38,5 +41,3 @@ summarizes each component and its permissive license.
 | torchvision | BSD-3-Clause | Computer vision models |
 | opencv-python-headless | Apache-2.0 | Computer vision toolkit |
 | Default social perception model | MIT | Bundled classifier weights |
-
-All of these licenses permit commercial and derivative use with attribution.

--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -78,6 +78,13 @@ retention:
   `limits`, `interest`, or `workqueue` when provisioning streams to control how
   long scored events are stored.
 
-These options allow deployments to honor user preferences and organizational
-data policies.
+Example configuration:
+
+```bash
+export PERCEPTION_REQUIRE_CONSENT=1
+export PERCEPTION_RETENTION_POLICY=workqueue
+```
+
+These options allow deployments to honor user preferences and organizational data
+policies.
 


### PR DESCRIPTION
## Summary
- reference licenses guide from README and expand third-party list intro
- document consent toggle and retention policy in perception service docs
- note consent and retention options in README's social perception section

## Testing
- no tests run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_68a0bc7a19348326b74460ae2d6ec7f3