### PR TITLE
docs: update perception service for multimodal fusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,7 +586,7 @@ if await svc.is_trusted("u1", 0.5):
     print("trusted user")
 ```
 
-Manipulation attempts are flagged by the social perception classifier. The bot
+Manipulation attempts are flagged by the Perception Service, which fuses cues from text, image, and audio inputs. The bot
 records its internal assessments in a private channel when
 `THOUGHT_CHANNEL` is set. Messages are scored with
 `manipulation_score`, and any positive value decreases the user's trust
@@ -685,15 +685,16 @@ A minimal notebook demonstrating retrieval-augmented generation is available at 
 ## Social Perception
 
 The classifier produces probabilities for five cues—flirtation, avoidance,
-manipulation, sarcasm, and supportiveness. A lightweight keyword model is bundled
-with the repository and used automatically when `SOCIAL_PERCEPTION_MODEL` is not
-set. To use a custom transformer model instead, download the weights and point
-the environment variable to the local directory:
+manipulation, sarcasm, and supportiveness—across text, image, and audio inputs.
+A lightweight keyword model is bundled for text and used automatically when
+`SOCIAL_PERCEPTION_MODEL` is not set. To use a custom transformer model instead,
+download the weights and point the environment variable to the local directory:
 
 ```bash
 pip install huggingface_hub
 huggingface-cli download myorg/social-cue-classifier --local-dir ./models/social_perception
-export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception  # text component
+# optional image/audio models: PERCEPTION_IMAGE_MODEL and PERCEPTION_AUDIO_MODEL
 ```
 
 ### Manipulation Detection
@@ -730,7 +731,7 @@ print(scores["Happy"])
 Set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming messages include a
 `"consent": true` flag before they are scored. Configure JetStream retention with
 `PERCEPTION_RETENTION_POLICY`, choosing `limits`, `interest`, or `workqueue` to
-control how long perception events are stored.
+control how long multimodal perception events are stored.
 
 See [docs/perception_service.md](docs/perception_service.md#privacy-controls) for
 details.
@@ -806,7 +807,7 @@ DeepThought-ReThought offers switches to manage user data handling:
   consent flag on incoming messages. Events without consent are ignored.
 - **Retention policy:** the JetStream setup uses `limits` retention by default.
   Override `PERCEPTION_RETENTION_POLICY` with `limits`, `interest`, or
-  `workqueue` when provisioning streams to control how long perception events
+  `workqueue` when provisioning streams to control how long multimodal perception events
   persist.
 
 ## Testing

--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -1,25 +1,40 @@
 # Perception Service
 
-## Purpose
+## Overview
 
-The **PerceptionService** evaluates incoming user messages for social cues
-such as flirtation, avoidance, manipulation, sarcasm and supportiveness.
-Downstream modules can use the scores to adjust trust levels, choose
-personas or trigger safeguards.
+The **PerceptionService** scores text, image, and audio inputs for social cues such as flirtation, avoidance, manipulation, sarcasm and supportiveness. Each modality is processed separately and a simple fusion step averages the signals into a combined vector. Downstream modules can use the fused or per-modality scores to adjust trust levels, choose personas or trigger safeguards.
+
+## JetStream Subjects
+
+The service listens for incoming messages on:
+
+- `dtr.input.text`
+- `dtr.input.image`
+- `dtr.input.audio`
+
+After scoring, results are published to JetStream under:
+
+- `dtr.perception.text`
+- `dtr.perception.image`
+- `dtr.perception.audio`
+- `dtr.perception.fused`
+
+All subjects are persisted in the `PERCEPTION` stream created by `setup_jetstream.py`.
 
 ## Event Schema
 
-PerceptionService subscribes to `dtr.input.received` events and publishes
-`dtr.perception.scored` once analysis completes. A published payload
-contains the original `input_id` plus the classifier scores:
+A fused perception event bundles the modality scores and the averaged result:
 
 ```json
 {
   "input_id": "42",
-  "perception": {
+  "text": {"manipulation": 0.1},
+  "image": {"manipulation": 0.0},
+  "audio": {"manipulation": 0.2},
+  "fused": {
     "flirtation": 0.2,
     "avoidance": 0.1,
-    "manipulation": 0.0,
+    "manipulation": 0.1,
     "sarcasm": 0.3,
     "supportiveness": 0.4
   },
@@ -27,56 +42,39 @@ contains the original `input_id` plus the classifier scores:
 }
 ```
 
-Consumers can store these events in memory, update trust scores or trigger
-policy checks.
+Per-modality events omit the other sections and include only the scores for that input type.
 
-## CLI Usage
+## Running the Service
 
-The service uses the social perception model specified by
-`SOCIAL_PERCEPTION_MODEL` or the bundled defaults. Start the service after
-configuring a NATS connection:
+Provide a NATS connection and optional model paths before launching:
 
 ```bash
 export NATS_URL=nats://localhost:4222
-# optional custom model path
-export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception
+# optional custom model paths
+export SOCIAL_PERCEPTION_MODEL=$(pwd)/models/social_perception      # text
+export PERCEPTION_IMAGE_MODEL=$(pwd)/models/image_perception        # image
+export PERCEPTION_AUDIO_MODEL=$(pwd)/models/audio_perception        # audio
 python -m deepthought.services.perception_service
 ```
 
-The module listens for new inputs and continuously publishes
-`dtr.perception.scored` events to the bus.
+The module continuously publishes scored events to the subjects listed above.
 
 ## Replaying Perception Events
 
-The `setup_jetstream.py` script provisions a `PERCEPTION` stream with two
-durable consumers: `memory-perception-consumer` and
-`analytics-perception-consumer`. You can replay stored perception events from
-JetStream using the NATS CLI. The following commands retrieve the next 10
-messages from each consumer:
+`setup_jetstream.py` provisions a `PERCEPTION` stream with durable consumers `memory-perception-consumer` and `analytics-perception-consumer`. Use the NATS CLI to inspect past events. For example, replay the next ten fused events:
 
 ```bash
-# Replay from the memory consumer
-nats consumer next PERCEPTION memory-perception-consumer --count=10 --json
-
-# Replay from the analytics consumer
-nats consumer next PERCEPTION analytics-perception-consumer --count=10 --json
+nats consumer next PERCEPTION memory-perception-consumer --filter dtr.perception.fused --count=10 --json
 ```
 
-These commands help inspect past perception embeddings for debugging or
-analysis.
+Swap the `--filter` value for `dtr.perception.text`, `dtr.perception.image`, or `dtr.perception.audio` to retrieve scores for individual modalities.
 
 ## Privacy Controls
 
-The perception service provides basic controls over user consent and data
-retention:
+The perception service provides basic controls over user consent and data retention:
 
-- **Consent toggle:** set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming
-  messages to include a `"consent": true` flag. Events without consent are
-  ignored.
-- **Retention policy:** the `PERCEPTION` stream defaults to the JetStream
-  `limits` retention policy. Override `PERCEPTION_RETENTION_POLICY` with
-  `limits`, `interest`, or `workqueue` when provisioning streams to control how
-  long scored events are stored.
+- **Consent toggle:** set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming messages to include a `"consent": true` flag. Events without consent are ignored.
+- **Retention policy:** the `PERCEPTION` stream defaults to the JetStream `limits` retention policy. Override `PERCEPTION_RETENTION_POLICY` with `limits`, `interest`, or `workqueue` when provisioning streams to control how long scored events are stored.
 
 Example configuration:
 
@@ -85,6 +83,4 @@ export PERCEPTION_REQUIRE_CONSENT=1
 export PERCEPTION_RETENTION_POLICY=workqueue
 ```
 
-These options allow deployments to honor user preferences and organizational data
-policies.
-
+These options allow deployments to honor user preferences and organizational data policies.


### PR DESCRIPTION
## Summary
- document multimodal perception inputs, fusion, JetStream subjects, and replay examples
- refresh README to reference new perception service and model options

## Testing
- no tests run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68a490b52b348326ba8bc47f25db9057