### PR TITLE
feat: add embedding-based audio worker

### DIFF
--- a/src/deepthought/perception/worker_audio.py
+++ b/src/deepthought/perception/worker_audio.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 """Audio worker utilities.
 
-This module extracts simple windowed features from ``.wav`` files and caches
-results using memory-mapped arrays. Each window emits a ``[start, end]``
- timestamp that aligns with the text worker grid.
+This module extracts windowed audio embeddings and caches results using
+memory-mapped arrays. Each window emits a ``[start, end]`` timestamp that
+aligns with the text worker grid. Embeddings are produced from either
+``WavLM`` or ``CLAP`` models.
 """
 
 from pathlib import Path
-from typing import Tuple
+from typing import Callable, Tuple
 
 import numpy as np
 from scipy.io import wavfile
@@ -16,13 +17,71 @@ from scipy.io import wavfile
 from deepthought.config import get_settings
 
 
+def _select_embedding_fn(
+    model: str,
+    model_path: str | None,
+    sampling_rate: int,
+) -> Callable[[np.ndarray], np.ndarray]:
+    """Return a function that maps a waveform to an embedding.
+
+    Parameters
+    ----------
+    model:
+        Which embedding model to use (``"wavlm"`` or ``"clap"``).
+    model_path:
+        Optional Hugging Face model identifier.
+    sampling_rate:
+        Sampling rate of the audio in Hertz.
+    """
+
+    model = model.lower()
+    if model == "wavlm":
+        import torch
+        from transformers import WavLMFeatureExtractor, WavLMModel  # type: ignore
+
+        name = model_path or "microsoft/wavlm-base-plus"
+        extractor = WavLMFeatureExtractor.from_pretrained(name)
+        mdl = WavLMModel.from_pretrained(name)
+        mdl.eval()
+
+        def embed(window: np.ndarray) -> np.ndarray:
+            inputs = extractor(window, sampling_rate=sampling_rate, return_tensors="pt")
+            with torch.no_grad():
+                hidden = mdl(**inputs).last_hidden_state.mean(dim=1).squeeze(0)
+            return hidden.cpu().numpy().astype(np.float32)
+
+        return embed
+
+    if model == "clap":
+        import torch
+        from transformers import ClapModel, ClapProcessor  # type: ignore
+
+        name = model_path or "laion/clap-htsat-unfused"
+        processor = ClapProcessor.from_pretrained(name)
+        mdl = ClapModel.from_pretrained(name)
+        mdl.eval()
+
+        def embed(window: np.ndarray) -> np.ndarray:
+            inputs = processor(audios=window, sampling_rate=sampling_rate, return_tensors="pt")
+            with torch.no_grad():
+                hidden = mdl.get_audio_features(**inputs).squeeze(0)
+            return hidden.cpu().numpy().astype(np.float32)
+
+        return embed
+
+    raise ValueError(f"Unsupported model: {model}")
+
+
 def extract_windowed_features(
     audio_path: str | Path,
     window_size: float = 0.02,
     step_size: float = 0.01,
     cache_dir: str | Path | None = None,
+    *,
+    model: str = "wavlm",
+    model_path: str | None = None,
 ) -> Tuple[np.memmap, np.ndarray]:
-    """Return RMS features and per-window timestamps for ``audio_path``.
+    """Return embedding features and per-window timestamps for ``audio_path``.
 
     Parameters
     ----------
@@ -35,6 +94,10 @@ def extract_windowed_features(
     cache_dir:
         Optional directory in which to store the memmap file. Defaults to the
         parent directory of ``audio_path``.
+    model:
+        Name of the embedding model to use (``"wavlm"`` or ``"clap"``).
+    model_path:
+        Optional Hugging Face identifier or local path for the model.
     """
 
     audio_path = Path(audio_path)
@@ -46,6 +109,11 @@ def extract_windowed_features(
     sr, data = wavfile.read(audio_path)
     if data.ndim > 1:
         data = data.mean(axis=1)
+    if data.dtype.kind in "iu":
+        data = data.astype(np.float32) / np.iinfo(data.dtype).max
+    else:
+        data = data.astype(np.float32)
+
     win_samples = int(window_size * sr)
     step_samples = int(step_size * sr)
     if win_samples <= 0 or step_samples <= 0:
@@ -57,19 +125,27 @@ def extract_windowed_features(
     else:
         num_windows = 1 + (n_samples - win_samples) // step_samples
 
-    memmap_path = cache_dir / f"{audio_path.stem}_ws{window_size}_ss{step_size}.dat"
-    shape = (num_windows, 1)
+    memmap_path = cache_dir / f"{audio_path.stem}_{model}_ws{window_size}_ss{step_size}.dat"
 
     if memmap_path.exists():
-        features = np.memmap(memmap_path, dtype=np.float32, mode="r", shape=shape)
+        file_size = memmap_path.stat().st_size
+        emb_dim = 0 if num_windows == 0 else int(file_size // (4 * num_windows))
+        features = np.memmap(memmap_path, dtype=np.float32, mode="r", shape=(num_windows, emb_dim))
     else:
-        features = np.memmap(memmap_path, dtype=np.float32, mode="w+", shape=shape)
-        for i in range(num_windows):
-            start = i * step_samples
-            end = start + win_samples
-            window = data[start:end]
-            features[i, 0] = np.sqrt(np.mean(window.astype(np.float32) ** 2))
-        features.flush()
+        embed = _select_embedding_fn(model, model_path, sr)
+        if num_windows == 0:
+            features = np.memmap(memmap_path, dtype=np.float32, mode="w+", shape=(0, 0))
+        else:
+            first = embed(data[:win_samples])
+            emb_dim = int(first.shape[0])
+            features = np.memmap(memmap_path, dtype=np.float32, mode="w+", shape=(num_windows, emb_dim))
+            features[0] = first
+            for i in range(1, num_windows):
+                start = i * step_samples
+                end = start + win_samples
+                window = data[start:end]
+                features[i] = embed(window)
+            features.flush()
 
     starts = np.arange(num_windows) * step_size
     ends = starts + window_size

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -10,6 +10,11 @@ class PerceptionConfig(BaseSettings):
     """Settings controlling the perception service."""
 
     nats_url: str = Field("nats://localhost:4222", env="DT_NATS_URL")
+    audio_model: str = "wavlm"
+    audio_model_path: str | None = None
+    audio_window_size: float = 0.02
+    audio_step_size: float = 0.01
+    audio_cache_dir: str | None = None
 
     class Config:
         env_prefix = "DT_PERCEPTION_"

--- a/src/deepthought/services/perception/worker_audio.py
+++ b/src/deepthought/services/perception/worker_audio.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Audio perception worker producing windowed RMS features."""
+"""Audio perception worker producing windowed audio embeddings."""
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -10,10 +10,12 @@ import numpy as np
 
 from deepthought.perception.worker_audio import extract_windowed_features
 
+from .config import PerceptionConfig
+
 
 @dataclass
 class AudioPerceptionWorker:
-    """Extract windowed RMS features from an audio file.
+    """Extract windowed embeddings from an audio file.
 
     Parameters
     ----------
@@ -21,26 +23,30 @@ class AudioPerceptionWorker:
         Size of each analysis window in seconds.
     step_size:
         Step between windows in seconds.
+    model:
+        Embedding model to use (``"wavlm"`` or ``"clap"``).
+    model_path:
+        Optional path or identifier for the embedding model.
+    cache_dir:
+        Default directory in which to store memmap files.
     """
 
-    window_size: float = 0.02
-    step_size: float = 0.01
+    _cfg = PerceptionConfig()
+
+    window_size: float = _cfg.audio_window_size
+    step_size: float = _cfg.audio_step_size
+    model: str = _cfg.audio_model
+    model_path: str | None = _cfg.audio_model_path
+    cache_dir: str | Path | None = _cfg.audio_cache_dir
 
     def __call__(self, audio_path: str | Path, cache_dir: str | Path | None = None) -> Tuple[np.memmap, np.ndarray]:
-        """Return features and per-window timestamps for ``audio_path``.
-
-        Parameters
-        ----------
-        audio_path:
-            Path to a ``.wav`` file.
-        cache_dir:
-            Optional directory in which to store the memmap file. Defaults to the
-            parent directory of ``audio_path``.
-        """
+        """Return features and per-window timestamps for ``audio_path``."""
 
         return extract_windowed_features(
             audio_path,
             window_size=self.window_size,
             step_size=self.step_size,
-            cache_dir=cache_dir,
+            cache_dir=cache_dir or self.cache_dir,
+            model=self.model,
+            model_path=self.model_path,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,6 @@ if "torch" not in sys.modules:
     except Exception:
         torch_stub = types.ModuleType("torch")
 
-
         class _NoGrad:
             def __enter__(self):
                 return None
@@ -148,6 +147,21 @@ if "transformers" not in sys.modules:
     transformers_stub.AutoModelForSequenceClassification = _DummyModel
     transformers_stub.AutoTokenizer = _DummyModel
     sys.modules["transformers"] = transformers_stub
+
+import numpy as np
+
+import deepthought.perception.worker_audio as _wa
+
+
+def _dummy_select(model: str, model_path: str | None, sr: int):
+    def _embed(window: np.ndarray) -> np.ndarray:
+        m = float(np.mean(window))
+        return np.array([m, m + 1, m + 2, m + 3], dtype=np.float32)
+
+    return _embed
+
+
+_wa._select_embedding_fn = _dummy_select
 
 import pytest
 

--- a/tests/integration/test_perception_event_publish_memory.py
+++ b/tests/integration/test_perception_event_publish_memory.py
@@ -16,6 +16,7 @@ def _ensure_real_torch():
         importlib.reload(torch_parameter)
         importlib.reload(torch.nn.modules.linear)
 
+
 from deepthought.eda.events import EventSubjects
 from deepthought.modules.fuser import ModalityFuser
 from deepthought.services.perception.publisher import PerceptionPublisher
@@ -67,7 +68,7 @@ async def test_perception_event_publishing_and_memory_upsert(monkeypatch, tmp_pa
 
     store = UserEmbeddings(tmp_path / "emb.json")
     try:
-        fuser = ModalityFuser({"audio": 1, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
+        fuser = ModalityFuser({"audio": 4, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
     except AttributeError as exc:  # pragma: no cover - environment-specific
         pytest.skip(str(exc))
     modalities = {

--- a/tests/test_perception_workers.py
+++ b/tests/test_perception_workers.py
@@ -22,7 +22,7 @@ def test_audio_perception_worker(tmp_path):
     worker = AudioPerceptionWorker(window_size=0.02, step_size=0.01)
     features, times = worker(path)
 
-    assert features.shape == (4, 1)
+    assert features.shape == (4, 4)
     assert times.shape == (4, 2)
 
 

--- a/tests/unit/perception/test_worker_audio.py
+++ b/tests/unit/perception/test_worker_audio.py
@@ -11,20 +11,16 @@ def test_extract_windowed_features(tmp_path):
     audio_file = tmp_path / "test.wav"
     wavfile.write(audio_file, sr, data)
 
-    features, timestamps = extract_windowed_features(
-        audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path
-    )
+    features, timestamps = extract_windowed_features(audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path)
 
-    assert features.shape == (19, 1)
+    assert features.shape == (19, 4)
     assert timestamps.shape == (19, 2)
     assert np.allclose(timestamps[0], [0.0, 0.1])
     assert np.allclose(timestamps[1], [0.05, 0.15])
 
     # Second call should reuse memmap and produce identical results
-    features2, timestamps2 = extract_windowed_features(
-        audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path
-    )
+    features2, timestamps2 = extract_windowed_features(audio_file, window_size=0.1, step_size=0.05, cache_dir=tmp_path)
     assert np.allclose(features, features2)
     assert np.allclose(timestamps, timestamps2)
-    memmap_path = tmp_path / "test_ws0.1_ss0.05.dat"
+    memmap_path = tmp_path / "test_wavlm_ws0.1_ss0.05.dat"
     assert memmap_path.exists()

--- a/tests/unit/services/perception/test_audio_worker.py
+++ b/tests/unit/services/perception/test_audio_worker.py
@@ -14,7 +14,7 @@ def test_worker_audio_memmap(tmp_path):
     worker = AudioPerceptionWorker(window_size=0.1, step_size=0.05)
     features, timestamps = worker(audio_file, cache_dir=tmp_path)
 
-    assert features.shape == (19, 1)
+    assert features.shape == (19, 4)
     assert timestamps.shape == (19, 2)
     assert np.allclose(timestamps[0], [0.0, 0.1])
     assert np.allclose(timestamps[1], [0.05, 0.15])
@@ -22,5 +22,5 @@ def test_worker_audio_memmap(tmp_path):
     features2, timestamps2 = worker(audio_file, cache_dir=tmp_path)
     assert np.allclose(features, features2)
     assert np.allclose(timestamps, timestamps2)
-    memmap_path = tmp_path / "test_ws0.1_ss0.05.dat"
+    memmap_path = tmp_path / "test_wavlm_ws0.1_ss0.05.dat"
     assert memmap_path.exists()


### PR DESCRIPTION
## Summary
- replace RMS audio features with model-driven embeddings and cache to memmaps
- allow perception audio worker to select embedding model and cache location
- expose audio model and hop configuration in perception settings

## Testing
- `SKIP=pytest pre-commit run --files src/deepthought/perception/worker_audio.py src/deepthought/services/perception/worker_audio.py src/deepthought/services/perception/config.py tests/unit/perception/test_worker_audio.py tests/unit/services/perception/test_audio_worker.py tests/test_perception_workers.py tests/integration/test_perception_event_publish_memory.py tests/conftest.py`
- `pytest tests/unit/perception/test_worker_audio.py tests/unit/services/perception/test_audio_worker.py tests/test_perception_workers.py tests/integration/test_perception_event_publish_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a32fe45e80832698bb8559bac8d2d6