### PR TITLE
Verify model licenses from PerceptionConfig

### DIFF
--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -49,3 +49,18 @@ upstream projects for the most current license information.
 | CLAP checkpoints | CC0 | Pretrained weights |
 | SigLIP | Apache-2.0 | Vision-language model |
 | SigLIP checkpoints | Apache-2.0 | Pretrained weights |
+
+## License verification workflow
+
+Encoder model defaults live in `src/deepthought/services/perception/config.py`.
+When these defaults change, update `scripts/model_version_whitelist.json` with
+the new versions and their corresponding license information. After updating the
+whitelist and this document, verify everything with:
+
+```
+python scripts/check_model_versions.py
+python scripts/verify_licenses.py
+```
+
+Both scripts will report an error if the versions or licenses diverge from the
+whitelist or if required entries are missing from this table.

--- a/scripts/model_version_whitelist.json
+++ b/scripts/model_version_whitelist.json
@@ -1,5 +1,10 @@
 {
   "text_model": "intfloat/e5-small-v2@9d1db5bedc62f5d6c594bb4a7f14c04b1e5e6a0c",
   "audio_model": "wavlm@60e4d1c438ae0de1f5c9463c5b44e7c2f7b2a7fa",
-  "video_model": "siglip@4a5b96c2d9b60f1a8327db6a36e5b92a9c3ad6fa"
+  "video_model": "siglip@4a5b96c2d9b60f1a8327db6a36e5b92a9c3ad6fa",
+  "licenses": {
+    "text_model": {"component": "E5", "license": "MIT"},
+    "audio_model": {"component": "WavLM", "license": "MIT"},
+    "video_model": {"component": "SigLIP", "license": "Apache-2.0"}
+  }
 }

--- a/scripts/verify_licenses.py
+++ b/scripts/verify_licenses.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python3
-"""Verify required third-party license entries."""
+"""Verify third-party model license entries."""
 from __future__ import annotations
 
+import ast
+import json
 from pathlib import Path
 
 LICENSE_FILE = Path(__file__).resolve().parents[1] / "docs" / "licenses.md"
-REQUIRED_ENTRIES = {
-    "WavLM": "MIT",
-    "WavLM checkpoints": "MIT",
-    "CLAP": "CC0",
-    "CLAP checkpoints": "CC0",
-    "SigLIP": "Apache-2.0",
-    "SigLIP checkpoints": "Apache-2.0",
-}
+CONFIG_PATH = Path("src/deepthought/services/perception/config.py")
+WHITELIST_PATH = Path(__file__).with_name("model_version_whitelist.json")
 
 
 def parse_table(text: str) -> dict[str, str]:
@@ -29,6 +25,18 @@ def parse_table(text: str) -> dict[str, str]:
     return entries
 
 
+def load_config_models() -> dict[str, str]:
+    """Return default model names from :class:`PerceptionConfig`."""
+    tree = ast.parse(CONFIG_PATH.read_text(encoding="utf-8"))
+    models: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name = node.target.id
+            if name in {"text_model", "audio_model", "video_model"}:
+                models[name] = ast.literal_eval(node.value)
+    return models
+
+
 def main() -> int:
     """Entry point for the license verifier."""
     if not LICENSE_FILE.exists():
@@ -38,11 +46,20 @@ def main() -> int:
     content = LICENSE_FILE.read_text(encoding="utf-8")
     entries = parse_table(content)
 
-    missing = [
-        f"{component} ({expected})"
-        for component, expected in REQUIRED_ENTRIES.items()
-        if entries.get(component) != expected
-    ]
+    models = load_config_models()
+    whitelist = json.loads(WHITELIST_PATH.read_text(encoding="utf-8"))
+    license_info = whitelist.get("licenses", {})
+
+    missing: list[str] = []
+    for field in models:
+        info = license_info.get(field)
+        if info is None:
+            missing.append(f"{field} missing from license whitelist")
+            continue
+        component = info["component"]
+        expected = info["license"]
+        if entries.get(component) != expected:
+            missing.append(f"{component} ({expected})")
 
     if missing:
         print("Missing or incorrect license entries:")

--- a/tests/unit/test_verify_licenses.py
+++ b/tests/unit/test_verify_licenses.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import importlib.util
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "verify_licenses.py"
+spec = importlib.util.spec_from_file_location("verify_licenses", SCRIPT_PATH)
+verify_licenses = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(verify_licenses)
+
+
+def _write_whitelist(path: Path) -> Path:
+    data = {
+        "text_model": "intfloat/e5-small-v2@9d1db5bedc62f5d6c594bb4a7f14c04b1e5e6a0c",
+        "audio_model": "wavlm@60e4d1c438ae0de1f5c9463c5b44e7c2f7b2a7fa",
+        "video_model": "siglip@4a5b96c2d9b60f1a8327db6a36e5b92a9c3ad6fa",
+        "licenses": {
+            "text_model": {"component": "E5", "license": "MIT"},
+            "audio_model": {"component": "WavLM", "license": "MIT"},
+            "video_model": {"component": "SigLIP", "license": "Apache-2.0"},
+        },
+    }
+    whitelist = path / "model_version_whitelist.json"
+    whitelist.write_text(json.dumps(data))
+    return whitelist
+
+
+def _write_licenses(path: Path, entries: list[tuple[str, str]]) -> Path:
+    lines = ["| Component | License |", "| --- | --- |"]
+    lines.extend([f"| {name} | {license} |" for name, license in entries])
+    license_file = path / "licenses.md"
+    license_file.write_text("\n".join(lines))
+    return license_file
+
+
+def test_verify_licenses_pass(monkeypatch, tmp_path):
+    whitelist = _write_whitelist(tmp_path)
+    license_file = _write_licenses(
+        tmp_path, [("E5", "MIT"), ("WavLM", "MIT"), ("SigLIP", "Apache-2.0")]
+    )
+    monkeypatch.setattr(verify_licenses, "LICENSE_FILE", license_file)
+    monkeypatch.setattr(verify_licenses, "WHITELIST_PATH", whitelist)
+    assert verify_licenses.main() == 0
+
+
+def test_verify_licenses_missing(monkeypatch, tmp_path):
+    whitelist = _write_whitelist(tmp_path)
+    license_file = _write_licenses(tmp_path, [("E5", "MIT"), ("WavLM", "MIT")])
+    monkeypatch.setattr(verify_licenses, "LICENSE_FILE", license_file)
+    monkeypatch.setattr(verify_licenses, "WHITELIST_PATH", whitelist)
+    assert verify_licenses.main() == 1


### PR DESCRIPTION
## Summary
- verify licenses for text/audio/video models defined in `PerceptionConfig`
- whitelist model licenses and versions in `model_version_whitelist.json`
- document how to check model versions and licenses

## Testing
- `ruff check scripts/verify_licenses.py`
- `pytest tests/unit/test_verify_licenses.py`


------
https://chatgpt.com/codex/tasks/task_e_68c03c61b230832686d157d733f092e5