### PR TITLE
Fix perception publisher contribution mask handling

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -192,7 +192,6 @@ class PerceptionEmbeddingsPayload(EventPayload):
     spans: list[list[int]] = field(default_factory=list)
     modality_mask: Dict[str, list[bool]] = field(default_factory=dict)
     by_modality: Dict[str, ModalityEmbeddings] = field(default_factory=dict)
-    spans: Optional[list[list[int]]] = None
     contribution_mask: Dict[str, list[bool]] = field(default_factory=dict)
 
     @classmethod
@@ -211,11 +210,16 @@ class PerceptionEmbeddingsPayload(EventPayload):
                 mask=mask_list,
             )
         fused = data.get("fused")
-        spans = [[int(span[0]), int(span[1])] for span in data.get("spans", [])]
+        spans = [
+            [int(span[0]), int(span[1])] for span in data.get("spans", []) if len(span) >= 2
+        ]
         modality_mask = {
             name: [bool(flag) for flag in mask]
             for name, mask in data.get("modality_mask", {}).items()
-
+        }
+        contribution_mask = {
+            name: [bool(flag) for flag in mask]
+            for name, mask in data.get("contribution_mask", {}).items()
         }
         return cls(
             message_id=data["message_id"],
@@ -224,8 +228,7 @@ class PerceptionEmbeddingsPayload(EventPayload):
             spans=spans,
             modality_mask=modality_mask,
             by_modality=by_modality,
-            spans=[[int(span[0]), int(span[1])] for span in spans] if spans is not None else None,
-            contribution_mask=mask_map,
+            contribution_mask=contribution_mask,
         )
 
     @classmethod

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -33,9 +33,8 @@ class PerceptionPublisher:
         by_modality: Mapping[str, Mapping[str, Any]] | None = None,
         spans: Sequence[Sequence[int]] | None = None,
         modality_mask: Mapping[str, Sequence[bool | int]] | None = None,
+        contribution_mask: Mapping[str, Sequence[bool | int]] | None = None,
         provenance: Dict[str, Any] | None = None,
-        spans: Sequence[Sequence[int]] | None = None,
-        contribution_mask: Mapping[str, Sequence[bool]] | None = None,
         retries: int = 3,
     ) -> Dict | None:
         """Publish a :class:`PerceptionEmbeddingsEvent` with retries.
@@ -50,13 +49,16 @@ class PerceptionPublisher:
             Sequence of fused embedding vectors aligned to the common hop grid.
         by_modality:
             Mapping of modality name to its embeddings, spans and encoders.
-        provenance:
-            Provenance information about how the embeddings were generated.
         spans:
             Optional list of common grid spans shared across modalities.
+        modality_mask:
+            Optional mapping of modality name to a boolean list indicating the
+            hops for which that modality produced embeddings.
         contribution_mask:
             Optional mapping of modality name to a boolean list indicating
             whether that modality contributed to each hop of ``spans``.
+        provenance:
+            Provenance information about how the embeddings were generated.
         retries:
             Number of times to retry publishing on failure.
         """
@@ -90,6 +92,11 @@ class PerceptionPublisher:
             for name, flags in (modality_mask or {}).items()
         }
 
+        contribution_mask_payload: dict[str, list[bool]] = {
+            name: [bool(flag) for flag in flags]
+            for name, flags in (contribution_mask or {}).items()
+        }
+
 
         payload = PerceptionEmbeddingsPayload(
             message_id=message_id,
@@ -98,8 +105,7 @@ class PerceptionPublisher:
             spans=span_payload,
             modality_mask=mask_payload,
             by_modality=modality_payloads,
-            spans=span_payload,
-            contribution_mask=mask_payload,
+            contribution_mask=contribution_mask_payload,
         )
 
         # Deduplicate encoders across modalities to avoid redundant metadata

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -549,9 +549,8 @@ class PerceptionService:
             by_modality=modality_payload,
             spans=grid_spans,
             modality_mask=modality_mask_payload,
-            provenance=provenance,
-            spans=grid_spans,
             contribution_mask=hop_contribution_mask,
+            provenance=provenance,
         )
 
         if wandb_run is not None:

--- a/tests/unit/services/perception/test_perception_publisher.py
+++ b/tests/unit/services/perception/test_perception_publisher.py
@@ -1,4 +1,7 @@
+from types import ModuleType
 from unittest.mock import AsyncMock
+
+import sys
 
 import pytest
 
@@ -6,6 +9,17 @@ from deepthought.eda.events import (
     EventSubjects,
     PerceptionEmbeddingsEvent,
 )
+
+if "deepthought.services.perception.worker_video" not in sys.modules:
+    worker_video_stub = ModuleType("deepthought.services.perception.worker_video")
+    worker_video_stub.VideoPerceptionWorker = type("VideoPerceptionWorker", (), {})
+    sys.modules["deepthought.services.perception.worker_video"] = worker_video_stub
+
+if "deepthought.perception.worker_video" not in sys.modules:
+    perception_worker_stub = ModuleType("deepthought.perception.worker_video")
+    perception_worker_stub.video_to_feature_grid = lambda *args, **kwargs: None
+    sys.modules["deepthought.perception.worker_video"] = perception_worker_stub
+
 from deepthought.services.perception import publisher as perception_publisher
 
 
@@ -42,6 +56,7 @@ async def test_publish_embeddings(monkeypatch):
         },
         spans=[[0, 1]],
         modality_mask={"text": [True]},
+        contribution_mask={"text": [False]},
         provenance={"source": "unit"},
     )
 
@@ -54,6 +69,7 @@ async def test_publish_embeddings(monkeypatch):
     assert event.payload.fused == [[0.0, 0.1]]
     assert event.payload.spans == [[0, 1]]
     assert event.payload.modality_mask == {"text": [True]}
+    assert event.payload.contribution_mask == {"text": [False]}
     text_mod = event.payload.by_modality["text"]
 
     assert text_mod.encoders[0].name == "test"


### PR DESCRIPTION
## Summary
- ensure the perception publisher builds payloads with a single spans field and distinct contribution masks
- repair the perception embeddings payload dataclass to parse contribution masks correctly
- update perception publisher unit tests to cover the new argument and stub heavy optional dependencies

## Testing
- flake8 src tests
- pytest tests/unit/services/perception/test_perception_publisher.py

------
https://chatgpt.com/codex/tasks/task_e_68dd235acd2883268f29a0bc8bdc3b19