### PR TITLE
Normalize priority tags during backfill and expand command tests

### DIFF
--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -775,8 +775,12 @@ class ProjectsBoard(commands.Cog):
         updates: list[tuple[Any, ...]] = []
         for row in rows:
             tags = json.loads(row["tags"]) if row["tags"] else []
-            priority = self._priority_from_tags(tags)
-            project_type = self._project_type_from_tags(tags)
+            normalised_tags = self._apply_priority_tags(tags, _MISSING)
+            tags_json: str | None = None
+            if normalised_tags != tags:
+                tags_json = json.dumps(normalised_tags)
+            priority = self._priority_from_tags(normalised_tags)
+            project_type = self._project_type_from_tags(normalised_tags)
             desired_guild_id = row["guild_id"] if row["guild_id"] else guild_id
             needs_update = False
             current_priority = row["priority"]
@@ -788,15 +792,28 @@ class ProjectsBoard(commands.Cog):
                 needs_update = True
             if desired_guild_id is not None and desired_guild_id != current_guild_id:
                 needs_update = True
+            if tags_json is not None:
+                needs_update = True
             if not needs_update:
                 continue
-            updates.append((priority, project_type, desired_guild_id, row["project_id"]))
+            updates.append(
+                (
+                    priority,
+                    project_type,
+                    desired_guild_id,
+                    tags_json,
+                    row["project_id"],
+                )
+            )
         if not updates:
             return
         await self._conn.executemany(
             """
             UPDATE projects
-            SET priority = ?, project_type = ?, guild_id = COALESCE(?, guild_id)
+            SET priority = ?,
+                project_type = ?,
+                guild_id = COALESCE(?, guild_id),
+                tags = COALESCE(?, tags)
             WHERE project_id = ?
             """,
             updates,

--- a/tests/unit/plugins/test_projects_board.py
+++ b/tests/unit/plugins/test_projects_board.py
@@ -3,6 +3,7 @@ import importlib
 import re
 import sys
 from datetime import UTC, datetime, timedelta
+import json
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -620,5 +621,47 @@ async def test_project_persistence_tracks_priority_type_and_guild(
     assert updated_type is not None
     assert updated_type.project_type == "collaboration"
     assert "🤝 Collaboration" in updated_type.tags
+
+    await board._close_db()
+
+
+@pytest.mark.asyncio
+async def test_backfill_project_metadata_normalises_priority_tags(
+    tmp_path: Path,
+    projects_board_module: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "board.db"
+    settings_stub = SimpleNamespace(social_graph_db=str(db_path))
+    monkeypatch.setattr(projects_board_module, "get_settings", lambda: settings_stub)
+
+    board = await create_board(projects_board_module, monkeypatch)
+    await board._init_db()
+
+    assert board._conn is not None
+    now_iso = datetime.now(UTC).isoformat()
+    legacy_tags = json.dumps(["🔥 Now", "Feature"])
+    await board._conn.execute(
+        """
+        INSERT INTO projects (guild_id, name, status, holiday, tags, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (123, "Legacy Priority", "to-do", 0, legacy_tags, now_iso, now_iso),
+    )
+    await board._conn.commit()
+
+    await board._backfill_project_metadata()
+
+    cursor = await board._conn.execute(
+        "SELECT priority, tags FROM projects WHERE name = ?", ("Legacy Priority",)
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+
+    assert row is not None
+    assert row["priority"] == "p0"
+    updated_tags = json.loads(row["tags"])
+    assert updated_tags[-1] == "🔥 P0"
+    assert "Feature" in updated_tags
 
     await board._close_db()

--- a/tests/unit/plugins/test_projects_board_commands.py
+++ b/tests/unit/plugins/test_projects_board_commands.py
@@ -25,6 +25,12 @@ async def test_command_registration(projects_board_module) -> None:
     assert tag_group.get_command("add") is not None
     assert tag_group.get_command("remove") is not None
 
+    assert priority_cmd is not None
+    priority_param = priority_cmd._params.get("priority")  # type: ignore[attr-defined]
+    assert priority_param is not None
+    choice_names = {choice.name for choice in priority_param.choices}
+    assert {"🔥 P0", "🟠 P1", "🟢 P2"} <= choice_names
+
 
 @pytest.mark.asyncio
 async def test_status_command_updates_record(


### PR DESCRIPTION
## Summary
- normalise stored project priority tags to the canonical emoji labels when backfilling metadata
- cover the legacy priority tag migration path and assert the slash command choices expose the renamed priorities

## Testing
- pytest tests/unit/plugins/test_projects_board.py tests/unit/plugins/test_projects_board_commands.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163e042a608326b2d11b02514fa84e)