### PR TITLE
Handle span embeddings

### DIFF
--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -17,6 +17,7 @@ from ..eda.events import (
     EventSubjects,
     MemoryRetrievedPayload,
     PerceptionEmbeddingsEvent,
+    PerceptionEmbeddingsPayload,
 )
 from ..memory import create_memory_backend
 from ..memory.tiered import TieredMemory
@@ -203,22 +204,52 @@ class CognitiveCoreService(BaseService):
             INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(duration)
 
     async def _handle_embeddings(self, msg: Msg) -> None:
-        """Store fused perception embeddings in the vector store and KG."""
+        """Store perception embeddings in the vector store and knowledge graph."""
         try:
             payload = PerceptionEmbeddingsPayload.from_json(msg.data.decode())
-            if payload.fused:
-                vector = [float(sum(col) / len(payload.fused)) for col in zip(*payload.fused)]
+            message_id = str(payload.message_id)
+            store = getattr(self._memory, "_store", None)
+            graph = getattr(self._memory, "graph_backend", None)
 
-                message_id = str(payload.message_id)
-                store = getattr(self._memory, "_store", None)
-                if store and hasattr(store, "upsert_vectors"):
-                    store.upsert_vectors([vector], [message_id])
-                graph = getattr(self._memory, "graph_backend", None)
-                if graph:
-                    graph.query_subgraph(
-                        "MERGE (m:Message {id: $id}) SET m.embedding = $embedding",
-                        {"id": message_id, "embedding": vector},
-                    )
+            # Upsert vectors for each span keyed by (message_id, span_index)
+            if store and hasattr(store, "upsert_vectors"):
+                vectors = payload.fused
+                # Fall back to the first modality if fused embeddings are unavailable
+                if vectors is None and payload.by_modality:
+                    first_mod = next(iter(payload.by_modality.values()))
+                    vectors = first_mod.embeddings
+                if vectors:
+                    for idx, vector in enumerate(vectors):
+                        store.upsert_vectors([vector], [f"{message_id}:{idx}"])
+
+            # Insert nodes/edges in the KG with modality and timestamp metadata
+            if graph:
+                timestamp = datetime.now(timezone.utc).isoformat()
+                for modality, mod in payload.by_modality.items():
+                    for idx, span in enumerate(mod.spans):
+                        span_id = f"{message_id}:{idx}"
+                        vector = None
+                        if payload.fused and idx < len(payload.fused):
+                            vector = payload.fused[idx]
+                        elif idx < len(mod.embeddings):
+                            vector = mod.embeddings[idx]
+                        graph.query_subgraph(
+                            "MERGE (m:Message {id: $mid}) "
+                            "MERGE (s:Span {id: $sid}) "
+                            "SET s.embedding = $embedding, s.start = $start, s.end = $end, "
+                            "s.modality = $modality, s.timestamp = $timestamp "
+                            "MERGE (m)-[:HAS_SPAN {modality: $modality, timestamp: $timestamp}]->(s)",
+                            {
+                                "mid": message_id,
+                                "sid": span_id,
+                                "embedding": vector,
+                                "start": span[0],
+                                "end": span[1],
+                                "modality": modality,
+                                "timestamp": timestamp,
+                            },
+                        )
+
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -85,6 +85,31 @@ sys.modules.setdefault("nats.js", fake_nats.js)
 sys.modules.setdefault("nats.js.client", js_client_mod)
 sys.modules.setdefault("nats.errors", err_mod)
 
+pp_mod = types.ModuleType("pyperplan")
+pp_pddl = types.ModuleType("pddl")
+pp_parser = types.ModuleType("parser")
+setattr(pp_parser, "Parser", object)
+pp_pddl.parser = pp_parser
+pp_mod.pddl = pp_pddl
+pp_planner = types.ModuleType("planner")
+setattr(pp_planner, "_ground", lambda *a, **k: None)
+pp_mod.planner = pp_planner
+pp_search = types.ModuleType("search")
+setattr(pp_search, "breadth_first_search", lambda *a, **k: None)
+pp_mod.search = pp_search
+sys.modules.setdefault("pyperplan", pp_mod)
+sys.modules.setdefault("pyperplan.pddl", pp_pddl)
+sys.modules.setdefault("pyperplan.pddl.parser", pp_parser)
+sys.modules.setdefault("pyperplan.planner", pp_planner)
+sys.modules.setdefault("pyperplan.search", pp_search)
+
+planning_stub = types.ModuleType("planning_service")
+setattr(planning_stub, "PlanningService", object)
+reasoning_stub = types.ModuleType("reasoning_service")
+setattr(reasoning_stub, "ReasoningService", object)
+sys.modules.setdefault("deepthought.services.planning_service", planning_stub)
+sys.modules.setdefault("deepthought.services.reasoning_service", reasoning_stub)
+
 
 class DummyBase:
     def __init__(self, **kwargs):
@@ -107,6 +132,7 @@ from deepthought.eda.events import (
     InputReceivedPayload,
     PerceptionEmbeddingsEvent,
     PerceptionEmbeddingsPayload,
+    ModalityEmbeddings,
 )
 from deepthought.services.cognitive_core_service import CognitiveCoreService
 
@@ -254,13 +280,27 @@ async def test_handle_embeddings_upserts(monkeypatch):
     payload = PerceptionEmbeddingsPayload(
         message_id="m1",
         user_id="u",
-        fused=[[0.1, 0.2]],
-        by_modality={},
-        provenance={},
-
+        fused=[[0.1, 0.2], [0.3, 0.4]],
+        by_modality={
+            "audio": ModalityEmbeddings(
+                spans=[[0, 1], [1, 2]],
+                embeddings=[[0.1, 0.2], [0.3, 0.4]],
+                encoders=[],
+            )
+        },
     )
     msg = DummyMsg(payload.to_json())
     await service._handle_embeddings(msg)
     assert msg.acked
-    assert memory._store.upserts == [([[0.1, 0.2]], ["m1"])]
-    assert memory.graph_backend.queries[0][1]["id"] == "m1"
+    assert memory._store.upserts == [
+        ([[0.1, 0.2]], ["m1:0"]),
+        ([[0.3, 0.4]], ["m1:1"]),
+    ]
+    assert len(memory.graph_backend.queries) == 2
+    params = memory.graph_backend.queries[0][1]
+    assert params["mid"] == "m1"
+    assert params["sid"] == "m1:0"
+    assert params["modality"] == "audio"
+    assert params["start"] == 0
+    assert params["end"] == 1
+    assert "timestamp" in params


### PR DESCRIPTION
## Summary
- upsert perception vectors for each span keyed by message and index
- record span nodes and edges in knowledge graph with modality and timestamps
- extend tests for span-level embeddings

## Testing
- `flake8 src/deepthought/services/cognitive_core_service.py tests/unit/services/test_cognitive_core_service.py`
- `pytest tests/unit/services/test_cognitive_core_service.py::test_handle_embeddings_upserts -q`

------
https://chatgpt.com/codex/tasks/task_e_68af121a872483269a06f4fffd4cc6d8