### PR TITLE
Add Discord gateway service

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,36 @@ Users would typically incorporate these scripts into their Unity projects and us
         ```
 5.  **Run Components/Tests:** (Specific instructions TBD as components are developed)
 
+### Discord Gateway Bot
+
+The repository includes a Discord gateway that bridges channels with the DeepThought
+event bus. To run the bot locally:
+
+1.  Create a Discord application and bot token via the [Discord Developer Portal](https://discord.com/developers/applications).
+    Invite the bot to your server with the `Send Messages` and `Read Message History`
+    permissions.
+2.  Ensure JetStream has a durable consumer for the `dtr.response.ranked` subject.
+    When using `setup_jetstream.py`, the stream created for DeepThought events can be
+    reused; just make sure the consumer allows queue subscriptions under the durable
+    name `gw_ranked_v1`.
+3.  Export the required environment variables:
+
+    ```bash
+    export DISCORD_BOT_TOKEN="your-bot-token"
+    export NATS_URL="nats://localhost:4222"              # optional when using defaults
+    export NATS_CREDS_FILE="/path/to/creds.creds"        # optional user credentials file
+    ```
+
+4.  Start the gateway:
+
+    ```bash
+    python bot_gateway.py
+    ```
+
+The gateway publishes text messages from Discord to the `discord.message.text`
+subject and posts responses from `dtr.response.ranked` back into the originating
+Discord channels using the durable consumer `gw_ranked_v1` for reliable delivery.
+
 ## Deployment
 
 The repository includes an `orchestrator.yaml` manifest that captures the

--- a/bot_gateway.py
+++ b/bot_gateway.py
@@ -1,0 +1,63 @@
+"""Entrypoint for running the Discord gateway."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+from contextlib import suppress
+from typing import Any, Dict
+
+from nats.aio.client import Client as NATS
+
+from src.deepthought.config import load_config_from_env
+from src.deepthought.eda.publisher import Publisher
+from src.deepthought.eda.subscriber import Subscriber
+from src.deepthought.edge.discord_gateway import DiscordGateway
+
+
+async def _main() -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(name)s: %(message)s")
+
+    discord_token = os.getenv("DISCORD_BOT_TOKEN")
+    if not discord_token:
+        raise RuntimeError("DISCORD_BOT_TOKEN environment variable must be set.")
+
+    config = load_config_from_env()
+    nats_client = NATS()
+    connect_kwargs: Dict[str, Any] = {"servers": config.nats_url}
+    creds_file = os.getenv("NATS_CREDS_FILE")
+    if creds_file:
+        connect_kwargs["user_credentials"] = creds_file
+    await nats_client.connect(**connect_kwargs)
+    js = nats_client.jetstream()
+
+    publisher = Publisher(nats_client, js)
+    subscriber = Subscriber(nats_client, js)
+    gateway = DiscordGateway(publisher=publisher, subscriber=subscriber)
+
+    stop_event = asyncio.Event()
+
+    def _handle_stop(*_: object) -> None:
+        logging.info("Received shutdown signal")
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, _handle_stop)
+
+    runner = asyncio.create_task(gateway.run(discord_token))
+
+    await stop_event.wait()
+    runner.cancel()
+    with suppress(asyncio.CancelledError):
+        await runner
+
+    await gateway.stop()
+    await nats_client.drain()
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/src/deepthought/edge/__init__.py
+++ b/src/deepthought/edge/__init__.py
@@ -1,0 +1,5 @@
+"""Edge integrations for DeepThought."""
+
+from .discord_gateway import DiscordGateway, DiscordGatewayConfig
+
+__all__ = ["DiscordGateway", "DiscordGatewayConfig"]

--- a/src/deepthought/edge/discord_gateway.py
+++ b/src/deepthought/edge/discord_gateway.py
@@ -1,0 +1,186 @@
+"""Discord gateway for DeepThought's event bus."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+try:  # pragma: no cover - import guard for optional dependency
+    import discord
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests without discord.py
+    discord = None  # type: ignore
+
+from nats.aio.msg import Msg
+
+from ..eda.events import EventSubjects
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class DiscordGatewayConfig:
+    """Configuration for the Discord gateway."""
+
+    incoming_subject: str = "discord.message.text"
+    response_subject: str = EventSubjects.RESPONSE_RANKED
+    durable_name: str = "gw_ranked_v1"
+
+
+class DiscordGateway:
+    """Bridge Discord messages to the DeepThought event bus."""
+
+    def __init__(
+        self,
+        publisher: Publisher,
+        subscriber: Subscriber,
+        *,
+        client: Optional[Any] = None,
+        config: Optional[DiscordGatewayConfig] = None,
+    ) -> None:
+        self._publisher = publisher
+        self._subscriber = subscriber
+        self._config = config or DiscordGatewayConfig()
+        self._client = client or self._create_default_client()
+        self._response_subscription_started = False
+        self._registered_events = False
+        logger.debug("DiscordGateway initialized with subjects %s -> %s", self._config.incoming_subject, self._config.response_subject)
+
+    def _create_default_client(self) -> Any:
+        """Create a default Discord client instance."""
+        if discord is None:
+            raise RuntimeError(
+                "discord.py is not installed. Provide a pre-configured client when constructing DiscordGateway."
+            )
+        intents = discord.Intents.default()
+        intents.message_content = True
+        return discord.Client(intents=intents)
+
+    def _register_client_events(self) -> None:
+        if self._registered_events:
+            return
+
+        @self._client.event
+        async def on_ready() -> None:  # pragma: no cover - trivial logging
+            logger.info("Discord gateway connected as %%s", getattr(self._client, "user", "unknown"))
+
+        @self._client.event
+        async def on_message(message: Any) -> None:
+            await self._handle_discord_message(message)
+
+        self._registered_events = True
+        logger.debug("Discord client events registered")
+
+    async def _handle_discord_message(self, message: Any) -> None:
+        """Translate a Discord message into a bus event."""
+        author = getattr(message, "author", None)
+        if author and getattr(author, "bot", False):
+            logger.debug("Ignoring bot message from %s", getattr(author, "id", "unknown"))
+            return
+
+        content = getattr(message, "content", None)
+        if not content:
+            logger.debug("Ignoring Discord message without content")
+            return
+
+        payload: Dict[str, Any] = {
+            "message_id": getattr(message, "id", None),
+            "channel_id": getattr(getattr(message, "channel", None), "id", None),
+            "author_id": getattr(author, "id", None),
+            "author_name": getattr(author, "name", None),
+            "content": content,
+        }
+        logger.info("Publishing Discord message %s to %s", payload["message_id"], self._config.incoming_subject)
+        await self._publisher.publish(self._config.incoming_subject, payload, use_jetstream=True)
+
+    async def _handle_ranked_response(self, msg: Msg) -> None:
+        """Post ranked responses back into Discord."""
+        try:
+            data = json.loads(msg.data.decode()) if msg.data else {}
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to decode ranked response payload: %s", exc)
+            await msg.ack()
+            return
+
+        channel_id = data.get("channel_id")
+        message_content = self._extract_message_content(data)
+
+        if not channel_id or not message_content:
+            logger.warning("Ranked response missing channel or content: %s", data)
+            await msg.ack()
+            return
+
+        channel = None
+        if hasattr(self._client, "get_channel"):
+            channel = self._client.get_channel(channel_id)
+
+        if channel is None:
+            logger.warning("Discord channel %s not found for response", channel_id)
+            await msg.ack()
+            return
+
+        send_method: Optional[Callable[[str], Any]] = getattr(channel, "send", None)
+        if send_method is None:
+            logger.error("Channel %s does not support async send", channel_id)
+            await msg.ack()
+            return
+
+        logger.info("Sending ranked response to channel %s", channel_id)
+        result = send_method(message_content)
+        if asyncio.iscoroutine(result):
+            await result
+        else:
+            logger.error("Channel %s send method did not return a coroutine", channel_id)
+            await msg.ack()
+            return
+        await msg.ack()
+
+    @staticmethod
+    def _extract_message_content(data: Dict[str, Any]) -> Optional[str]:
+        message_content = data.get("content") or data.get("final_response")
+        if message_content:
+            return message_content
+        ranked = data.get("ranked_candidates")
+        if isinstance(ranked, list) and ranked:
+            first = ranked[0]
+            if isinstance(first, dict):
+                return first.get("content") or first.get("text")
+            if isinstance(first, str):
+                return first
+        return None
+
+    async def setup(self) -> None:
+        """Prepare the gateway by registering events and subscriptions."""
+        self._register_client_events()
+        if not self._response_subscription_started:
+            await self._subscriber.subscribe(
+                subject=self._config.response_subject,
+                handler=self._handle_ranked_response,
+                use_jetstream=True,
+                durable=self._config.durable_name,
+            )
+            self._response_subscription_started = True
+            logger.debug(
+                "Subscribed to %s with durable %s", self._config.response_subject, self._config.durable_name
+            )
+
+    async def run(self, token: str) -> None:
+        """Run the Discord client after ensuring subscriptions are ready."""
+        await self.setup()
+        await self._client.start(token)
+
+    async def stop(self) -> None:
+        """Cleanly shut down the gateway."""
+        if self._response_subscription_started:
+            await self._subscriber.unsubscribe_all()
+            self._response_subscription_started = False
+        close_method = getattr(self._client, "close", None)
+        if close_method is not None:
+            result = close_method()
+            if asyncio.iscoroutine(result):
+                await result
+        logger.info("Discord gateway stopped")

--- a/tests/test_discord_gateway.py
+++ b/tests/test_discord_gateway.py
@@ -1,0 +1,163 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from src.deepthought.edge.discord_gateway import DiscordGateway, DiscordGatewayConfig
+
+
+class FakePublisher:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.calls.append({
+            "subject": subject,
+            "payload": payload,
+            "use_jetstream": use_jetstream,
+            "timeout": timeout,
+        })
+
+
+class FakeSubscriber:
+    def __init__(self) -> None:
+        self.subscriptions = []
+        self.unsubscribed = False
+
+    async def subscribe(self, subject, handler, queue="", use_jetstream=False, durable=""):
+        self.subscriptions.append({
+            "subject": subject,
+            "handler": handler,
+            "queue": queue,
+            "use_jetstream": use_jetstream,
+            "durable": durable,
+        })
+        self.handler = handler
+
+    async def unsubscribe_all(self):
+        self.unsubscribed = True
+
+
+class FakeChannel:
+    def __init__(self, channel_id):
+        self.id = channel_id
+        self.sent_messages = []
+
+    async def send(self, content):
+        self.sent_messages.append(content)
+
+
+class FakeDiscordClient:
+    def __init__(self):
+        self._events = {}
+        self._channels = {}
+        self.closed = False
+
+    def event(self, coro):
+        self._events[coro.__name__] = coro
+        return coro
+
+    def get_channel(self, channel_id):
+        return self._channels.get(channel_id)
+
+    def add_channel(self, channel):
+        self._channels[channel.id] = channel
+
+    async def start(self, token):  # pragma: no cover - not exercised in unit tests
+        self.started_token = token
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeMsg:
+    def __init__(self, data):
+        self.data = data
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_gateway_publishes_discord_messages():
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    client = FakeDiscordClient()
+    gateway = DiscordGateway(publisher=publisher, subscriber=subscriber, client=client)
+
+    await gateway.setup()
+
+    message_handler = client._events["on_message"]
+    message = SimpleNamespace(
+        id="m-1",
+        content="Hello DeepThought",
+        author=SimpleNamespace(id="user-123", name="Tester", bot=False),
+        channel=SimpleNamespace(id=999),
+    )
+
+    await message_handler(message)
+
+    assert len(publisher.calls) == 1
+    call = publisher.calls[0]
+    assert call["subject"] == DiscordGatewayConfig().incoming_subject
+    assert call["payload"]["content"] == "Hello DeepThought"
+    assert call["payload"]["channel_id"] == 999
+    assert call["use_jetstream"] is True
+
+    assert len(subscriber.subscriptions) == 1
+    sub = subscriber.subscriptions[0]
+    assert sub["durable"] == DiscordGatewayConfig().durable_name
+    assert sub["use_jetstream"] is True
+
+
+@pytest.mark.asyncio
+async def test_gateway_ignores_bot_messages():
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    client = FakeDiscordClient()
+    gateway = DiscordGateway(publisher=publisher, subscriber=subscriber, client=client)
+
+    await gateway.setup()
+
+    message_handler = client._events["on_message"]
+    bot_message = SimpleNamespace(
+        id="m-2",
+        content="Bot message",
+        author=SimpleNamespace(id="bot-1", name="Bot", bot=True),
+        channel=SimpleNamespace(id=1),
+    )
+
+    await message_handler(bot_message)
+
+    assert publisher.calls == []
+
+
+@pytest.mark.asyncio
+async def test_ranked_responses_post_to_discord():
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    client = FakeDiscordClient()
+    channel = FakeChannel(77)
+    client.add_channel(channel)
+    gateway = DiscordGateway(publisher=publisher, subscriber=subscriber, client=client)
+
+    await gateway.setup()
+
+    sub = subscriber.subscriptions[0]
+    handler = sub["handler"]
+    payload = {
+        "channel_id": 77,
+        "content": "Hello from the bus",
+    }
+    msg = FakeMsg(json.dumps(payload).encode())
+
+    await handler(msg)
+
+    assert channel.sent_messages == ["Hello from the bus"]
+    assert msg.acked is True
+
+    await gateway.stop()
+    assert subscriber.unsubscribed is True
+    assert client.closed is True


### PR DESCRIPTION
## Summary
- add a Discord gateway that bridges Discord messages to the existing event bus and consumes ranked responses via durable `gw_ranked_v1`
- provide a `bot_gateway.py` entrypoint that wires the reusable Publisher/Subscriber with optional NATS credentials support
- document the new gateway setup flow and cover the translation logic with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de8c3748c48326aac900dbe416d8e3