### PR TITLE
Add bandit update step for ModalityFuser

### DIFF
--- a/src/deepthought/modules/fuser.py
+++ b/src/deepthought/modules/fuser.py
@@ -181,3 +181,35 @@ class ModalityFuser(nn.Module):
                     embedding_store.update_from_gradient(user_id, grad, lr=lr)
 
                 optimizer.step()
+
+    def bandit_step(
+        self,
+        modalities: Dict[str, torch.Tensor],
+        reward: float,
+        context: Sequence[float] | torch.Tensor,
+        user_id: str,
+        embedding_store: "UserEmbeddings",
+    ) -> torch.Tensor:
+        """Fuse ``modalities`` and update ``user_id`` with bandit feedback.
+
+        Parameters
+        ----------
+        modalities:
+            Mapping from modality name to tensor inputs.
+        reward:
+            Scalar reward used to scale the update.
+        context:
+            Feature vector indicating the direction of the update.
+        user_id:
+            Identifier whose embedding should be updated.
+        embedding_store:
+            Store managing persistent user embeddings.
+
+        Returns
+        -------
+        torch.Tensor
+            The fused embedding produced from ``modalities``.
+        """
+
+        embedding_store.update_from_bandit(user_id, reward, context)
+        return self.forward(modalities, user_id=user_id, embedding_store=embedding_store)

--- a/tests/test_modality_fuser.py
+++ b/tests/test_modality_fuser.py
@@ -5,6 +5,7 @@ if not hasattr(torch, "SymBool"):
     pytest.skip("PyTorch lacks SymBool", allow_module_level=True)
 
 from deepthought.modules.fuser import ModalityFuser
+from deepthought.services.perception.user_embeddings import UserEmbeddings
 
 
 def _make_fuser(*args, **kwargs):
@@ -45,3 +46,23 @@ def test_modality_fuser_missing_modalities():
     text = torch.ones((1, 2))
     with pytest.raises(RuntimeError):
         fuser({"text": text})
+
+
+def test_bandit_step_positive_reward(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    fuser = _make_fuser({"text": 2}, fused_dim=2, user_dim=3)
+    modalities = {"text": torch.ones((1, 2))}
+    context = torch.tensor([0.5, -0.5, 1.0])
+    fuser.bandit_step(modalities, 1.0, context, "u1", store)
+    expected = 0.01 * context
+    assert torch.allclose(store.get("u1"), expected)
+
+
+def test_bandit_step_negative_reward(tmp_path):
+    store = UserEmbeddings(tmp_path / "store.json")
+    fuser = _make_fuser({"text": 2}, fused_dim=2, user_dim=3)
+    modalities = {"text": torch.ones((1, 2))}
+    context = torch.tensor([0.5, -0.5, 1.0])
+    fuser.bandit_step(modalities, -1.0, context, "u1", store)
+    expected = -0.01 * context
+    assert torch.allclose(store.get("u1"), expected)


### PR DESCRIPTION
## Summary
- add `bandit_step` to `ModalityFuser` to update user embeddings using bandit feedback
- test positive and negative reward updates

## Testing
- `flake8 src/deepthought/modules/fuser.py tests/test_modality_fuser.py`
- `pytest tests/test_modality_fuser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c032ef8bec832689ecd06cd2109109