### PR TITLE
Enhance perception encoder metadata

### DIFF
--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Dict, Mapping, Sequence
 
@@ -52,14 +53,19 @@ class PerceptionPublisher:
             Number of times to retry publishing on failure.
         """
 
-        modality_payloads = {
-            name: ModalityEmbeddings(
+        modality_payloads: Dict[str, ModalityEmbeddings] = {}
+        for name, meta in (by_modality or {}).items():
+            encoders_meta = []
+            for enc in meta.get("encoders", []):
+                if isinstance(enc, EncoderMetadata):
+                    encoders_meta.append(enc)
+                else:
+                    encoders_meta.append(EncoderMetadata(**enc))
+            modality_payloads[name] = ModalityEmbeddings(
                 spans=[[int(span[0]), int(span[1])] for span in meta.get("spans", [])],
                 embeddings=[list(map(float, emb)) for emb in meta.get("embeddings", [])],
-                encoders=[EncoderMetadata(**enc) for enc in meta.get("encoders", [])],
+                encoders=encoders_meta,
             )
-            for name, meta in (by_modality or {}).items()
-        }
 
         fused_vectors: list[list[float]] | None = None
         if fused is not None:
@@ -77,10 +83,11 @@ class PerceptionPublisher:
         )
 
         # Deduplicate encoders across modalities to avoid redundant metadata
-        top_encoders_map: dict[tuple[str, str | None], EncoderMetadata] = {}
+        top_encoders_map: dict[tuple[str | None, str | None, int | None, str], EncoderMetadata] = {}
         for mod in modality_payloads.values():
             for enc in mod.encoders:
-                key = (enc.name, enc.modality)
+                params_key = json.dumps(enc.parameters, sort_keys=True, default=str) if enc.parameters else "{}"
+                key = (enc.name, enc.modality, enc.dim, params_key)
                 top_encoders_map.setdefault(key, enc)
         top_encoders = list(top_encoders_map.values())
 

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Sequence
@@ -33,6 +34,33 @@ from .worker_video import VideoPerceptionWorker
 
 
 logger = logging.getLogger(__name__)
+
+
+def _split_model_identifier(identifier: str | None) -> tuple[str | None, str | None]:
+    """Return ``(model, revision)`` for ``identifier`` split on ``@``."""
+
+    if not identifier:
+        return None, None
+    if "@" not in identifier:
+        return identifier, None
+    model, revision = identifier.rsplit("@", 1)
+    return model, revision
+
+
+def _clean_parameters(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Remove ``None`` values and stringify paths for metadata parameters."""
+
+    cleaned: Dict[str, Any] = {}
+    for key, value in data.items():
+        if value is None:
+            continue
+        if isinstance(value, Path):
+            cleaned[key] = str(value)
+        elif isinstance(value, (np.floating, np.integer)):
+            cleaned[key] = value.item()
+        else:
+            cleaned[key] = value
+    return cleaned
 
 
 @dataclass
@@ -83,9 +111,9 @@ class PerceptionService:
                 wandb_run = None
 
         store_embedding: torch.Tensor | None = None
+        provenance = dict(provenance or {})
 
         if embeddings is None:
-            provenance = dict(provenance or {})
             modality_arrays: Dict[str, np.ndarray] = {}
             modality_times: Dict[str, np.ndarray] = {}
             encoder_meta: Dict[str, Dict[str, Any]] = {}
@@ -93,7 +121,9 @@ class PerceptionService:
 
             if self.text_worker is not None and text_tokens:
                 feats = times = None
+                meta: Dict[str, Any] | None = None
                 cache_dir = Path(cfg.text_cache_dir) if cfg.text_cache_dir else None
+                meta_file: Path | None = None
                 if cache_dir is not None:
                     cache_dir.mkdir(parents=True, exist_ok=True)
                     token_bytes = json.dumps(list(text_tokens), sort_keys=True).encode()
@@ -104,7 +134,6 @@ class PerceptionService:
                         meta = json.loads(meta_file.read_text())
                         feats = np.memmap(feats_file, dtype="float32", mode="r", shape=tuple(meta["shape"]))
                         times = np.asarray(meta["timestamps"], dtype=np.float32)
-                        encoder_meta["text"] = meta["encoder"]
                     else:
                         start = time.perf_counter()
                         feats, times = self.text_worker(text_tokens, str(feats_file))
@@ -114,11 +143,9 @@ class PerceptionService:
                         meta = {
                             "shape": list(feats.shape),
                             "timestamps": times.tolist(),
-                            "encoder": {"name": self.text_worker.__class__.__name__},
                             "created": time.time(),
                         }
                         meta_file.write_text(json.dumps(meta))
-                        encoder_meta["text"] = meta["encoder"]
                 else:
                     with NamedTemporaryFile(suffix=".mm", delete=False) as tmp:
                         start = time.perf_counter()
@@ -126,10 +153,37 @@ class PerceptionService:
                         MODALITY_INFERENCE_LATENCY_SECONDS.labels(
                             service="perception_service", modality="text"
                         ).observe(time.perf_counter() - start)
-                    encoder_meta["text"] = {"name": self.text_worker.__class__.__name__}
                     Path(tmp.name).unlink(missing_ok=True)
-                modality_arrays["text"] = np.asarray(feats)
-                modality_times["text"] = np.asarray(times)
+                if feats is None or times is None:
+                    raise RuntimeError("Failed to compute text embeddings")
+                text_array = np.asarray(feats)
+                text_times = np.asarray(times)
+                text_model, text_revision = _split_model_identifier(cfg.text_model)
+                text_parameters = _clean_parameters(
+                    {
+                        "model": text_model or getattr(self.text_worker, "model_name", None),
+                        "revision": text_revision,
+                        "config_source": "PerceptionConfig.text_model",
+                        "config_value": cfg.text_model,
+                        "hop_size": float(cfg.text_hop_size),
+                        "cache_enabled": cache_dir is not None,
+                        "cache_path": cache_dir,
+                    }
+                )
+                text_dim = int(text_array.shape[-1]) if text_array.ndim > 1 else int(text_array.shape[0])
+                text_metadata = {
+                    "name": self.text_worker.__class__.__name__,
+                    "modality": "text",
+                    "dim": text_dim,
+                    "parameters": text_parameters,
+                }
+                if meta is not None and meta_file is not None:
+                    if meta.get("encoder") != text_metadata:
+                        meta["encoder"] = text_metadata
+                        meta_file.write_text(json.dumps(meta))
+                modality_arrays["text"] = text_array
+                modality_times["text"] = text_times
+                encoder_meta["text"] = text_metadata
 
             if self.audio_worker is not None and audio_path is not None:
                 if audio_opt_in is not True:
@@ -147,7 +201,6 @@ class PerceptionService:
                     meta = json.loads(meta_file.read_text())
                     feats = np.memmap(feats_file, dtype="float32", mode="r", shape=tuple(meta["shape"]))
                     times = np.asarray(meta["timestamps"], dtype=np.float32)
-                    encoder_meta["audio"] = meta["encoder"]
                 else:
                     start = time.perf_counter()
                     feats, times = self.audio_worker(audio_path, cache_dir=cache_dir)
@@ -157,13 +210,38 @@ class PerceptionService:
                     meta = {
                         "shape": list(feats.shape),
                         "timestamps": times.tolist(),
-                        "encoder": {"name": self.audio_worker.__class__.__name__},
                         "created": time.time(),
                     }
                     meta_file.write_text(json.dumps(meta))
-                    encoder_meta["audio"] = meta["encoder"]
-                modality_arrays["audio"] = np.asarray(feats)
-                modality_times["audio"] = np.asarray(times)
+                audio_array = np.asarray(feats)
+                audio_times = np.asarray(times)
+                audio_model, audio_revision = _split_model_identifier(cfg.audio_model)
+                audio_parameters = _clean_parameters(
+                    {
+                        "model": audio_model or getattr(self.audio_worker, "model", None),
+                        "revision": audio_revision,
+                        "config_source": "PerceptionConfig.audio_model",
+                        "config_value": cfg.audio_model,
+                        "window_size": float(getattr(self.audio_worker, "window_size", cfg.audio_window_size)),
+                        "hop_size": float(getattr(self.audio_worker, "step_size", cfg.audio_hop_size)),
+                        "cache_enabled": bool(getattr(self.audio_worker, "cache_dir", None) or cfg.audio_cache_dir),
+                        "cache_path": cache_dir,
+                        "model_path": getattr(self.audio_worker, "model_path", None) or cfg.audio_model_path,
+                    }
+                )
+                audio_dim = int(audio_array.shape[-1]) if audio_array.ndim > 1 else int(audio_array.shape[0])
+                audio_metadata = {
+                    "name": self.audio_worker.__class__.__name__,
+                    "modality": "audio",
+                    "dim": audio_dim,
+                    "parameters": audio_parameters,
+                }
+                if meta.get("encoder") != audio_metadata:
+                    meta["encoder"] = audio_metadata
+                    meta_file.write_text(json.dumps(meta))
+                modality_arrays["audio"] = audio_array
+                modality_times["audio"] = audio_times
+                encoder_meta["audio"] = audio_metadata
                 if not retain_media:
                     audio_path.unlink(missing_ok=True)
 
@@ -186,7 +264,6 @@ class PerceptionService:
                     feats = np.load(feats_file, mmap_mode="r")
                     meta = json.loads(meta_file.read_text())
                     times_arr = np.asarray(meta["timestamps"], dtype=np.float32)
-                    encoder_meta["video"] = meta["encoder"]
                 else:
                     start = time.perf_counter()
                     feats, times_arr = self.video_worker(video_path)
@@ -198,11 +275,9 @@ class PerceptionService:
                     meta = {
                         "shape": list(feats.shape),
                         "timestamps": times_arr.tolist(),
-                        "encoder": {"name": self.video_worker.__class__.__name__},
                         "created": time.time(),
                     }
                     meta_file.write_text(json.dumps(meta))
-                    encoder_meta["video"] = meta["encoder"]
                 times = np.asarray(meta["timestamps"], dtype=np.float32)
                 if times.ndim == 1:
                     if len(times) > 1:
@@ -211,8 +286,35 @@ class PerceptionService:
                         fps = grid_fps or decode_fps
                         step = 1.0 / float(fps)
                     times = np.column_stack((times, times + step))
-                modality_arrays["video"] = np.asarray(feats)
+                video_array = np.asarray(feats)
                 modality_times["video"] = times
+                video_model, video_revision = _split_model_identifier(cfg.video_model)
+                video_parameters = _clean_parameters(
+                    {
+                        "model": video_model or getattr(self.video_worker, "model_type", None),
+                        "revision": video_revision,
+                        "config_source": "PerceptionConfig.video_model",
+                        "config_value": cfg.video_model,
+                        "hop_size": float(cfg.video_hop_size),
+                        "cache_enabled": bool(getattr(self.video_worker, "cache_dir", None) or cfg.video_cache_dir),
+                        "cache_path": cache_dir,
+                        "decode_fps": decode_fps,
+                        "grid_fps": grid_fps,
+                        "model_variant": getattr(self.video_worker, "model_type", None),
+                    }
+                )
+                video_dim = int(video_array.shape[-1]) if video_array.ndim > 1 else int(video_array.shape[0])
+                video_metadata = {
+                    "name": self.video_worker.__class__.__name__,
+                    "modality": "video",
+                    "dim": video_dim,
+                    "parameters": video_parameters,
+                }
+                if meta.get("encoder") != video_metadata:
+                    meta["encoder"] = video_metadata
+                    meta_file.write_text(json.dumps(meta))
+                modality_arrays["video"] = video_array
+                encoder_meta["video"] = video_metadata
                 if not retain_media:
                     video_path.unlink(missing_ok=True)
 
@@ -263,7 +365,7 @@ class PerceptionService:
                 if name in modality_arrays:
                     arr = modality_arrays[name]
                     times = modality_times[name]
-                    dim = arr.shape[1]
+                    dim = int(arr.shape[-1]) if arr.ndim > 1 else int(arr.shape[0])
                     aligned = np.zeros((num_spans, dim), dtype=np.float32)
                     for i, (gs, ge) in enumerate(zip(grid_starts, grid_ends)):
                         mask = (gs < times[:, 1]) & (ge > times[:, 0])
@@ -355,6 +457,9 @@ class PerceptionService:
 
         if self.user_embeddings is not None and store_embedding is not None and store_embedding.numel() > 0:
             self.user_embeddings.set(user_id, store_embedding)
+
+        if "timestamp" not in provenance:
+            provenance["timestamp"] = datetime.now(timezone.utc).isoformat()
 
         await self.publisher.publish(
             message_id=message_id,

--- a/tests/integration/test_perception_listener_text_only.py
+++ b/tests/integration/test_perception_listener_text_only.py
@@ -220,6 +220,12 @@ async def test_listener_processes_text_only_payload(monkeypatch, tmp_path):
     hop_ms = int(hop * 1000)
     assert text_payload["spans"] == [[0, hop_ms], [hop_ms, hop_ms * 2]]
     assert text_payload["embeddings"] == [[1.0, 2.0], [2.0, 3.0]]
-    assert text_payload["encoders"] == [{"name": "RecordingTextWorker"}] * 2
-    assert event_kwargs["provenance"] == {"modalities": ["text"]}
+    assert len(text_payload["encoders"]) == 2
+    encoder = text_payload["encoders"][0]
+    assert encoder["name"] == "RecordingTextWorker"
+    assert encoder["modality"] == "text"
+    assert encoder["parameters"]["config_source"] == "PerceptionConfig.text_model"
+    assert "hop_size" in encoder["parameters"]
+    assert event_kwargs["provenance"]["modalities"] == ["text"]
+    assert "timestamp" in event_kwargs["provenance"]
 

--- a/tests/test_perception_publisher.py
+++ b/tests/test_perception_publisher.py
@@ -30,7 +30,17 @@ async def test_perception_publisher(monkeypatch):
             "text": {
                 "spans": [[0, 1]],
                 "embeddings": [[0.1, 0.2]],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "enc",
+                        "modality": "text",
+                        "dim": 2,
+                        "parameters": {
+                            "hop_size": 0.5,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             }
         },
         provenance={"p": 1},
@@ -49,7 +59,9 @@ async def test_perception_publisher(monkeypatch):
 
     assert text_mod.spans == [[0, 1]]
     assert text_mod.encoders[0].name == "enc"
+    assert text_mod.encoders[0].parameters["hop_size"] == 0.5
     assert event.encoders[0].name == "enc"
+    assert event.encoders[0].parameters["config_source"] == "PerceptionConfig.text_model"
     assert event.provenance == {"p": 1}
 
 
@@ -88,12 +100,32 @@ async def test_perception_publisher_deduplicates_encoders(monkeypatch):
             "a": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "enc",
+                        "modality": "text",
+                        "dim": 2,
+                        "parameters": {
+                            "hop_size": 0.5,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             },
             "b": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "enc",
+                        "modality": "text",
+                        "dim": 2,
+                        "parameters": {
+                            "hop_size": 0.5,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             },
         },
     )

--- a/tests/unit/services/perception/test_perception_publisher.py
+++ b/tests/unit/services/perception/test_perception_publisher.py
@@ -37,7 +37,17 @@ async def test_publish_embeddings(monkeypatch):
             "text": {
                 "spans": [[0, 1]],
                 "embeddings": [[0.0, 0.1]],
-                "encoders": [{"name": "test", "dim": 2, "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "test",
+                        "dim": 2,
+                        "modality": "text",
+                        "parameters": {
+                            "hop_size": 0.25,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             }
         },
         provenance={"source": "unit"},
@@ -53,8 +63,10 @@ async def test_publish_embeddings(monkeypatch):
     text_mod = event.payload.by_modality["text"]
 
     assert text_mod.encoders[0].name == "test"
+    assert text_mod.encoders[0].parameters["hop_size"] == 0.25
     assert event.provenance == {"source": "unit"}
     assert event.encoders[0].name == "test"
+    assert event.encoders[0].parameters["config_source"] == "PerceptionConfig.text_model"
     assert captured["use_jetstream"] is True
     assert captured["retries"] == 3
 
@@ -83,12 +95,32 @@ async def test_publish_deduplicates_encoders(monkeypatch):
             "a": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "enc",
+                        "modality": "text",
+                        "dim": 2,
+                        "parameters": {
+                            "hop_size": 0.25,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             },
             "b": {
                 "spans": [],
                 "embeddings": [],
-                "encoders": [{"name": "enc", "modality": "text"}],
+                "encoders": [
+                    {
+                        "name": "enc",
+                        "modality": "text",
+                        "dim": 2,
+                        "parameters": {
+                            "hop_size": 0.25,
+                            "config_source": "PerceptionConfig.text_model",
+                        },
+                    }
+                ],
             },
         },
     )

--- a/tests/unit/test_perception_service.py
+++ b/tests/unit/test_perception_service.py
@@ -79,8 +79,16 @@ def test_service_publishes_raw_embeddings_and_metadata():
     text_meta = publisher.kwargs["by_modality"]["text"]
     assert text_meta["spans"] == [[0, 50], [50, 100]]
     assert text_meta["embeddings"] == [[1.0, 2.0], [3.0, 4.0]]
-    assert text_meta["encoders"] == [{"name": "DummyTextWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["text"]}
+    assert len(text_meta["encoders"]) == 2
+    text_encoder = text_meta["encoders"][0]
+    assert text_encoder["name"] == "DummyTextWorker"
+    assert text_encoder["modality"] == "text"
+    assert text_encoder["dim"] == 2
+    assert text_encoder["parameters"]["config_source"] == "PerceptionConfig.text_model"
+    assert "hop_size" in text_encoder["parameters"]
+    assert publisher.kwargs["provenance"]["test"] is True
+    assert publisher.kwargs["provenance"]["modalities"] == ["text"]
+    assert "timestamp" in publisher.kwargs["provenance"]
 
 
 class DummyVideoWorker:
@@ -109,8 +117,16 @@ def test_service_handles_video_modality():
     assert "video" in publisher.kwargs["by_modality"]
     video_meta = publisher.kwargs["by_modality"]["video"]
     assert video_meta["spans"] == [[0, 1000], [1000, 2000]]
-    assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}
+    assert len(video_meta["encoders"]) == 2
+    video_encoder = video_meta["encoders"][0]
+    assert video_encoder["name"] == "DummyVideoWorker"
+    assert video_encoder["modality"] == "video"
+    assert video_encoder["dim"] == 2
+    assert video_encoder["parameters"]["config_source"] == "PerceptionConfig.video_model"
+    assert "hop_size" in video_encoder["parameters"]
+    assert publisher.kwargs["provenance"]["test"] is True
+    assert publisher.kwargs["provenance"]["modalities"] == ["video"]
+    assert "timestamp" in publisher.kwargs["provenance"]
 
 
 def test_service_requires_fuser_for_multiple_modalities(tmp_path):

--- a/tests/unit/test_perception_service_video.py
+++ b/tests/unit/test_perception_service_video.py
@@ -32,6 +32,7 @@ def test_service_publishes_video_embeddings_and_metadata():
             message_id="m1",
             user_id="u1",
             video_path="v.mp4",
+            video_opt_in=True,
             provenance={"test": True},
         )
     )
@@ -44,5 +45,13 @@ def test_service_publishes_video_embeddings_and_metadata():
     video_meta = publisher.kwargs["by_modality"]["video"]
     assert video_meta["spans"] == [[0, 50], [50, 100]]
     assert video_meta["embeddings"] == [[5.0, 6.0], [7.0, 8.0]]
-    assert video_meta["encoders"] == [{"name": "DummyVideoWorker"}] * 2
-    assert publisher.kwargs["provenance"] == {"test": True, "modalities": ["video"]}
+    assert len(video_meta["encoders"]) == 2
+    video_encoder = video_meta["encoders"][0]
+    assert video_encoder["name"] == "DummyVideoWorker"
+    assert video_encoder["modality"] == "video"
+    assert video_encoder["dim"] == 2
+    assert video_encoder["parameters"]["config_source"] == "PerceptionConfig.video_model"
+    assert "hop_size" in video_encoder["parameters"]
+    assert publisher.kwargs["provenance"]["test"] is True
+    assert publisher.kwargs["provenance"]["modalities"] == ["video"]
+    assert "timestamp" in publisher.kwargs["provenance"]


### PR DESCRIPTION
## Summary
- capture model identifiers, runtime hop/window/cache settings, and encoder dimensions when building perception metadata and stamp provenance with a publication timestamp
- update `PerceptionPublisher` to accept the richer encoder payload while deduplicating entries using parameter-aware keys
- refresh perception service and publisher tests to assert the expanded encoder metadata structure

## Testing
- pytest *(fails: repository-wide suite imports optional services that are unavailable in this environment)*
- pytest tests/test_perception_publisher.py tests/unit/services/perception/test_perception_publisher.py tests/unit/test_perception_service.py tests/unit/test_perception_service_video.py tests/integration/test_perception_listener_text_only.py

------
https://chatgpt.com/codex/tasks/task_e_68d2a016f1f08326869b3d97af273edf