### PR TITLE
Add contribution mask metadata to perception embeddings

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -179,6 +179,7 @@ class ModalityEmbeddings(EventPayload):
     spans: list[list[int]] = field(default_factory=list)
     embeddings: list[list[float]] = field(default_factory=list)
     encoders: list[EncoderMetadata] = field(default_factory=list)
+    mask: list[bool] | None = None
 
 
 @dataclass
@@ -189,23 +190,37 @@ class PerceptionEmbeddingsPayload(EventPayload):
     user_id: str
     fused: Optional[list[list[float]]] = None
     by_modality: Dict[str, ModalityEmbeddings] = field(default_factory=dict)
+    spans: Optional[list[list[int]]] = None
+    contribution_mask: Dict[str, list[bool]] = field(default_factory=dict)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PerceptionEmbeddingsPayload":
-        by_modality = {
-            name: ModalityEmbeddings(
+        by_modality = {}
+        for name, meta in data.get("by_modality", {}).items():
+            mask = meta.get("mask") if isinstance(meta, dict) else None
+            if mask is not None:
+                mask_list = [bool(value) for value in mask]
+            else:
+                mask_list = None
+            by_modality[name] = ModalityEmbeddings(
                 spans=[[int(span[0]), int(span[1])] for span in meta.get("spans", [])],
                 embeddings=[list(map(float, emb)) for emb in meta.get("embeddings", [])],
                 encoders=[EncoderMetadata(**enc) for enc in meta.get("encoders", [])],
+                mask=mask_list,
             )
-            for name, meta in data.get("by_modality", {}).items()
-        }
         fused = data.get("fused")
+        spans = data.get("spans")
+        mask_map = {
+            name: [bool(value) for value in values]
+            for name, values in (data.get("contribution_mask") or {}).items()
+        }
         return cls(
             message_id=data["message_id"],
             user_id=data["user_id"],
             fused=[[float(x) for x in emb] for emb in fused] if fused is not None else None,
             by_modality=by_modality,
+            spans=[[int(span[0]), int(span[1])] for span in spans] if spans is not None else None,
+            contribution_mask=mask_map,
         )
 
     @classmethod

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -32,6 +32,8 @@ class PerceptionPublisher:
         fused: Sequence[Sequence[float]] | None = None,
         by_modality: Mapping[str, Mapping[str, Any]] | None = None,
         provenance: Dict[str, Any] | None = None,
+        spans: Sequence[Sequence[int]] | None = None,
+        contribution_mask: Mapping[str, Sequence[bool]] | None = None,
         retries: int = 3,
     ) -> Dict | None:
         """Publish a :class:`PerceptionEmbeddingsEvent` with retries.
@@ -48,18 +50,24 @@ class PerceptionPublisher:
             Mapping of modality name to its embeddings, spans and encoders.
         provenance:
             Provenance information about how the embeddings were generated.
+        spans:
+            Optional list of common grid spans shared across modalities.
+        contribution_mask:
+            Optional mapping of modality name to a boolean list indicating
+            whether that modality contributed to each hop of ``spans``.
         retries:
             Number of times to retry publishing on failure.
         """
 
-        modality_payloads = {
-            name: ModalityEmbeddings(
+        modality_payloads: Dict[str, ModalityEmbeddings] = {}
+        for name, meta in (by_modality or {}).items():
+            mask = meta.get("mask") if isinstance(meta, Mapping) else None
+            modality_payloads[name] = ModalityEmbeddings(
                 spans=[[int(span[0]), int(span[1])] for span in meta.get("spans", [])],
                 embeddings=[list(map(float, emb)) for emb in meta.get("embeddings", [])],
                 encoders=[EncoderMetadata(**enc) for enc in meta.get("encoders", [])],
+                mask=[bool(value) for value in mask] if mask is not None else None,
             )
-            for name, meta in (by_modality or {}).items()
-        }
 
         fused_vectors: list[list[float]] | None = None
         if fused is not None:
@@ -69,11 +77,27 @@ class PerceptionPublisher:
             else:
                 fused_vectors = [[float(x) for x in emb] for emb in fused_list]
 
+        span_payload = (
+            [[int(span[0]), int(span[1])] for span in spans]
+            if spans is not None
+            else None
+        )
+        mask_payload = (
+            {
+                name: [bool(value) for value in values]
+                for name, values in contribution_mask.items()
+            }
+            if contribution_mask is not None
+            else {}
+        )
+
         payload = PerceptionEmbeddingsPayload(
             message_id=message_id,
             user_id=user_id,
             fused=fused_vectors,
             by_modality=modality_payloads,
+            spans=span_payload,
+            contribution_mask=mask_payload,
         )
 
         # Deduplicate encoders across modalities to avoid redundant metadata

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -151,6 +151,9 @@ class PerceptionService:
         provenance = dict(provenance or {})
         provenance.setdefault("timestamp", time.time())
 
+        grid_spans: list[list[int]] | None = None
+        hop_contribution_mask: Dict[str, list[bool]] | None = None
+
         if embeddings is None:
             modality_arrays: Dict[str, np.ndarray] = {}
             modality_times: Dict[str, np.ndarray] = {}
@@ -411,7 +414,7 @@ class PerceptionService:
             num_spans = int(np.ceil((end - start) / hop))
             grid_starts = start + np.arange(num_spans) * hop
             grid_ends = grid_starts + hop
-            spans = [[int(gs * 1000), int(ge * 1000)] for gs, ge in zip(grid_starts, grid_ends)]
+            grid_spans = [[int(gs * 1000), int(ge * 1000)] for gs, ge in zip(grid_starts, grid_ends)]
 
             if self.fuser is not None:
                 expected_order = list(self.fuser.modality_dims.keys())
@@ -420,6 +423,7 @@ class PerceptionService:
 
             aligned_modalities: Dict[str, torch.Tensor] = {}
             modality_payload: Dict[str, Dict[str, Any]] = {}
+            hop_contribution_mask = {name: [False] * num_spans for name in expected_order}
             for name in expected_order:
                 if name in modality_arrays:
                     arr = modality_arrays[name]
@@ -430,14 +434,16 @@ class PerceptionService:
                         mask = (gs < times[:, 1]) & (ge > times[:, 0])
                         if mask.any():
                             aligned[i] = arr[mask].mean(axis=0)
+                            hop_contribution_mask[name][i] = True
                     try:
                         aligned_modalities[name] = torch.from_numpy(aligned)
                     except RuntimeError:  # pragma: no cover - torch built without numpy
                         aligned_modalities[name] = torch.tensor(aligned.tolist(), dtype=torch.float32)
                     modality_payload[name] = {
-                        "spans": spans,
+                        "spans": grid_spans,
                         "embeddings": aligned.tolist(),
                         "encoders": [encoder_meta[name]] * num_spans,
+                        "mask": hop_contribution_mask[name],
                     }
                 elif self.fuser is not None and name in self.fuser.modality_dims:
                     dim = self.fuser.modality_dims[name]
@@ -456,7 +462,7 @@ class PerceptionService:
                             if expanded.ndim == 1:
                                 expanded = expanded.unsqueeze(0)
                             if expanded.ndim == 2:
-                                span_count = len(spans)
+                                span_count = len(grid_spans or [])
                                 if span_count == 0:
                                     logger.warning("No spans generated; skipping stored embedding for user %s", user_id)
                                 else:
@@ -506,6 +512,9 @@ class PerceptionService:
         else:
             modality_payload = {}
             fused_list = embeddings  # type: ignore[assignment]
+            if spans is not None:
+                grid_spans = [[int(span[0]), int(span[1])] for span in spans]
+            hop_contribution_mask = None
             if self.user_embeddings is not None:
                 fused_tensor = torch.tensor(embeddings, dtype=torch.float32)
                 if fused_tensor.numel() > 0:
@@ -523,6 +532,8 @@ class PerceptionService:
             fused=fused_list,
             by_modality=modality_payload,
             provenance=provenance,
+            spans=grid_spans,
+            contribution_mask=hop_contribution_mask,
         )
 
         if wandb_run is not None:


### PR DESCRIPTION
## Summary
- retain grid spans and modality contribution masks in the perception service and include them in published payloads
- extend perception embedding event payloads to carry shared spans and per-modality mask information
- update the perception publisher to emit the new fields while remaining backward compatible

## Testing
- flake8 src/deepthought/services/perception/service.py src/deepthought/services/perception/publisher.py src/deepthought/eda/events.py
- pytest tests/unit/test_perception_service.py
- pytest tests/unit/test_perception_spans_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68dd126e1db48326bec9ed666724b058