### PR TITLE
Ensure project reminders publish without scheduler

### DIFF
--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -76,7 +76,9 @@ await sched.stop()
 Projects board reminders now enqueue a single message that already points back to
 the project thread when one exists. If the downstream scheduler service is
 unavailable, the bot immediately publishes the reminder payload instead of
-dropping it so project discussions still receive timely nudges.
+dropping it so project discussions still receive timely nudges. When a thread
+mention is included, the fallback path also attempts to post the reminder
+directly into that thread so Discord users still see the update in context.
 
 ## Additional Safety Features
 

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import random
+import re
 import uuid
 from collections import deque
 from datetime import timedelta, timezone
@@ -217,6 +218,8 @@ except Exception:  # pragma: no cover - optional dependency
 
 
 logger = logging.getLogger(__name__)
+
+_CHANNEL_MENTION_RE = re.compile(r"<#(\d+)>")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 DB_PATH = get_settings().social_graph_db
@@ -554,6 +557,40 @@ async def process_deep_reflections(bot: discord.Client) -> None:
             break
 
 
+async def _maybe_post_reminder_to_thread(bot: "SocialGraphBot", message: str) -> None:
+    """Attempt to echo reminder ``message`` to a referenced project thread."""
+
+    match = _CHANNEL_MENTION_RE.search(message)
+    if match is None:
+        return
+
+    try:
+        thread_id = int(match.group(1))
+    except (TypeError, ValueError):
+        return
+
+    channel = None
+    get_channel = getattr(bot, "get_channel", None)
+    if callable(get_channel):
+        channel = get_channel(thread_id)
+
+    if channel is None:
+        fetch_channel = getattr(bot, "fetch_channel", None)
+        if callable(fetch_channel):
+            try:
+                channel = await fetch_channel(thread_id)
+            except Exception:
+                channel = None
+
+    if channel is None or not hasattr(channel, "send"):
+        return
+
+    try:
+        await channel.send(message)
+    except Exception:
+        logger.debug("Failed to post reminder to thread %s", thread_id)
+
+
 async def process_goals(bot: "SocialGraphBot") -> None:
     """Background task that schedules reminders for queued goals."""
     await bot.wait_until_ready()
@@ -576,6 +613,7 @@ async def process_goals(bot: "SocialGraphBot") -> None:
                         # When the scheduler service is unavailable we still emit the reminder
                         # immediately so the project thread continues to receive updates.
                         await publish_plan_requested(message)
+                        await _maybe_post_reminder_to_thread(bot, message)
             await asyncio.sleep(1)
         except asyncio.CancelledError:
             logger.info("process_goals cancelled")

--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -2572,22 +2572,14 @@ class ProjectsBoard(commands.Cog):
         )
         reminder_at = _normalize_datetime(reminder_time)
         now = datetime.now(UTC)
-        delay_seconds = max(0, math.ceil((reminder_at - now).total_seconds()))
-        if delay_seconds == 0:
+        delay_seconds = math.ceil((reminder_at - now).total_seconds())
+        if delay_seconds <= 0:
             reminder_at = now
+            delay_seconds = 0
         reminder_text = reminder_at.isoformat()
         message = (
             f"Reminder: project {record.name} (ID #{record.project_id}) is due {due_display} "
             f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)."
-        )
-        delay_seconds = max(0, math.ceil((reminder_at - now).total_seconds()))
-        reminder_message = (
-            f"Reminder: project {record.name} is due {due_display} "
-            f"(schedule at {reminder_text}, {DEFAULT_REMINDER_LEAD} ahead)"
-        )
-        self._scheduler.add_goal(
-            f"{delay_seconds}:{reminder_message}",
-            priority=5,
         )
         if record.thread_id:
             message = f"{message} Discuss in <#{record.thread_id}>."

--- a/tests/unit/plugins/test_projects_board.py
+++ b/tests/unit/plugins/test_projects_board.py
@@ -372,14 +372,10 @@ async def test_sync_due_date_reminder_falls_back_to_scheduler(
     await board._sync_due_date_reminder(record, guild)  # type: ignore[arg-type]
 
     guild.create_scheduled_event.assert_awaited()
-    assert scheduler_mock.call_count == 2
-    first_call, second_call = scheduler_mock.call_args_list
-    first_message = first_call.args[0]
-    second_message = second_call.args[0]
-    assert record.name in first_message
-    assert record.name in second_message
-    assert first_call.kwargs.get("priority") == 5
-    assert second_call.kwargs.get("priority") == 5
+    assert scheduler_mock.call_count == 1
+    queued_message = scheduler_mock.call_args.args[0]
+    assert record.name in queued_message
+    assert scheduler_mock.call_args.kwargs.get("priority") == 5
 
 
 @pytest.mark.asyncio
@@ -415,13 +411,10 @@ async def test_queue_goal_scheduler_reminder_formats_goal_for_scheduler(
     reminder_time = now + timedelta(minutes=45)
     board._queue_goal_scheduler_reminder(record, reminder_time)
 
-    assert scheduler_mock.call_count == 2
-    goal_argument = scheduler_mock.call_args_list[0].args[0]
-    priority = scheduler_mock.call_args_list[0].kwargs["priority"]
-    follow_up_argument = scheduler_mock.call_args_list[1].args[0]
-    follow_up_priority = scheduler_mock.call_args_list[1].kwargs["priority"]
+    assert scheduler_mock.call_count == 1
+    goal_argument = scheduler_mock.call_args.args[0]
+    priority = scheduler_mock.call_args.kwargs["priority"]
     assert priority == 5
-    assert follow_up_priority == 5
 
     match = re.match(r"^(\d+):(.*)$", goal_argument)
     assert match is not None
@@ -430,21 +423,19 @@ async def test_queue_goal_scheduler_reminder_formats_goal_for_scheduler(
     message = match.group(2)
     assert record.name in message
     assert reminder_time.isoformat() in message
-    assert record.name in follow_up_argument
 
     scheduler_mock.reset_mock()
 
     past_time = now - timedelta(minutes=5)
     board._queue_goal_scheduler_reminder(record, past_time)
 
-    assert scheduler_mock.call_count == 2
-    for call in scheduler_mock.call_args_list:
-        past_goal_argument = call.args[0]
-        past_match = re.match(r"^(\d+):(.*)$", past_goal_argument)
-        assert past_match is not None
-        assert int(past_match.group(1)) == 0
-        assert record.name in past_match.group(2)
-        assert call.kwargs.get("priority") == 5
+    assert scheduler_mock.call_count == 1
+    past_goal_argument = scheduler_mock.call_args.args[0]
+    past_match = re.match(r"^(\d+):(.*)$", past_goal_argument)
+    assert past_match is not None
+    assert int(past_match.group(1)) == 0
+    assert record.name in past_match.group(2)
+    assert scheduler_mock.call_args.kwargs.get("priority") == 5
 
 
 @pytest.mark.asyncio

--- a/tests/unit/plugins/test_projects_board_reminders.py
+++ b/tests/unit/plugins/test_projects_board_reminders.py
@@ -54,6 +54,13 @@ async def test_process_goals_publishes_without_scheduler_service(monkeypatch: py
         raising=False,
     )
 
+    post_mock = AsyncMock()
+    monkeypatch.setattr(
+        social_graph_bot,
+        "_maybe_post_reminder_to_thread",
+        post_mock,
+    )
+
     async def fake_sleep(_seconds: float) -> None:
         bot._closed = True
         return None
@@ -66,6 +73,8 @@ async def test_process_goals_publishes_without_scheduler_service(monkeypatch: py
     published_message = publish_mock.await_args.args[0]
     assert published_message == reminder_message
     assert bot.goal_scheduler.next_goal() is None
+    post_mock.assert_awaited_once()
+    assert post_mock.await_args.args[1] == reminder_message
 
 
 @pytest.mark.asyncio
@@ -106,3 +115,51 @@ async def test_queue_goal_scheduler_reminder_single_entry(monkeypatch: pytest.Mo
     assert delay_str == str(int(timedelta(hours=3).total_seconds()))
     assert f"<#{record.thread_id}>" in message
     assert record.due_date.isoformat() in message
+    assert f"ID #{record.project_id}" in message
+
+
+@pytest.mark.asyncio
+async def test_process_goals_posts_to_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    channel_messages: list[str] = []
+
+    class _Channel:
+        async def send(self, content: str) -> None:
+            channel_messages.append(content)
+
+    bot = SimpleNamespace()
+    bot.scheduler_service = None
+    bot.goal_scheduler = GoalScheduler()
+    bot._closed = False
+    bot.get_channel = lambda _cid: _Channel()
+    bot.fetch_channel = AsyncMock(return_value=_Channel())
+
+    async def wait_until_ready() -> None:
+        return None
+
+    def is_closed() -> bool:
+        return bot._closed
+
+    bot.wait_until_ready = wait_until_ready
+    bot.is_closed = is_closed
+
+    reminder_message = "Reminder: Visit thread <#4321>"
+    bot.goal_scheduler.add_goal(f"0:{reminder_message}", priority=5)
+
+    publish_mock = AsyncMock()
+    monkeypatch.setattr(
+        social_graph_bot,
+        "publish_plan_requested",
+        publish_mock,
+        raising=False,
+    )
+
+    async def fake_sleep(_seconds: float) -> None:
+        bot._closed = True
+        return None
+
+    monkeypatch.setattr(social_graph_bot.asyncio, "sleep", fake_sleep)
+
+    await social_graph_bot.process_goals(bot)  # type: ignore[arg-type]
+
+    publish_mock.assert_awaited_once()
+    assert channel_messages == [reminder_message]


### PR DESCRIPTION
## Summary
- ensure the social graph bot publishes and forwards reminder payloads even when the scheduler service is unavailable
- queue a single projects board reminder entry that embeds the thread reference when present
- add regression tests covering the reminder queue format and fallback behaviour and document the change for maintainers

## Testing
- pytest tests/unit/plugins/test_projects_board_reminders.py tests/unit/plugins/test_projects_board.py
- flake8 src tests examples --count

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163e031fd88326a1b88c448582c1db)