### PR TITLE
Document perception embeddings and durable consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,21 @@ scores = detect_emotions("I'm feeling thrilled today!")
 print(scores["Happy"])
 ```
 
+### Perception Embeddings and Durable Consumers
+
+The perception service emits `PERCEPTION.EMBEDDINGS` events on the
+`dtr.perception.embeddings` subject. Each message bundles fused and
+per-modality embedding vectors with encoder metadata and the originating
+`user_id`. Durable JetStream consumers (for example,
+`memory-perception-consumer`) can replay this stream to rebuild indexes or
+analytics pipelines after a restart.
+
+Storing embeddings per user enables lightweight personalization. Downstream
+modules can perform nearest-neighbour search on a user's history to tailor
+responses. See
+[docs/perception_service.md#embedding-events](docs/perception_service.md#embedding-events)
+for the full schema and examples.
+
 ### Privacy Controls
 
 Set `PERCEPTION_REQUIRE_CONSENT=1` to require incoming messages include a

--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -36,6 +36,7 @@ After scoring, results are published to JetStream under:
 - `dtr.perception.image`
 - `dtr.perception.audio`
 - `dtr.perception.fused`
+- `dtr.perception.embeddings`
 
 All subjects are persisted in the `PERCEPTION` stream created by `setup_jetstream.py`.
 
@@ -61,6 +62,43 @@ A fused perception event bundles the modality scores and the averaged result:
 ```
 
 Per-modality events omit the other sections and include only the scores for that input type.
+
+## Embedding Events
+
+`PERCEPTION.EMBEDDINGS` events on the `dtr.perception.embeddings` subject carry the
+vector representations produced for each message. The payload includes the
+`message_id`, `user_id`, optional fused embeddings, and per-modality vectors with
+their spans and encoder metadata. A simplified example:
+
+```json
+{
+  "event": "dtr.perception.embeddings",
+  "version": 1,
+  "payload": {
+    "message_id": "42",
+    "user_id": "alice",
+    "fused": [[0.1, 0.2, 0.3]],
+    "by_modality": {
+      "text": {
+        "spans": [[0, 12]],
+        "embeddings": [[0.4, 0.5, 0.6]],
+        "encoders": [{"name": "gte-small"}]
+      }
+    }
+  }
+}
+```
+
+Durable consumers such as `memory-perception-consumer` can subscribe to the
+stream and resume from the last acknowledged message after restarts. This makes
+it easy for downstream modules to build analytics pipelines or persistent
+indexes.
+
+### Personalization
+
+Storing embeddings per `user_id` enables simple personalization. A consumer can
+aggregate a user's history and perform nearest-neighbour search to tailor model
+responses or retrieve context relevant to that individual.
 
 ## Running the Service
 
@@ -93,7 +131,7 @@ The module continuously publishes scored events to the subjects listed above.
    ```bash
    nats consumer next PERCEPTION memory-perception-consumer --filter dtr.perception.fused --count=10 --json
    ```
-   Replace the `--filter` subject with `dtr.perception.text`, `dtr.perception.image`, or `dtr.perception.audio` to inspect individual modalities.
+   Replace the `--filter` subject with `dtr.perception.text`, `dtr.perception.image`, `dtr.perception.audio`, or `dtr.perception.embeddings` to inspect individual modalities or the raw vectors.
 
 ### Monitoring with Weights & Biases
 


### PR DESCRIPTION
## Summary
- document PERCEPTION.EMBEDDINGS events and durable JetStream consumers
- explain user-embedding personalization
- add link to perception service docs

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b85bd7aea083268e6787187de27f1f