### PR TITLE
Add video modality to perception service

### DIFF
--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -16,6 +16,7 @@ from .publisher import PerceptionPublisher
 from .user_embeddings import UserEmbeddings
 from .worker_audio import AudioPerceptionWorker
 from .worker_text import TextPerceptionWorker, Token
+from .worker_video import VideoPerceptionWorker
 
 
 @dataclass
@@ -25,6 +26,7 @@ class PerceptionService:
     publisher: PerceptionPublisher
     text_worker: TextPerceptionWorker | None = None
     audio_worker: AudioPerceptionWorker | None = None
+    video_worker: VideoPerceptionWorker | None = None
     fuser: ModalityFuser | None = None
     user_embeddings: UserEmbeddings | None = None
 
@@ -39,6 +41,7 @@ class PerceptionService:
         provenance: Dict[str, Any] | None = None,
         text_tokens: Sequence[Token] | None = None,
         audio_path: str | Path | None = None,
+        video_path: str | Path | None = None,
     ) -> None:
         """Fuse worker outputs and publish via the ``publisher``."""
         settings = get_settings()
@@ -73,6 +76,16 @@ class PerceptionService:
                 modality_arrays["audio"] = np.asarray(feats)
                 modality_times["audio"] = np.asarray(times)
                 encoder_meta["audio"] = {"name": self.audio_worker.__class__.__name__}
+
+            if self.video_worker is not None and video_path is not None:
+                feats, times = self.video_worker(video_path)
+                times_arr = np.asarray(times)
+                if times_arr.ndim == 1:
+                    hop = float(np.min(np.diff(times_arr))) if times_arr.size > 1 else 0.0
+                    times_arr = np.column_stack((times_arr, times_arr + hop))
+                modality_arrays["video"] = np.asarray(feats)
+                modality_times["video"] = times_arr
+                encoder_meta["video"] = {"name": self.video_worker.__class__.__name__}
 
             if not modality_arrays:
                 raise ValueError("No modalities available for publication")
@@ -111,9 +124,11 @@ class PerceptionService:
                     user_id=user_id,
                     embedding_store=self.user_embeddings,
                 )
-                fused_list = fused_tensor.tolist()
-                if self.user_embeddings is not None:
-                    self.user_embeddings.set(user_id, fused_tensor.mean(0))
+            else:
+                fused_tensor = torch.stack(list(aligned_modalities.values())).mean(0)
+            fused_list = fused_tensor.tolist()
+            if self.user_embeddings is not None:
+                self.user_embeddings.set(user_id, fused_tensor.mean(0))
 
         else:
             modality_payload = {}

--- a/tests/unit/test_perception_service_video.py
+++ b/tests/unit/test_perception_service_video.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict
+
+import numpy as np
+
+from deepthought.services.perception.service import PerceptionService
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.kwargs: Dict | None = None
+
+    async def publish(self, **kwargs) -> None:  # pragma: no cover - simple async stub
+        self.kwargs = kwargs
+
+
+class DummyVideoWorker:
+    def __call__(self, path: str):
+        data = np.array([[5.0, 6.0], [7.0, 8.0]], dtype="float32")
+        times = np.array([[0.0, 0.05], [0.05, 0.1]], dtype=np.float32)
+        return data, times
+
+
+def test_service_publishes_video_embeddings_and_metadata():
+    publisher = DummyPublisher()
+    service = PerceptionService(publisher, video_worker=DummyVideoWorker())
+
+    asyncio.run(
+        service.run(
+            message_id="m1",
+            user_id="u1",
+            video_path="v.mp4",
+            provenance={"test": True},
+        )
+    )
+
+    assert publisher.kwargs is not None
+    assert publisher.kwargs["message_id"] == "m1"
+    assert publisher.kwargs["user_id"] == "u1"
+    assert publisher.kwargs["fused"] == [[5.0, 6.0], [7.0, 8.0]]
+    assert "video" in publisher.kwargs["by_modality"]
+    video_meta = publisher.kwargs["by_modality"]["video"]
+    assert video_meta["spans"] == [[0, 1], [1, 2]]
+    assert video_meta["embeddings"] == [[5.0, 6.0], [7.0, 8.0]]
+    assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
+    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}


### PR DESCRIPTION
## Summary
- support video modality in PerceptionService by wiring VideoPerceptionWorker and averaging modalities when no fuser is provided
- add unit test for video modality publication

## Testing
- `pytest tests/unit/test_perception_service.py tests/unit/test_perception_service_video.py -q`
- `SKIP=pytest pre-commit run --files src/deepthought/services/perception/service.py tests/unit/test_perception_service_video.py tests/unit/test_perception_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68a5d4515d34832697a943f7d5afe1e6