### PR TITLE
Add gradient and bandit user embedding tests

### DIFF
--- a/tests/unit/services/perception/test_user_embeddings.py
+++ b/tests/unit/services/perception/test_user_embeddings.py
@@ -1,9 +1,20 @@
 import sys
 import types
+from pathlib import Path
 
 import pytest
 
+repo_root = Path(__file__).resolve().parents[4]
+
 # Stub perception modules with heavy dependencies so we can import UserEmbeddings
+services_pkg = types.ModuleType("deepthought.services")
+services_pkg.__path__ = [str(repo_root / "src" / "deepthought" / "services")]
+sys.modules["deepthought.services"] = services_pkg
+
+perception_pkg = types.ModuleType("deepthought.services.perception")
+perception_pkg.__path__ = [str(repo_root / "src" / "deepthought" / "services" / "perception")]
+sys.modules["deepthought.services.perception"] = perception_pkg
+
 for name, attr in [
     ("cli", "main"),
     ("config", "PerceptionConfig"),
@@ -18,15 +29,27 @@ for name, attr in [
         setattr(mod, attr, lambda *a, **k: None)
     else:
         setattr(mod, attr, type(attr, (), {}))
-    sys.modules[f"deepthought.services.perception.{name}"] = mod
+sys.modules[f"deepthought.services.perception.{name}"] = mod
+
+# Stub prometheus_client to avoid requiring the dependency
+prometheus_client = types.ModuleType("prometheus_client")
+prometheus_client.Counter = lambda *a, **k: None
+prometheus_client.Histogram = lambda *a, **k: None
+prometheus_client.REGISTRY = types.SimpleNamespace(_names_to_collectors={})
+sys.modules["prometheus_client"] = prometheus_client
+
+# Stub deepthought.modules package to avoid heavy imports
+modules_pkg = types.ModuleType("deepthought.modules")
+modules_pkg.__path__ = [str(Path(__file__).resolve().parents[4] / "src" / "deepthought" / "modules")]
+sys.modules["deepthought.modules"] = modules_pkg
 
 try:  # Attempt to import the real torch library
     import torch  # noqa: F401
 except Exception as exc:  # pragma: no cover - optional dependency
     pytest.skip(f"torch import failed: {exc}")
 
-from deepthought.modules.fuser import ModalityFuser
-from deepthought.services.perception.user_embeddings import UserEmbeddings
+from deepthought.modules.fuser import ModalityFuser  # noqa: E402
+from deepthought.services.perception.user_embeddings import UserEmbeddings  # noqa: E402
 
 
 def test_modality_fuser_updates_and_retrieves(tmp_path):
@@ -76,3 +99,39 @@ def test_user_embedding_persistence_across_instances(tmp_path):
     stored = new_store.get("alice")
     assert stored is not None
     assert torch.allclose(stored, emb2.squeeze(0))
+
+
+def test_update_from_gradient(tmp_path):
+    path = tmp_path / "grad.json"
+    store = UserEmbeddings(path)
+
+    torch.manual_seed(0)
+    modalities = {"text": torch.randn(1, 2)}
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+
+    emb = torch.zeros(1, 3, requires_grad=True)
+    output = fuser(modalities, user_embedding=emb)
+    loss = output.pow(2).sum()
+    loss.backward()
+
+    grad = emb.grad.squeeze(0)
+    updated = store.update_from_gradient("carol", grad, lr=0.1)
+    assert torch.allclose(updated, -0.1 * grad)
+
+
+def test_update_from_bandit(tmp_path):
+    path = tmp_path / "bandit.json"
+    store = UserEmbeddings(path)
+
+    torch.manual_seed(0)
+    modalities = {"text": torch.randn(1, 2)}
+    fuser = ModalityFuser({"text": 2}, fused_dim=4, user_dim=3)
+
+    context = torch.tensor([0.5, -0.25, 0.1])
+    reward = 2.0
+    fuser.bandit_step(modalities, reward, context, user_id="dave", embedding_store=store)
+
+    expected = 0.01 * reward * context
+    stored = store.get("dave")
+    assert stored is not None
+    assert torch.allclose(stored, expected)


### PR DESCRIPTION
## Summary
- cover gradient descent updates for user embeddings
- test bandit-based updates via ModalityFuser

## Testing
- `ruff check tests/unit/services/perception/test_user_embeddings.py`
- `pytest tests/unit/services/perception/test_user_embeddings.py`

------
https://chatgpt.com/codex/tasks/task_e_68c03c62319083268c14b2956bf780d4