### PR TITLE
Add DBManager project helpers and tests

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from datetime import datetime, timedelta
+from typing import Any, Mapping
 
 import aiosqlite
 
@@ -48,6 +49,9 @@ MAX_THEORY_LENGTH = 256
 MAX_PROMPT_LENGTH = 2000
 AFFINITY_POS_DELTA = int(os.getenv("AFFINITY_POS_DELTA", "1"))
 AFFINITY_NEG_DELTA = int(os.getenv("AFFINITY_NEG_DELTA", "-1"))
+
+
+UNSET = object()
 
 
 class DBManager:
@@ -218,6 +222,20 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS projects (
+            project_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            thread_id INTEGER UNIQUE,
+            title TEXT NOT NULL,
+            priority INTEGER DEFAULT 0,
+            status TEXT NOT NULL,
+            due_date TEXT,
+            holiday INTEGER DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            archived_at TEXT
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS lies (
             quest_id INTEGER,
             question TEXT,
@@ -321,6 +339,7 @@ class DBManager:
             if dir_path:
                 os.makedirs(dir_path, exist_ok=True)
             self._db = await aiosqlite.connect(self.db_path)
+            self._db.row_factory = aiosqlite.Row
             if not self._initialized:
                 for query in self.CREATE_TABLE_QUERIES:
                     await self._db.execute(query)
@@ -344,6 +363,56 @@ class DBManager:
             await self._db.execute("ALTER TABLE relationships ADD COLUMN interaction_weight REAL DEFAULT 0")
         if "last_interaction" not in cols:
             await self._db.execute("ALTER TABLE relationships ADD COLUMN last_interaction DATETIME")
+
+    @staticmethod
+    def _normalize_timestamp_input(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.replace(microsecond=0).isoformat()
+        if isinstance(value, str):
+            text = value.strip()
+            return text or None
+        if hasattr(value, "isoformat"):
+            return value.isoformat()
+        raise TypeError("timestamp value must be datetime, str, or None")
+
+    @staticmethod
+    def _format_timestamp(value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.replace(microsecond=0).isoformat()
+        if isinstance(value, str):
+            text = value.strip()
+            if not text:
+                return None
+            for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S.%f"):
+                try:
+                    parsed = datetime.strptime(text, fmt)
+                    return parsed.replace(microsecond=0).isoformat()
+                except ValueError:
+                    continue
+            try:
+                parsed = datetime.fromisoformat(text)
+            except ValueError:
+                return text
+            return parsed.replace(microsecond=0).isoformat()
+        return str(value)
+
+    def _project_row_to_dict(self, row: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "project_id": row["project_id"],
+            "thread_id": row["thread_id"],
+            "title": row["title"],
+            "priority": row["priority"],
+            "status": row["status"],
+            "due_date": self._format_timestamp(row["due_date"]),
+            "holiday": bool(row["holiday"]),
+            "created_at": self._format_timestamp(row["created_at"]),
+            "updated_at": self._format_timestamp(row["updated_at"]),
+            "archived_at": self._format_timestamp(row["archived_at"]),
+        }
 
     def _create_table_statements(self) -> list[str]:
         """Return SQL statements for creating required tables."""
@@ -835,6 +904,165 @@ class DBManager:
             (task_id,),
         )
         await self._db.commit()
+
+    async def create_project(
+        self,
+        thread_id: int | None,
+        title: str,
+        *,
+        priority: int = 0,
+        status: str = "active",
+        due_date: datetime | str | None = None,
+        holiday: bool = False,
+    ) -> dict[str, Any]:
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError("title must be a non-empty string")
+        if not isinstance(status, str) or not status.strip():
+            raise ValueError("status must be a non-empty string")
+        await self.connect()
+        assert self._db
+        due_value = self._normalize_timestamp_input(due_date)
+        cur = await self._db.execute(
+            """
+            INSERT INTO projects (thread_id, title, priority, status, due_date, holiday)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                int(thread_id) if thread_id is not None else None,
+                title.strip(),
+                int(priority),
+                status.strip(),
+                due_value,
+                int(bool(holiday)),
+            ),
+        )
+        await self._db.commit()
+        project_id = cur.lastrowid
+        if project_id is None:
+            raise RuntimeError("Failed to determine project identifier")
+        project = await self.get_project(project_id)
+        if project is None:
+            raise RuntimeError("Failed to load project after creation")
+        return project
+
+    async def update_project(
+        self,
+        thread_id: int,
+        *,
+        title: str | None = None,
+        priority: int | None = None,
+        status: str | None = None,
+        due_date: datetime | str | None | object = UNSET,
+        holiday: bool | None = None,
+    ) -> dict[str, Any] | None:
+        await self.connect()
+        assert self._db
+        clauses: list[str] = []
+        params: list[Any] = []
+        if title is not None:
+            if not isinstance(title, str) or not title.strip():
+                raise ValueError("title must be a non-empty string")
+            clauses.append("title = ?")
+            params.append(title.strip())
+        if priority is not None:
+            clauses.append("priority = ?")
+            params.append(int(priority))
+        if status is not None:
+            if not isinstance(status, str) or not status.strip():
+                raise ValueError("status must be a non-empty string")
+            clauses.append("status = ?")
+            params.append(status.strip())
+        if due_date is not UNSET:
+            due_value = self._normalize_timestamp_input(due_date)
+            clauses.append("due_date = ?")
+            params.append(due_value)
+        if holiday is not None:
+            clauses.append("holiday = ?")
+            params.append(int(bool(holiday)))
+        if not clauses:
+            return await self.get_project_by_thread(thread_id)
+        clauses.append("updated_at = CURRENT_TIMESTAMP")
+        query = f"UPDATE projects SET {', '.join(clauses)} WHERE thread_id = ?"
+        params.append(int(thread_id))
+        cur = await self._db.execute(query, params)
+        await self._db.commit()
+        if cur.rowcount == 0:
+            return None
+        return await self.get_project_by_thread(thread_id)
+
+    async def get_project(self, project_id: int) -> dict[str, Any] | None:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            """
+            SELECT project_id, thread_id, title, priority, status, due_date, holiday, created_at, updated_at, archived_at
+            FROM projects
+            WHERE project_id = ?
+            """,
+            (int(project_id),),
+        ) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return self._project_row_to_dict(row)
+
+    async def get_project_by_thread(self, thread_id: int | None) -> dict[str, Any] | None:
+        await self.connect()
+        assert self._db
+        if thread_id is None:
+            query = (
+                "SELECT project_id, thread_id, title, priority, status, due_date, holiday, created_at, updated_at, archived_at "
+                "FROM projects WHERE thread_id IS NULL"
+            )
+            params = ()
+        else:
+            query = (
+                "SELECT project_id, thread_id, title, priority, status, due_date, holiday, created_at, updated_at, archived_at "
+                "FROM projects WHERE thread_id = ?"
+            )
+            params = (int(thread_id),)
+        async with self._db.execute(query, params) as cur:
+            row = await cur.fetchone()
+        if row is None:
+            return None
+        return self._project_row_to_dict(row)
+
+    async def list_projects(self, *, include_archived: bool = False) -> list[dict[str, Any]]:
+        await self.connect()
+        assert self._db
+        query = (
+            "SELECT project_id, thread_id, title, priority, status, due_date, holiday, created_at, updated_at, archived_at "
+            "FROM projects"
+        )
+        if not include_archived:
+            query += " WHERE archived_at IS NULL"
+        query += " ORDER BY priority DESC, COALESCE(due_date, ''), title"
+        async with self._db.execute(query) as cur:
+            rows = await cur.fetchall()
+        return [self._project_row_to_dict(row) for row in rows]
+
+    async def archive_project(
+        self,
+        thread_id: int,
+        *,
+        status: str | None = "archived",
+    ) -> dict[str, Any] | None:
+        await self.connect()
+        assert self._db
+        clauses = ["archived_at = CURRENT_TIMESTAMP", "updated_at = CURRENT_TIMESTAMP"]
+        params: list[Any] = []
+        if status is not None:
+            if not isinstance(status, str) or not status.strip():
+                raise ValueError("status must be a non-empty string")
+            clauses.append("status = ?")
+            params.append(status.strip())
+        query = f"UPDATE projects SET {', '.join(clauses)} WHERE thread_id = ?"
+        params.append(int(thread_id))
+        cur = await self._db.execute(query, params)
+        await self._db.commit()
+        if cur.rowcount == 0:
+            return None
+        return await self.get_project_by_thread(thread_id)
 
     async def add_intention(self, goal: str, priority: int) -> int:
         """Queue an intention with ``goal`` and ``priority``."""

--- a/tests/unit/services/test_db_manager_projects.py
+++ b/tests/unit/services/test_db_manager_projects.py
@@ -1,0 +1,150 @@
+"""Tests for DBManager project helpers."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+MODULE_PATH = Path(__file__).resolve().parents[3] / "src" / "deepthought" / "services" / "db_manager.py"
+package_root = MODULE_PATH.parent.parent
+deepthought_pkg = types.ModuleType("deepthought")
+deepthought_pkg.__path__ = [str(package_root)]  # type: ignore[attr-defined]
+deepthought_spec = importlib.machinery.ModuleSpec("deepthought", loader=None, is_package=True)
+deepthought_spec.submodule_search_locations = [str(package_root)]
+deepthought_pkg.__spec__ = deepthought_spec
+services_pkg = types.ModuleType("deepthought.services")
+services_pkg.__path__ = [str(MODULE_PATH.parent)]  # type: ignore[attr-defined]
+services_spec = importlib.machinery.ModuleSpec("deepthought.services", loader=None, is_package=True)
+services_spec.submodule_search_locations = [str(MODULE_PATH.parent)]
+services_pkg.__spec__ = services_spec
+sys.modules.setdefault("deepthought", deepthought_pkg)
+sys.modules.setdefault("deepthought.services", services_pkg)
+
+config_path = package_root / "config.py"
+config_spec = importlib.util.spec_from_file_location("deepthought.config", config_path)
+assert config_spec and config_spec.loader
+config_module = importlib.util.module_from_spec(config_spec)
+sys.modules.setdefault("deepthought.config", config_module)
+sys.modules.setdefault("deepthought.services.config", config_module)
+config_spec.loader.exec_module(config_module)
+
+SPEC = importlib.util.spec_from_file_location(
+    "deepthought.services.db_manager",
+    MODULE_PATH,
+    submodule_search_locations=[str(MODULE_PATH.parent)],
+)
+assert SPEC and SPEC.loader
+_db_manager = importlib.util.module_from_spec(SPEC)
+sys.modules["deepthought.services.db_manager"] = _db_manager
+SPEC.loader.exec_module(_db_manager)
+
+DBManager = _db_manager.DBManager
+
+
+@pytest.mark.asyncio
+async def test_create_and_get_project_records_embed_ready_dict() -> None:
+    manager = DBManager(":memory:")
+    await manager.init_db()
+    try:
+        due_date = datetime(2024, 5, 1, 12, 0, tzinfo=timezone.utc)
+        record = await manager.create_project(
+            thread_id=1234567890,
+            title="Launch Sequence",
+            priority=5,
+            status="active",
+            due_date=due_date,
+            holiday=True,
+        )
+
+        assert record["thread_id"] == 1234567890
+        assert record["title"] == "Launch Sequence"
+        assert record["priority"] == 5
+        assert record["status"] == "active"
+        assert record["holiday"] is True
+        assert record["due_date"] is not None and "2024-05-01" in record["due_date"]
+        assert record["created_at"] is not None and "T" in record["created_at"]
+        assert record["updated_at"] is not None and "T" in record["updated_at"]
+        assert record["archived_at"] is None
+
+        fetched = await manager.get_project_by_thread(1234567890)
+        assert fetched == record
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_update_and_archive_project_flow() -> None:
+    manager = DBManager(":memory:")
+    await manager.init_db()
+    try:
+        created = await manager.create_project(
+            thread_id=222,
+            title="Test Project",
+            priority=1,
+            status="planning",
+        )
+
+        updated = await manager.update_project(
+            222,
+            status="completed",
+            due_date=None,
+            holiday=False,
+            priority=10,
+        )
+        assert updated is not None
+        assert updated["status"] == "completed"
+        assert updated["due_date"] is None
+        assert updated["holiday"] is False
+        assert updated["priority"] == 10
+        assert updated["updated_at"] >= created["updated_at"]
+
+        archived = await manager.archive_project(222)
+        assert archived is not None
+        assert archived["archived_at"] is not None
+        assert archived["status"] == "archived"
+
+        active_projects = await manager.list_projects()
+        assert all(project["archived_at"] is None for project in active_projects)
+
+        all_projects = await manager.list_projects(include_archived=True)
+        assert len(all_projects) == 1
+        assert all_projects[0]["archived_at"] is not None
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_list_projects_orders_by_priority_and_filters_archived() -> None:
+    manager = DBManager(":memory:")
+    await manager.init_db()
+    try:
+        await manager.create_project(
+            thread_id=1,
+            title="Low",
+            priority=1,
+            status="active",
+        )
+        await manager.create_project(
+            thread_id=2,
+            title="High",
+            priority=5,
+            status="active",
+        )
+        await manager.archive_project(1)
+
+        active = await manager.list_projects()
+        assert len(active) == 1
+        assert active[0]["thread_id"] == 2
+
+        all_projects = await manager.list_projects(include_archived=True)
+        assert [project["priority"] for project in all_projects] == [5, 1]
+    finally:
+        await manager.close()


### PR DESCRIPTION
## Summary
- add the projects table DDL to the shared DB initialisation
- implement async project CRUD helpers that emit embed-friendly dicts
- cover the new helpers with unit tests against an in-memory SQLite database

## Testing
- pytest tests/unit/services/test_db_manager_projects.py
- flake8 src tests

------
https://chatgpt.com/codex/tasks/task_e_68dfeef96d308326bd6b19c8a9489ea3