### PR TITLE
Configure PERCEPTION stream durability options

### DIFF
--- a/docs/perception_service.md
+++ b/docs/perception_service.md
@@ -33,6 +33,8 @@ After alignment and optional fusion, embeddings are published to:
 - `dtr.perception.embeddings`
 
 All messages are stored in the `PERCEPTION` stream created by `setup_jetstream.py`.
+The stream now persists data to disk by default so replay jobs survive
+process or node restarts.
 
 ## Event Schema
 
@@ -133,6 +135,35 @@ python -m deepthought.services.perception.cli --grid-hop-size 0.1 --listen
 
 The listener consumes `dtr.input.received` messages and publishes aligned embeddings to `dtr.perception.embeddings`.
 
+## Durability Configuration
+
+`setup_jetstream.py` configures the `PERCEPTION` stream with file-backed JetStream
+storage and exposes several environment variables for tuning durability:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PERCEPTION_RETENTION_POLICY` | `limits` | Retention policy (`limits`, `interest`, or `workqueue`). |
+| `PERCEPTION_MAX_MSGS_PER_SUBJECT` | `10000` | Cap on messages per subject (set to `0` or unset for unlimited). |
+| `PERCEPTION_MAX_MSGS` | unset | Global message limit across the stream. |
+| `PERCEPTION_MAX_BYTES` | unset | Byte budget for the stream. |
+| `PERCEPTION_MAX_AGE_SECONDS` | unset | Age limit before JetStream evicts entries. |
+
+Unset values fall back to JetStream defaults (`-1`/unlimited). For production
+commercialization we recommend budgeting disk space explicitly and pinning a
+retention window, for example:
+
+```bash
+export PERCEPTION_RETENTION_POLICY=limits
+export PERCEPTION_MAX_BYTES=$((80 * 1024 * 1024 * 1024))   # 80 GiB
+export PERCEPTION_MAX_MSGS_PER_SUBJECT=0                   # unlimited per subject
+export PERCEPTION_MAX_AGE_SECONDS=$((7 * 24 * 60 * 60))    # 7 days
+```
+
+These settings keep roughly a week of perception traffic while preventing the
+stream from exhausting disk space. Increase `PERCEPTION_MAX_BYTES` or shorten
+`PERCEPTION_MAX_AGE_SECONDS` based on observed throughput and retention
+requirements.
+
 ## Replay and Monitoring
 
 ### Replaying Events
@@ -196,7 +227,7 @@ Key flags:
 Perception inputs may contain personally identifiable information. Deployments **must** obtain user consent and disclose how media and derived embeddings are stored or shared.
 
 - **Consent toggles:** set `PERCEPTION_REQUIRE_CONSENT=1` to ignore messages without an explicit `"consent": true` flag. Per-modality variables such as `DT_REQUIRE_AUDIO_CONSENT` and `DT_AUDIO_CONSENT` can enforce and grant consent for specific media types.
-- **Data retention:** the `PERCEPTION` stream defaults to JetStream's `limits` policy. Override `PERCEPTION_RETENTION_POLICY` with `limits`, `interest`, or `workqueue` to control storage duration.
+- **Data retention:** adjust the environment variables above to match your legal and operational policies. File-backed storage means embeddings persist until retention limits or quotas evict them.
 - **External monitoring:** enabling W&B (`DT_WANDB_ENABLED=1`) sends metrics to a third-party service. Ensure this complies with your privacy policy.
 
 Example configuration:

--- a/setup_jetstream.py
+++ b/setup_jetstream.py
@@ -9,6 +9,7 @@ import logging
 import os
 import socket
 import sys
+from typing import Any, Dict
 from urllib.parse import urlparse
 
 from nats.aio.client import Client as NATS
@@ -36,6 +37,79 @@ PERCEPTION_CONSUMERS = [
     "memory-perception-consumer",
     "analytics-perception-consumer",
 ]
+
+
+_RETENTION_POLICY_ALIASES: Dict[str, RetentionPolicy] = {
+    "limits": RetentionPolicy.LIMITS,
+    "interest": RetentionPolicy.INTEREST,
+    "workqueue": RetentionPolicy.WORK_QUEUE,
+    "work_queue": RetentionPolicy.WORK_QUEUE,
+    "work-queue": RetentionPolicy.WORK_QUEUE,
+}
+
+
+def _get_retention_policy(env_value: str | None) -> RetentionPolicy:
+    """Return the :class:`RetentionPolicy` for ``env_value``.
+
+    If ``env_value`` is ``None`` or invalid, ``RetentionPolicy.LIMITS`` is used.
+    """
+
+    if not env_value:
+        return RetentionPolicy.LIMITS
+
+    policy = _RETENTION_POLICY_ALIASES.get(env_value.strip().lower())
+    if policy is None:
+        logger.warning(
+            "Unknown PERCEPTION_RETENTION_POLICY '%s'; defaulting to LIMITS",
+            env_value,
+        )
+        return RetentionPolicy.LIMITS
+    return policy
+
+
+def _get_optional_int(env_var: str) -> int | None:
+    """Return an ``int`` from ``env_var`` or ``None`` if unset/invalid."""
+
+    raw = os.getenv(env_var)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid integer for %s: %s", env_var, raw)
+        return None
+
+
+def _build_perception_stream_config() -> StreamConfig:
+    """Create the PERCEPTION stream configuration honoring environment overrides."""
+
+    retention_policy = _get_retention_policy(os.getenv("PERCEPTION_RETENTION_POLICY"))
+    max_msgs_per_subject = _get_optional_int("PERCEPTION_MAX_MSGS_PER_SUBJECT")
+    max_msgs = _get_optional_int("PERCEPTION_MAX_MSGS")
+    max_bytes = _get_optional_int("PERCEPTION_MAX_BYTES")
+    max_age_seconds = _get_optional_int("PERCEPTION_MAX_AGE_SECONDS")
+
+    config_kwargs: Dict[str, Any] = {
+        "name": "PERCEPTION",
+        "subjects": ["dtr.perception.>"],
+        "retention": retention_policy,
+        "storage": StorageType.FILE,
+        "discard": DiscardPolicy.OLD,
+    }
+
+    if max_msgs_per_subject is not None:
+        config_kwargs["max_msgs_per_subject"] = max_msgs_per_subject
+    else:
+        config_kwargs["max_msgs_per_subject"] = 10000
+
+    if max_msgs is not None:
+        config_kwargs["max_msgs"] = max_msgs
+    if max_bytes is not None:
+        config_kwargs["max_bytes"] = max_bytes
+    if max_age_seconds is not None:
+        config_kwargs["max_age"] = max_age_seconds * 1_000_000_000
+
+    return StreamConfig(**config_kwargs)
 
 
 def check_nats_server_running(url: str = NATS_URL) -> bool:
@@ -123,15 +197,8 @@ async def setup_jetstream() -> None:
             stream = await js.update_stream(config=stream_config)
             logger.info(f"Updated JetStream stream: {stream.config.name}")
 
-        # Define PERCEPTION stream
-        perception_stream = StreamConfig(
-            name="PERCEPTION",
-            subjects=["dtr.perception.>"],
-            retention=RetentionPolicy.LIMITS,
-            storage=StorageType.MEMORY,
-            max_msgs_per_subject=10000,
-            discard=DiscardPolicy.OLD,
-        )
+        # Define PERCEPTION stream with durability configuration overrides
+        perception_stream = _build_perception_stream_config()
 
         try:
             await js.add_stream(config=perception_stream)

--- a/tests/integration/test_perception_cli_replay.py
+++ b/tests/integration/test_perception_cli_replay.py
@@ -95,3 +95,33 @@ async def test_perception_cli_replay_honors_consent(monkeypatch, nats_server):
 
     assert len(received) == 1
     assert received[0]["message_id"] == "m1"
+
+
+@pytest.mark.asyncio
+async def test_setup_script_configures_file_storage(monkeypatch, nats_server):
+    if not nats_server_available(nats_server):
+        pytest.skip("NATS server not available")
+
+    monkeypatch.setenv("NATS_URL", nats_server)
+    monkeypatch.setenv("PERCEPTION_RETENTION_POLICY", "workqueue")
+    monkeypatch.setenv("PERCEPTION_MAX_MSGS_PER_SUBJECT", "4321")
+    monkeypatch.setenv("PERCEPTION_MAX_MSGS", "9000")
+    monkeypatch.setenv("PERCEPTION_MAX_BYTES", "1048576")
+    monkeypatch.setenv("PERCEPTION_MAX_AGE_SECONDS", "60")
+
+    setup_mod = importlib.import_module("setup_jetstream")
+    setup_mod = importlib.reload(setup_mod)
+    await setup_mod.setup_jetstream()
+
+    nc = await NATS().connect(servers=[nats_server])
+    js = nc.jetstream()
+    info = await js.stream_info("PERCEPTION")
+
+    assert info.config.storage == StorageType.FILE
+    assert info.config.retention == RetentionPolicy.WORK_QUEUE
+    assert info.config.max_msgs_per_subject == 4321
+    assert info.config.max_msgs == 9000
+    assert info.config.max_bytes == 1048576
+    assert info.config.max_age == 60 * 1_000_000_000
+
+    await nc.drain()


### PR DESCRIPTION
## Summary
- switch the PERCEPTION JetStream stream to file-backed storage and allow retention and limit overrides via environment variables
- document the new durability controls and recommend production-ready defaults for commercialization
- add integration coverage that asserts the setup script configures file storage and honors limit overrides

## Testing
- pytest tests/integration/test_perception_cli_replay.py *(skipped: nats-server executable not available)*

------
https://chatgpt.com/codex/tasks/task_e_68de8b907dac8326ac577db416c468bb