### PR TITLE
Add integration tests for perception workers

### DIFF
--- a/tests/integration/test_perception_event_publish_memory.py
+++ b/tests/integration/test_perception_event_publish_memory.py
@@ -100,3 +100,132 @@ async def test_perception_event_publishing_and_memory_upsert(monkeypatch, tmp_pa
     payload = json.loads(data.decode())
     assert payload["message_id"] == "m1"
     assert payload["user_id"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_perception_modality_dropout(monkeypatch, tmp_path):
+    """Ensure publishing still succeeds when a modality is dropped."""
+
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: DummySentenceModel(),
+    )
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (
+            np.asarray([[1.0, 2.0]], dtype=np.float32),
+            np.asarray([0.0], dtype=np.float32),
+        ),
+    )
+
+    sr = 16000
+    audio_path = tmp_path / "a.wav"
+    wavfile.write(audio_path, sr, np.ones(sr // 10, dtype=np.int16))
+
+    audio_worker = AudioPerceptionWorker()
+    audio_feats, _ = audio_worker(audio_path)
+    text_worker = TextPerceptionWorker(hop_seconds=0.05)
+    text_feats = text_worker([("hi", 0.0, 0.05)], tmp_path / "t.dat")
+    video_worker = VideoPerceptionWorker()
+    video_feats, _ = video_worker("v.mp4")
+
+    store = UserEmbeddings(tmp_path / "emb.json")
+    try:
+        fuser = ModalityFuser({"audio": 4, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
+    except AttributeError as exc:  # pragma: no cover - environment-specific
+        pytest.skip(str(exc))
+    modalities = {
+        "audio": torch.from_numpy(audio_feats[:1]).float(),
+        "text": torch.from_numpy(text_feats[:1]).float(),
+        # simulate dropout by zeroing video modality
+        "video": torch.zeros_like(torch.from_numpy(video_feats[:1]).float()),
+    }
+    fused = fuser(modalities, user_embedding=torch.ones((1, 2)), user_id="u1", embedding_store=store)
+    assert "u1" in store
+
+    js = DummyJetStream()
+    pub = PerceptionPublisher(DummyNats(), js)
+    await pub.publish(
+        "m1",
+        "u1",
+        fused=fused.squeeze(0).detach().numpy().tolist(),
+        by_modality={
+            "text": {
+                "spans": [[0, 1]],
+                "embeddings": fused.squeeze(0).detach().numpy().reshape(1, -1).tolist(),
+                "encoders": [],
+            }
+        },
+    )
+
+    js.publish.assert_awaited_once()
+    subject, data = js.publish.call_args[0]
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
+    payload = json.loads(data.decode())
+    assert payload["user_id"] == "u1"
+
+
+@pytest.mark.asyncio
+async def test_user_embedding_update(monkeypatch, tmp_path):
+    """User embeddings are updated on subsequent fusions."""
+
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_text.SentenceTransformer",
+        lambda name: DummySentenceModel(),
+    )
+    monkeypatch.setattr(
+        "deepthought.services.perception.worker_video.video_to_feature_grid",
+        lambda path, decode_fps, model_type, grid_fps: (
+            np.asarray([[1.0, 2.0]], dtype=np.float32),
+            np.asarray([0.0], dtype=np.float32),
+        ),
+    )
+
+    sr = 16000
+    audio_path = tmp_path / "a.wav"
+    wavfile.write(audio_path, sr, np.ones(sr // 10, dtype=np.int16))
+
+    audio_worker = AudioPerceptionWorker()
+    audio_feats, _ = audio_worker(audio_path)
+    text_worker = TextPerceptionWorker(hop_seconds=0.05)
+    text_feats = text_worker([("hi", 0.0, 0.05)], tmp_path / "t.dat")
+    video_worker = VideoPerceptionWorker()
+    video_feats, _ = video_worker("v.mp4")
+
+    store = UserEmbeddings(tmp_path / "emb.json")
+    try:
+        fuser = ModalityFuser({"audio": 4, "text": 2, "video": 2}, fused_dim=3, user_dim=2)
+    except AttributeError as exc:  # pragma: no cover - environment-specific
+        pytest.skip(str(exc))
+    modalities = {
+        "audio": torch.from_numpy(audio_feats[:1]).float(),
+        "text": torch.from_numpy(text_feats[:1]).float(),
+        "video": torch.from_numpy(video_feats[:1]).float(),
+    }
+
+    fused1 = fuser(modalities, user_embedding=torch.zeros((1, 2)), user_id="u1", embedding_store=store)
+    first = store.get("u1").clone()
+
+    js = DummyJetStream()
+    pub = PerceptionPublisher(DummyNats(), js)
+    await pub.publish(
+        "m1",
+        "u1",
+        fused=fused1.squeeze(0).detach().numpy().tolist(),
+        by_modality={},
+    )
+
+    fused2 = fuser(modalities, user_embedding=torch.ones((1, 2)), user_id="u1", embedding_store=store)
+    second = store.get("u1")
+    assert not torch.allclose(first, second)
+
+    await pub.publish(
+        "m2",
+        "u1",
+        fused=fused2.squeeze(0).detach().numpy().tolist(),
+        by_modality={},
+    )
+
+    assert js.publish.await_count == 2
+    subject, data = js.publish.call_args[0]
+    assert subject == EventSubjects.PERCEPTION_EMBEDDINGS


### PR DESCRIPTION
## Summary
- extend perception integration tests to cover modality dropout handling
- add test for updating persisted user embeddings across calls

## Testing
- `SKIP=pytest pre-commit run --files tests/integration/test_perception_event_publish_memory.py`
- `pytest tests/integration/test_perception_event_publish_memory.py::test_perception_event_publishing_and_memory_upsert -q`
- `pytest tests/integration/test_perception_event_publish_memory.py::test_perception_modality_dropout -q`
- `pytest tests/integration/test_perception_event_publish_memory.py::test_user_embedding_update -q`


------
https://chatgpt.com/codex/tasks/task_e_68a490b794f08326bf78f666e2a2b43b