### PR TITLE
Use PerceptionServiceListener in CLI

### DIFF
--- a/src/deepthought/services/perception/cli.py
+++ b/src/deepthought/services/perception/cli.py
@@ -8,11 +8,11 @@ import json
 import os
 
 from nats.aio.client import Client as NATS
-from nats.aio.msg import Msg
 from nats.js.api import DeliverPolicy
 
-from ...eda.events import EventSubjects, InputReceivedPayload
+from ...eda.events import EventSubjects
 from .config import PerceptionConfig
+from .listener import PerceptionServiceListener
 from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .service import run as run_service
@@ -125,34 +125,13 @@ async def _main() -> None:
     )
 
     if args.listen:
-
-        async def _handle_input(msg: Msg) -> None:
-            try:
-                raw = json.loads(msg.data.decode())
-            except Exception:
-                raw = {}
-            if os.getenv("PERCEPTION_REQUIRE_CONSENT", "").lower() in {"1", "true", "yes"}:
-                if not raw.get("consent"):
-                    if hasattr(msg, "ack") and callable(msg.ack):
-                        await msg.ack()
-                    return
-            try:
-                payload = InputReceivedPayload.from_dict(raw)
-                message_id = payload.input_id or "unknown"
-            except Exception:
-                payload = None
-                message_id = "unknown"
-            user_id = (msg.headers.get("user_id") if msg.headers else None) or args.user_id
-            await service.run(message_id=message_id, user_id=user_id, embeddings=[[0.0]])
-            if hasattr(msg, "ack") and callable(msg.ack):
-                await msg.ack()
-
+        listener = PerceptionServiceListener(service, nc, js, default_user_id=args.user_id)
         deliver_policy = DeliverPolicy.ALL if args.replay else DeliverPolicy.NEW
         await js.subscribe(
             EventSubjects.INPUT_RECEIVED,
             durable=args.durable,
             deliver_policy=deliver_policy,
-            cb=_handle_input,
+            cb=listener._handle,
             manual_ack=True,
         )
         try:

--- a/src/deepthought/services/perception/listener.py
+++ b/src/deepthought/services/perception/listener.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import Any, Dict
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ...eda.events import EventSubjects
+from ...eda.events import EventSubjects, InputReceivedPayload
 from ...eda.subscriber import Subscriber
 from .service import PerceptionService
 
@@ -23,9 +24,12 @@ class PerceptionServiceListener:
         service: PerceptionService,
         nats_client: NATS,
         js_context: JetStreamContext,
+        *,
+        default_user_id: str = "user",
     ) -> None:
         self._service = service
         self._subscriber = Subscriber(nats_client, js_context)
+        self._default_user_id = default_user_id
 
     async def start(self, durable_name: str = "perception_listener") -> bool:
         """Begin listening for input events."""
@@ -39,20 +43,41 @@ class PerceptionServiceListener:
     async def _handle(self, msg: Msg) -> None:
         """Decode event payload and dispatch to the service."""
         try:
-            payload: Dict[str, Any] = json.loads(msg.data.decode())
-            keys = [
-                "message_id",
-                "user_id",
-                "spans",
-                "embeddings",
-                "encoders",
-                "provenance",
-                "text_tokens",
-                "audio_path",
-                "video_path",
-            ]
-            kwargs = {k: payload[k] for k in keys if k in payload}
-            await self._service.run(**kwargs)
+            try:
+                raw: Dict[str, Any] = json.loads(msg.data.decode())
+            except Exception:
+                raw = {}
+
+            if os.getenv("PERCEPTION_REQUIRE_CONSENT", "").lower() in {"1", "true", "yes"}:
+                if not raw.get("consent"):
+                    if hasattr(msg, "ack") and callable(msg.ack):
+                        await msg.ack()
+                    return
+
+            try:
+                payload = InputReceivedPayload.from_dict(raw)
+                message_id = payload.input_id or "unknown"
+            except Exception:
+                message_id = raw.get("message_id") or "unknown"
+
+            user_id = (
+                raw.get("user_id")
+                or (msg.headers.get("user_id") if msg.headers else None)
+                or self._default_user_id
+            )
+
+            kwargs = {
+                "message_id": message_id,
+                "user_id": user_id,
+                "spans": raw.get("spans"),
+                "embeddings": raw.get("embeddings"),
+                "encoders": raw.get("encoders"),
+                "provenance": raw.get("provenance"),
+                "text_tokens": raw.get("text_tokens"),
+                "audio_path": raw.get("audio_path"),
+                "video_path": raw.get("video_path"),
+            }
+            await self._service.run(**{k: v for k, v in kwargs.items() if v is not None})
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:  # pragma: no cover - defensive

--- a/tests/unit/services/perception/test_worker_text.py
+++ b/tests/unit/services/perception/test_worker_text.py
@@ -7,7 +7,7 @@ def test_worker_text_memmap(tmp_path):
     tokens = [("hi", 0.0, 0.1), ("world", 0.1, 0.2)]
     worker = TextPerceptionWorker(hop_seconds=0.05)
     memmap_file = tmp_path / "features.dat"
-    feats = worker(tokens, str(memmap_file))
+    feats, _ = worker(tokens, str(memmap_file))
 
     assert feats.shape == (4, 1)
     assert np.allclose(feats[0], feats[1])


### PR DESCRIPTION
## Summary
- delegate perception event handling to `PerceptionServiceListener` in CLI listen mode
- parse `InputReceivedPayload` within listener and forward modality paths/tokens to the service
- adjust text worker unit test to unpack tuple return

## Testing
- `ruff check tests/unit/services/perception/test_worker_text.py src/deepthought/services/perception/cli.py src/deepthought/services/perception/listener.py`
- `pytest tests/integration/test_perception_cli_replay.py tests/unit/services/perception/test_worker_text.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03c61dd5083269a5e3a0bc43dc85f