### PR TITLE
Handle stored user embeddings spanning grid windows

### DIFF
--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -36,7 +36,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class PerceptionService:
-    """Orchestrate worker outputs and publish fused embeddings."""
+    """Orchestrate worker outputs and publish fused embeddings.
+
+    When multiple modalities are processed a :class:`~deepthought.modules.fuser.ModalityFuser`
+    must be provided. Configuring :class:`~.user_embeddings.UserEmbeddings` enables persistence of the
+    fused representation for the associated ``user_id`` after each run.
+    """
 
     publisher: PerceptionPublisher
     text_worker: TextPerceptionWorker | None = None
@@ -75,6 +80,8 @@ class PerceptionService:
                 )
             except Exception:  # pragma: no cover - wandb may be missing
                 wandb_run = None
+
+        store_embedding: torch.Tensor | None = None
 
         if embeddings is None:
             provenance = dict(provenance or {})
@@ -226,6 +233,9 @@ class PerceptionService:
             if not modality_arrays:
                 raise ValueError("No modalities available for publication")
 
+            if len(modality_arrays) > 1 and self.fuser is None:
+                raise ValueError("Multiple modalities available but no fuser configured")
+
             provenance.setdefault("modalities", list(modality_arrays.keys()))
 
             hop = (
@@ -272,23 +282,77 @@ class PerceptionService:
 
             fused_list: Sequence[Sequence[float]] | None = None
             if self.fuser is not None:
-                existing_user_embedding = (
-                    self.user_embeddings.get(user_id) if self.user_embeddings is not None else None
-                )
+                embedding_store = None
+                existing_user_embedding = None
+                if self.user_embeddings is not None and getattr(self.fuser, "user_dim", 0) > 0:
+                    embedding_store = self.user_embeddings
+                    stored_embedding = embedding_store.get(user_id)
+                    if stored_embedding is not None:
+                        if stored_embedding.shape[-1] == self.fuser.user_dim:
+                            expanded = stored_embedding.detach().clone()
+                            if expanded.ndim == 1:
+                                expanded = expanded.unsqueeze(0)
+                            if expanded.ndim == 2:
+                                span_count = len(spans)
+                                if span_count == 0:
+                                    logger.warning("No spans generated; skipping stored embedding for user %s", user_id)
+                                else:
+                                    if expanded.size(0) == 1 and span_count > 1:
+                                        expanded = expanded.expand(span_count, -1)
+                                    if expanded.size(0) == span_count:
+                                        existing_user_embedding = expanded
+                                    else:
+                                        logger.warning(
+                                            "Stored embedding for user %s has %s spans but %s expected; ignoring",
+                                            user_id,
+                                            expanded.size(0),
+                                            span_count,
+                                        )
+                            else:
+                                logger.warning(
+                                    "Stored embedding for user %s has %s dimensions; expected 1 or 2", user_id, expanded.ndim
+                                )
+                        else:
+                            logger.warning(
+                                "Stored embedding for user %s has dimension %s but expected %s; ignoring",
+                                user_id,
+                                stored_embedding.shape[-1],
+                                self.fuser.user_dim,
+                            )
                 fused_tensor = self.fuser(
                     aligned_modalities,
                     user_embedding=existing_user_embedding,
                     user_id=user_id,
-                    embedding_store=self.user_embeddings,
+                    embedding_store=embedding_store,
                 )
                 fused_list = fused_tensor.tolist()
+                if fused_tensor.numel() > 0:
+                    if fused_tensor.ndim > 1:
+                        store_embedding = fused_tensor.mean(dim=0).detach()
+                    else:
+                        store_embedding = fused_tensor.detach()
             else:
                 first = next(iter(aligned_modalities.values()))
                 fused_list = first.tolist()
+                if first.numel() > 0:
+                    if first.ndim > 1:
+                        store_embedding = first.mean(dim=0).detach()
+                    else:
+                        store_embedding = first.detach()
 
         else:
             modality_payload = {}
             fused_list = embeddings  # type: ignore[assignment]
+            if self.user_embeddings is not None:
+                fused_tensor = torch.tensor(embeddings, dtype=torch.float32)
+                if fused_tensor.numel() > 0:
+                    if fused_tensor.ndim > 1:
+                        store_embedding = fused_tensor.mean(dim=0)
+                    else:
+                        store_embedding = fused_tensor
+
+        if self.user_embeddings is not None and store_embedding is not None and store_embedding.numel() > 0:
+            self.user_embeddings.set(user_id, store_embedding)
 
         await self.publisher.publish(
             message_id=message_id,

--- a/tests/unit/test_perception_service.py
+++ b/tests/unit/test_perception_service.py
@@ -4,8 +4,11 @@ import asyncio
 from typing import Dict, Sequence, Tuple
 
 import numpy as np
+import pytest
+import torch
 
 from deepthought.services.perception.service import PerceptionService
+from deepthought.services.perception.user_embeddings import UserEmbeddings
 
 
 class DummyPublisher:
@@ -24,6 +27,35 @@ class DummyTextWorker:
         mm.flush()
         times = np.array([[0.0, 0.05], [0.05, 0.1]], dtype=np.float32)
         return mm, times
+
+
+class DummyAudioWorker:
+    cache_dir = None
+    model = "dummy"
+    window_size = 1
+    step_size = 1
+
+    def __call__(self, path: str, cache_dir=None):  # pragma: no cover - simple stub
+        feats = np.array([[0.5, 0.5], [0.25, 0.25]], dtype="float32")
+        times = np.array([[0.0, 0.05], [0.05, 0.1]], dtype=np.float32)
+        return feats, times
+
+
+class SumFuser:
+    def __init__(self):
+        self.modality_dims = {"text": 2, "audio": 2}
+        self.user_dim = 0
+
+    def __call__(
+        self,
+        modalities: Dict[str, torch.Tensor],
+        user_embedding=None,
+        user_id: str | None = None,
+        embedding_store=None,
+    ) -> torch.Tensor:  # pragma: no cover - deterministic stub
+        ordered = [modalities[name] for name in sorted(modalities.keys())]
+        stacked = torch.stack(ordered, dim=0)
+        return stacked.sum(dim=0)
 
 
 def test_service_publishes_raw_embeddings_and_metadata():
@@ -67,6 +99,7 @@ def test_service_handles_video_modality():
             message_id="m1",
             user_id="u1",
             video_path="video.mp4",
+            video_opt_in=True,
             provenance={"test": True},
         )
     )
@@ -78,3 +111,108 @@ def test_service_handles_video_modality():
     assert video_meta["spans"] == [[0, 1000], [1000, 2000]]
     assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
     assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}
+
+
+def test_service_requires_fuser_for_multiple_modalities(tmp_path):
+    publisher = DummyPublisher()
+    service = PerceptionService(
+        publisher,
+        text_worker=DummyTextWorker(),
+        audio_worker=DummyAudioWorker(),
+    )
+
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"00")
+
+    with pytest.raises(ValueError, match="fuser"):
+        asyncio.run(
+            service.run(
+                message_id="m1",
+                user_id="u1",
+                text_tokens=[("hi", 0.0, 0.1)],
+                audio_path=audio_path,
+                audio_opt_in=True,
+                retain_media=True,
+            )
+        )
+
+
+def test_service_updates_user_embeddings(tmp_path):
+    publisher = DummyPublisher()
+    store_path = tmp_path / "store.json"
+    user_store = UserEmbeddings(store_path)
+    service = PerceptionService(
+        publisher,
+        text_worker=DummyTextWorker(),
+        audio_worker=DummyAudioWorker(),
+        fuser=SumFuser(),
+        user_embeddings=user_store,
+    )
+
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"00")
+
+    asyncio.run(
+        service.run(
+            message_id="m1",
+            user_id="u1",
+            text_tokens=[("hi", 0.0, 0.1)],
+            audio_path=audio_path,
+            audio_opt_in=True,
+            retain_media=True,
+        )
+    )
+
+    assert publisher.kwargs is not None
+    assert publisher.kwargs["fused"] == [[1.5, 2.5], [3.25, 4.25]]
+
+    stored = user_store.get("u1")
+    assert stored is not None
+    expected = torch.tensor([2.375, 3.375], dtype=torch.float32)
+    assert torch.allclose(stored, expected)
+
+
+class UserAwareFuser:
+    def __init__(self):
+        self.modality_dims = {"text": 2}
+        self.user_dim = 2
+
+    def __call__(
+        self,
+        modalities: Dict[str, torch.Tensor],
+        user_embedding=None,
+        user_id: str | None = None,
+        embedding_store=None,
+    ) -> torch.Tensor:
+        assert user_embedding is not None
+        assert user_embedding.shape == modalities["text"].shape
+        return modalities["text"] + user_embedding
+
+
+def test_service_expands_stored_user_embedding(tmp_path):
+    publisher = DummyPublisher()
+    store_path = tmp_path / "store.json"
+    user_store = UserEmbeddings(store_path)
+    user_store.set("u1", torch.tensor([0.5, 1.5], dtype=torch.float32))
+    service = PerceptionService(
+        publisher,
+        text_worker=DummyTextWorker(),
+        fuser=UserAwareFuser(),
+        user_embeddings=user_store,
+    )
+
+    asyncio.run(
+        service.run(
+            message_id="m1",
+            user_id="u1",
+            text_tokens=[("hi", 0.0, 0.1)],
+        )
+    )
+
+    assert publisher.kwargs is not None
+    assert publisher.kwargs["fused"] == [[1.5, 3.5], [3.5, 5.5]]
+
+    stored = user_store.get("u1")
+    assert stored is not None
+    expected = torch.tensor([2.5, 4.5], dtype=torch.float32)
+    assert torch.allclose(stored, expected)


### PR DESCRIPTION
## Summary
- expand persisted user embeddings to the perception grid span count before passing them to the fuser, including warnings for mismatched shapes
- require video consent in the unit test harness and add coverage that stored embeddings broadcast correctly across spans

## Testing
- flake8 src tests
- pytest tests/unit/test_perception_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c978d12f488326883653d93fef7fd5