### PR TITLE
Log missing modalities and track metrics

### DIFF
--- a/src/deepthought/metrics/__init__.py
+++ b/src/deepthought/metrics/__init__.py
@@ -71,7 +71,7 @@ def actions_per_second(trace: Iterable[TraceEvent]) -> float:
     return len(latencies) / total if total > 0 else 0.0
 
 
-from .prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+from .prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL, MISSING_MODALITY_TOTAL
 
 __all__ = [
     "bleu",
@@ -80,4 +80,5 @@ __all__ = [
     "actions_per_second",
     "INPUTS_TOTAL",
     "INPUT_LATENCY_SECONDS",
+    "MISSING_MODALITY_TOTAL",
 ]

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -36,9 +36,19 @@ if "rule_evaluation_errors_total" not in REGISTRY._names_to_collectors:
 else:  # pragma: no cover - already registered
     RULE_EVALUATION_ERRORS_TOTAL = REGISTRY._names_to_collectors["rule_evaluation_errors_total"]  # type: ignore
 
+if "missing_modality_total" not in REGISTRY._names_to_collectors:
+    MISSING_MODALITY_TOTAL = Counter(
+        "missing_modality_total",
+        "Total number of times a modality was absent",
+        labelnames=["modality"],
+    )
+else:  # pragma: no cover - already registered
+    MISSING_MODALITY_TOTAL = REGISTRY._names_to_collectors["missing_modality_total"]  # type: ignore
+
 __all__ = [
     "INPUTS_TOTAL",
     "INPUT_LATENCY_SECONDS",
     "RULE_EVALUATIONS_TOTAL",
     "RULE_EVALUATION_ERRORS_TOTAL",
+    "MISSING_MODALITY_TOTAL",
 ]

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -11,11 +11,16 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Sequence
 
+import logging
 import numpy as np
 import torch
 
 from ...config import get_settings
-from ...metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+from ...metrics.prometheus import (
+    INPUT_LATENCY_SECONDS,
+    INPUTS_TOTAL,
+    MISSING_MODALITY_TOTAL,
+)
 from ...modules import ModalityFuser
 from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
@@ -23,6 +28,9 @@ from .user_embeddings import UserEmbeddings
 from .worker_audio import AudioPerceptionWorker
 from .worker_text import TextPerceptionWorker, Token
 from .worker_video import VideoPerceptionWorker
+
+
+logger = logging.getLogger(__name__)
 
 
 def _consent_granted(kind: str) -> bool:
@@ -191,6 +199,21 @@ class PerceptionService:
                 if not retain_media:
                     video_path.unlink(missing_ok=True)
 
+            expected_modalities = set()
+            if self.fuser is not None:
+                expected_modalities.update(self.fuser.modality_dims.keys())
+            for name, worker in (
+                ("text", self.text_worker),
+                ("audio", self.audio_worker),
+                ("video", self.video_worker),
+            ):
+                if worker is not None:
+                    expected_modalities.add(name)
+            missing_modalities = expected_modalities.difference(modality_arrays.keys())
+            for name in sorted(missing_modalities):
+                logger.warning("%s modality absent for message %s", name, message_id)
+                MISSING_MODALITY_TOTAL.labels(modality=name).inc()
+
             if not modality_arrays:
                 raise ValueError("No modalities available for publication")
 
@@ -204,22 +227,32 @@ class PerceptionService:
             grid_ends = grid_starts + hop
             spans = [[int(gs * 1000), int(ge * 1000)] for gs, ge in zip(grid_starts, grid_ends)]
 
+            if self.fuser is not None:
+                expected_order = list(self.fuser.modality_dims.keys())
+            else:
+                expected_order = list(modality_arrays.keys())
+
             aligned_modalities: Dict[str, torch.Tensor] = {}
             modality_payload: Dict[str, Dict[str, Any]] = {}
-            for name, arr in modality_arrays.items():
-                times = modality_times[name]
-                dim = arr.shape[1]
-                aligned = np.zeros((num_spans, dim), dtype=np.float32)
-                for i, (gs, ge) in enumerate(zip(grid_starts, grid_ends)):
-                    mask = (gs < times[:, 1]) & (ge > times[:, 0])
-                    if mask.any():
-                        aligned[i] = arr[mask].mean(axis=0)
-                aligned_modalities[name] = torch.from_numpy(aligned)
-                modality_payload[name] = {
-                    "spans": spans,
-                    "embeddings": aligned.tolist(),
-                    "encoders": [encoder_meta[name]] * num_spans,
-                }
+            for name in expected_order:
+                if name in modality_arrays:
+                    arr = modality_arrays[name]
+                    times = modality_times[name]
+                    dim = arr.shape[1]
+                    aligned = np.zeros((num_spans, dim), dtype=np.float32)
+                    for i, (gs, ge) in enumerate(zip(grid_starts, grid_ends)):
+                        mask = (gs < times[:, 1]) & (ge > times[:, 0])
+                        if mask.any():
+                            aligned[i] = arr[mask].mean(axis=0)
+                    aligned_modalities[name] = torch.from_numpy(aligned)
+                    modality_payload[name] = {
+                        "spans": spans,
+                        "embeddings": aligned.tolist(),
+                        "encoders": [encoder_meta[name]] * num_spans,
+                    }
+                elif self.fuser is not None and name in self.fuser.modality_dims:
+                    dim = self.fuser.modality_dims[name]
+                    aligned_modalities[name] = torch.zeros((num_spans, dim), dtype=torch.float32)
 
             fused_list: Sequence[Sequence[float]] | None = None
             if self.fuser is not None:

--- a/tests/unit/test_missing_modality_metrics.py
+++ b/tests/unit/test_missing_modality_metrics.py
@@ -1,0 +1,96 @@
+import asyncio
+import sys
+from typing import Dict, Sequence, Tuple
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+import importlib.util
+
+import numpy as np
+import pytest
+
+torch = sys.modules.get("torch")
+if not getattr(torch, "nn", None):  # pragma: no cover - optional dependency missing
+    pytest.skip("torch not available", allow_module_level=True)
+
+# Bypass heavy package imports by injecting lightweight modules
+root = Path(__file__).resolve().parents[2] / "src"
+services_pkg = types.ModuleType("deepthought.services")
+services_pkg.__path__ = [str(root / "deepthought" / "services")]
+sys.modules.setdefault("deepthought.services", services_pkg)
+modules_pkg = types.ModuleType("deepthought.modules")
+modules_pkg.__path__ = [str(root / "deepthought" / "modules")]
+sys.modules.setdefault("deepthought.modules", modules_pkg)
+
+# Load ModalityFuser directly and expose through the lightweight package
+spec = importlib.util.spec_from_file_location(
+    "deepthought.modules.fuser", root / "deepthought" / "modules" / "fuser.py"
+)
+fuser_module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(fuser_module)
+sys.modules["deepthought.modules.fuser"] = fuser_module
+modules_pkg.ModalityFuser = fuser_module.ModalityFuser
+
+# Stub out video worker to avoid OpenCV dependency
+wv_module = types.ModuleType("deepthought.services.perception.worker_video")
+class _DummyVideoWorker:  # pragma: no cover - simple stub
+    pass
+
+wv_module.VideoPerceptionWorker = _DummyVideoWorker
+sys.modules.setdefault("deepthought.services.perception.worker_video", wv_module)
+
+from deepthought.metrics.prometheus import MISSING_MODALITY_TOTAL
+from deepthought.modules.fuser import ModalityFuser
+from deepthought.services.perception.service import PerceptionService
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.kwargs: Dict | None = None
+
+    async def publish(self, **kwargs) -> None:  # pragma: no cover - simple async stub
+        self.kwargs = kwargs
+
+
+class DummyTextWorker:
+    def __call__(self, tokens: Sequence[Tuple[str, float, float]], memmap_path: str):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+        mm = np.memmap(memmap_path, dtype="float32", mode="w+", shape=data.shape)
+        mm[:] = data
+        mm.flush()
+        times = np.array([[0.0, 0.05], [0.05, 0.1]], dtype=np.float32)
+        return mm, times
+
+
+def _counter_value(counter, modality: str) -> float:
+    for sample in counter.collect()[0].samples:
+        if sample.labels.get("modality") == modality:
+            return sample.value
+    return 0.0
+
+
+def test_missing_modality_triggers_metrics(caplog):
+    publisher = DummyPublisher()
+    fuser = ModalityFuser({"text": 2, "audio": 2}, fused_dim=3)
+    fuser.eval()
+    service = PerceptionService(publisher, text_worker=DummyTextWorker(), fuser=fuser)
+
+    before = _counter_value(MISSING_MODALITY_TOTAL, "audio")
+    with caplog.at_level("WARNING"):
+        asyncio.run(
+            service.run(
+                message_id="m1",
+                user_id="u1",
+                text_tokens=[("hi", 0.0, 0.1)],
+            )
+        )
+    after = _counter_value(MISSING_MODALITY_TOTAL, "audio")
+
+    assert after == before + 1
+    assert "audio modality absent" in caplog.text
+    assert publisher.kwargs is not None
+    fused = np.asarray(publisher.kwargs["fused"], dtype=float)
+    assert fused.shape == (2, 3)


### PR DESCRIPTION
## Summary
- add Prometheus counter for missing modalities
- warn and increment metrics when a modality is absent during perception fusion
- include dropout-based fallback and unit test for missing modalities

## Testing
- `python -m flake8 tests/unit/test_missing_modality_metrics.py src/deepthought/metrics/__init__.py src/deepthought/metrics/prometheus.py src/deepthought/services/perception/service.py`
- `pytest tests/unit/test_missing_modality_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8447a4998832697edeca0e5704b83