### PR TITLE
Add text token synthesis utilities and update perception listener

### DIFF
--- a/src/deepthought/services/perception/cli.py
+++ b/src/deepthought/services/perception/cli.py
@@ -18,6 +18,7 @@ from .listener import PerceptionServiceListener
 from .publisher import PerceptionPublisher
 from .service import PerceptionService
 from .service import run as run_service
+from .text_utils import hop_aligned_tokens, scrub_tokens
 from .user_embeddings import UserEmbeddings
 from .worker_audio import AudioPerceptionWorker
 from .worker_text import TextPerceptionWorker
@@ -142,12 +143,11 @@ async def _main() -> None:
         if args.tokens_json:
             with open(args.tokens_json, "r", encoding="utf8") as f:
                 raw_tokens = json.load(f)
-            text_tokens = [(t[0], float(t[1]), float(t[2])) for t in raw_tokens]
+            text_tokens = scrub_tokens(raw_tokens)
         elif args.text_path:
             with open(args.text_path, "r", encoding="utf8") as f:
-                words = f.read().strip().split()
-            hop = cfg.text_hop_size
-            text_tokens = [(w, i * hop, (i + 1) * hop) for i, w in enumerate(words)]
+                text_content = f.read()
+            text_tokens = hop_aligned_tokens(text_content, cfg.text_hop_size)
 
     audio_worker = None
     if args.audio_path:

--- a/src/deepthought/services/perception/listener.py
+++ b/src/deepthought/services/perception/listener.py
@@ -14,6 +14,7 @@ from ...eda.events import EventSubjects, InputReceivedPayload
 from ...eda.subscriber import Subscriber
 from .config import PerceptionConfig
 from .service import PerceptionService
+from .text_utils import hop_aligned_tokens, scrub_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ class PerceptionServiceListener:
         self._default_user_id = default_user_id
         self._asr = asr
         cfg = PerceptionConfig()
+        self._config = cfg
         self._enable_asr_transcription = bool(getattr(cfg, "enable_asr_transcription", False))
 
     async def start(self, durable_name: str = "perception_listener") -> bool:
@@ -64,11 +66,23 @@ class PerceptionServiceListener:
                         await msg.ack()
                     return
 
+            payload_user_input: str | None = None
+            payload_input_id: str | None = None
             try:
                 payload = InputReceivedPayload.from_dict(raw)
-                message_id = payload.input_id or "unknown"
             except Exception:
-                message_id = raw.get("message_id") or "unknown"
+                payload_input_id = raw.get("input_id")
+                payload_user_input = raw.get("user_input")
+            else:
+                payload_input_id = payload.input_id
+                payload_user_input = payload.user_input
+
+            message_id = (
+                payload_input_id
+                or raw.get("message_id")
+                or raw.get("input_id")
+                or "unknown"
+            )
 
             user_id = (
                 raw.get("user_id")
@@ -93,6 +107,12 @@ class PerceptionServiceListener:
 
             audio_path = kwargs.get("audio_path")
             text_tokens = kwargs.get("text_tokens")
+            if text_tokens is None and isinstance(payload_user_input, str):
+                generated_tokens = hop_aligned_tokens(payload_user_input, self._config.text_hop_size)
+                if generated_tokens:
+                    kwargs["text_tokens"] = generated_tokens
+                    text_tokens = generated_tokens
+
             audio_opt_in = kwargs.get("audio_opt_in")
             if (
                 text_tokens is None
@@ -117,7 +137,9 @@ class PerceptionServiceListener:
                         extracted = tokens
 
                     if extracted is not None:
-                        kwargs["text_tokens"] = extracted
+                        sanitized = scrub_tokens(extracted)
+                        if sanitized:
+                            kwargs["text_tokens"] = sanitized
 
             await self._service.run(**{k: v for k, v in kwargs.items() if v is not None})
             if hasattr(msg, "ack") and callable(msg.ack):

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -27,7 +27,8 @@ from .config import PerceptionConfig
 from .publisher import PerceptionPublisher
 from .user_embeddings import UserEmbeddings
 from .worker_audio import AudioPerceptionWorker
-from .worker_text import TextPerceptionWorker, Token
+from .text_utils import Token
+from .worker_text import TextPerceptionWorker
 from .worker_video import VideoPerceptionWorker
 
 
@@ -231,7 +232,8 @@ class PerceptionService:
                 MISSING_MODALITY_TOTAL.labels(modality=name).inc()
 
             if not modality_arrays:
-                raise ValueError("No modalities available for publication")
+                logger.warning("No modalities available for message %s; skipping", message_id)
+                return
 
             if len(modality_arrays) > 1 and self.fuser is None:
                 raise ValueError("Multiple modalities available but no fuser configured")

--- a/src/deepthought/services/perception/text_utils.py
+++ b/src/deepthought/services/perception/text_utils.py
@@ -1,0 +1,54 @@
+"""Utilities for handling text tokens used by perception components."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Sequence, Tuple
+
+Token = Tuple[str, float, float]
+
+# Regular expressions matching common personally identifiable information (PII).
+PII_PATTERNS = [
+    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
+    re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"),
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+]
+
+
+def scrub_text(text: str) -> str:
+    """Redact common PII patterns from ``text``."""
+
+    for pattern in PII_PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text
+
+
+def scrub_tokens(tokens: Iterable[Sequence[object]]) -> List[Token]:
+    """Return tokens with their textual component scrubbed for PII."""
+
+    sanitized: List[Token] = []
+    for raw in tokens:
+        if len(raw) != 3:
+            continue
+        text, start, end = raw
+        sanitized.append((scrub_text(str(text)), float(start), float(end)))
+    return sanitized
+
+
+def hop_aligned_tokens(text: str, hop_seconds: float) -> List[Token]:
+    """Tokenize ``text`` into hop-aligned spans using ``hop_seconds``."""
+
+    if hop_seconds <= 0:
+        raise ValueError("hop_seconds must be positive")
+
+    scrubbed = scrub_text(text)
+    if not scrubbed:
+        return []
+
+    words = scrubbed.split()
+    tokens: List[Token] = []
+    for index, word in enumerate(words):
+        start = index * hop_seconds
+        end = (index + 1) * hop_seconds
+        tokens.append((word, start, end))
+    return tokens

--- a/src/deepthought/services/perception/worker_text.py
+++ b/src/deepthought/services/perception/worker_text.py
@@ -9,7 +9,6 @@ processing.
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence, Tuple
@@ -19,21 +18,7 @@ from sentence_transformers import SentenceTransformer
 
 from deepthought.config import get_settings
 
-# A token is represented as ``(text, start_time, end_time)`` where times are in seconds.
-Token = Tuple[str, float, float]
-
-
-PII_PATTERNS = [
-    re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"),
-    re.compile(r"\b\d{3}[-.]?\d{3}[-.]?\d{4}\b"),
-    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
-]
-
-
-def _scrub(text: str) -> str:
-    for pattern in PII_PATTERNS:
-        text = pattern.sub("[REDACTED]", text)
-    return text
+from .text_utils import Token, scrub_text
 
 
 @dataclass
@@ -69,7 +54,9 @@ class TextPerceptionWorker:
 
         memmap_path = Path(memmap_path)
 
-        scrubbed_tokens = [(_scrub(text), start, end) for text, start, end in tokens]
+        scrubbed_tokens = [
+            (scrub_text(str(text)), float(start), float(end)) for text, start, end in tokens
+        ]
 
         # Pre-compute embeddings to determine dimensionality
         embeddings = [np.asarray(self._model.encode(text)) for text, _, _ in scrubbed_tokens]

--- a/tests/integration/test_perception_listener.py
+++ b/tests/integration/test_perception_listener.py
@@ -63,6 +63,7 @@ from deepthought.eda.events import EventSubjects
 from deepthought.services.perception.listener import PerceptionServiceListener
 from deepthought.services.perception.publisher import PerceptionPublisher
 from deepthought.services.perception.service import PerceptionService
+from deepthought.services.perception.text_utils import hop_aligned_tokens
 
 
 class DummyPublisher:
@@ -108,10 +109,38 @@ async def test_perception_listener_publishes_embeddings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_listener_generates_tokens_from_user_input(monkeypatch):
+    monkeypatch.setattr(
+        "deepthought.services.perception.listener.PerceptionConfig",
+        lambda: SimpleNamespace(enable_asr_transcription=False, text_hop_size=0.05),
+    )
+
+    service = SimpleNamespace(run=AsyncMock())
+    listener = PerceptionServiceListener(
+        service,
+        FakeNATS(),
+        object(),
+        default_user_id="user",
+    )
+
+    payload = {"input_id": "m5", "user_input": "Email me at foo@example.com"}
+    msg = SimpleNamespace(data=json.dumps(payload).encode(), ack=AsyncMock(), headers=None)
+
+    await listener._handle(msg)
+
+    msg.ack.assert_awaited_once()
+    assert service.run.await_count == 1
+    _, kwargs = service.run.await_args
+    assert kwargs["message_id"] == "m5"
+    expected_tokens = hop_aligned_tokens(payload["user_input"], 0.05)
+    assert kwargs["text_tokens"] == expected_tokens
+
+
+@pytest.mark.asyncio
 async def test_listener_transcribes_audio_when_tokens_missing(monkeypatch):
     monkeypatch.setattr(
         "deepthought.services.perception.listener.PerceptionConfig",
-        lambda: SimpleNamespace(enable_asr_transcription=True),
+        lambda: SimpleNamespace(enable_asr_transcription=True, text_hop_size=0.05),
     )
     asr = SimpleNamespace(transcribe=AsyncMock(return_value=[("hello", 0.0, 1.0)]))
     service = SimpleNamespace(run=AsyncMock())
@@ -145,7 +174,7 @@ async def test_listener_transcribes_audio_when_tokens_missing(monkeypatch):
 async def test_listener_skips_asr_without_flag(monkeypatch):
     monkeypatch.setattr(
         "deepthought.services.perception.listener.PerceptionConfig",
-        lambda: SimpleNamespace(enable_asr_transcription=False),
+        lambda: SimpleNamespace(enable_asr_transcription=False, text_hop_size=0.05),
     )
 
     asr = SimpleNamespace(transcribe=AsyncMock(return_value=[("ignored", 0.0, 1.0)]))
@@ -179,7 +208,7 @@ async def test_listener_skips_asr_without_flag(monkeypatch):
 async def test_listener_skips_asr_without_audio_consent(monkeypatch):
     monkeypatch.setattr(
         "deepthought.services.perception.listener.PerceptionConfig",
-        lambda: SimpleNamespace(enable_asr_transcription=True),
+        lambda: SimpleNamespace(enable_asr_transcription=True, text_hop_size=0.05),
     )
 
     asr = SimpleNamespace(transcribe=AsyncMock(return_value=[("hello", 0.0, 1.0)]))
@@ -213,7 +242,7 @@ async def test_listener_skips_asr_without_audio_consent(monkeypatch):
 async def test_listener_skips_asr_when_audio_consent_missing(monkeypatch):
     monkeypatch.setattr(
         "deepthought.services.perception.listener.PerceptionConfig",
-        lambda: SimpleNamespace(enable_asr_transcription=True),
+        lambda: SimpleNamespace(enable_asr_transcription=True, text_hop_size=0.05),
     )
 
     asr = SimpleNamespace(transcribe=AsyncMock(return_value=[("hello", 0.0, 1.0)]))

--- a/tests/unit/services/perception/test_text_utils.py
+++ b/tests/unit/services/perception/test_text_utils.py
@@ -1,0 +1,20 @@
+from deepthought.services.perception.text_utils import hop_aligned_tokens, scrub_tokens
+
+
+def test_hop_aligned_tokens_redacts_pii():
+    tokens = hop_aligned_tokens("Contact me at 555-123-4567", 0.1)
+    assert tokens == [
+        ("Contact", 0.0, 0.1),
+        ("me", 0.1, 0.2),
+        ("at", 0.2, 0.30000000000000004),
+        ("[REDACTED]", 0.30000000000000004, 0.4),
+    ]
+
+
+def test_scrub_tokens_casts_and_redacts():
+    raw_tokens = [["foo@example.com", "0", "0.5"], ("hello", 0.5, 1)]
+    sanitized = scrub_tokens(raw_tokens)
+    assert sanitized == [
+        ("[REDACTED]", 0.0, 0.5),
+        ("hello", 0.5, 1.0),
+    ]


### PR DESCRIPTION
## Summary
- add a reusable `text_utils` helper module that scrubs PII and generates hop-aligned tokens reused by the text worker and CLI
- update the perception listener to synthesize sanitized text tokens from `user_input`, reuse the helper for ASR output, and avoid raising when no modalities are produced
- refresh perception tests to cover the new helper and listener behaviour, and keep `TextPerceptionWorker` aligned with the shared scrubber

## Testing
- pytest tests/integration/test_perception_listener.py
- pytest tests/unit/services/perception/test_text_utils.py
- pytest tests/unit/services/perception/test_perception_service.py
- python -m flake8 src/deepthought/services/perception tests/integration/test_perception_listener.py tests/unit/services/perception/test_text_utils.py
- pytest *(fails: environment lacks DBManager/PersonaManager and torch build expects NumPy 1.x)*

------
https://chatgpt.com/codex/tasks/task_e_68d1497dcee88326ac5eced259bc6124