### PR TITLE
docs: add license entries for audio/vision models

### DIFF
--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -41,3 +41,9 @@ upstream projects for the most current license information.
 | torchvision | BSD-3-Clause | Computer vision models |
 | opencv-python-headless | Apache-2.0 | Computer vision toolkit |
 | Default social perception model | MIT | Bundled classifier weights |
+| WavLM | MIT | Speech representation model |
+| WavLM checkpoints | MIT | Pretrained weights |
+| CLAP | CC0 | Contrastive language-audio model |
+| CLAP checkpoints | CC0 | Pretrained weights |
+| SigLIP | Apache-2.0 | Vision-language model |
+| SigLIP checkpoints | Apache-2.0 | Pretrained weights |

--- a/scripts/verify_licenses.py
+++ b/scripts/verify_licenses.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify required third-party license entries."""
+from __future__ import annotations
+
+from pathlib import Path
+
+LICENSE_FILE = Path(__file__).resolve().parents[1] / "docs" / "licenses.md"
+REQUIRED_ENTRIES = {
+    "WavLM": "MIT",
+    "WavLM checkpoints": "MIT",
+    "CLAP": "CC0",
+    "CLAP checkpoints": "CC0",
+    "SigLIP": "Apache-2.0",
+    "SigLIP checkpoints": "Apache-2.0",
+}
+
+
+def parse_table(text: str) -> dict[str, str]:
+    """Parse Markdown table rows into a mapping of component to license."""
+    entries: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line.startswith("|"):
+            continue
+        parts = [p.strip() for p in line.strip().split("|")[1:-1]]
+        if len(parts) < 2:
+            continue
+        component, license_name = parts[0], parts[1]
+        entries[component] = license_name
+    return entries
+
+
+def main() -> int:
+    """Entry point for the license verifier."""
+    if not LICENSE_FILE.exists():
+        print(f"License file not found: {LICENSE_FILE}")
+        return 1
+
+    content = LICENSE_FILE.read_text(encoding="utf-8")
+    entries = parse_table(content)
+
+    missing = [
+        f"{component} ({expected})"
+        for component, expected in REQUIRED_ENTRIES.items()
+        if entries.get(component) != expected
+    ]
+
+    if missing:
+        print("Missing or incorrect license entries:")
+        for item in missing:
+            print(f" - {item}")
+        return 1
+
+    print("All required license entries present.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document WavLM, CLAP, and SigLIP licenses and checkpoints
- add script to verify required license entries

## Testing
- `flake8 scripts/verify_licenses.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a490b5fa788326a1b7bf529d8fb378