### PR TITLE
feat: add configurable grid hop size

### DIFF
--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The **PerceptionService** generates time-aligned embeddings for text, audio and video inputs.  Each modality is processed by a dedicated worker that emits embedding vectors with timestamps.  The service aligns these modality-specific streams onto a common grid, optionally fuses them into a single representation, and publishes the result.  Downstream modules can consume either the fused embeddings or per-modality outputs.
+The **PerceptionService** generates time-aligned embeddings for text, audio and video inputs.  Each modality is processed by a dedicated worker that emits embedding vectors with timestamps.  The service aligns these modality-specific streams onto a common grid, optionally fuses them into a single representation, and publishes the result.  The grid resolution defaults to the smallest hop across modalities but can be overridden with the `--grid-hop-size` CLI flag or the `DT_PERCEPTION_GRID_HOP_SIZE` environment variable.  Downstream modules can consume either the fused embeddings or per-modality outputs.
 
 ## Architecture and Flow
 
@@ -126,8 +126,8 @@ Provide a NATS connection and optional model paths before launching:
 
 ```bash
 export NATS_URL=nats://localhost:4222
-# optional overrides for model names or cache directories
-python -m deepthought.services.perception.cli --listen
+# optional overrides for model names, cache directories or grid hop size
+python -m deepthought.services.perception.cli --grid-hop-size 0.1 --listen
 ```
 
 The listener consumes `dtr.input.received` messages and publishes aligned embeddings to `dtr.perception.embeddings`.

--- a/src/deepthought/services/perception/cli.py
+++ b/src/deepthought/services/perception/cli.py
@@ -30,6 +30,12 @@ async def _main() -> None:
     parser.add_argument("--replay", action="store_true", help="Replay existing stream messages from start")
     parser.add_argument("--message-id")
     parser.add_argument("--user-id", default="user")
+    parser.add_argument(
+        "--grid-hop-size",
+        type=float,
+        default=defaults.grid_hop_size,
+        help="Override grid hop size in seconds",
+    )
     parser.add_argument("--text-model", default=defaults.text_model)
     parser.add_argument("--text-hop-size", type=float, default=defaults.text_hop_size)
     parser.add_argument("--text-cache-dir", default=defaults.text_cache_dir)
@@ -57,6 +63,7 @@ async def _main() -> None:
             "text_model",
             "text_hop_size",
             "text_cache_dir",
+            "grid_hop_size",
             "audio_model",
             "audio_hop_size",
             "audio_cache_dir",

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -26,6 +26,8 @@ class PerceptionConfig(BaseSettings):
     video_hop_size: float = 1.0
     video_cache_dir: str | None = None
 
+    grid_hop_size: float | None = None
+
     wandb_project: str | None = Field(None, env="DT_WANDB_PROJECT")
     wandb_sweep_id: str | None = Field(None, env="DT_WANDB_SWEEP_ID")
 

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -20,6 +20,7 @@ from ...metrics.prometheus import (
     INPUT_LATENCY_SECONDS,
     INPUTS_TOTAL,
     MODALITY_INFERENCE_LATENCY_SECONDS,
+    MISSING_MODALITY_TOTAL,
 
 )
 from ...modules import ModalityFuser
@@ -236,7 +237,11 @@ class PerceptionService:
 
             provenance.setdefault("modalities", list(modality_arrays.keys()))
 
-            hop = min(np.min(t[:, 1] - t[:, 0]) for t in modality_times.values())
+            hop = (
+                cfg.grid_hop_size
+                if cfg.grid_hop_size is not None
+                else min(np.min(t[:, 1] - t[:, 0]) for t in modality_times.values())
+            )
             start = min(t[0, 0] for t in modality_times.values())
             end = max(t[-1, 1] for t in modality_times.values())
             num_spans = int(np.ceil((end - start) / hop))
@@ -261,7 +266,10 @@ class PerceptionService:
                         mask = (gs < times[:, 1]) & (ge > times[:, 0])
                         if mask.any():
                             aligned[i] = arr[mask].mean(axis=0)
-                    aligned_modalities[name] = torch.from_numpy(aligned)
+                    try:
+                        aligned_modalities[name] = torch.from_numpy(aligned)
+                    except RuntimeError:  # pragma: no cover - torch built without numpy
+                        aligned_modalities[name] = torch.tensor(aligned.tolist(), dtype=torch.float32)
                     modality_payload[name] = {
                         "spans": spans,
                         "embeddings": aligned.tolist(),

--- a/tests/unit/services/perception/test_perception_service.py
+++ b/tests/unit/services/perception/test_perception_service.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import os
+import sys
+import types
+from types import SimpleNamespace
+from typing import Dict, Sequence, Tuple
+
+import numpy as np
+import pytest
+
+os.environ.setdefault("DEEPTHOUGHT_LIGHT_IMPORT", "1")
+sys.modules.setdefault("deepthought.services", types.ModuleType("deepthought.services"))
+sys.modules["deepthought.services"].__path__ = ["src/deepthought/services"]
+sys.modules.setdefault(
+    "deepthought.services.perception", types.ModuleType("deepthought.services.perception")
+)
+sys.modules["deepthought.services.perception"].__path__ = [
+    "src/deepthought/services/perception"
+]
+worker_video_stub = types.ModuleType("deepthought.services.perception.worker_video")
+worker_video_stub.VideoPerceptionWorker = object
+sys.modules["deepthought.services.perception.worker_video"] = worker_video_stub
+from deepthought.services.perception import service as service_module  # noqa: E402
+from deepthought.services.perception.service import PerceptionService  # noqa: E402
+
+
+class DummyPublisher:
+    def __init__(self) -> None:
+        self.kwargs: Dict | None = None
+
+    async def publish(self, **kwargs) -> None:  # pragma: no cover - simple async stub
+        self.kwargs = kwargs
+
+
+class DummyTextWorker:
+    def __call__(self, tokens: Sequence[Tuple[str, float, float]], memmap_path: str):
+        data = np.array([[1.0, 2.0], [3.0, 4.0]], dtype="float32")
+        mm = np.memmap(memmap_path, dtype="float32", mode="w+", shape=data.shape)
+        mm[:] = data
+        mm.flush()
+        times = np.array([[0.0, 0.05], [0.05, 0.1]], dtype=np.float32)
+        return mm, times
+
+
+@pytest.mark.asyncio
+async def test_grid_hop_size_overrides_default(monkeypatch):
+    fake_cfg = SimpleNamespace(
+        grid_hop_size=0.1,
+        text_cache_dir=None,
+        audio_cache_dir=None,
+        video_cache_dir=None,
+        audio_window_size=0.02,
+        audio_hop_size=0.01,
+        audio_model="",
+        audio_model_path=None,
+        text_model="",
+        text_hop_size=0.03,
+        video_model="",
+        video_hop_size=1.0,
+        wandb_project=None,
+        wandb_sweep_id=None,
+        nats_url="",
+    )
+    monkeypatch.setattr(service_module, "PerceptionConfig", lambda: fake_cfg)
+    publisher = DummyPublisher()
+    service = PerceptionService(publisher, text_worker=DummyTextWorker())
+
+    await service.run(
+        message_id="m1",
+        user_id="u1",
+        text_tokens=[("hi", 0.0, 0.1)],
+    )
+
+    assert publisher.kwargs is not None
+    assert publisher.kwargs["fused"] == [[2.0, 3.0]]
+    text_meta = publisher.kwargs["by_modality"]["text"]
+    assert text_meta["spans"] == [[0, 100]]
+    assert text_meta["embeddings"] == [[2.0, 3.0]]


### PR DESCRIPTION
## Summary
- allow perception spans to use a configurable grid hop size
- expose `--grid-hop-size` in CLI and document usage
- add unit test verifying grid hop override
- fall back to `torch.tensor` when PyTorch lacks NumPy support

## Testing
- `ruff check src/deepthought/services/perception/service.py src/deepthought/services/perception/cli.py src/deepthought/services/perception/config.py tests/unit/services/perception/test_perception_service.py`
- `pytest tests/unit/services/perception/test_perception_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0526e35f88326a33d4608395cb687