### PR TITLE
Validate user embedding dimensions in fuser

### DIFF
--- a/src/deepthought/modules/fuser.py
+++ b/src/deepthought/modules/fuser.py
@@ -72,16 +72,29 @@ class ModalityFuser(nn.Module):
             pieces.append(tensor)
 
         if embedding_store is not None and user_id is not None:
-            if user_embedding is not None:
-                embedding_store.set(user_id, user_embedding.mean(dim=0))
-            elif self.user_dim > 0:
+            if self.user_dim <= 0:
+                raise ValueError("user_dim must be > 0 when using user embeddings")
+
+            if user_embedding is None:
                 stored = embedding_store.get(user_id)
                 if stored is not None:
+                    if stored.shape[-1] != self.user_dim:
+                        raise ValueError(
+                            f"Stored embedding for user '{user_id}' has dimension {stored.shape[-1]} "
+                            f"but expected {self.user_dim}"
+                        )
                     base = next(iter(modalities.values()))
                     stored = stored.to(base.device)
                     if stored.ndim == 1:
                         stored = stored.unsqueeze(0)
                     user_embedding = stored.expand(base.size(0), -1)
+            else:
+                if user_embedding.shape[-1] != self.user_dim:
+                    raise ValueError(
+                        f"Provided user_embedding has dimension {user_embedding.shape[-1]} "
+                        f"but expected {self.user_dim}"
+                    )
+                embedding_store.set(user_id, user_embedding.mean(dim=0))
 
         if user_embedding is not None:
             pieces.append(user_embedding)

--- a/tests/unit/test_fuser.py
+++ b/tests/unit/test_fuser.py
@@ -56,3 +56,22 @@ def test_fuser_missing_modalities_raises():
     fuser = ModalityFuser({"text": 2, "audio": 1}, fused_dim=3)
     with pytest.raises(RuntimeError):
         fuser({"text": torch.randn(1, 2)})
+
+
+def test_fuser_raises_on_mismatched_stored_vector(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    store.set("u1", torch.ones(4))
+
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+    mods = {"text": torch.randn(1, 2)}
+    with pytest.raises(ValueError, match="dimension"):
+        fuser(mods, user_id="u1", embedding_store=store)
+
+
+def test_fuser_raises_on_mismatched_provided_vector(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+    mods = {"text": torch.randn(1, 2)}
+    bad_embed = torch.randn(1, 4)
+    with pytest.raises(ValueError, match="dimension"):
+        fuser(mods, bad_embed, user_id="u1", embedding_store=store)


### PR DESCRIPTION
## Summary
- automatically load or persist user embeddings when `user_id` and an embedding store are provided
- check stored and provided embeddings match `user_dim`, raising errors on mismatches
- add unit tests for dimension validation

## Testing
- `flake8 src/deepthought/modules/fuser.py tests/unit/test_fuser.py`
- `pytest tests/unit/test_fuser.py tests/test_modality_fuser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a709ad4b04832690905724c5c2a6c7