### PR TITLE
Improve perception compatibility with numpy-less torch

### DIFF
--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -6,6 +6,96 @@ import os
 import sys
 import types
 
+
+def _ensure_torch_numpy_compat() -> None:
+    """Provide a fallback ``torch.from_numpy`` when NumPy bindings are missing."""
+
+    try:  # pragma: no cover - optional dependency may be missing
+        import torch
+        import numpy as _np
+    except Exception:
+        return
+
+    if getattr(torch, "_deepthought_numpy_checked", False):  # pragma: no branch - simple guard
+        return
+
+    torch._deepthought_numpy_checked = True  # type: ignore[attr-defined]
+
+    try:
+        torch.from_numpy(_np.zeros(1, dtype=_np.float32))
+    except RuntimeError as exc:
+        if "Numpy is not available" not in str(exc):
+            return
+
+        dtype_map = {
+            _np.dtype(_np.float32): torch.float32,
+            _np.dtype(_np.float64): torch.float64,
+            _np.dtype(_np.float16): torch.float16,
+            _np.dtype(_np.int64): torch.int64,
+            _np.dtype(_np.int32): torch.int32,
+            _np.dtype(_np.int16): torch.int16,
+            _np.dtype(_np.int8): torch.int8,
+            _np.dtype(_np.uint8): torch.uint8,
+            _np.dtype(_np.uint16): torch.int32,
+            _np.dtype(_np.uint32): torch.int64,
+            _np.dtype(_np.uint64): torch.int64,
+            _np.dtype(_np.bool_): torch.bool,
+            _np.dtype(_np.complex64): torch.complex64,
+            _np.dtype(_np.complex128): torch.complex128,
+        }
+        if hasattr(_np, "float128"):
+            dtype_map[_np.dtype(_np.float128)] = torch.float64
+
+        def _from_numpy_fallback(array: object):  # pragma: no cover - exercised indirectly in tests
+            if isinstance(array, (list, tuple)) and len(array) == 1 and isinstance(
+                array[0], (_np.ndarray, _np.memmap)
+            ):
+                array = array[0]
+            arr = _np.asarray(array)
+            dtype = dtype_map.get(arr.dtype)
+            if arr.ndim == 0:
+                value = arr.item()
+                if dtype is None:
+                    return torch.tensor(value)
+                return torch.tensor(value, dtype=dtype)
+            data = _np.array(arr, copy=True)
+            if dtype is None:
+                tensor = torch.tensor(data)
+            else:
+                tensor = torch.tensor(data, dtype=dtype)
+            if tensor.shape != arr.shape:
+                tensor = tensor.reshape(arr.shape)
+            return tensor
+
+        torch.from_numpy = _from_numpy_fallback  # type: ignore[assignment]
+
+        tensor_dtype_map = {
+            torch.float32: _np.float32,
+            torch.float64: _np.float64,
+            torch.float16: _np.float16,
+            torch.int64: _np.int64,
+            torch.int32: _np.int32,
+            torch.int16: _np.int16,
+            torch.int8: _np.int8,
+            torch.uint8: _np.uint8,
+            torch.bool: _np.bool_,
+            torch.complex64: _np.complex64,
+            torch.complex128: _np.complex128,
+        }
+
+        def _tensor_numpy(self):  # pragma: no cover - exercised indirectly in tests
+            array = self.detach().cpu()
+            dtype = tensor_dtype_map.get(array.dtype)
+            data = array.tolist()
+            if dtype is None:
+                return _np.asarray(data)
+            return _np.asarray(data, dtype=dtype)
+
+        torch.Tensor.numpy = _tensor_numpy  # type: ignore[assignment]
+
+
+_ensure_torch_numpy_compat()
+
 try:  # Ensure prometheus_client is loaded before tests patch it
     import prometheus_client  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
@@ -19,7 +109,7 @@ except Exception:  # pragma: no cover - optional dependency may be missing
 __version__ = "0.1.0"
 
 # Re-export modules subpackage for convenient access
-from . import affinity  # noqa: F401
+from . import affinity  # noqa: F401,E402
 
 # Importing heavy submodules like ``goal_scheduler`` at module import time can
 # trigger circular import errors during test collection.  Avoid eager imports and
@@ -59,8 +149,8 @@ try:  # pragma: no cover - optional dependency may be missing
     from . import orchestrator  # type: ignore  # noqa: F401
 except Exception:  # pragma: no cover - optional dependency may be missing
     pass
-from . import persona  # noqa: F401
-from . import utils  # noqa: F401
+from . import persona  # noqa: F401,E402
+from . import utils  # noqa: F401,E402
 
 # neuromorphic uses optional nengo dependency
 try:  # pragma: no cover - optional dependency may be missing
@@ -69,4 +159,4 @@ except Exception:  # pragma: no cover - optional dependency may be missing
     neuromorphic = None  # type: ignore
 
 # risk scoring utilities rely only on builtin dependencies
-from . import risk  # noqa: F401
+from . import risk  # noqa: F401,E402

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -223,6 +223,21 @@ class PerceptionEmbeddingsEvent(EventPayload):
     provenance: Dict[str, Any] = field(default_factory=dict)
     payload: PerceptionEmbeddingsPayload | None = None
 
+    def to_json(self) -> str:
+        """Return a JSON representation with flattened payload fields."""
+
+        payload_dict = asdict(self.payload) if self.payload else {}
+        base = {
+            "event": self.event,
+            "version": self.version,
+            "encoders": [asdict(enc) for enc in self.encoders],
+            "provenance": dict(self.provenance),
+        }
+        combined = {**base, **payload_dict}
+        if self.payload:
+            combined["payload"] = payload_dict
+        return json.dumps(combined)
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PerceptionEmbeddingsEvent":
         # Deduplicate encoders by (name, modality) to mirror publisher behaviour
@@ -231,7 +246,10 @@ class PerceptionEmbeddingsEvent(EventPayload):
             key = (enc.get("name"), enc.get("modality"))
             enc_map.setdefault(key, EncoderMetadata(**enc))
         encoders = list(enc_map.values())
-        payload_data = data.get("payload", {})
+        payload_data = data.get("payload")
+        if not payload_data:
+            payload_keys = {"message_id", "user_id", "fused", "by_modality"}
+            payload_data = {k: data[k] for k in payload_keys if k in data}
         payload = PerceptionEmbeddingsPayload.from_dict(payload_data) if payload_data else None
         return cls(
             event=data.get("event", EventSubjects.PERCEPTION_EMBEDDINGS),

--- a/src/deepthought/memory/vector_store.py
+++ b/src/deepthought/memory/vector_store.py
@@ -33,6 +33,16 @@ except Exception:  # pragma: no cover - chromadb not installed
         def count(self) -> int:
             return len(self.docs)
 
+        def get(self, ids, include=None):  # type: ignore[override]
+            existing_ids: list[str] = []
+            docs: list[Any] = []
+            for _id in ids:
+                key = str(_id)
+                if key in self.docs:
+                    existing_ids.append(key)
+                    docs.append(self.docs[key])
+            return {"ids": existing_ids, "documents": docs}
+
     class _DummyClient:
         def get_or_create_collection(self, name, embedding_function=None):
             return _DummyCollection()
@@ -88,6 +98,15 @@ class VectorStore(ABC):
         metadatas: Optional[Sequence[dict]] = None,
     ) -> None:
         """Upsert pre-computed vectors keyed by ``ids``."""
+
+    def missing_ids(self, ids: Sequence[str]) -> list[str]:
+        """Return IDs from ``ids`` that are not already present in the store."""
+        try:
+            res = self.collection.get(ids=list(ids))
+            existing = set(res.get("ids", []))
+        except Exception:  # pragma: no cover - best effort
+            existing = set()
+        return [str(_id) for _id in ids if str(_id) not in existing]
 
 
 class ChromaVectorStore(VectorStore):
@@ -181,6 +200,9 @@ class FaissVectorStore(VectorStore):
                 self._outer._delete(ids)
 
         return _Coll(self)
+
+    def missing_ids(self, ids: Sequence[str]) -> list[str]:
+        return [str(_id) for _id in ids if str(_id) not in self._id_to_internal_id]
 
     def _delete(self, ids: Sequence[str]) -> None:
         import numpy as np

--- a/src/deepthought/perception/worker_audio.py
+++ b/src/deepthought/perception/worker_audio.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """Audio worker utilities.
 
 This module extracts windowed audio embeddings and caches results using
@@ -7,6 +5,8 @@ memory-mapped arrays. Each window emits a ``[start, end]`` timestamp that
 aligns with the text worker grid. Embeddings are produced from either
 ``WavLM`` or ``CLAP`` models.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable, Tuple
@@ -17,9 +17,27 @@ from scipy.io import wavfile
 from deepthought.config import get_settings
 
 
+def _parse_model_spec(spec: str | Path | None) -> tuple[str | Path | None, str | None]:
+    """Return a normalized (identifier, revision) tuple for ``spec``."""
+
+    if spec is None:
+        return None, None
+    if isinstance(spec, Path):
+        return spec, None
+    name = spec.strip()
+    if not name:
+        return None, None
+    if "@" not in name:
+        return name, None
+    base, revision = name.split("@", 1)
+    base = base.strip() or None
+    revision = revision.strip() or None
+    return base, revision
+
+
 def _select_embedding_fn(
     model: str,
-    model_path: str | None,
+    model_path: str | Path | None,
     sampling_rate: int,
 ) -> Callable[[np.ndarray], np.ndarray]:
     """Return a function that maps a waveform to an embedding.
@@ -34,15 +52,24 @@ def _select_embedding_fn(
         Sampling rate of the audio in Hertz.
     """
 
-    model = model.lower()
-    if model == "wavlm":
+    model_name, model_revision = _parse_model_spec(model)
+    if not model_name:
+        raise ValueError(f"Unsupported model: {model}")
+    model_key = str(model_name).lower()
+
+    path_name, path_revision = _parse_model_spec(model_path)
+
+    if model_key == "wavlm":
         try:
             import torch
             from transformers import WavLMFeatureExtractor, WavLMModel  # type: ignore
 
-            name = model_path or "microsoft/wavlm-base-plus"
-            extractor = WavLMFeatureExtractor.from_pretrained(name)
-            mdl = WavLMModel.from_pretrained(name)
+            name = str(path_name) if path_name is not None else "microsoft/wavlm-base-plus"
+            revision = path_revision or (model_revision if path_name is None else None)
+            load_kwargs = {"revision": revision} if revision else {}
+
+            extractor = WavLMFeatureExtractor.from_pretrained(name, **load_kwargs)
+            mdl = WavLMModel.from_pretrained(name, **load_kwargs)
             mdl.eval()
 
             def embed(window: np.ndarray) -> np.ndarray:
@@ -55,14 +82,17 @@ def _select_embedding_fn(
         except Exception:  # pragma: no cover - optional dependency
             pass
 
-    elif model == "clap":
+    elif model_key == "clap":
         try:
             import torch
             from transformers import ClapModel, ClapProcessor  # type: ignore
 
-            name = model_path or "laion/clap-htsat-unfused"
-            processor = ClapProcessor.from_pretrained(name)
-            mdl = ClapModel.from_pretrained(name)
+            name = str(path_name) if path_name is not None else "laion/clap-htsat-unfused"
+            revision = path_revision or (model_revision if path_name is None else None)
+            load_kwargs = {"revision": revision} if revision else {}
+
+            processor = ClapProcessor.from_pretrained(name, **load_kwargs)
+            mdl = ClapModel.from_pretrained(name, **load_kwargs)
             mdl.eval()
 
             def embed(window: np.ndarray) -> np.ndarray:
@@ -100,7 +130,7 @@ def extract_windowed_features(
     cache_dir: str | Path | None = None,
     *,
     model: str = "wavlm",
-    model_path: str | None = None,
+    model_path: str | Path | None = None,
 ) -> Tuple[np.memmap, np.ndarray]:
     """Return embedding features and per-window timestamps for ``audio_path``.
 

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -16,7 +16,6 @@ from ..eda.events import (
     BDIIntentionPayload,
     EventSubjects,
     MemoryRetrievedPayload,
-    PerceptionEmbeddingsEvent,
     PerceptionEmbeddingsPayload,
 )
 from ..memory import create_memory_backend
@@ -219,8 +218,11 @@ class CognitiveCoreService(BaseService):
                     first_mod = next(iter(payload.by_modality.values()))
                     vectors = first_mod.embeddings
                 if vectors:
-                    for idx, vector in enumerate(vectors):
-                        store.upsert_vectors([vector], [f"{message_id}:{idx}"])
+                    ids = [f"{message_id}:{idx}" for idx in range(len(vectors))]
+                    missing = getattr(store, "missing_ids", lambda x: list(x))(ids)
+                    if missing:
+                        new_vectors = [v for v, _id in zip(vectors, ids) if _id in missing]
+                        store.upsert_vectors(new_vectors, missing)
 
             # Insert nodes/edges in the KG with modality and timestamp metadata
             if graph:
@@ -228,6 +230,15 @@ class CognitiveCoreService(BaseService):
                 for modality, mod in payload.by_modality.items():
                     for idx, span in enumerate(mod.spans):
                         span_id = f"{message_id}:{idx}"
+                        try:
+                            exists = graph.query_subgraph(
+                                "MATCH (:Message {id: $mid})-[:HAS_SPAN]->(:Span {id: $sid}) RETURN 1",
+                                {"mid": message_id, "sid": span_id},
+                            )
+                            if exists:
+                                continue
+                        except Exception:  # pragma: no cover - defensive
+                            pass
                         vector = None
                         if payload.fused and idx < len(payload.fused):
                             vector = payload.fused[idx]

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -61,10 +61,18 @@ class PerceptionPublisher:
             for name, meta in (by_modality or {}).items()
         }
 
+        fused_vectors: list[list[float]] | None = None
+        if fused is not None:
+            fused_list = list(fused)
+            if fused_list and isinstance(fused_list[0], (int, float)):
+                fused_vectors = [[float(x) for x in fused_list]]
+            else:
+                fused_vectors = [[float(x) for x in emb] for emb in fused_list]
+
         payload = PerceptionEmbeddingsPayload(
             message_id=message_id,
             user_id=user_id,
-            fused=[[float(x) for x in emb] for emb in fused] if fused is not None else None,
+            fused=fused_vectors,
             by_modality=modality_payloads,
         )
 


### PR DESCRIPTION
## Summary
- allow audio model specs with revision suffixes and propagate revisions to wavlm/clap loaders
- add torch numpy fallbacks and flatten perception event JSON for tests when numpy-backed conversion is unavailable
- normalize fused embeddings input to handle single-vector sequences

## Testing
- `ruff check src/deepthought/perception/worker_audio.py`
- `ruff check src/deepthought/__init__.py`
- `ruff check src/deepthought/eda/events.py`
- `ruff check src/deepthought/services/perception/publisher.py`
- `pytest tests/integration/test_perception_event_publish_memory.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c81d9db0d88326ad43da8ab00eb6a2