### PR TITLE
Integrate projects board cog into social graph bot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -59,6 +59,7 @@ DYNAMIC_COVER_REPLIES = bot_deception.DYNAMIC_COVER_REPLIES
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.perception.emotion_detection import detect_emotions
 from deepthought.perception.social_perception import analyze as analyze_social
+from deepthought.plugins.projects_board import ProjectsBoard
 from deepthought.services import PersonaManager, TrustService
 from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
@@ -829,7 +830,16 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
 class SocialGraphBot(commands.Bot):
     """Discord bot that records interactions and demonstrates simple awareness."""
 
-    def __init__(self, *args, monitor_channel_id: int, command_prefix: str = "!", **kwargs):
+    def __init__(
+        self,
+        *args,
+        monitor_channel_id: int,
+        forum_channel_id: int | None = None,
+        index_channel_id: int | None = None,
+        require_scheduled_events: bool = False,
+        command_prefix: str = "!",
+        **kwargs,
+    ):
         intents = discord.Intents.default()
         intents.message_content = True
         intents.members = True
@@ -838,11 +848,15 @@ class SocialGraphBot(commands.Bot):
         if not hasattr(self, "tree"):
             self.tree = discord.app_commands.CommandTree(self)
         self.monitor_channel_id = monitor_channel_id
+        self.forum_channel_id = forum_channel_id
+        self.index_channel_id = index_channel_id
+        self.require_scheduled_events = require_scheduled_events
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
         self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
         self.persona_manager = PersonaManager(db_manager)
         self._subscriber: Subscriber | None = None
+        self._projects_board: ProjectsBoard | None = None
 
     async def setup_hook(self) -> None:
         await db_manager.connect()
@@ -868,6 +882,17 @@ class SocialGraphBot(commands.Bot):
             except Exception as exc:  # pragma: no cover - subscription error
                 logger.warning("Failed to subscribe to CHAT_RAW: %s", exc)
                 self._subscriber = None
+
+        self._projects_board = ProjectsBoard(
+            self,
+            db_manager,
+            self.goal_scheduler,
+            forum_channel_id=self.forum_channel_id,
+            index_channel_id=self.index_channel_id,
+            monitor_channel_id=self.monitor_channel_id,
+            require_events=self.require_scheduled_events,
+        )
+        await self.add_cog(self._projects_board)
 
         self._bg_tasks.append(asyncio.create_task(monitor_channels(self, self.monitor_channel_id)))
         self._bg_tasks.append(asyncio.create_task(process_deep_reflections(self)))
@@ -1132,9 +1157,21 @@ class SocialGraphBot(commands.Bot):
         await super().close()
 
 
-async def run(token: str, monitor_channel_id: int) -> None:
+async def run(
+    token: str,
+    monitor_channel_id: int,
+    *,
+    forum_channel_id: int | None = None,
+    index_channel_id: int | None = None,
+    require_scheduled_events: bool = False,
+) -> None:
     """Run the SocialGraphBot."""
-    bot = SocialGraphBot(monitor_channel_id=monitor_channel_id)
+    bot = SocialGraphBot(
+        monitor_channel_id=monitor_channel_id,
+        forum_channel_id=forum_channel_id,
+        index_channel_id=index_channel_id,
+        require_scheduled_events=require_scheduled_events,
+    )
     try:
         await bot.start(token)
     finally:
@@ -1161,4 +1198,12 @@ if __name__ == "__main__":
         asyncio.run(enqueue_goal(args.enqueue_goal, args.priority))
     else:
         env = load_bot_env()
-        asyncio.run(run(env.DISCORD_TOKEN, env.MONITOR_CHANNEL))
+        asyncio.run(
+            run(
+                env.DISCORD_TOKEN,
+                env.MONITOR_CHANNEL,
+                forum_channel_id=env.PROJECTS_FORUM_CHANNEL,
+                index_channel_id=env.PROJECTS_INDEX_CHANNEL,
+                require_scheduled_events=env.PROJECTS_REQUIRE_EVENTS,
+            )
+        )

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -251,6 +251,9 @@ class BotEnv(BaseSettings):
 
     DISCORD_TOKEN: str
     MONITOR_CHANNEL: int
+    PROJECTS_FORUM_CHANNEL: int | None = None
+    PROJECTS_INDEX_CHANNEL: int | None = None
+    PROJECTS_REQUIRE_EVENTS: bool = False
     NATS_URL: AnyUrl = "nats://localhost:4222"
 
     model_config = SettingsConfigDict(env_prefix="")

--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -18,6 +18,7 @@ from discord.ext import commands
 
 from ..config import get_settings
 from ..goal_scheduler import GoalScheduler
+from ..services.db_manager import DBManager
 
 __all__ = ["ProjectsBoard", "ProjectRecord"]
 
@@ -105,15 +106,28 @@ class ProjectsBoard(commands.Cog):
     def __init__(
         self,
         bot: commands.Bot,
-        *,
+        db_manager: DBManager | None = None,
         scheduler: GoalScheduler | None = None,
+        *,
+        forum_channel_id: int | None = None,
+        index_channel_id: int | None = None,
+        monitor_channel_id: int | None = None,
+        require_events: bool = False,
     ) -> None:
         self.bot = bot
-        self._scheduler = scheduler or GoalScheduler()
+        self._db_manager = db_manager
+        self._scheduler = scheduler or GoalScheduler(db_manager)
         self._db_path = get_settings().social_graph_db
         self._conn: aiosqlite.Connection | None = None
         self._lock = asyncio.Lock()
-        self._forum_channel_id = self._resolve_forum_channel_id()
+        self._forum_channel_id = (
+            forum_channel_id
+            if forum_channel_id is not None
+            else self._resolve_forum_channel_id()
+        )
+        self._index_channel_id = index_channel_id
+        self._monitor_channel_id = monitor_channel_id
+        self._require_events = require_events
         self._startup_task: asyncio.Task[None] | None = None
         self._ready = asyncio.Event()
         if self.bot.loop.is_running():
@@ -750,6 +764,15 @@ class ProjectsBoard(commands.Cog):
     async def _locate_index_thread(
         self, channel: discord.ForumChannel
     ) -> discord.Thread | None:
+        if self._index_channel_id is not None:
+            thread = self.bot.get_channel(self._index_channel_id)
+            if thread is None:
+                with contextlib.suppress(discord.HTTPException, discord.NotFound, discord.Forbidden):
+                    thread = await self.bot.fetch_channel(self._index_channel_id)
+            if isinstance(thread, discord.Thread):
+                return thread
+            if thread is not None:
+                _LOG.warning("Configured projects index channel %s is not a thread", thread)
         for thread in channel.threads:
             if thread.name == INDEX_THREAD_NAME:
                 return thread
@@ -804,6 +827,8 @@ class ProjectsBoard(commands.Cog):
         self, record: ProjectRecord, guild: discord.Guild | None
     ) -> None:
         if guild is None or record is None:
+            return
+        if not self._require_events:
             return
         if record.archived_at:
             await self._cancel_scheduled_event(record, guild)


### PR DESCRIPTION
## Summary
- import and configure the ProjectsBoard cog within the social graph bot, including new channel and toggle options
- extend the ProjectsBoard cog to accept injected services and configuration overrides
- expose forum/index channel IDs and scheduled-event toggle through bot environment configuration and CLI helper

## Testing
- pytest *(fails: missing optional dependencies such as discord, torch, aiosqlite, rdflib)*
- ruff check *(fails: repository has existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68dfec6ad5548326b783091274ceef8d