### PR TITLE
test: verify audio consent required

### DIFF
--- a/tests/integration/test_perception_consent.py
+++ b/tests/integration/test_perception_consent.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deepthought.services.perception.service import PerceptionService
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.publish = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_audio_consent_required(monkeypatch):
+    monkeypatch.setenv("DT_REQUIRE_AUDIO_CONSENT", "1")
+    monkeypatch.delenv("DT_AUDIO_CONSENT", raising=False)
+
+    service = PerceptionService(publisher=DummyPublisher(), audio_worker=object())
+
+    with pytest.raises(PermissionError):
+        await service.run("m1", "u1", audio_path="dummy.wav")
+
+    service.publisher.publish.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add integration test ensuring audio consent is required before processing

## Testing
- `SKIP=pytest pre-commit run --files tests/integration/test_perception_consent.py`
- `pytest tests/integration/test_perception_consent.py`


------
https://chatgpt.com/codex/tasks/task_e_68bef79270a08326ba5adec9bb4447f7