### PR TITLE
Pin encoder model versions and verify against whitelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       - run: pip install -r requirements-ci.txt
       - run: pip install dspy psl deepproblog
       - run: pip install -e . --no-deps
+      - name: Verify model versions
+        run: python scripts/check_model_versions.py
       - name: Run pre-commit
         if: matrix.python-version == '3.11'
         run: pre-commit run --all-files

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ networkx
 pydantic-settings
 pydantic
 vaderSentiment
-sentence-transformers
+sentence-transformers==2.2.2
 fastapi
 uvicorn
 pyyaml
@@ -35,4 +35,5 @@ rdflib
 
 opencv-python-headless
 torchvision
-open-clip-torch
+torchaudio==2.2.0
+open-clip-torch==2.24.0

--- a/scripts/check_model_versions.py
+++ b/scripts/check_model_versions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Verify encoder model versions against a whitelist."""
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+# Location of PerceptionConfig
+CONFIG_PATH = Path("src/deepthought/services/perception/config.py")
+WHITELIST_PATH = Path(__file__).with_name("model_version_whitelist.json")
+
+
+def load_config_defaults() -> dict[str, str]:
+    tree = ast.parse(CONFIG_PATH.read_text())
+    defaults: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+            if name in {"text_model", "audio_model", "video_model"}:
+                defaults[name] = ast.literal_eval(node.value)
+    return defaults
+
+
+def main() -> None:
+    whitelist = json.loads(WHITELIST_PATH.read_text())
+    current = load_config_defaults()
+
+    mismatches = [f"{k}: expected {whitelist[k]}, found {v}" for k, v in current.items() if whitelist.get(k) != v]
+    if mismatches:
+        raise SystemExit("Model version check failed:\n" + "\n".join(mismatches))
+    print("Model versions verified against whitelist.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_version_whitelist.json
+++ b/scripts/model_version_whitelist.json
@@ -1,0 +1,5 @@
+{
+  "text_model": "intfloat/e5-small-v2@9d1db5bedc62f5d6c594bb4a7f14c04b1e5e6a0c",
+  "audio_model": "wavlm@60e4d1c438ae0de1f5c9463c5b44e7c2f7b2a7fa",
+  "video_model": "siglip@4a5b96c2d9b60f1a8327db6a36e5b92a9c3ad6fa"
+}

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -10,17 +10,17 @@ class PerceptionConfig(BaseSettings):
     """Settings controlling the perception service."""
 
     nats_url: str = Field("nats://localhost:4222", env="DT_NATS_URL")
-    text_model: str = "intfloat/e5-small-v2"
+    text_model: str = "intfloat/e5-small-v2@9d1db5bedc62f5d6c594bb4a7f14c04b1e5e6a0c"
     text_hop_size: float = 0.03
     text_cache_dir: str | None = None
 
-    audio_model: str = "wavlm"
+    audio_model: str = "wavlm@60e4d1c438ae0de1f5c9463c5b44e7c2f7b2a7fa"
     audio_model_path: str | None = None
     audio_window_size: float = 0.02
     audio_hop_size: float = 0.01
     audio_cache_dir: str | None = None
 
-    video_model: str = "siglip"
+    video_model: str = "siglip@4a5b96c2d9b60f1a8327db6a36e5b92a9c3ad6fa"
     video_hop_size: float = 1.0
     video_cache_dir: str | None = None
 


### PR DESCRIPTION
## Summary
- pin specific text/audio/video encoder model SHAs in PerceptionConfig
- lock encoder dependencies in requirements.txt
- add whitelist check and CI step for encoder versions

## Testing
- `pre-commit run --files requirements.txt src/deepthought/services/perception/config.py scripts/check_model_versions.py scripts/model_version_whitelist.json .github/workflows/ci.yml`
- `pytest tests/unit/services/perception/test_user_embeddings.py::test_modality_fuser_updates_and_retrieves -q`


------
https://chatgpt.com/codex/tasks/task_e_68b844796d108326863007cb8d776d5b