### PR TITLE
Fix goal scheduler reminder formatting

### DIFF
--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -2182,7 +2182,6 @@ class ProjectsBoard(commands.Cog):
                     description=description,
                     start_time=start_time,
                     end_time=end_time,
-                    location=DEFAULT_EVENT_LOCATION,
                     entity_type=discord.EntityType.external,
                     location=SCHEDULED_EVENT_LOCATION,
                 )
@@ -2194,7 +2193,6 @@ class ProjectsBoard(commands.Cog):
                     description=description,
                     privacy_level=discord.PrivacyLevel.guild_only,
                     entity_type=discord.EntityType.external,
-                    location=DEFAULT_EVENT_LOCATION,
                     location=SCHEDULED_EVENT_LOCATION,
                 )
                 await self._set_scheduled_event_id(record.project_id, event.id)
@@ -2211,20 +2209,26 @@ class ProjectsBoard(commands.Cog):
         due_display = (
             _normalize_datetime(record.due_date).isoformat()
             if record.due_date is not None
-            else ""
+            else "unspecified"
         )
         reminder_at = _normalize_datetime(reminder_time)
         now = datetime.now(UTC)
-        if reminder_at < now:
+        delay_seconds = max(0, (reminder_at - now).total_seconds())
+        delay = int(delay_seconds)
+        if delay == 0:
             reminder_at = now
         reminder_text = reminder_at.isoformat()
-        self._scheduler.add_goal(
-            (
-                f"Reminder: project {record.name} is due {due_display} "
-                f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)"
-            ),
-            priority=5,
+        message = (
+            f"Reminder: project {record.name} (ID #{record.project_id}) is due {due_display} "
+            f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)."
         )
+        if record.thread_id:
+            message = f"{message} Discuss in <#{record.thread_id}>."
+        else:
+            message = (
+                f"{message} Follow up via the projects board for project #{record.project_id}."
+            )
+        self._scheduler.add_goal(f"{delay}:{message}", priority=5)
 
     async def _cancel_scheduled_event(
         self, record: ProjectRecord, guild: discord.Guild | None

--- a/tests/test_projects_board_goal_scheduler.py
+++ b/tests/test_projects_board_goal_scheduler.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from src.deepthought.goal_scheduler import GoalScheduler
+from src.deepthought.plugins.projects_board import ProjectRecord, ProjectsBoard
+
+
+class _FixedDateTime(datetime):
+    _now: datetime = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz is None:
+            return cls._now
+        return cls._now.astimezone(tz)
+
+
+@pytest.fixture()
+def fixed_now(monkeypatch):
+    monkeypatch.setattr(
+        "src.deepthought.plugins.projects_board.datetime",
+        _FixedDateTime,
+    )
+    return _FixedDateTime._now
+
+
+def _make_board() -> ProjectsBoard:
+    board = ProjectsBoard.__new__(ProjectsBoard)
+    board._scheduler = GoalScheduler()
+    return board
+
+
+def _make_record(**overrides):
+    base = dict(
+        project_id=42,
+        guild_id=100,
+        thread_id=200,
+        name="Launch Sequence",
+        summary=None,
+        owner_id=None,
+        status="to-do",
+        due_date=datetime(2024, 1, 2, 15, 0, tzinfo=UTC),
+        holiday=False,
+        tags=[],
+        priority=None,
+        project_type=None,
+        scheduled_event_id=None,
+        created_at=_FixedDateTime._now,
+        updated_at=_FixedDateTime._now,
+        archived_at=None,
+    )
+    base.update(overrides)
+    return ProjectRecord(**base)
+
+
+def test_queue_goal_scheduler_reminder_formats_delay_and_reference(fixed_now):
+    board = _make_board()
+    reminder_time = fixed_now + timedelta(hours=2, minutes=5)
+    record = _make_record()
+
+    board._queue_goal_scheduler_reminder(record, reminder_time)
+
+    queued = board._scheduler.next_goal()
+    assert queued is not None
+    delay_str, message = queued.split(":", 1)
+    assert delay_str == str(int((reminder_time - fixed_now).total_seconds()))
+    assert f"<#{record.thread_id}>" in message
+    assert f"#{record.project_id}" in message
+    assert record.due_date.isoformat() in message
+
+
+def test_queue_goal_scheduler_reminder_now_when_past_due(fixed_now):
+    board = _make_board()
+    reminder_time = fixed_now - timedelta(minutes=1)
+    record = _make_record(thread_id=None)
+
+    board._queue_goal_scheduler_reminder(record, reminder_time)
+
+    queued = board._scheduler.next_goal()
+    assert queued is not None
+    delay_str, message = queued.split(":", 1)
+    assert delay_str == "0"
+    assert f"project #{record.project_id}" in message


### PR DESCRIPTION
## Summary
- queue project reminders with a delay prefix and context that links back to the project discussion
- remove duplicate scheduled event location arguments when editing or creating reminders
- cover the reminder formatting with unit tests so process_goals can parse the queue entries

## Testing
- flake8 src tests
- pytest tests/test_projects_board_goal_scheduler.py

------
https://chatgpt.com/codex/tasks/task_e_68f8e63149088326b9b7794385f7e6ca