### PR TITLE
docs: add BGE and E5 license entries

### DIFF
--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -40,6 +40,8 @@ upstream projects for the most current license information.
 | OpenCLIP (open-clip-torch) | MIT | CLIP implementation |
 | torchvision | BSD-3-Clause | Computer vision models |
 | opencv-python-headless | Apache-2.0 | Computer vision toolkit |
+| BGE | MIT | Optional `PerceptionConfig.text_model` |
+| E5 | MIT | Default `PerceptionConfig.text_model` |
 | Default social perception model | MIT | Bundled classifier weights |
 | WavLM | MIT | Speech representation model |
 | WavLM checkpoints | MIT | Pretrained weights |

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -10,6 +10,8 @@ class PerceptionConfig(BaseSettings):
     """Settings controlling the perception service."""
 
     nats_url: str = Field("nats://localhost:4222", env="DT_NATS_URL")
+    # Default text embedding model (E5). Alternative: BGE.
+    # See docs/licenses.md for license details.
     text_model: str = "intfloat/e5-small-v2@9d1db5bedc62f5d6c594bb4a7f14c04b1e5e6a0c"
     text_hop_size: float = 0.03
     text_cache_dir: str | None = None


### PR DESCRIPTION
## Summary
- document MIT licenses for BGE and E5 and note their use in `PerceptionConfig.text_model`
- annotate perception config to reference E5 default and BGE alternative with link to license documentation

## Testing
- `python scripts/verify_licenses.py`


------
https://chatgpt.com/codex/tasks/task_e_68b86108a1388326828061d70eefdae9