### PR TITLE
Pass user context to fuser

### DIFF
--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -124,18 +124,19 @@ class PerceptionService:
 
             fused_list: Sequence[Sequence[float]] | None = None
             if self.fuser is not None:
+                existing_user_embedding = (
+                    self.user_embeddings.get(user_id) if self.user_embeddings is not None else None
+                )
                 fused_tensor = self.fuser(
                     aligned_modalities,
+                    user_embedding=existing_user_embedding,
                     user_id=user_id,
                     embedding_store=self.user_embeddings,
                 )
                 fused_list = fused_tensor.tolist()
-                if self.user_embeddings is not None:
-                    self.user_embeddings.set(user_id, fused_tensor.mean(0))
             else:
                 first = next(iter(aligned_modalities.values()))
                 fused_list = first.tolist()
-
 
         else:
             modality_payload = {}


### PR DESCRIPTION
## Summary
- pass existing user embedding and user context to modality fuser
- rely on fuser to handle persistence

## Testing
- `pre-commit run --files src/deepthought/services/perception/service.py`
- `pytest` *(fails: ImportError: cannot import name 'WavLMFeatureExtractor')*


------
https://chatgpt.com/codex/tasks/task_e_68a709ae0efc832686818440db724fdc