### PR TITLE
test: add coverage for embeddings and cognitive core spans

### DIFF
--- a/tests/unit/services/perception/test_user_embeddings.py
+++ b/tests/unit/services/perception/test_user_embeddings.py
@@ -1,4 +1,24 @@
+import sys
+import types
+
 import pytest
+
+# Stub perception modules with heavy dependencies so we can import UserEmbeddings
+for name, attr in [
+    ("cli", "main"),
+    ("config", "PerceptionConfig"),
+    ("publisher", "PerceptionPublisher"),
+    ("service", "PerceptionService"),
+    ("worker_audio", "AudioPerceptionWorker"),
+    ("worker_text", "TextPerceptionWorker"),
+    ("worker_video", "VideoPerceptionWorker"),
+]:
+    mod = types.ModuleType(f"deepthought.services.perception.{name}")
+    if attr == "main":
+        setattr(mod, attr, lambda *a, **k: None)
+    else:
+        setattr(mod, attr, type(attr, (), {}))
+    sys.modules[f"deepthought.services.perception.{name}"] = mod
 
 try:  # Attempt to import the real torch library
     import torch  # noqa: F401
@@ -32,3 +52,27 @@ def test_modality_fuser_updates_and_retrieves(tmp_path):
     manual = fuser(modalities, user_embedding=stored2.unsqueeze(0))
     retrieved = fuser(modalities, user_id="bob", embedding_store=store)
     assert torch.allclose(retrieved, manual)
+
+
+def test_user_embedding_persistence_across_instances(tmp_path):
+    path = tmp_path / "store.json"
+    store = UserEmbeddings(path)
+
+    torch.manual_seed(0)
+    modalities = {"text": torch.randn(1, 2)}
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+
+    emb1 = torch.randn(1, 3)
+    fuser(modalities, user_embedding=emb1, user_id="alice", embedding_store=store)
+    emb2 = torch.randn(1, 3)
+    fuser(modalities, user_embedding=emb2, user_id="alice", embedding_store=store)
+
+    new_store = UserEmbeddings(path)
+    new_fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+    manual = new_fuser(modalities, user_embedding=emb2)
+    retrieved = new_fuser(modalities, user_id="alice", embedding_store=new_store)
+    assert torch.allclose(retrieved, manual)
+
+    stored = new_store.get("alice")
+    assert stored is not None
+    assert torch.allclose(stored, emb2.squeeze(0))

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -7,6 +7,7 @@ fake_pyd = types.ModuleType("pydantic")
 fake_pyd.AnyUrl = str
 fake_pyd.ValidationError = Exception
 fake_pyd.Field = lambda default=None, **kwargs: default
+fake_pyd.__spec__ = importlib.machinery.ModuleSpec("pydantic", loader=None)
 sys.modules.setdefault("pydantic", fake_pyd)
 fake_ps = types.ModuleType("pydantic_settings")
 
@@ -121,18 +122,34 @@ fake_ps.BaseSettings = DummyBase
 fake_ps.SettingsConfigDict = dict
 sys.modules.setdefault("pydantic_settings", fake_ps)
 
+import importlib.util
 import json
+import pathlib
 
 import pytest
 
-import deepthought.services.cognitive_core_service as cognitive_core_service
+SRC = pathlib.Path(__file__).resolve().parents[3] / "src"
+deep_pkg = types.ModuleType("deepthought")
+deep_pkg.__path__ = [str(SRC / "deepthought")]
+deep_pkg.__spec__ = importlib.machinery.ModuleSpec("deepthought", loader=None, is_package=True)
+services_pkg = types.ModuleType("deepthought.services")
+services_pkg.__path__ = [str(SRC / "deepthought" / "services")]
+services_pkg.__spec__ = importlib.machinery.ModuleSpec("deepthought.services", loader=None, is_package=True)
+sys.modules.setdefault("deepthought", deep_pkg)
+sys.modules.setdefault("deepthought.services", services_pkg)
+spec = importlib.util.spec_from_file_location(
+    "deepthought.services.cognitive_core_service", SRC / "deepthought/services/cognitive_core_service.py"
+)
+cognitive_core_service = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cognitive_core_service)
+sys.modules.setdefault("deepthought.services.cognitive_core_service", cognitive_core_service)
 from deepthought.config import Settings
 from deepthought.eda.events import (
     EventSubjects,
     InputReceivedPayload,
+    ModalityEmbeddings,
     PerceptionEmbeddingsEvent,
     PerceptionEmbeddingsPayload,
-    ModalityEmbeddings,
 )
 from deepthought.services.cognitive_core_service import CognitiveCoreService
 
@@ -304,3 +321,36 @@ async def test_handle_embeddings_upserts(monkeypatch):
     assert params["start"] == 0
     assert params["end"] == 1
     assert "timestamp" in params
+
+
+@pytest.mark.asyncio
+async def test_handle_embeddings_uses_modality_when_fused_absent():
+    memory = DummyMem2()
+    db = DummyDB()
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+    payload = PerceptionEmbeddingsPayload(
+        message_id="m2",
+        user_id="u",
+        by_modality={
+            "audio": ModalityEmbeddings(
+                spans=[[0, 1], [1, 2]],
+                embeddings=[[0.5, 0.6], [0.7, 0.8]],
+                encoders=[],
+            )
+        },
+        fused=None,
+    )
+    msg = DummyMsg(payload.to_json())
+    await service._handle_embeddings(msg)
+    assert msg.acked
+    assert memory._store.upserts == [
+        ([[0.5, 0.6]], ["m2:0"]),
+        ([[0.7, 0.8]], ["m2:1"]),
+    ]
+    assert len(memory.graph_backend.queries) == 2
+    params0 = memory.graph_backend.queries[0][1]
+    params1 = memory.graph_backend.queries[1][1]
+    assert params0["sid"] == "m2:0"
+    assert params1["sid"] == "m2:1"


### PR DESCRIPTION
## Summary
- test ModalityFuser user embeddings persist and reload across instances
- test CognitiveCoreService stores vectors and KG nodes per span

## Testing
- `SKIP=pytest pre-commit run --files tests/unit/services/perception/test_user_embeddings.py tests/unit/services/test_cognitive_core_service.py`
- `pytest tests/unit/services/perception/test_user_embeddings.py -q`
- `DEEPTHOUGHT_LIGHT_IMPORT=1 PYTHONPATH=src pytest tests/unit/services/test_cognitive_core_service.py -k test_handle_embeddings_uses_modality_when_fused_absent -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1da03e4c8326a77874bc48b9eaea