### PR TITLE
Add Whisper ASR with transcript caching

### DIFF
--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -1,5 +1,6 @@
 """Perception utilities for DeepThought services."""
 
+from .asr import transcribe_audio_tokens
 from .cli import main
 from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
@@ -12,6 +13,7 @@ from .worker_video import VideoPerceptionWorker
 __all__ = [
     "TextPerceptionWorker",
     "AudioPerceptionWorker",
+    "transcribe_audio_tokens",
     "PerceptionService",
     "PerceptionPublisher",
     "UserEmbeddings",

--- a/src/deepthought/services/perception/asr.py
+++ b/src/deepthought/services/perception/asr.py
@@ -1,0 +1,269 @@
+"""Automatic speech recognition utilities for the perception service.
+
+This module provides a thin wrapper around the MIT-licensed `openai/whisper`
+model family. It exposes :func:`transcribe_audio_tokens` which yields
+time-aligned ``(token, start, end)`` tuples for a given audio file and stores
+results next to cached audio feature memmaps for later reuse.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+from pathlib import Path
+from typing import Any, Iterable, List, Sequence, Tuple
+
+from .config import PerceptionConfig
+
+# A recognised token represented as ``(text, start_time, end_time)`` in seconds.
+Token = Tuple[str, float, float]
+
+_LOG = logging.getLogger(__name__)
+_CACHE_VERSION = 1
+_MODEL_CACHE: dict[tuple[str, str | None], Any] = {}
+
+
+def _resolve_cache_dir(audio_path: Path, cache_dir: str | Path | None, cfg: PerceptionConfig) -> Path:
+    """Return the directory that should contain cache artefacts."""
+
+    if cache_dir is not None:
+        base = Path(cache_dir)
+    elif cfg.audio_cache_dir is not None:
+        base = Path(cfg.audio_cache_dir)
+    else:
+        base = audio_path.parent
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _transcript_cache_path(
+    audio_path: Path,
+    cache_dir: Path,
+    audio_model: str,
+    window_size: float,
+    step_size: float,
+) -> Path:
+    """Return the JSON cache path mirroring the audio memmap naming scheme."""
+
+    memmap_name = f"{audio_path.stem}_{audio_model}_ws{window_size}_ss{step_size}.dat"
+    memmap_path = cache_dir / memmap_name
+    return memmap_path.with_suffix(".transcript.json")
+
+
+def _load_cached_tokens(
+    cache_path: Path,
+    *,
+    expected_model: str,
+    expected_language: str | None,
+    expected_mtime_ns: int,
+) -> List[Token] | None:
+    """Load cached tokens if the metadata matches the current request."""
+
+    try:
+        with cache_path.open("r", encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except Exception:  # pragma: no cover - cache corruption is rare
+        _LOG.warning("Failed to read ASR cache at %%s", cache_path, exc_info=True)
+        return None
+
+    if payload.get("version") != _CACHE_VERSION:
+        return None
+    if payload.get("model") != expected_model:
+        return None
+    if payload.get("requested_language") != expected_language:
+        return None
+    if payload.get("audio_mtime_ns") != expected_mtime_ns:
+        return None
+
+    tokens_payload = payload.get("tokens")
+    if not isinstance(tokens_payload, list):
+        return None
+
+    tokens: List[Token] = []
+    try:
+        for item in tokens_payload:
+            text = str(item["text"])
+            start = float(item["start"])
+            end = float(item["end"])
+            tokens.append((text, start, end))
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    return tokens
+
+
+def _store_cached_tokens(
+    cache_path: Path,
+    tokens: Sequence[Token],
+    *,
+    model: str,
+    language: str | None,
+    detected_language: str | None,
+    audio_mtime_ns: int,
+) -> None:
+    """Persist a transcript cache entry in JSON format."""
+
+    payload = {
+        "version": _CACHE_VERSION,
+        "model": model,
+        "requested_language": language,
+        "detected_language": detected_language,
+        "audio_mtime_ns": audio_mtime_ns,
+        "tokens": [
+            {"text": text, "start": start, "end": end}
+            for text, start, end in tokens
+        ],
+    }
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = cache_path.with_suffix(cache_path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+    tmp_path.replace(cache_path)
+
+
+def _load_whisper_model(model_name: str, device: str | None) -> Any:
+    """Return a cached Whisper model instance."""
+
+    cache_key = (model_name, device)
+    if cache_key in _MODEL_CACHE:
+        return _MODEL_CACHE[cache_key]
+
+    try:
+        whisper = importlib.import_module("whisper")
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(
+            "The 'whisper' package is required for ASR support. Install it via "
+            "'pip install openai-whisper'."
+        ) from exc
+
+    load_kwargs: dict[str, Any] = {}
+    if device is not None:
+        load_kwargs["device"] = device
+
+    model = whisper.load_model(model_name, **load_kwargs)
+    _MODEL_CACHE[cache_key] = model
+    return model
+
+
+def _extract_tokens(result: dict[str, Any]) -> List[Token]:
+    """Convert a Whisper transcription result into ``Token`` objects."""
+
+    segments: Iterable[dict[str, Any]] = result.get("segments", []) or []
+    tokens: List[Token] = []
+
+    for segment in segments:
+        words = segment.get("words")
+        if words:
+            for word in words:
+                start = word.get("start")
+                end = word.get("end")
+                text = word.get("word", "")
+                if start is None or end is None:
+                    continue
+                text = str(text).strip()
+                if not text:
+                    continue
+                tokens.append((text, float(start), float(end)))
+        else:
+            start = segment.get("start")
+            end = segment.get("end")
+            text = segment.get("text", "")
+            if start is None or end is None:
+                continue
+            text = str(text).strip()
+            if not text:
+                continue
+            tokens.append((text, float(start), float(end)))
+
+    tokens.sort(key=lambda item: item[1])
+    return tokens
+
+
+def transcribe_audio_tokens(
+    audio_path: str | Path,
+    *,
+    model_name: str = "small",
+    language: str | None = None,
+    device: str | None = None,
+    cache_dir: str | Path | None = None,
+    audio_model: str | None = None,
+    window_size: float | None = None,
+    step_size: float | None = None,
+) -> List[Token]:
+    """Return a list of ``(token, start, end)`` tuples for ``audio_path``.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to an input audio file compatible with Whisper.
+    model_name:
+        Whisper model variant to load (e.g. ``"small"`` or ``"base"``).
+    language:
+        Optional language code. When ``None`` Whisper performs language
+        detection automatically.
+    device:
+        Optional device specifier (e.g. ``"cuda"``) forwarded to Whisper.
+    cache_dir:
+        Directory in which to store transcript caches. When omitted, the
+        perception configuration determines the location and falls back to the
+        audio file's parent directory.
+    audio_model, window_size, step_size:
+        Parameters mirroring the audio feature extraction configuration. They
+        ensure transcript caches live beside the corresponding audio memmaps.
+    """
+
+    audio_path = Path(audio_path)
+    if not audio_path.exists():
+        raise FileNotFoundError(f"Audio file not found: {audio_path}")
+
+    cfg = PerceptionConfig()
+    effective_audio_model = audio_model or cfg.audio_model
+    effective_window_size = window_size if window_size is not None else cfg.audio_window_size
+    effective_step_size = step_size if step_size is not None else cfg.audio_hop_size
+
+    cache_base = _resolve_cache_dir(audio_path, cache_dir, cfg)
+    transcript_path = _transcript_cache_path(
+        audio_path,
+        cache_base,
+        effective_audio_model,
+        effective_window_size,
+        effective_step_size,
+    )
+
+    audio_mtime_ns = audio_path.stat().st_mtime_ns
+    cached = _load_cached_tokens(
+        transcript_path,
+        expected_model=model_name,
+        expected_language=language,
+        expected_mtime_ns=audio_mtime_ns,
+    )
+    if cached is not None:
+        return cached
+
+    model = _load_whisper_model(model_name, device)
+    result = model.transcribe(
+        str(audio_path),
+        language=language,
+        task="transcribe",
+        word_timestamps=True,
+        verbose=False,
+    )
+
+    tokens = _extract_tokens(result)
+    detected_language = result.get("language") if isinstance(result, dict) else None
+
+    _store_cached_tokens(
+        transcript_path,
+        tokens,
+        model=model_name,
+        language=language,
+        detected_language=detected_language,
+        audio_mtime_ns=audio_mtime_ns,
+    )
+
+    return tokens

--- a/tests/test_perception_workers.py
+++ b/tests/test_perception_workers.py
@@ -1,10 +1,101 @@
+import os
+import sys
+import types
+from pathlib import Path
+
+os.environ.setdefault("DEEPTHOUGHT_LIGHT_IMPORT", "1")
+
+import importlib.util
+
 import numpy as np
 import pytest
 from scipy.io import wavfile
 
-from deepthought.services.perception.worker_audio import AudioPerceptionWorker
-from deepthought.services.perception.worker_text import TextPerceptionWorker
-from deepthought.services.perception.worker_video import VideoPerceptionWorker
+_stub_aiosqlite = types.ModuleType("aiosqlite")
+_stub_aiosqlite.connect = None  # type: ignore[attr-defined]
+sys.modules.setdefault("aiosqlite", _stub_aiosqlite)
+
+_stub_pyperplan = types.ModuleType("pyperplan")
+_stub_pyperplan_pddl = types.ModuleType("pyperplan.pddl")
+_stub_pyperplan_parser = types.ModuleType("pyperplan.pddl.parser")
+_stub_pyperplan_planner = types.ModuleType("pyperplan.planner")
+_stub_pyperplan_search = types.ModuleType("pyperplan.search")
+
+_stub_pyperplan.__path__ = []  # type: ignore[attr-defined]
+
+
+class _DummyParser:  # pragma: no cover - never executed in these tests
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise RuntimeError("pyperplan is not available in the test environment")
+
+
+_stub_pyperplan_parser.Parser = _DummyParser  # type: ignore[attr-defined]
+_stub_pyperplan_pddl.parser = _stub_pyperplan_parser  # type: ignore[attr-defined]
+_stub_pyperplan.pddl = _stub_pyperplan_pddl  # type: ignore[attr-defined]
+_stub_pyperplan_planner._ground = lambda problem: problem  # type: ignore[attr-defined]
+_stub_pyperplan_search.breadth_first_search = lambda task: []  # type: ignore[attr-defined]
+
+sys.modules.setdefault("pyperplan", _stub_pyperplan)
+sys.modules.setdefault("pyperplan.pddl", _stub_pyperplan_pddl)
+sys.modules.setdefault("pyperplan.pddl.parser", _stub_pyperplan_parser)
+sys.modules.setdefault("pyperplan.planner", _stub_pyperplan_planner)
+sys.modules.setdefault("pyperplan.search", _stub_pyperplan_search)
+sys.modules.setdefault("cv2", types.ModuleType("cv2"))
+
+_stub_pil = types.ModuleType("PIL")
+_stub_pil_image = types.ModuleType("PIL.Image")
+_stub_pil.Image = _stub_pil_image  # type: ignore[attr-defined]
+sys.modules.setdefault("PIL", _stub_pil)
+sys.modules.setdefault("PIL.Image", _stub_pil_image)
+
+_services_stub = types.ModuleType("deepthought.services")
+_services_stub.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "src" / "deepthought" / "services")
+]
+sys.modules.setdefault("deepthought.services", _services_stub)
+
+import deepthought  # noqa: E402  # ensure the root package is loaded
+
+setattr(deepthought, "services", _services_stub)
+
+_perception_stub = types.ModuleType("deepthought.services.perception")
+_perception_stub.__path__ = [
+    str(Path(__file__).resolve().parents[1] / "src" / "deepthought" / "services" / "perception")
+]
+sys.modules.setdefault("deepthought.services.perception", _perception_stub)
+setattr(_services_stub, "perception", _perception_stub)
+
+
+def _load_perception_module(module: str):
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "deepthought"
+        / "services"
+        / "perception"
+        / f"{module}.py"
+    )
+    full_name = f"deepthought.services.perception.{module}"
+    spec = importlib.util.spec_from_file_location(full_name, module_path)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = loaded
+    spec.loader.exec_module(loaded)
+    setattr(_perception_stub, module, loaded)
+    return loaded
+
+
+config_module = _load_perception_module("config")
+worker_audio_module = _load_perception_module("worker_audio")
+worker_text_module = _load_perception_module("worker_text")
+worker_video_module = _load_perception_module("worker_video")
+asr_module = _load_perception_module("asr")
+
+PerceptionConfig = config_module.PerceptionConfig
+AudioPerceptionWorker = worker_audio_module.AudioPerceptionWorker
+TextPerceptionWorker = worker_text_module.TextPerceptionWorker
+VideoPerceptionWorker = worker_video_module.VideoPerceptionWorker
+transcribe_audio_tokens = asr_module.transcribe_audio_tokens
 
 
 class _DummySentenceModel:
@@ -79,3 +170,66 @@ def test_text_perception_worker_redacts_pii(monkeypatch, tmp_path):
     assert model.last_text == expected
     exp_len = len(expected)
     assert np.allclose(feats[0], [exp_len, exp_len + 1])
+
+
+def test_asr_transcribe_audio_tokens_caches(monkeypatch, tmp_path):
+    audio_path = tmp_path / "sample.wav"
+    audio_path.write_bytes(b"RIFF")
+
+    load_calls: list[tuple[str, str | None]] = []
+
+    class _DummyModel:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def transcribe(self, path: str, **_: object):
+            self.calls += 1
+            return {
+                "language": "en",
+                "segments": [
+                    {
+                        "start": 0.0,
+                        "end": 1.0,
+                        "text": "hello world",
+                        "words": [
+                            {"word": "hello", "start": 0.0, "end": 0.5},
+                            {"word": "world", "start": 0.5, "end": 1.0},
+                        ],
+                    }
+                ],
+            }
+
+    dummy_model = _DummyModel()
+
+    def _load_model(name: str, *, device: str | None = None, **_: object):
+        load_calls.append((name, device))
+        return dummy_model
+
+    whisper_module = types.ModuleType("whisper")
+    whisper_module.load_model = _load_model  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "whisper", whisper_module)
+
+    from deepthought.services.perception import asr as asr_module
+
+    asr_module._MODEL_CACHE.clear()
+
+    tokens = transcribe_audio_tokens(audio_path, cache_dir=tmp_path, model_name="small", language="en")
+    assert tokens == [("hello", 0.0, 0.5), ("world", 0.5, 1.0)]
+    assert dummy_model.calls == 1
+    assert load_calls == [("small", None)]
+
+    # Second call should reuse the cached transcript and avoid another model invocation.
+    cached_tokens = transcribe_audio_tokens(audio_path, cache_dir=tmp_path, model_name="small", language="en")
+    assert cached_tokens == tokens
+    assert dummy_model.calls == 1
+    assert load_calls == [("small", None)]
+
+    cfg = PerceptionConfig()
+    expected_cache = (
+        tmp_path
+        / f"{audio_path.stem}_{cfg.audio_model}_ws{cfg.audio_window_size}_ss{cfg.audio_hop_size}.transcript.json"
+    )
+    assert expected_cache.exists()
+
+    asr_module._MODEL_CACHE.clear()


### PR DESCRIPTION
## Summary
- add a Whisper-based `transcribe_audio_tokens` helper that caches JSON transcripts next to audio feature memmaps
- expose the ASR helper from the perception package for reuse
- extend perception worker tests with lightweight dependency stubs and an ASR caching check

## Testing
- pytest tests/test_perception_workers.py
- flake8 src tests

------
https://chatgpt.com/codex/tasks/task_e_68cacda74ab08326b97f079d0d4e98c6