### PR TITLE
Ensure perception encoder metadata is comprehensive

### DIFF
--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -35,6 +35,71 @@ from .worker_video import VideoPerceptionWorker
 logger = logging.getLogger(__name__)
 
 
+def _split_model_revision(value: str | None) -> tuple[str | None, str | None]:
+    """Return model name and optional revision from a ``model@revision`` string."""
+
+    if not value:
+        return None, None
+    if "@" in value:
+        name, revision = value.split("@", 1)
+        return name, revision
+    return value, None
+
+
+def _build_parameters(model_value: str | None, **extras: Any) -> Dict[str, Any]:
+    """Construct encoder parameter metadata with normalized values."""
+
+    params: Dict[str, Any] = {}
+    model_name, revision = _split_model_revision(model_value)
+    if model_name:
+        params["model"] = model_name
+    if revision:
+        params["revision"] = revision
+    for key, value in extras.items():
+        if value is None:
+            continue
+        if isinstance(value, (np.generic,)):
+            params[key] = value.item()
+        else:
+            params[key] = value
+    return params
+
+
+def _ensure_encoder_metadata(
+    existing: Dict[str, Any] | None,
+    *,
+    name: str,
+    modality: str,
+    dim: int | None,
+    parameters: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    """Merge encoder metadata with defaults ensuring required fields exist."""
+
+    meta = dict(existing or {})
+    meta.setdefault("name", name)
+    meta.setdefault("modality", modality)
+
+    if "dim" in meta and meta["dim"] is not None:
+        try:
+            meta["dim"] = int(meta["dim"])
+        except (TypeError, ValueError):
+            if dim is not None:
+                meta["dim"] = int(dim)
+            else:
+                meta.pop("dim", None)
+    elif dim is not None:
+        meta["dim"] = int(dim)
+
+    params = dict(meta.get("parameters") or {})
+    if parameters:
+        for key, value in parameters.items():
+            if value is None or key in params:
+                continue
+            params[key] = value
+    meta["parameters"] = params
+    return meta
+
+
 @dataclass
 class PerceptionService:
     """Orchestrate worker outputs and publish fused embeddings.
@@ -83,9 +148,10 @@ class PerceptionService:
                 wandb_run = None
 
         store_embedding: torch.Tensor | None = None
+        provenance = dict(provenance or {})
+        provenance.setdefault("timestamp", time.time())
 
         if embeddings is None:
-            provenance = dict(provenance or {})
             modality_arrays: Dict[str, np.ndarray] = {}
             modality_times: Dict[str, np.ndarray] = {}
             encoder_meta: Dict[str, Dict[str, Any]] = {}
@@ -94,6 +160,14 @@ class PerceptionService:
             if self.text_worker is not None and text_tokens:
                 feats = times = None
                 cache_dir = Path(cfg.text_cache_dir) if cfg.text_cache_dir else None
+                text_params = _build_parameters(
+                    getattr(cfg, "text_model", None),
+                    hop_size=getattr(cfg, "text_hop_size", None),
+                )
+                default_dim = None
+                modality_dims = getattr(cfg, "modality_dims", {}) or {}
+                if isinstance(modality_dims, dict):
+                    default_dim = modality_dims.get("text")
                 if cache_dir is not None:
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     token_bytes = json.dumps(list(text_tokens), sort_keys=True).encode()
@@ -104,21 +178,40 @@ class PerceptionService:
                         meta = json.loads(meta_file.read_text())
                         feats = np.memmap(feats_file, dtype="float32", mode="r", shape=tuple(meta["shape"]))
                         times = np.asarray(meta["timestamps"], dtype=np.float32)
-                        encoder_meta["text"] = meta["encoder"]
+                        dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                        encoder_info = _ensure_encoder_metadata(
+                            meta.get("encoder"),
+                            name=self.text_worker.__class__.__name__,
+                            modality="text",
+                            dim=dim if dim is not None else default_dim,
+                            parameters=text_params,
+                        )
+                        if meta.get("encoder") != encoder_info:
+                            meta["encoder"] = encoder_info
+                            meta_file.write_text(json.dumps(meta))
+                        encoder_meta["text"] = encoder_info
                     else:
                         start = time.perf_counter()
                         feats, times = self.text_worker(text_tokens, str(feats_file))
                         MODALITY_INFERENCE_LATENCY_SECONDS.labels(
                             service="perception_service", modality="text"
                         ).observe(time.perf_counter() - start)
+                        dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                        encoder_info = _ensure_encoder_metadata(
+                            None,
+                            name=self.text_worker.__class__.__name__,
+                            modality="text",
+                            dim=dim if dim is not None else default_dim,
+                            parameters=text_params,
+                        )
                         meta = {
                             "shape": list(feats.shape),
                             "timestamps": times.tolist(),
-                            "encoder": {"name": self.text_worker.__class__.__name__},
+                            "encoder": encoder_info,
                             "created": time.time(),
                         }
                         meta_file.write_text(json.dumps(meta))
-                        encoder_meta["text"] = meta["encoder"]
+                        encoder_meta["text"] = encoder_info
                 else:
                     with NamedTemporaryFile(suffix=".mm", delete=False) as tmp:
                         start = time.perf_counter()
@@ -126,7 +219,14 @@ class PerceptionService:
                         MODALITY_INFERENCE_LATENCY_SECONDS.labels(
                             service="perception_service", modality="text"
                         ).observe(time.perf_counter() - start)
-                    encoder_meta["text"] = {"name": self.text_worker.__class__.__name__}
+                    dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                    encoder_meta["text"] = _ensure_encoder_metadata(
+                        None,
+                        name=self.text_worker.__class__.__name__,
+                        modality="text",
+                        dim=dim if dim is not None else default_dim,
+                        parameters=text_params,
+                    )
                     Path(tmp.name).unlink(missing_ok=True)
                 modality_arrays["text"] = np.asarray(feats)
                 modality_times["text"] = np.asarray(times)
@@ -137,6 +237,20 @@ class PerceptionService:
                 audio_path = Path(audio_path)
                 cache_dir = Path(self.audio_worker.cache_dir or cfg.audio_cache_dir or audio_path.parent)
                 cache_dir.mkdir(parents=True, exist_ok=True)
+                model_value = getattr(self.audio_worker, "model", None) or getattr(cfg, "audio_model", None)
+                extras: Dict[str, Any] = {
+                    "window_size": getattr(self.audio_worker, "window_size", getattr(cfg, "audio_window_size", None)),
+                    "step_size": getattr(self.audio_worker, "step_size", getattr(cfg, "audio_hop_size", None)),
+                }
+                model_path_value = getattr(self.audio_worker, "model_path", None) or getattr(
+                    cfg, "audio_model_path", None
+                )
+                if model_path_value is not None:
+                    extras["model_path"] = str(model_path_value)
+                audio_params = _build_parameters(model_value, **extras)
+                default_dim = None
+                if isinstance(getattr(cfg, "modality_dims", None), dict):
+                    default_dim = cfg.modality_dims.get("audio")
                 base = (
                     f"{audio_path.stem}_{self.audio_worker.model}_ws{self.audio_worker.window_size}"
                     f"_ss{self.audio_worker.step_size}"
@@ -147,21 +261,40 @@ class PerceptionService:
                     meta = json.loads(meta_file.read_text())
                     feats = np.memmap(feats_file, dtype="float32", mode="r", shape=tuple(meta["shape"]))
                     times = np.asarray(meta["timestamps"], dtype=np.float32)
-                    encoder_meta["audio"] = meta["encoder"]
+                    dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                    encoder_info = _ensure_encoder_metadata(
+                        meta.get("encoder"),
+                        name=self.audio_worker.__class__.__name__,
+                        modality="audio",
+                        dim=dim if dim is not None else default_dim,
+                        parameters=audio_params,
+                    )
+                    if meta.get("encoder") != encoder_info:
+                        meta["encoder"] = encoder_info
+                        meta_file.write_text(json.dumps(meta))
+                    encoder_meta["audio"] = encoder_info
                 else:
                     start = time.perf_counter()
                     feats, times = self.audio_worker(audio_path, cache_dir=cache_dir)
                     MODALITY_INFERENCE_LATENCY_SECONDS.labels(service="perception_service", modality="audio").observe(
                         time.perf_counter() - start
                     )
+                    dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                    encoder_info = _ensure_encoder_metadata(
+                        None,
+                        name=self.audio_worker.__class__.__name__,
+                        modality="audio",
+                        dim=dim if dim is not None else default_dim,
+                        parameters=audio_params,
+                    )
                     meta = {
                         "shape": list(feats.shape),
                         "timestamps": times.tolist(),
-                        "encoder": {"name": self.audio_worker.__class__.__name__},
+                        "encoder": encoder_info,
                         "created": time.time(),
                     }
                     meta_file.write_text(json.dumps(meta))
-                    encoder_meta["audio"] = meta["encoder"]
+                    encoder_meta["audio"] = encoder_info
                 modality_arrays["audio"] = np.asarray(feats)
                 modality_times["audio"] = np.asarray(times)
                 if not retain_media:
@@ -178,6 +311,15 @@ class PerceptionService:
                 decode_fps = getattr(self.video_worker, "decode_fps", 1)
                 model_type = getattr(self.video_worker, "model_type", "model")
                 grid_fps = getattr(self.video_worker, "grid_fps", None)
+                model_value = getattr(cfg, "video_model", None) or model_type
+                video_params = _build_parameters(
+                    model_value,
+                    decode_fps=int(decode_fps),
+                    grid_fps=int(grid_fps) if grid_fps is not None else int(decode_fps),
+                )
+                default_dim = None
+                if isinstance(getattr(cfg, "modality_dims", None), dict):
+                    default_dim = cfg.modality_dims.get("video")
                 suffix = f"{decode_fps}_{model_type}_{grid_fps or decode_fps}"
                 base = f"{video_path.stem}_{suffix}"
                 feats_file = cache_dir / f"{base}_feats.npy"
@@ -186,7 +328,18 @@ class PerceptionService:
                     feats = np.load(feats_file, mmap_mode="r")
                     meta = json.loads(meta_file.read_text())
                     times_arr = np.asarray(meta["timestamps"], dtype=np.float32)
-                    encoder_meta["video"] = meta["encoder"]
+                    dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                    encoder_info = _ensure_encoder_metadata(
+                        meta.get("encoder"),
+                        name=self.video_worker.__class__.__name__,
+                        modality="video",
+                        dim=dim if dim is not None else default_dim,
+                        parameters=video_params,
+                    )
+                    if meta.get("encoder") != encoder_info:
+                        meta["encoder"] = encoder_info
+                        meta_file.write_text(json.dumps(meta))
+                    encoder_meta["video"] = encoder_info
                 else:
                     start = time.perf_counter()
                     feats, times_arr = self.video_worker(video_path)
@@ -195,14 +348,22 @@ class PerceptionService:
                     )
                     if not feats_file.exists():
                         np.save(feats_file, np.asarray(feats))
+                    dim = feats.shape[1] if feats.ndim > 1 else default_dim
+                    encoder_info = _ensure_encoder_metadata(
+                        None,
+                        name=self.video_worker.__class__.__name__,
+                        modality="video",
+                        dim=dim if dim is not None else default_dim,
+                        parameters=video_params,
+                    )
                     meta = {
                         "shape": list(feats.shape),
                         "timestamps": times_arr.tolist(),
-                        "encoder": {"name": self.video_worker.__class__.__name__},
+                        "encoder": encoder_info,
                         "created": time.time(),
                     }
                     meta_file.write_text(json.dumps(meta))
-                    encoder_meta["video"] = meta["encoder"]
+                    encoder_meta["video"] = encoder_info
                 times = np.asarray(meta["timestamps"], dtype=np.float32)
                 if times.ndim == 1:
                     if len(times) > 1:

--- a/tests/integration/test_perception_listener_text_only.py
+++ b/tests/integration/test_perception_listener_text_only.py
@@ -220,6 +220,14 @@ async def test_listener_processes_text_only_payload(monkeypatch, tmp_path):
     hop_ms = int(hop * 1000)
     assert text_payload["spans"] == [[0, hop_ms], [hop_ms, hop_ms * 2]]
     assert text_payload["embeddings"] == [[1.0, 2.0], [2.0, 3.0]]
-    assert text_payload["encoders"] == [{"name": "RecordingTextWorker"}] * 2
-    assert event_kwargs["provenance"] == {"modalities": ["text"]}
+    encoder = text_payload["encoders"][0]
+    assert encoder["name"] == "RecordingTextWorker"
+    assert encoder["modality"] == "text"
+    assert encoder["dim"] == 2
+    params = encoder["parameters"]
+    assert params.get("model") == "dummy"
+    assert params["hop_size"] == pytest.approx(hop)
+    provenance = event_kwargs["provenance"]
+    assert provenance["modalities"] == ["text"]
+    assert isinstance(provenance["timestamp"], float)
 

--- a/tests/test_perception_publisher.py
+++ b/tests/test_perception_publisher.py
@@ -30,7 +30,7 @@ async def test_perception_publisher(monkeypatch):
             "text": {
                 "spans": [[0, 1]],
                 "embeddings": [[0.1, 0.2]],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [{"name": "enc", "modality": "text", "parameters": {}}],
             }
         },
         provenance={"p": 1},
@@ -88,12 +88,12 @@ async def test_perception_publisher_deduplicates_encoders(monkeypatch):
             "a": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [{"name": "enc", "modality": "text", "parameters": {}}],
             },
             "b": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [{"name": "enc", "modality": "text", "parameters": {}}],
             },
         },
     )

--- a/tests/unit/services/perception/test_perception_publisher.py
+++ b/tests/unit/services/perception/test_perception_publisher.py
@@ -37,7 +37,7 @@ async def test_publish_embeddings(monkeypatch):
             "text": {
                 "spans": [[0, 1]],
                 "embeddings": [[0.0, 0.1]],
-                "encoders": [{"name": "test", "dim": 2, "modality": "text"}],
+                "encoders": [{"name": "test", "dim": 2, "modality": "text", "parameters": {}}],
             }
         },
         provenance={"source": "unit"},
@@ -83,12 +83,12 @@ async def test_publish_deduplicates_encoders(monkeypatch):
             "a": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [{"name": "enc", "modality": "text", "parameters": {}}],
             },
             "b": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [{"name": "enc", "modality": "text", "parameters": {}}],
             },
         },
     )

--- a/tests/unit/services/perception/test_perception_service.py
+++ b/tests/unit/services/perception/test_perception_service.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+import json
 import os
 import sys
 import types
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Dict, Sequence, Tuple
 
@@ -76,3 +78,95 @@ async def test_grid_hop_size_overrides_default(monkeypatch):
     text_meta = publisher.kwargs["by_modality"]["text"]
     assert text_meta["spans"] == [[0, 100]]
     assert text_meta["embeddings"] == [[2.0, 3.0]]
+    encoder = text_meta["encoders"][0]
+    assert encoder["name"] == "DummyTextWorker"
+    assert encoder["modality"] == "text"
+    assert encoder["dim"] == 2
+    assert encoder["parameters"]["hop_size"] == pytest.approx(0.03)
+    provenance = publisher.kwargs["provenance"]
+    assert provenance["modalities"] == ["text"]
+    assert isinstance(provenance["timestamp"], float)
+
+
+@pytest.mark.asyncio
+async def test_text_encoder_metadata_cache_roundtrip(monkeypatch, tmp_path):
+    cache_dir = tmp_path / "text"
+    fake_cfg = SimpleNamespace(
+        grid_hop_size=0.05,
+        text_cache_dir=str(cache_dir),
+        audio_cache_dir=None,
+        video_cache_dir=None,
+        audio_window_size=0.02,
+        audio_hop_size=0.01,
+        audio_model="wavlm@unit",
+        audio_model_path=None,
+        text_model="unit/model@revA",
+        text_hop_size=0.05,
+        video_model="siglip@revV",
+        video_hop_size=1.0,
+        wandb_project=None,
+        wandb_sweep_id=None,
+        nats_url="",
+        modality_dims={"text": 2},
+    )
+
+    class DummySettings:
+        wandb_enabled = False
+        wandb_project = None
+        wandb_sweep_id = None
+        wandb_upload_artifacts = False
+
+    monkeypatch.setattr(service_module, "PerceptionConfig", lambda: fake_cfg)
+    monkeypatch.setattr(service_module, "get_settings", lambda: DummySettings())
+
+    publisher = DummyPublisher()
+    service = PerceptionService(publisher, text_worker=DummyTextWorker())
+
+    monkeypatch.setattr(service_module.time, "time", lambda: 1234.0)
+    await service.run(
+        message_id="m1",
+        user_id="u1",
+        text_tokens=[("hi", 0.0, 0.1)],
+    )
+
+    assert publisher.kwargs is not None
+    text_meta = publisher.kwargs["by_modality"]["text"]
+    encoder = text_meta["encoders"][0]
+    assert encoder == {
+        "name": "DummyTextWorker",
+        "modality": "text",
+        "dim": 2,
+        "parameters": {"model": "unit/model", "revision": "revA", "hop_size": 0.05},
+    }
+    provenance = publisher.kwargs["provenance"]
+    assert provenance["modalities"] == ["text"]
+    assert provenance["timestamp"] == pytest.approx(1234.0)
+
+    meta_path = next(Path(fake_cfg.text_cache_dir).glob("*_meta.json"))
+    meta_data = json.loads(meta_path.read_text())
+    override_meta = {
+        "name": "CachedDummy",
+        "modality": "text",
+        "dim": 4,
+        "parameters": {
+            "model": "cached/model",
+            "revision": "revB",
+            "hop_size": 0.07,
+            "note": "override",
+        },
+    }
+    meta_data["encoder"] = override_meta
+    meta_path.write_text(json.dumps(meta_data))
+
+    publisher.kwargs = None
+    monkeypatch.setattr(service_module.time, "time", lambda: 5678.0)
+    await service.run(
+        message_id="m1",
+        user_id="u1",
+        text_tokens=[("hi", 0.0, 0.1)],
+    )
+
+    assert publisher.kwargs is not None
+    hit_meta = publisher.kwargs["by_modality"]["text"]
+    assert hit_meta["encoders"][0] == override_meta
+    assert publisher.kwargs["provenance"]["timestamp"] == pytest.approx(5678.0)

--- a/tests/unit/test_perception_service.py
+++ b/tests/unit/test_perception_service.py
@@ -79,8 +79,18 @@ def test_service_publishes_raw_embeddings_and_metadata():
     text_meta = publisher.kwargs["by_modality"]["text"]
     assert text_meta["spans"] == [[0, 50], [50, 100]]
     assert text_meta["embeddings"] == [[1.0, 2.0], [3.0, 4.0]]
-    assert text_meta["encoders"] == [{"name": "DummyTextWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["text"]}
+    encoder = text_meta["encoders"][0]
+    assert encoder["name"] == "DummyTextWorker"
+    assert encoder["modality"] == "text"
+    assert encoder["dim"] == 2
+    params = encoder["parameters"]
+    assert params["hop_size"] == pytest.approx(0.03)
+    assert params.get("model")
+    assert "revision" in params
+    provenance = publisher.kwargs["provenance"]
+    assert provenance["test"] is True
+    assert provenance["modalities"] == ["text"]
+    assert isinstance(provenance["timestamp"], float)
 
 
 class DummyVideoWorker:
@@ -109,8 +119,17 @@ def test_service_handles_video_modality():
     assert "video" in publisher.kwargs["by_modality"]
     video_meta = publisher.kwargs["by_modality"]["video"]
     assert video_meta["spans"] == [[0, 1000], [1000, 2000]]
-    assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}
+    encoder = video_meta["encoders"][0]
+    assert encoder["name"] == "DummyVideoWorker"
+    assert encoder["modality"] == "video"
+    assert encoder["dim"] == 2
+    params = encoder["parameters"]
+    assert params.get("model")
+    assert "decode_fps" in params and "grid_fps" in params
+    provenance = publisher.kwargs["provenance"]
+    assert provenance["test"] is True
+    assert provenance["modalities"] == ["video"]
+    assert isinstance(provenance["timestamp"], float)
 
 
 def test_service_requires_fuser_for_multiple_modalities(tmp_path):

--- a/tests/unit/test_perception_service_video.py
+++ b/tests/unit/test_perception_service_video.py
@@ -32,6 +32,7 @@ def test_service_publishes_video_embeddings_and_metadata():
             message_id="m1",
             user_id="u1",
             video_path="v.mp4",
+            video_opt_in=True,
             provenance={"test": True},
         )
     )
@@ -44,5 +45,14 @@ def test_service_publishes_video_embeddings_and_metadata():
     video_meta = publisher.kwargs["by_modality"]["video"]
     assert video_meta["spans"] == [[0, 50], [50, 100]]
     assert video_meta["embeddings"] == [[5.0, 6.0], [7.0, 8.0]]
-    assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}
+    encoder = video_meta["encoders"][0]
+    assert encoder["name"] == "DummyVideoWorker"
+    assert encoder["modality"] == "video"
+    assert encoder["dim"] == 2
+    params = encoder["parameters"]
+    assert params.get("model")
+    assert "decode_fps" in params and "grid_fps" in params
+    provenance = publisher.kwargs["provenance"]
+    assert provenance["test"] is True
+    assert provenance["modalities"] == ["video"]
+    assert isinstance(provenance["timestamp"], float)


### PR DESCRIPTION
## Summary
- augment `PerceptionService` to normalize encoder metadata with modality, dimension, and parameter defaults and to stamp provenance timestamps
- extend unit and integration tests to validate encoder metadata contents and timestamp presence, and add coverage for cache hit/miss behavior
- adjust publisher tests to account for richer encoder metadata

## Testing
- `pytest tests/unit/services/perception/test_perception_service.py`
- `pytest tests/unit/test_perception_service.py`
- `pytest tests/unit/test_perception_service_video.py`
- `pytest tests/test_perception_publisher.py`
- `pytest tests/unit/services/perception/test_perception_publisher.py`
- `pytest tests/integration/test_perception_listener_text_only.py`


------
https://chatgpt.com/codex/tasks/task_e_68d2a01725e8832681b9594e31316509