### PR TITLE
Handle revision-qualified video models

### DIFF
--- a/src/deepthought/perception/worker_video.py
+++ b/src/deepthought/perception/worker_video.py
@@ -16,6 +16,7 @@ from PIL import Image
 from pathlib import Path
 
 from deepthought.config import get_settings
+from deepthought.utils.model_specs import split_model_revision
 
 try:  # pragma: no cover - optional dependency
     import open_clip
@@ -172,7 +173,8 @@ def video_to_feature_grid(
         Optional path to a ``.npy`` file for caching frame embeddings.
     """
     frames, timestamps = decode_video(path, decode_fps)
-    feats = embed_frames(frames, model_type=model_type, cache_path=embed_cache)
+    model_key, _ = split_model_revision(model_type)
+    feats = embed_frames(frames, model_type=model_key, cache_path=embed_cache)
     if grid_fps is None:
         grid_fps = decode_fps
     if len(timestamps) == 0:

--- a/src/deepthought/services/perception/cli.py
+++ b/src/deepthought/services/perception/cli.py
@@ -164,7 +164,8 @@ async def _main() -> None:
         fps = max(1, min(3, int(round(1 / cfg.video_hop_size))))
         video_worker = VideoPerceptionWorker(
             decode_fps=fps,
-            model_type=cfg.video_model,
+            model_type=cfg.video_model_key,
+            model_revision=cfg.video_model_revision,
             grid_fps=fps,
             cache_dir=cfg.video_cache_dir,
         )

--- a/src/deepthought/services/perception/config.py
+++ b/src/deepthought/services/perception/config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings
 
+from ...utils.model_specs import split_model_revision
+
 
 def _default_modality_dims() -> dict[str, int]:
     """Return default embedding dimensions for supported modalities."""
@@ -53,3 +55,17 @@ class PerceptionConfig(BaseSettings):
 
     class Config:
         env_prefix = "DT_PERCEPTION_"
+
+    @property
+    def video_model_key(self) -> str:
+        """Return the base model identifier without any revision suffix."""
+
+        model_key, _ = split_model_revision(self.video_model)
+        return model_key
+
+    @property
+    def video_model_revision(self) -> str | None:
+        """Return the revision component for ``video_model`` if provided."""
+
+        _, revision = split_model_revision(self.video_model)
+        return revision

--- a/src/deepthought/services/perception/worker_video.py
+++ b/src/deepthought/services/perception/worker_video.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from deepthought.config import get_settings
 from deepthought.perception.worker_video import video_to_feature_grid
+from deepthought.utils.model_specs import split_model_revision
 
 
 @dataclass
@@ -39,12 +40,18 @@ class VideoPerceptionWorker:
     model_type: str = "siglip"
     grid_fps: int | None = None
     cache_dir: Path | None = None
+    model_revision: str | None = None
 
     def __post_init__(self) -> None:  # pragma: no cover - simple validation
         if not 1 <= self.decode_fps <= 3:
             raise ValueError("decode_fps must be between 1 and 3 fps")
         if self.grid_fps is not None and self.grid_fps <= 0:
             raise ValueError("grid_fps must be positive")
+        model_key, inferred_revision = split_model_revision(self.model_type)
+        revision = self.model_revision or inferred_revision
+        self._model_key = model_key
+        self.model_revision = revision
+        self.model_type = f"{model_key}@{revision}" if revision else model_key
 
     def __call__(self, path: str | Path) -> Tuple[np.ndarray, np.ndarray]:
         """Process ``path`` and return ``(features, times)`` arrays.
@@ -63,7 +70,8 @@ class VideoPerceptionWorker:
         if self.cache_dir is not None:
             cache_dir = Path(self.cache_dir)
             cache_dir.mkdir(parents=True, exist_ok=True)
-            suffix = f"{self.decode_fps}_{self.model_type}_{self.grid_fps or self.decode_fps}"
+            suffix_model = self.model_type
+            suffix = f"{self.decode_fps}_{suffix_model}_{self.grid_fps or self.decode_fps}"
             stem = path.stem
             feats_file = cache_dir / f"{stem}_{suffix}_feats.npy"
             times_file = cache_dir / f"{stem}_{suffix}_times.npy"
@@ -78,7 +86,7 @@ class VideoPerceptionWorker:
                 feats, times = video_to_feature_grid(
                     str(path),
                     self.decode_fps,
-                    self.model_type,
+                    self._model_key,
                     self.grid_fps,
                     embed_cache=embed_file,
                 )
@@ -86,7 +94,7 @@ class VideoPerceptionWorker:
                 feats, times = video_to_feature_grid(
                     str(path),
                     self.decode_fps,
-                    self.model_type,
+                    self._model_key,
                     self.grid_fps,
                 )
             if feats_file and times_file:

--- a/src/deepthought/utils/model_specs.py
+++ b/src/deepthought/utils/model_specs.py
@@ -1,0 +1,19 @@
+"""Utilities for working with model specification strings."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+
+def split_model_revision(spec: str) -> Tuple[str, str | None]:
+    """Return ``(model_key, revision)`` parsed from ``spec``.
+
+    ``spec`` strings may optionally include a ``@revision`` suffix. When no
+    suffix is present the revision component is ``None``. Whitespace is
+    preserved to avoid accidentally changing model identifiers.
+    """
+
+    if "@" not in spec:
+        return spec, None
+    model_key, revision = spec.split("@", 1)
+    return model_key, revision or None

--- a/tests/unit/perception/test_worker_video.py
+++ b/tests/unit/perception/test_worker_video.py
@@ -1,19 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
 import numpy as np
 
-from deepthought.services.perception.worker_video import VideoPerceptionWorker
+dummy_cv2 = ModuleType("cv2")
+
+
+class _DummyCapture:  # pragma: no cover - test shim
+    def __init__(self, *args, **kwargs):
+        self._released = False
+
+    def get(self, *_args, **_kwargs):
+        return 1.0
+
+    def read(self):
+        return False, None
+
+    def release(self):  # pragma: no cover - shim
+        self._released = True
+
+
+dummy_cv2.CAP_PROP_FPS = 5
+dummy_cv2.COLOR_BGR2RGB = 0
+dummy_cv2.VideoCapture = lambda *args, **kwargs: _DummyCapture()
+dummy_cv2.cvtColor = lambda frame, _code: frame
+
+sys.modules.setdefault("cv2", dummy_cv2)
+
+pil_module = ModuleType("PIL")
+image_module = ModuleType("PIL.Image")
+image_module.fromarray = lambda array: array
+pil_module.Image = image_module
+sys.modules.setdefault("PIL", pil_module)
+sys.modules.setdefault("PIL.Image", image_module)
+
+MODULE_NAME = "deepthought.services.perception.worker_video"
+MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "src"
+    / "deepthought"
+    / "services"
+    / "perception"
+    / "worker_video.py"
+)
+
+
+def _load_worker_module() -> ModuleType:
+    if MODULE_NAME in sys.modules:
+        return sys.modules[MODULE_NAME]  # pragma: no cover - reuse cached module
+
+    services_pkg = ModuleType("deepthought.services")
+    services_pkg.__path__ = []  # type: ignore[attr-defined]
+    perception_pkg = ModuleType("deepthought.services.perception")
+    perception_pkg.__path__ = []  # type: ignore[attr-defined]
+    services_pkg.perception = perception_pkg
+    sys.modules["deepthought.services"] = services_pkg
+    sys.modules["deepthought.services.perception"] = perception_pkg
+
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError(f"Unable to load module spec for {MODULE_NAME}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    perception_pkg.worker_video = module
+    return module
+
+
+_worker_module = _load_worker_module()
+VideoPerceptionWorker = _worker_module.VideoPerceptionWorker
 
 
 def test_video_perception_worker(monkeypatch):
     feats = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
     times = np.array([0.0, 1.0], dtype=np.float32)
 
-    monkeypatch.setattr(
-        "deepthought.services.perception.worker_video.video_to_feature_grid",
-        lambda path, decode_fps, model_type, grid_fps: (feats, times),
-    )
+    def fake_grid(path, decode_fps, model_type, grid_fps, embed_cache=None):
+        assert model_type == "siglip"
+        return feats, times
+
+    monkeypatch.setattr(_worker_module, "video_to_feature_grid", fake_grid)
 
     worker = VideoPerceptionWorker(decode_fps=1, model_type="siglip")
     out_feats, out_times = worker("dummy.mp4")
 
     assert np.array_equal(out_feats, feats)
     assert np.array_equal(out_times, times)
+
+
+def test_video_perception_worker_with_revision(monkeypatch, tmp_path):
+    feats = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    times = np.array([0.0, 1.0], dtype=np.float32)
+    captured: dict[str, object] = {}
+
+    def fake_grid(path, decode_fps, model_type, grid_fps, embed_cache=None):
+        captured["args"] = {
+            "path": path,
+            "decode_fps": decode_fps,
+            "model_type": model_type,
+            "grid_fps": grid_fps,
+            "embed_cache": embed_cache,
+        }
+        return feats, times
+
+    monkeypatch.setattr(_worker_module, "video_to_feature_grid", fake_grid)
+
+    cache_dir = tmp_path / "cache"
+    worker = VideoPerceptionWorker(
+        decode_fps=1,
+        model_type="siglip@myrev",
+        grid_fps=1,
+        cache_dir=cache_dir,
+    )
+
+    video_path = tmp_path / "sample.mp4"
+    out_feats, out_times = worker(video_path)
+
+    assert np.array_equal(out_feats, feats)
+    assert np.array_equal(out_times, times)
+
+    args = captured["args"]
+    assert isinstance(args, dict)
+    assert args["model_type"] == "siglip"
+    assert worker.model_type == "siglip@myrev"
+    assert worker.model_revision == "myrev"
+
+    feats_path = cache_dir / "sample_1_siglip@myrev_1_feats.npy"
+    times_path = cache_dir / "sample_1_siglip@myrev_1_times.npy"
+    embed_path = cache_dir / "sample_1_siglip@myrev_1_embed.npy"
+    assert feats_path.exists()
+    assert times_path.exists()
+    assert args["embed_cache"] == embed_path


### PR DESCRIPTION
## Summary
- add a shared helper for splitting model@revision strings and update the video embedding pipeline to use it
- ensure the perception CLI passes sanitized video model keys to the worker while metadata retains the full specification
- expand unit coverage for revision-qualified models in the video worker path

## Testing
- pytest tests/unit/perception/test_worker_video.py

------
https://chatgpt.com/codex/tasks/task_e_68de8b9057908326aa2235afc94546d8