### PR TITLE
Add perception event round-trip tests

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -205,19 +205,27 @@ class PerceptionEmbeddingsPayload(EventPayload):
                     meta_dict = asdict(meta)
                 else:
                     meta_dict = dict(meta) if isinstance(meta, dict) else {}
+
                 mask = meta_dict.get("mask")
                 mask_list = [bool(value) for value in mask] if mask is not None else None
+                spans = [
+                    [int(span[0]), int(span[1])]
+                    for span in meta_dict.get("spans", [])
+                    if isinstance(span, (list, tuple)) and len(span) >= 2
+                ]
+                embeddings = [
+                    [float(x) for x in emb]
+                    for emb in meta_dict.get("embeddings", [])
+                    if isinstance(emb, (list, tuple))
+                ]
+                encoders = [
+                    enc if isinstance(enc, EncoderMetadata) else EncoderMetadata(**enc)
+                    for enc in meta_dict.get("encoders", [])
+                ]
                 by_modality[name] = ModalityEmbeddings(
-                    spans=[
-                        [int(span[0]), int(span[1])]
-                        for span in meta_dict.get("spans", [])
-                        if isinstance(span, (list, tuple)) and len(span) >= 2
-                    ],
-                    embeddings=[
-                        [float(x) for x in emb]
-                        for emb in meta_dict.get("embeddings", [])
-                    ],
-                    encoders=[EncoderMetadata(**enc) for enc in meta_dict.get("encoders", [])],
+                    spans=spans,
+                    embeddings=embeddings,
+                    encoders=encoders,
                     mask=mask_list,
                 )
 
@@ -225,45 +233,40 @@ class PerceptionEmbeddingsPayload(EventPayload):
         fused_vectors: Optional[list[list[float]]] = None
         if fused_raw is not None:
             fused_vectors = []
-            fused_list = list(fused_raw)
-            if fused_list and isinstance(fused_list[0], (int, float)):
-                fused_vectors.append([float(x) for x in fused_list])
-            else:
-                mask_list = None
-            by_modality[name] = ModalityEmbeddings(
-                spans=[[int(span[0]), int(span[1])] for span in meta.get("spans", [])],
-                embeddings=[list(map(float, emb)) for emb in meta.get("embeddings", [])],
-                encoders=[EncoderMetadata(**enc) for enc in meta.get("encoders", [])],
-                mask=mask_list,
-            )
-        fused = data.get("fused")
+            if isinstance(fused_raw, (list, tuple)):
+                if fused_raw and isinstance(fused_raw[0], (int, float)):
+                    fused_vectors.append([float(x) for x in fused_raw])
+                else:
+                    for vector in fused_raw:
+                        if isinstance(vector, (list, tuple)):
+                            fused_vectors.append([float(x) for x in vector])
+            if not fused_vectors:
+                fused_vectors = None
+
         spans = [
-            [int(span[0]), int(span[1])] for span in data.get("spans", []) if len(span) >= 2
+            [int(span[0]), int(span[1])]
+            for span in data.get("spans", [])
+            if isinstance(span, (list, tuple)) and len(span) >= 2
         ]
+
         modality_mask = {
             name: [bool(flag) for flag in mask]
-            for name, mask in data.get("modality_mask", {}).items()
+            for name, mask in (data.get("modality_mask") or {}).items()
         }
+
         contribution_mask = {
             name: [bool(flag) for flag in mask]
-            for name, mask in data.get("contribution_mask", {}).items()
-
-        }
-        hop_mask = {
-            name: [bool(flag) for flag in mask]
-            for name, mask in data.get("hop_contribution_mask", {}).items()
+            for name, mask in (data.get("contribution_mask") or {}).items()
         }
 
         return cls(
             message_id=data["message_id"],
             user_id=data["user_id"],
             fused=fused_vectors,
-            spans=spans_list,
+            spans=spans,
             modality_mask=modality_mask,
-            contribution_mask=contribution_mask,
             by_modality=by_modality,
             contribution_mask=contribution_mask,
-
         )
 
     @classmethod

--- a/tests/unit/eda/test_perception_events.py
+++ b/tests/unit/eda/test_perception_events.py
@@ -1,0 +1,96 @@
+"""Round-trip tests for :mod:`deepthought.eda.events` perception payloads."""
+
+from deepthought.eda.events import (
+    EncoderMetadata,
+    ModalityEmbeddings,
+    PerceptionEmbeddingsEvent,
+    PerceptionEmbeddingsPayload,
+)
+
+
+def _encoder(name: str, modality: str, dim: int) -> EncoderMetadata:
+    return EncoderMetadata(name=name, modality=modality, dim=dim)
+
+
+def test_roundtrip_without_fused_vectors():
+    payload = PerceptionEmbeddingsPayload(
+        message_id="msg-no-fused",
+        user_id="user-1",
+        spans=[[0, 5]],
+        modality_mask={"text": [True]},
+        contribution_mask={"text": [False]},
+        by_modality={
+            "text": ModalityEmbeddings(
+                spans=[[0, 5]],
+                embeddings=[[0.1, 0.2]],
+                encoders=[_encoder("text-enc", "text", 2)],
+                mask=[True],
+            )
+        },
+    )
+
+    event = PerceptionEmbeddingsEvent(
+        encoders=[_encoder("text-enc", "text", 2)],
+        provenance={"source": "unit-test"},
+        payload=payload,
+    )
+
+    encoded = event.to_json()
+    decoded = PerceptionEmbeddingsEvent.from_json(encoded)
+
+    assert decoded.payload == payload
+    assert decoded.payload.fused is None
+    assert decoded.payload.contribution_mask == payload.contribution_mask
+    assert decoded.encoders == event.encoders
+
+
+def test_roundtrip_with_multiple_modalities_and_masks():
+    payload = PerceptionEmbeddingsPayload(
+        message_id="msg-multi",
+        user_id="user-2",
+        fused=[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]],
+        spans=[[0, 10], [10, 20]],
+        modality_mask={
+            "audio": [True, False],
+            "vision": [True, True],
+        },
+        contribution_mask={
+            "audio": [True, False],
+            "vision": [False, True],
+        },
+        by_modality={
+            "audio": ModalityEmbeddings(
+                spans=[[0, 10], [10, 20]],
+                embeddings=[[0.05, 0.07], [0.08, 0.09]],
+                encoders=[_encoder("audio-enc", "audio", 2)],
+                mask=[True, False],
+            ),
+            "vision": ModalityEmbeddings(
+                spans=[[0, 10], [10, 20]],
+                embeddings=[[0.11, 0.12], [0.13, 0.14]],
+                encoders=[_encoder("vision-enc", "vision", 2)],
+                mask=[True, True],
+            ),
+        },
+    )
+
+    event = PerceptionEmbeddingsEvent(
+        encoders=[
+            _encoder("audio-enc", "audio", 2),
+            _encoder("vision-enc", "vision", 2),
+        ],
+        provenance={"source": "unit-test"},
+        payload=payload,
+    )
+
+    encoded = event.to_json()
+    decoded = PerceptionEmbeddingsEvent.from_json(encoded)
+
+    assert decoded.payload == payload
+    assert decoded.payload.fused == payload.fused
+    assert decoded.payload.modality_mask == payload.modality_mask
+    assert decoded.payload.contribution_mask == payload.contribution_mask
+    assert set(decoded.payload.by_modality) == {"audio", "vision"}
+    assert decoded.payload.by_modality["audio"].mask == [True, False]
+    assert decoded.payload.by_modality["vision"].mask == [True, True]
+    assert decoded.encoders == event.encoders


### PR DESCRIPTION
## Summary
- add dedicated perception event round-trip tests that exercise contribution masks, missing fused vectors, and multimodal payloads
- fix PerceptionEmbeddingsPayload.from_dict to correctly normalise modality metadata and fused embeddings

## Testing
- pytest tests/unit/eda/test_perception_events.py
- flake8 src tests

------
https://chatgpt.com/codex/tasks/task_e_68dd28839ec88326a999bc7f5a9aa30e