### PR TITLE
Track per-modality inference latency

### DIFF
--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -20,14 +20,19 @@ __version__ = "0.1.0"
 
 # Re-export modules subpackage for convenient access
 from . import affinity  # noqa: F401
+
+# Importing heavy submodules like ``goal_scheduler`` at module import time can
+# trigger circular import errors during test collection.  Avoid eager imports and
+# instead load them lazily when accessed.
 if not os.environ.get("DEEPTHOUGHT_LIGHT_IMPORT"):
-    from . import goal_scheduler  # noqa: F401
-    from . import harness  # noqa: F401
-    from . import learn  # noqa: F401
-else:  # pragma: no cover - skip heavy optional imports
-    goal_scheduler = None  # type: ignore
-    harness = None  # type: ignore
-    learn = None  # type: ignore
+    import importlib
+
+    def __getattr__(name: str):  # pragma: no cover - tiny wrapper
+        if name in {"goal_scheduler", "harness", "learn"}:
+            module = importlib.import_module(f".{name}", __name__)
+            globals()[name] = module
+            return module
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # modules depends on optional external packages (e.g. nats). Import it lazily

--- a/src/deepthought/metrics/__init__.py
+++ b/src/deepthought/metrics/__init__.py
@@ -71,7 +71,11 @@ def actions_per_second(trace: Iterable[TraceEvent]) -> float:
     return len(latencies) / total if total > 0 else 0.0
 
 
-from .prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+from .prometheus import (
+    INPUT_LATENCY_SECONDS,
+    INPUTS_TOTAL,
+    MODALITY_INFERENCE_LATENCY_SECONDS,
+)
 
 __all__ = [
     "bleu",
@@ -80,4 +84,5 @@ __all__ = [
     "actions_per_second",
     "INPUTS_TOTAL",
     "INPUT_LATENCY_SECONDS",
+    "MODALITY_INFERENCE_LATENCY_SECONDS",
 ]

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -18,6 +18,17 @@ if "input_latency_seconds" not in REGISTRY._names_to_collectors:
 else:  # pragma: no cover - already registered
     INPUT_LATENCY_SECONDS = REGISTRY._names_to_collectors["input_latency_seconds"]  # type: ignore
 
+if "modality_inference_latency_seconds" not in REGISTRY._names_to_collectors:
+    MODALITY_INFERENCE_LATENCY_SECONDS = Histogram(
+        "modality_inference_latency_seconds",
+        "Latency for processing individual modality inputs",
+        labelnames=["service", "modality"],
+    )
+else:  # pragma: no cover - already registered
+    MODALITY_INFERENCE_LATENCY_SECONDS = REGISTRY._names_to_collectors[
+        "modality_inference_latency_seconds"
+    ]  # type: ignore
+
 if "rule_evaluations_total" not in REGISTRY._names_to_collectors:
     RULE_EVALUATIONS_TOTAL = Counter(
         "rule_evaluations_total",
@@ -39,6 +50,7 @@ else:  # pragma: no cover - already registered
 __all__ = [
     "INPUTS_TOTAL",
     "INPUT_LATENCY_SECONDS",
+    "MODALITY_INFERENCE_LATENCY_SECONDS",
     "RULE_EVALUATIONS_TOTAL",
     "RULE_EVALUATION_ERRORS_TOTAL",
 ]

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -15,7 +15,11 @@ import numpy as np
 import torch
 
 from ...config import get_settings
-from ...metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
+from ...metrics.prometheus import (
+    INPUT_LATENCY_SECONDS,
+    INPUTS_TOTAL,
+    MODALITY_INFERENCE_LATENCY_SECONDS,
+)
 from ...modules import ModalityFuser
 from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
@@ -97,7 +101,11 @@ class PerceptionService:
                         times = np.asarray(meta["timestamps"], dtype=np.float32)
                         encoder_meta["text"] = meta["encoder"]
                     else:
+                        start = time.perf_counter()
                         feats, times = self.text_worker(text_tokens, str(feats_file))
+                        MODALITY_INFERENCE_LATENCY_SECONDS.labels(
+                            service="perception_service", modality="text"
+                        ).observe(time.perf_counter() - start)
                         meta = {
                             "shape": list(feats.shape),
                             "timestamps": times.tolist(),
@@ -108,7 +116,11 @@ class PerceptionService:
                         encoder_meta["text"] = meta["encoder"]
                 else:
                     with NamedTemporaryFile(suffix=".mm", delete=False) as tmp:
+                        start = time.perf_counter()
                         feats, times = self.text_worker(text_tokens, tmp.name)
+                        MODALITY_INFERENCE_LATENCY_SECONDS.labels(
+                            service="perception_service", modality="text"
+                        ).observe(time.perf_counter() - start)
                     encoder_meta["text"] = {"name": self.text_worker.__class__.__name__}
                     Path(tmp.name).unlink(missing_ok=True)
                 modality_arrays["text"] = np.asarray(feats)
@@ -132,7 +144,11 @@ class PerceptionService:
                     times = np.asarray(meta["timestamps"], dtype=np.float32)
                     encoder_meta["audio"] = meta["encoder"]
                 else:
+                    start = time.perf_counter()
                     feats, times = self.audio_worker(audio_path, cache_dir=cache_dir)
+                    MODALITY_INFERENCE_LATENCY_SECONDS.labels(service="perception_service", modality="audio").observe(
+                        time.perf_counter() - start
+                    )
                     meta = {
                         "shape": list(feats.shape),
                         "timestamps": times.tolist(),
@@ -167,7 +183,11 @@ class PerceptionService:
                     times_arr = np.asarray(meta["timestamps"], dtype=np.float32)
                     encoder_meta["video"] = meta["encoder"]
                 else:
+                    start = time.perf_counter()
                     feats, times_arr = self.video_worker(video_path)
+                    MODALITY_INFERENCE_LATENCY_SECONDS.labels(service="perception_service", modality="video").observe(
+                        time.perf_counter() - start
+                    )
                     if not feats_file.exists():
                         np.save(feats_file, np.asarray(feats))
                     meta = {

--- a/tools/benchmark_perception_latency.py
+++ b/tools/benchmark_perception_latency.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Benchmark perception workers and report P95 latency for each modality."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import numpy as np
+
+from deepthought.services.perception.worker_audio import AudioPerceptionWorker
+from deepthought.services.perception.worker_text import TextPerceptionWorker, Token
+from deepthought.services.perception.worker_video import VideoPerceptionWorker
+
+
+def _p95(values: list[float]) -> float:
+    return float(np.percentile(values, 95))
+
+
+def benchmark_text(runs: int) -> float:
+    tokens: list[Token] = [("hello world", 0.0, 1.0)]
+    worker = TextPerceptionWorker()
+    durations: list[float] = []
+    for _ in range(runs):
+        with NamedTemporaryFile(suffix=".mm") as tmp:
+            start = time.perf_counter()
+            worker(tokens, tmp.name)
+            durations.append(time.perf_counter() - start)
+    return _p95(durations)
+
+
+def benchmark_audio(path: Path, runs: int) -> float:
+    worker = AudioPerceptionWorker()
+    durations: list[float] = []
+    for _ in range(runs):
+        with TemporaryDirectory() as tmpdir:
+            start = time.perf_counter()
+            worker(path, cache_dir=tmpdir)
+            durations.append(time.perf_counter() - start)
+    return _p95(durations)
+
+
+def benchmark_video(path: Path, runs: int) -> float:
+    worker = VideoPerceptionWorker()
+    durations: list[float] = []
+    for _ in range(runs):
+        with TemporaryDirectory() as tmpdir:
+            worker.cache_dir = Path(tmpdir)
+            start = time.perf_counter()
+            worker(path)
+            durations.append(time.perf_counter() - start)
+    return _p95(durations)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--runs", type=int, default=20, help="Number of runs per modality")
+    parser.add_argument("--audio", type=Path, required=True, help="Path to an audio file")
+    parser.add_argument("--video", type=Path, required=True, help="Path to a video file")
+    args = parser.parse_args()
+
+    print(f"Text P95 latency: {benchmark_text(args.runs)*1000:.2f} ms")
+    print(f"Audio P95 latency: {benchmark_audio(args.audio, args.runs)*1000:.2f} ms")
+    print(f"Video P95 latency: {benchmark_video(args.video, args.runs)*1000:.2f} ms")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- record per-modality inference latency in perception service and publish Prometheus metrics
- expose new Prometheus histogram for modality latency
- add benchmarking tool to compute P95 latency for text, audio, and video workers
- lazily import heavy modules in package init to avoid circular imports during tests

## Testing
- `pre-commit run --files src/deepthought/__init__.py src/deepthought/metrics/__init__.py src/deepthought/metrics/prometheus.py src/deepthought/services/perception/service.py tools/benchmark_perception_latency.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'deepthought.learn.online_lora'; 'deepthought.learn' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68b843629d388326bb86e68639c7df03