### PR TITLE
Add metric persistence and training summary output

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ The `auto` mode samples a small portion of the dataset and enables packing when
 the average sequence length is under 70% of the maximum, mirroring the
 heuristics used by Predibase.
 
+Fine-tuning artifacts are written to the `--output-dir` (default:
+`./results/lora-adapter`). Training saves the adapter weights, checkpoints, and
+`train_results.json`, while evaluation adds `eval_results.json` that includes
+perplexity from the `compute_metrics` callback. A consolidated
+`metrics_summary.json` is emitted next to the saved model and echoed to the
+console so you can quickly see the train loss and eval perplexity after the
+run completes.
+
 Run ``dtrt finetune --help`` to see all available options.
 
 The CLI is also available as ``dtrt-finetune`` for convenience.

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Training utilities for fine-tuning language models."""
 
 import argparse
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -28,6 +29,7 @@ __all__ = [
     "_hf_model_loader",
     "_hf_dataset_loader",
     "create_trainer",
+    "compute_metrics",
     "run_training",
     "run",
     "estimate_vram",
@@ -199,6 +201,28 @@ def load_dataset(
     return fn(dataset_path, tokenizer, max_seq_length=max_seq_length, pack_sequences=pack_sequences)
 
 
+def compute_metrics(eval_pred) -> dict[str, float]:
+    """Compute perplexity for language modeling evaluations."""
+
+    import torch.nn.functional as F
+
+    predictions, labels = eval_pred
+    logits = predictions[0] if isinstance(predictions, tuple) else predictions
+    logits = torch.from_numpy(logits) if not torch.is_tensor(logits) else logits
+    labels = torch.from_numpy(labels) if not torch.is_tensor(labels) else labels
+
+    shift_logits = logits[..., :-1, :].contiguous()
+    shift_labels = labels[..., 1:].contiguous()
+    loss = F.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1),
+        ignore_index=-100,
+        reduction="mean",
+    )
+    perplexity = torch.exp(loss).item()
+    return {"perplexity": perplexity}
+
+
 def create_trainer(
     model: AutoModelForCausalLM,
     tokenizer: AutoTokenizer,
@@ -244,27 +268,6 @@ def create_trainer(
         eval_steps=eval_steps,
     )
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
-
-    def compute_metrics(eval_pred):
-        import torch.nn.functional as F
-
-        logits, labels = eval_pred
-        if isinstance(logits, tuple):
-            logits = logits[0]
-        logits = torch.from_numpy(logits) if not torch.is_tensor(logits) else logits
-        labels = torch.from_numpy(labels) if not torch.is_tensor(labels) else labels
-
-        with torch.no_grad():
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-            loss = F.cross_entropy(
-                shift_logits.view(-1, shift_logits.size(-1)),
-                shift_labels.view(-1),
-                ignore_index=-100,
-                reduction="mean",
-            )
-        perplexity = torch.exp(loss).item()
-        return {"eval_loss": loss.item(), "perplexity": perplexity}
 
     trainer = Trainer(
         model=model,
@@ -319,6 +322,7 @@ def run_training(config: TrainingConfig) -> int:
     trainer.save_metrics("train", train_result.metrics)
     train_metrics_path = os.path.join(config.output_dir, "train_results.json")
     logger.info("Training metrics saved to %s", train_metrics_path)
+    eval_metrics: dict[str, float] | None = None
     if config.evaluation_strategy != "no":
         eval_metrics = trainer.evaluate()
         trainer.save_metrics("eval", eval_metrics)
@@ -326,6 +330,20 @@ def run_training(config: TrainingConfig) -> int:
         logger.info("Evaluation metrics saved to %s", eval_metrics_path)
     trainer.save_model()
     trainer.save_state()
+    summary = {
+        "output_dir": config.output_dir,
+        "train_loss": train_result.metrics.get("train_loss"),
+    }
+    if eval_metrics:
+        summary["eval_loss"] = eval_metrics.get("eval_loss")
+        summary["eval_perplexity"] = eval_metrics.get("eval_perplexity")
+    summary_path = os.path.join(config.output_dir, "metrics_summary.json")
+    with open(summary_path, "w", encoding="utf-8") as fh:
+        json.dump(summary, fh, indent=2)
+    logger.info("Training summary saved to %s", summary_path)
+    logger.info("Training summary:\n%s", json.dumps(summary, indent=2))
+    print("Training summary:")
+    print(json.dumps(summary, indent=2))
     return 0
 
 


### PR DESCRIPTION
## Summary
- add a reusable compute_metrics callback that reports perplexity during evaluation
- persist evaluation results next to saved models and emit a metrics summary for the CLI
- document the finetuning output artifacts in the README

## Testing
- pytest (fails: missing optional dependencies such as aiosqlite/rdflib/discord and torch triton registration conflicts)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931effc50d08326bd1acf96ef1800cb)