### PR TITLE
Add CI enforcement for perception model licenses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,10 @@ jobs:
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-ci.txt
       - run: pip install -e . --no-deps
+      - name: Verify perception model versions and licenses
+        run: |
+          python scripts/check_model_versions.py
+          python scripts/verify_licenses.py
       - name: Run license audit
         run: python tools/license_audit.py
 
@@ -96,8 +100,6 @@ jobs:
       - run: pip install -r requirements-ci.txt
       - run: pip install dspy psl deepproblog
       - run: pip install -e . --no-deps
-      - name: Verify model versions
-        run: python scripts/check_model_versions.py
       - name: Run pre-commit
         if: matrix.python-version == '3.11'
         run: pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ DeepThought-ReThought is an experimental Artificial Intelligence (AI) project fo
 The project is hosted on GitHub: [https://github.com/d0tTino/DeepThought-ReThought](https://github.com/d0tTino/DeepThought-ReThought)
 
 See the [licenses guide](docs/licenses.md) for a list of bundled models and
-libraries and their permissive licenses.
+libraries and their permissive licenses, and review the
+[license verification workflow](docs/licenses.md#license-verification-workflow)
+before updating perception defaults.
 
 ## Installation
 

--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -53,14 +53,29 @@ upstream projects for the most current license information.
 ## License verification workflow
 
 Encoder model defaults live in `src/deepthought/services/perception/config.py`.
-When these defaults change, update `scripts/model_version_whitelist.json` with
-the new versions and their corresponding license information. After updating the
-whitelist and this document, verify everything with:
+Whenever you bump the `text_model`, `audio_model`, or `video_model` defaults you
+must keep `scripts/model_version_whitelist.json` and this license table in sync.
+The whitelist records the canonical model revisions alongside the license entry
+that should appear in this document.
+
+Follow this checklist when changing a perception default:
+
+1. Update the relevant field(s) in `PerceptionConfig`.
+2. Add the new revision and license metadata to
+   `scripts/model_version_whitelist.json` under both the top-level key and the
+   `licenses` section.
+3. Amend the table above so the **Component** and **License** columns match the
+   whitelist metadata.
+
+After editing the files, run the verification scripts locally to confirm the
+changes align:
 
 ```
 python scripts/check_model_versions.py
 python scripts/verify_licenses.py
 ```
 
-Both scripts will report an error if the versions or licenses diverge from the
-whitelist or if required entries are missing from this table.
+The CI `license_audit` job now executes the same commands. The workflow fails if
+the perception defaults drift from the whitelist or if the table omits required
+entries, ensuring perception model changes never merge without updated
+licenses.


### PR DESCRIPTION
## Summary
- ensure the license_audit job runs perception model and license verification scripts
- document the perception model and license update workflow and surface it from the README

## Testing
- flake8 scripts/check_model_versions.py scripts/verify_licenses.py
- pytest tests/unit/test_verify_licenses.py

------
https://chatgpt.com/codex/tasks/task_e_68cd658ba5d48326955c1e9314b857c6