### PR TITLE
Add asynchronous service layer for JetStream workflows

### DIFF
--- a/src/deepthought/bus.py
+++ b/src/deepthought/bus.py
@@ -1,0 +1,46 @@
+"""Shared bus interfaces for DeepThought services."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Protocol
+
+from .eda.publisher import Publisher as _Publisher
+from .eda.subscriber import Subscriber as _Subscriber
+
+MessageHandler = Callable[[Any], Awaitable[None]]
+
+
+class Publisher(Protocol):
+    """Protocol describing the publish interface used by services."""
+
+    async def publish(self, subject: str, payload: Any) -> None:
+        ...
+
+
+class Subscriber(Protocol):
+    """Protocol describing the subscribe interface used by services."""
+
+    async def subscribe(
+        self,
+        subject: str,
+        handler: MessageHandler,
+        queue: str = "",
+        use_jetstream: bool = False,
+        durable: str = "",
+    ) -> None:
+        ...
+
+
+__all__ = ["Publisher", "Subscriber", "MessageHandler", "get_publisher", "get_subscriber"]
+
+
+def get_publisher(publisher: _Publisher) -> Publisher:
+    """Return a Publisher compliant instance from the EDA layer."""
+
+    return publisher
+
+
+def get_subscriber(subscriber: _Subscriber) -> Subscriber:
+    """Return a Subscriber compliant instance from the EDA layer."""
+
+    return subscriber

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -43,6 +43,9 @@ class EventSubjects:
     QUEST_DONE = "dtr.quest.done"
     """Published when a quest has been completed."""
 
+    QUEST_SNAPSHOT = "dtr.quest.snapshot"
+    """Published with the current in-memory quest state."""
+
     # Response selection events
     RESPONSE_CANDIDATES = "dtr.response.candidates"
     """Published with the set of response candidates produced by responders."""
@@ -56,7 +59,10 @@ class EventSubjects:
 
     PERCEPTION_IMAGE_EMBED = "dtr.perception.image.embed"
     """Published when image perception embeddings are created."""
-    
+
+    PERCEPTION_FUSED = "dtr.perception.fused"
+    """Published when audio and image embeddings are fused."""
+
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
     # e.g., METRICS = "dtr.metrics.reported"
@@ -157,6 +163,15 @@ class QuestDonePayload(EventPayload):
 
 
 @dataclass
+class QuestSnapshotPayload(EventPayload):
+    """Payload for snapshots of the quest log."""
+
+    quests: List[Dict[str, Any]]
+    changed: Dict[str, Any]
+    timestamp: Optional[str] = None
+
+
+@dataclass
 class ResponseCandidatesPayload(EventPayload):
     """Payload for response candidate generation events."""
 
@@ -191,5 +206,15 @@ class PerceptionImageEmbedPayload(EventPayload):
 
     image_id: str
     embedding: List[float]
+    metadata: Optional[Dict[str, Any]] = None
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class PerceptionFusedPayload(EventPayload):
+    """Payload for fused multimodal perception events."""
+
+    input_id: str
+    features: Dict[str, Any]
     metadata: Optional[Dict[str, Any]] = None
     timestamp: Optional[str] = None

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -1,0 +1,17 @@
+"""Service layer for DeepThought event-driven components."""
+
+from .base import BaseService
+from .social_graph import SocialGraphService
+from .questlog import QuestLogService
+from .perception import PerceptionService
+from .responder import ResponderService
+from .selector import SelectorService
+
+__all__ = [
+    "BaseService",
+    "SocialGraphService",
+    "QuestLogService",
+    "PerceptionService",
+    "ResponderService",
+    "SelectorService",
+]

--- a/src/deepthought/services/base.py
+++ b/src/deepthought/services/base.py
@@ -1,0 +1,55 @@
+"""Shared helpers for DeepThought asynchronous services."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict
+
+from ..bus import Publisher, Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class BaseService:
+    """Base class that provides convenience helpers for services."""
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        self._subscriber = subscriber
+        self._publisher = publisher
+
+    @staticmethod
+    def _decode_message(msg: Any) -> Dict[str, Any]:
+        """Decode a NATS message into a dictionary."""
+        try:
+            if not hasattr(msg, "data"):
+                raise ValueError("Message does not contain raw data")
+            payload = msg.data
+            if isinstance(payload, bytes):
+                payload = payload.decode("utf-8")
+            if isinstance(payload, str):
+                return json.loads(payload)
+            if isinstance(payload, Dict):
+                return payload
+            raise TypeError(f"Unsupported payload type: {type(payload)!r}")
+        except Exception:
+            logger.exception("Failed to decode message payload.")
+            raise
+
+    @staticmethod
+    async def _ack_message(msg: Any) -> None:
+        """Safely acknowledge a JetStream message if possible."""
+        if hasattr(msg, "ack") and callable(msg.ack):
+            try:
+                await msg.ack()
+            except Exception:
+                logger.exception("Failed to acknowledge JetStream message.")
+                raise
+
+    async def _publish(self, subject: str, payload: Dict[str, Any]) -> None:
+        """Publish a payload and log failures."""
+        try:
+            await self._publisher.publish(subject, payload)
+        except Exception:
+            logger.exception("Failed to publish payload to %s", subject)
+            raise

--- a/src/deepthought/services/perception/__init__.py
+++ b/src/deepthought/services/perception/__init__.py
@@ -1,0 +1,5 @@
+"""Perception fusion service."""
+
+from .service import PerceptionService
+
+__all__ = ["PerceptionService"]

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -1,0 +1,86 @@
+"""Fuse perception embeddings into a multimodal representation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, MutableMapping
+
+from ...bus import Publisher, Subscriber
+from ...eda.events import EventSubjects
+from ..base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class PerceptionService(BaseService):
+    """Fuse audio and image embeddings and publish combined features."""
+
+    AUDIO_DURABLE = "perc_audio_v1"
+    IMAGE_DURABLE = "perc_image_v1"
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        super().__init__(subscriber, publisher)
+        self._embeddings: MutableMapping[str, Dict[str, Any]] = {}
+        self._start_lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        async with self._start_lock:
+            if self._started:
+                return
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_AUDIO_EMBED,
+                handler=self._handle_audio,
+                use_jetstream=True,
+                durable=self.AUDIO_DURABLE,
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_IMAGE_EMBED,
+                handler=self._handle_image,
+                use_jetstream=True,
+                durable=self.IMAGE_DURABLE,
+            )
+            self._started = True
+            logger.info(
+                "PerceptionService listening for audio (%s) and image (%s) embeddings",
+                EventSubjects.PERCEPTION_AUDIO_EMBED,
+                EventSubjects.PERCEPTION_IMAGE_EMBED,
+            )
+
+    async def _handle_audio(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        await self._update_embedding("audio", payload)
+        await self._ack_message(msg)
+
+    async def _handle_image(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        await self._update_embedding("image", payload)
+        await self._ack_message(msg)
+
+    async def _update_embedding(self, modality: str, payload: Dict[str, Any]) -> None:
+        input_id = payload.get("input_id") or payload.get("audio_id") or payload.get("image_id")
+        if not input_id:
+            logger.warning("Perception payload missing identifier: %s", payload)
+            return
+        record = self._embeddings.setdefault(input_id, {})
+        record[modality] = payload
+        logger.debug("Updated %s embedding for %s", modality, input_id)
+
+        if "audio" in record and "image" in record:
+            fused_payload = {
+                "input_id": input_id,
+                "features": {
+                    "audio": record["audio"].get("embedding"),
+                    "image": record["image"].get("embedding"),
+                },
+                "metadata": {
+                    "audio_meta": record["audio"].get("metadata"),
+                    "image_meta": record["image"].get("metadata"),
+                },
+                "meta": {"source": "perception_service"},
+            }
+            logger.debug("Publishing fused perception payload for %s", input_id)
+            await self._publish(EventSubjects.PERCEPTION_FUSED, fused_payload)

--- a/src/deepthought/services/questlog/__init__.py
+++ b/src/deepthought/services/questlog/__init__.py
@@ -1,0 +1,5 @@
+"""Quest log service."""
+
+from .service import QuestLogService
+
+__all__ = ["QuestLogService"]

--- a/src/deepthought/services/questlog/service.py
+++ b/src/deepthought/services/questlog/service.py
@@ -1,0 +1,131 @@
+"""Quest log service backed by JetStream."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict
+
+from ...bus import Publisher, Subscriber
+from ...eda.events import EventSubjects
+from ..base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class QuestLogService(BaseService):
+    """Track quest lifecycle events and emit snapshots and completions."""
+
+    CREATE_DURABLE = "ql_create_v1"
+    UPDATE_DURABLE = "ql_update_v1"
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        super().__init__(subscriber, publisher)
+        self._quests: Dict[str, Dict[str, Any]] = {}
+        self._start_lock = asyncio.Lock()
+        self._started = False
+        self._service_id = "questlog_service"
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        async with self._start_lock:
+            if self._started:
+                return
+            await self._subscriber.subscribe(
+                subject=EventSubjects.QUEST_CREATE,
+                handler=self._handle_create,
+                use_jetstream=True,
+                durable=self.CREATE_DURABLE,
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.QUEST_UPDATE,
+                handler=self._handle_update,
+                use_jetstream=True,
+                durable=self.UPDATE_DURABLE,
+            )
+            self._started = True
+            logger.info("QuestLogService listening on %s and %s", EventSubjects.QUEST_CREATE, EventSubjects.QUEST_UPDATE)
+
+    async def _handle_create(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        quest_id = payload.get("quest_id")
+        if not quest_id:
+            logger.warning("Quest create event missing quest_id: %s", payload)
+            await self._ack_message(msg)
+            return
+
+        meta = payload.get("meta", {})
+        if meta.get("source") == self._service_id:
+            await self._ack_message(msg)
+            return
+
+        quest_state = {
+            "quest_id": quest_id,
+            "name": payload.get("name"),
+            "description": payload.get("description"),
+            "status": payload.get("status", "created"),
+            "progress": payload.get("progress", 0.0),
+            "metadata": payload.get("metadata", {}),
+        }
+        self._quests[quest_id] = quest_state
+
+        snapshot = {
+            "quests": list(self._quests.values()),
+            "changed": quest_state,
+            "meta": {"source": self._service_id},
+        }
+        await self._publish(EventSubjects.QUEST_SNAPSHOT, snapshot)
+        await self._ack_message(msg)
+
+    async def _handle_update(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        quest_id = payload.get("quest_id")
+        if not quest_id:
+            logger.warning("Quest update event missing quest_id: %s", payload)
+            await self._ack_message(msg)
+            return
+
+        meta = payload.get("meta", {})
+        if meta.get("source") == self._service_id:
+            await self._ack_message(msg)
+            return
+
+        quest_state = self._quests.setdefault(
+            quest_id,
+            {
+                "quest_id": quest_id,
+                "name": payload.get("name"),
+                "description": payload.get("description"),
+                "status": "created",
+                "progress": 0.0,
+                "metadata": {},
+            },
+        )
+        if "status" in payload:
+            quest_state["status"] = payload["status"]
+        if "progress" in payload:
+            quest_state["progress"] = payload["progress"]
+        if "metadata" in payload and isinstance(payload["metadata"], dict):
+            quest_state.setdefault("metadata", {}).update(payload["metadata"])
+
+        snapshot = {
+            "quests": list(self._quests.values()),
+            "changed": quest_state,
+            "meta": {"source": self._service_id},
+        }
+        await self._publish(EventSubjects.QUEST_SNAPSHOT, snapshot)
+
+        status = quest_state.get("status", "").lower()
+        if status in {"completed", "done", "finished"}:
+            done_payload = {
+                "quest_id": quest_id,
+                "result": {
+                    "status": status,
+                    "progress": quest_state.get("progress", 1.0),
+                },
+                "meta": {"source": self._service_id},
+            }
+            await self._publish(EventSubjects.QUEST_DONE, done_payload)
+
+        await self._ack_message(msg)

--- a/src/deepthought/services/responder/__init__.py
+++ b/src/deepthought/services/responder/__init__.py
@@ -1,0 +1,5 @@
+"""Responder service."""
+
+from .service import ResponderService
+
+__all__ = ["ResponderService"]

--- a/src/deepthought/services/responder/service.py
+++ b/src/deepthought/services/responder/service.py
@@ -1,0 +1,106 @@
+"""Create response candidates from fused perception and memory."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, MutableMapping
+
+from ...bus import Publisher, Subscriber
+from ...eda.events import EventSubjects
+from ..base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class ResponderService(BaseService):
+    """Generate candidate responses using fused perception and memory context."""
+
+    FUSED_DURABLE = "resp_fused_v1"
+    MEMORY_DURABLE = "resp_memory_v1"
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        super().__init__(subscriber, publisher)
+        self._memory: MutableMapping[str, Dict[str, Any]] = {}
+        self._fused: MutableMapping[str, Dict[str, Any]] = {}
+        self._start_lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        async with self._start_lock:
+            if self._started:
+                return
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_FUSED,
+                handler=self._handle_fused,
+                use_jetstream=True,
+                durable=self.FUSED_DURABLE,
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.MEMORY_RETRIEVED,
+                handler=self._handle_memory,
+                use_jetstream=True,
+                durable=self.MEMORY_DURABLE,
+            )
+            self._started = True
+            logger.info(
+                "ResponderService listening for fused perception (%s) and memory (%s)",
+                EventSubjects.PERCEPTION_FUSED,
+                EventSubjects.MEMORY_RETRIEVED,
+            )
+
+    async def _handle_memory(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        input_id = payload.get("input_id") or payload.get("memory_id")
+        if not input_id:
+            logger.warning("Memory payload missing input_id: %s", payload)
+            await self._ack_message(msg)
+            return
+        self._memory[input_id] = payload
+        logger.debug("Stored memory context for %s", input_id)
+        await self._ack_message(msg)
+
+    async def _handle_fused(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        input_id = payload.get("input_id")
+        if not input_id:
+            logger.warning("Fused perception missing input_id: %s", payload)
+            await self._ack_message(msg)
+            return
+        self._fused[input_id] = payload
+        logger.debug("Stored fused features for %s", input_id)
+
+        memory = self._memory.get(input_id, {})
+        candidates = self._build_candidates(input_id, payload, memory)
+        response_payload = {
+            "input_id": input_id,
+            "candidates": candidates,
+            "meta": {"source": "responder_service"},
+        }
+        await self._publish(EventSubjects.RESPONSE_CANDIDATES, response_payload)
+        await self._ack_message(msg)
+
+    def _build_candidates(
+        self,
+        input_id: str,
+        fused: Dict[str, Any],
+        memory: Dict[str, Any],
+    ) -> Any:
+        features = fused.get("features", {})
+        audio = features.get("audio") or []
+        image = features.get("image") or []
+        memory_text = memory.get("retrieved_knowledge", {}).get("summary") if isinstance(memory.get("retrieved_knowledge"), dict) else None
+
+        candidate_primary = {
+            "id": f"{input_id}-primary",
+            "text": memory_text or "Default response based on perception.",
+            "confidence": 0.8 if memory_text else 0.5,
+        }
+        candidate_secondary = {
+            "id": f"{input_id}-alt",
+            "text": "Alternative generated response.",
+            "confidence": 0.4 + 0.1 * bool(audio) + 0.1 * bool(image),
+        }
+        return [candidate_primary, candidate_secondary]

--- a/src/deepthought/services/selector/__init__.py
+++ b/src/deepthought/services/selector/__init__.py
@@ -1,0 +1,5 @@
+"""Selector service."""
+
+from .service import SelectorService
+
+__all__ = ["SelectorService"]

--- a/src/deepthought/services/selector/service.py
+++ b/src/deepthought/services/selector/service.py
@@ -1,0 +1,61 @@
+"""Rank responder candidates."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from ...bus import Publisher, Subscriber
+from ...eda.events import EventSubjects
+from ..base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class SelectorService(BaseService):
+    """Rank response candidates and publish the selected result."""
+
+    CANDIDATE_DURABLE = "selector_candidates_v1"
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        super().__init__(subscriber, publisher)
+        self._start_lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        async with self._start_lock:
+            if self._started:
+                return
+            await self._subscriber.subscribe(
+                subject=EventSubjects.RESPONSE_CANDIDATES,
+                handler=self._handle_candidates,
+                use_jetstream=True,
+                durable=self.CANDIDATE_DURABLE,
+            )
+            self._started = True
+            logger.info("SelectorService listening on %s", EventSubjects.RESPONSE_CANDIDATES)
+
+    async def _handle_candidates(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        candidates: List[Dict[str, Any]] = payload.get("candidates") or []
+        if not isinstance(candidates, list):
+            logger.warning("Invalid candidates payload: %s", payload)
+            await self._ack_message(msg)
+            return
+
+        ranked = sorted(
+            candidates,
+            key=lambda candidate: candidate.get("confidence", 0.0),
+            reverse=True,
+        )
+        ranked_payload = {
+            "input_id": payload.get("input_id"),
+            "ranked_candidates": ranked,
+            "selected_index": 0 if ranked else None,
+            "meta": {"source": "selector_service"},
+        }
+        await self._publish(EventSubjects.RESPONSE_RANKED, ranked_payload)
+        await self._ack_message(msg)

--- a/src/deepthought/services/social_graph/__init__.py
+++ b/src/deepthought/services/social_graph/__init__.py
@@ -1,0 +1,5 @@
+"""Social graph service."""
+
+from .service import SocialGraphService
+
+__all__ = ["SocialGraphService"]

--- a/src/deepthought/services/social_graph/service.py
+++ b/src/deepthought/services/social_graph/service.py
@@ -1,0 +1,76 @@
+"""JetStream-driven social graph service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import defaultdict
+from typing import Any, Dict, DefaultDict
+
+from ...bus import Publisher, Subscriber
+from ...eda.events import EventSubjects
+from ..base import BaseService
+
+logger = logging.getLogger(__name__)
+
+
+class SocialGraphService(BaseService):
+    """Consume graph update events and emit snapshots."""
+
+    DURABLE_NAME = "sg_upd_v1"
+
+    def __init__(self, subscriber: Subscriber, publisher: Publisher) -> None:
+        super().__init__(subscriber, publisher)
+        self._graph: DefaultDict[str, Dict[str, Any]] = defaultdict(lambda: {"edges": {}})
+        self._start_lock = asyncio.Lock()
+        self._started = False
+
+    async def start(self) -> None:
+        """Subscribe to JetStream subjects for incremental updates."""
+        if self._started:
+            return
+        async with self._start_lock:
+            if self._started:
+                return
+            await self._subscriber.subscribe(
+                subject=EventSubjects.SOCIAL_GRAPH_UPDATE,
+                handler=self._handle_update,
+                use_jetstream=True,
+                durable=self.DURABLE_NAME,
+            )
+            self._started = True
+            logger.info("SocialGraphService listening on %s", EventSubjects.SOCIAL_GRAPH_UPDATE)
+
+    async def _handle_update(self, msg: Any) -> None:
+        payload = self._decode_message(msg)
+        user_id = payload.get("user_id")
+        if not user_id:
+            logger.warning("Received social graph update without user_id: %s", payload)
+            await self._ack_message(msg)
+            return
+
+        updates = payload.get("updates", {})
+        edges = updates.get("edges", [])
+        removals = updates.get("remove", [])
+
+        user_graph = self._graph[user_id]
+        edge_map: Dict[str, Any] = user_graph.setdefault("edges", {})
+        for edge in edges:
+            target = edge.get("target")
+            if not target:
+                continue
+            weight = edge.get("weight", 1.0)
+            edge_map[target] = weight
+        for target in removals:
+            edge_map.pop(target, None)
+
+        snapshot = {
+            "user_id": user_id,
+            "graph": {"edges": edge_map.copy()},
+            "timestamp": payload.get("timestamp"),
+            "meta": {"source": "social_graph_service"},
+        }
+
+        logger.debug("Publishing graph snapshot for %s with %d edges", user_id, len(edge_map))
+        await self._publish(EventSubjects.SOCIAL_GRAPH_SNAPSHOT, snapshot)
+        await self._ack_message(msg)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,168 @@
+"""Unit tests for service layer using a mocked bus."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.deepthought.bus import Publisher, Subscriber
+from src.deepthought.eda.events import EventSubjects
+from src.deepthought.services import (
+    SocialGraphService,
+    QuestLogService,
+    PerceptionService,
+    ResponderService,
+    SelectorService,
+)
+
+
+class FakeMsg:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode("utf-8")
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+class MockPublisher(Publisher):
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject: str, payload):
+        self.published.append((subject, payload))
+
+
+class MockSubscriber(Subscriber):
+    def __init__(self):
+        self.handlers = {}
+
+    async def subscribe(self, subject, handler, queue="", use_jetstream=False, durable=""):
+        self.handlers[(subject, durable)] = {
+            "handler": handler,
+            "use_jetstream": use_jetstream,
+        }
+
+
+@pytest.mark.asyncio
+async def test_social_graph_service_ack_and_publish():
+    publisher = MockPublisher()
+    subscriber = MockSubscriber()
+    service = SocialGraphService(subscriber, publisher)
+
+    await service.start()
+    key = (EventSubjects.SOCIAL_GRAPH_UPDATE, SocialGraphService.DURABLE_NAME)
+    handler = subscriber.handlers[key]["handler"]
+    assert subscriber.handlers[key]["use_jetstream"] is True
+
+    msg = FakeMsg(
+        {
+            "user_id": "u1",
+            "updates": {"edges": [{"target": "u2", "weight": 0.9}]},
+        }
+    )
+    await handler(msg)
+    assert msg.acked is True
+    assert publisher.published[0][0] == EventSubjects.SOCIAL_GRAPH_SNAPSHOT
+    snapshot_payload = publisher.published[0][1]
+    assert snapshot_payload["graph"]["edges"]["u2"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_questlog_service_publishes_snapshot_and_done():
+    publisher = MockPublisher()
+    subscriber = MockSubscriber()
+    service = QuestLogService(subscriber, publisher)
+
+    await service.start()
+
+    create_handler = subscriber.handlers[(EventSubjects.QUEST_CREATE, QuestLogService.CREATE_DURABLE)]["handler"]
+    update_handler = subscriber.handlers[(EventSubjects.QUEST_UPDATE, QuestLogService.UPDATE_DURABLE)]["handler"]
+
+    create_msg = FakeMsg({"quest_id": "q1", "name": "Intro"})
+    await create_handler(create_msg)
+    assert create_msg.acked is True
+    assert publisher.published[0][0] == EventSubjects.QUEST_SNAPSHOT
+
+    update_msg = FakeMsg({"quest_id": "q1", "status": "completed", "progress": 1.0})
+    await update_handler(update_msg)
+    assert update_msg.acked is True
+    subjects = [subject for subject, _ in publisher.published]
+    assert EventSubjects.QUEST_DONE in subjects
+
+
+@pytest.mark.asyncio
+async def test_perception_service_fuses_modalities():
+    publisher = MockPublisher()
+    subscriber = MockSubscriber()
+    service = PerceptionService(subscriber, publisher)
+
+    await service.start()
+
+    audio_handler = subscriber.handlers[(EventSubjects.PERCEPTION_AUDIO_EMBED, PerceptionService.AUDIO_DURABLE)]["handler"]
+    image_handler = subscriber.handlers[(EventSubjects.PERCEPTION_IMAGE_EMBED, PerceptionService.IMAGE_DURABLE)]["handler"]
+
+    audio_msg = FakeMsg({"input_id": "in1", "embedding": [0.1], "metadata": {"energy": 0.5}})
+    image_msg = FakeMsg({"input_id": "in1", "embedding": [0.2], "metadata": {"brightness": 0.8}})
+
+    await audio_handler(audio_msg)
+    await image_handler(image_msg)
+
+    assert audio_msg.acked is True
+    assert image_msg.acked is True
+    assert publisher.published[-1][0] == EventSubjects.PERCEPTION_FUSED
+    fused_payload = publisher.published[-1][1]
+    assert fused_payload["features"]["audio"] == [0.1]
+    assert fused_payload["features"]["image"] == [0.2]
+
+
+@pytest.mark.asyncio
+async def test_responder_service_creates_candidates():
+    publisher = MockPublisher()
+    subscriber = MockSubscriber()
+    service = ResponderService(subscriber, publisher)
+
+    await service.start()
+
+    memory_handler = subscriber.handlers[(EventSubjects.MEMORY_RETRIEVED, ResponderService.MEMORY_DURABLE)]["handler"]
+    fused_handler = subscriber.handlers[(EventSubjects.PERCEPTION_FUSED, ResponderService.FUSED_DURABLE)]["handler"]
+
+    memory_msg = FakeMsg({"input_id": "in1", "retrieved_knowledge": {"summary": "Hello"}})
+    fused_msg = FakeMsg({"input_id": "in1", "features": {"audio": [0.1], "image": [0.2]}})
+
+    await memory_handler(memory_msg)
+    await fused_handler(fused_msg)
+
+    assert memory_msg.acked is True
+    assert fused_msg.acked is True
+    assert publisher.published[-1][0] == EventSubjects.RESPONSE_CANDIDATES
+    candidates = publisher.published[-1][1]["candidates"]
+    assert candidates[0]["confidence"] >= candidates[1]["confidence"]
+
+
+@pytest.mark.asyncio
+async def test_selector_service_ranks_candidates():
+    publisher = MockPublisher()
+    subscriber = MockSubscriber()
+    service = SelectorService(subscriber, publisher)
+
+    await service.start()
+    handler = subscriber.handlers[(EventSubjects.RESPONSE_CANDIDATES, SelectorService.CANDIDATE_DURABLE)]["handler"]
+
+    msg = FakeMsg(
+        {
+            "input_id": "in1",
+            "candidates": [
+                {"id": "a", "confidence": 0.2},
+                {"id": "b", "confidence": 0.9},
+            ],
+        }
+    )
+    await handler(msg)
+
+    assert msg.acked is True
+    assert publisher.published[-1][0] == EventSubjects.RESPONSE_RANKED
+    ranked_payload = publisher.published[-1][1]
+    assert ranked_payload["ranked_candidates"][0]["id"] == "b"
+    assert ranked_payload["selected_index"] == 0


### PR DESCRIPTION
## Summary
- introduce a bus module that exposes Publisher and Subscriber protocols for service wiring
- add social graph, quest log, perception, responder, and selector services with JetStream subscriptions and downstream publications
- extend event definitions and add mocked bus tests to verify acknowledgements and emitted subjects

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de8c3674548326babddd61969bedb6