### PR TITLE
Handle canonical P0 priorities in projects board

### DIFF
--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -1384,6 +1384,11 @@ class ProjectsBoard(commands.Cog):
         holiday_bucket: list[ProjectRecord] = []
         done_bucket: list[ProjectRecord] = []
 
+        high_priority_keys = {"p0"}
+        legacy_high_key = PRIORITY_ALIASES.get("high")
+        if legacy_high_key:
+            high_priority_keys.add(legacy_high_key)
+
         for record in records:
             status_key = self._normalise_status_key(record.status)
             priority = self._priority_from_tags(record.tags)
@@ -1396,7 +1401,10 @@ class ProjectsBoard(commands.Cog):
                 done_bucket.append(record)
                 continue
 
-            if priority == "high" or (due_date is not None and due_date <= soon_cutoff):
+            if (
+                (priority and priority in high_priority_keys)
+                or (due_date is not None and due_date <= soon_cutoff)
+            ):
                 now_bucket.append(record)
             else:
                 next_bucket.append(record)

--- a/tests/unit/plugins/test_projects_board.py
+++ b/tests/unit/plugins/test_projects_board.py
@@ -255,6 +255,37 @@ async def test_build_board_embed_groups_records(
 
 
 @pytest.mark.asyncio
+async def test_build_board_embed_treats_canonical_p0_as_now(
+    projects_board_module: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    board = await create_board(projects_board_module, monkeypatch)
+    project_record_cls = projects_board_module.ProjectRecord
+
+    now = datetime.now(UTC)
+    high_priority = project_record_cls(
+        project_id=10,
+        thread_id=None,
+        name="Critical Initiative",
+        summary=None,
+        owner_id=None,
+        status="in-progress",
+        due_date=now + timedelta(days=45),
+        holiday=False,
+        tags=["🔥 P0"],
+        scheduled_event_id=None,
+        created_at=now - timedelta(days=3),
+        updated_at=now,
+        archived_at=None,
+    )
+
+    embed = board._build_board_embed([high_priority], holiday_only=False)
+
+    fields = {field.name: field.value for field in embed.fields}
+    assert high_priority.name in fields["🔥 Now"]
+    assert fields["🟠 Next"] == "_No upcoming projects in the queue._"
+
+
+@pytest.mark.asyncio
 async def test_sync_due_date_reminder_falls_back_to_scheduler(
     projects_board_module: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -304,7 +335,7 @@ async def test_is_holiday_project_helper(
 ) -> None:
     board = await create_board(projects_board_module, monkeypatch)
 
-    november_due = datetime(2025, 11, 5, tzinfo=UTC)
+    november_due = datetime(2025, 11, 27, tzinfo=UTC)
     october_due = datetime(2025, 10, 5, tzinfo=UTC)
 
     assert board._is_holiday_project(november_due, []) is True


### PR DESCRIPTION
## Summary
- treat canonical high priority keys the same as legacy "high" tags when building the board index
- add coverage ensuring 🔥 P0 projects stay in the "Now" bucket and update the holiday helper fixture to match production logic

## Testing
- pytest tests/unit/plugins/test_projects_board.py

------
https://chatgpt.com/codex/tasks/task_e_68f243ca46b88326ba2a03b1f6d37092