### PR TITLE
Handle projects board reminders when scheduler is unavailable

### DIFF
--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -73,6 +73,11 @@ sched.start(publisher, interval=5.0)  # seconds
 await sched.stop()
 ```
 
+Projects board reminders now enqueue a single message that already points back to
+the project thread when one exists. If the downstream scheduler service is
+unavailable, the bot immediately publishes the reminder payload instead of
+dropping it so project discussions still receive timely nudges.
+
 ## Additional Safety Features
 
 Recent iterations introduced several controls to moderate conversations:

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -559,10 +559,6 @@ async def process_goals(bot: "SocialGraphBot") -> None:
     await bot.wait_until_ready()
     while not bot.is_closed():
         try:
-            if bot.scheduler_service is None:
-                await asyncio.sleep(1)
-                continue
-
             goal = bot.goal_scheduler.next_goal()
             if goal:
                 try:
@@ -572,9 +568,14 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                     logger.warning("Invalid goal format: %s", goal)
                     await publish_plan_requested(goal)
                 else:
-                    when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
-                    bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
-                    await publish_plan_requested(message)
+                    if bot.scheduler_service is not None:
+                        when = discord.utils.utcnow().replace(tzinfo=timezone.utc) + timedelta(seconds=delay)
+                        bot.scheduler_service.schedule_reminder(message, when, str(uuid.uuid4()))
+                        await publish_plan_requested(message)
+                    else:
+                        # When the scheduler service is unavailable we still emit the reminder
+                        # immediately so the project thread continues to receive updates.
+                        await publish_plan_requested(message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
             logger.info("process_goals cancelled")

--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -2214,22 +2214,13 @@ class ProjectsBoard(commands.Cog):
         )
         reminder_at = _normalize_datetime(reminder_time)
         now = datetime.now(UTC)
-        delay_seconds = max(0, (reminder_at - now).total_seconds())
-        delay = int(delay_seconds)
-        if delay == 0:
+        delay_seconds = max(0, math.ceil((reminder_at - now).total_seconds()))
+        if delay_seconds == 0:
             reminder_at = now
         reminder_text = reminder_at.isoformat()
         message = (
             f"Reminder: project {record.name} (ID #{record.project_id}) is due {due_display} "
             f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)."
-        delay_seconds = max(0, math.ceil((reminder_at - now).total_seconds()))
-        reminder_message = (
-            f"Reminder: project {record.name} is due {due_display} "
-            f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)"
-        )
-        self._scheduler.add_goal(
-            f"{delay_seconds}:{reminder_message}",
-            priority=5,
         )
         if record.thread_id:
             message = f"{message} Discuss in <#{record.thread_id}>."
@@ -2237,7 +2228,10 @@ class ProjectsBoard(commands.Cog):
             message = (
                 f"{message} Follow up via the projects board for project #{record.project_id}."
             )
-        self._scheduler.add_goal(f"{delay}:{message}", priority=5)
+        self._scheduler.add_goal(
+            f"{delay_seconds}:{message}",
+            priority=5,
+        )
 
     async def _cancel_scheduled_event(
         self, record: ProjectRecord, guild: discord.Guild | None

--- a/tests/unit/plugins/test_projects_board_reminders.py
+++ b/tests/unit/plugins/test_projects_board_reminders.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deepthought.goal_scheduler import GoalScheduler
+from deepthought.plugins.projects_board import ProjectRecord, ProjectsBoard
+
+sys.modules.pop("examples.social_graph_bot", None)
+sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
+social_graph_bot = importlib.import_module("examples.social_graph_bot")
+
+
+class _FixedDateTime(datetime):
+    _now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    @classmethod
+    def now(cls, tz=None):  # type: ignore[override]
+        if tz is None:
+            return cls._now
+        return cls._now.astimezone(tz)
+
+
+@pytest.mark.asyncio
+async def test_process_goals_publishes_without_scheduler_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace()
+    bot.scheduler_service = None
+    bot.goal_scheduler = GoalScheduler()
+    bot._closed = False
+
+    async def wait_until_ready() -> None:
+        return None
+
+    def is_closed() -> bool:
+        return bot._closed
+
+    bot.wait_until_ready = wait_until_ready
+    bot.is_closed = is_closed
+
+    reminder_message = "Reminder: Check project thread"
+    bot.goal_scheduler.add_goal(f"0:{reminder_message}", priority=5)
+
+    publish_mock = AsyncMock()
+    monkeypatch.setattr(
+        social_graph_bot,
+        "publish_plan_requested",
+        publish_mock,
+        raising=False,
+    )
+
+    async def fake_sleep(_seconds: float) -> None:
+        bot._closed = True
+        return None
+
+    monkeypatch.setattr(social_graph_bot.asyncio, "sleep", fake_sleep)
+
+    await social_graph_bot.process_goals(bot)  # type: ignore[arg-type]
+
+    publish_mock.assert_awaited_once()
+    published_message = publish_mock.await_args.args[0]
+    assert published_message == reminder_message
+    assert bot.goal_scheduler.next_goal() is None
+
+
+@pytest.mark.asyncio
+async def test_queue_goal_scheduler_reminder_single_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "deepthought.plugins.projects_board.datetime",
+        _FixedDateTime,
+    )
+    board = ProjectsBoard.__new__(ProjectsBoard)
+    board._scheduler = GoalScheduler()
+
+    record = ProjectRecord(
+        project_id=101,
+        guild_id=555,
+        thread_id=404,
+        name="Regression Reminder",
+        summary=None,
+        owner_id=None,
+        status="in-progress",
+        due_date=_FixedDateTime._now + timedelta(days=1),
+        holiday=False,
+        tags=[],
+        priority=None,
+        project_type=None,
+        scheduled_event_id=None,
+        created_at=_FixedDateTime._now - timedelta(days=2),
+        updated_at=_FixedDateTime._now - timedelta(days=1),
+        archived_at=None,
+    )
+
+    board._queue_goal_scheduler_reminder(record, _FixedDateTime._now + timedelta(hours=3))
+
+    queued = board._scheduler.next_goal()
+    assert queued is not None
+    assert board._scheduler.next_goal() is None
+
+    delay_str, message = queued.split(":", 1)
+    assert delay_str == str(int(timedelta(hours=3).total_seconds()))
+    assert f"<#{record.thread_id}>" in message
+    assert record.due_date.isoformat() in message


### PR DESCRIPTION
## Summary
- ensure the social graph bot publishes queued reminders even if the scheduler service is missing
- collapse projects board reminder queuing into a single message that includes the thread reference when present
- add regression tests for the reminder queue format and document the degraded behaviour

## Testing
- pytest tests/unit/plugins/test_projects_board_reminders.py tests/unit/plugins/test_projects_board.py tests/test_projects_board_goal_scheduler.py
- flake8 examples/social_graph_bot.py src/deepthought/plugins/projects_board.py tests/unit/plugins/test_projects_board_reminders.py

------
https://chatgpt.com/codex/tasks/task_e_68f8f90efdac832685255312cb42595a