### PR TITLE
Fix metric key prefixing and add serialization tests

### DIFF
--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -9,7 +9,7 @@ import logging
 import os
 from pathlib import Path
 from dataclasses import dataclass
-from typing import Callable, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 from importlib import metadata
 
 import torch
@@ -367,7 +367,7 @@ def compute_metrics(eval_pred) -> Dict[str, float]:
             reduction="mean",
         )
     perplexity = torch.exp(loss).item()
-    return {"eval_loss": loss.item(), "perplexity": perplexity}
+    return {"loss": loss.item(), "perplexity": perplexity}
 
 
 def _save_json(path: str | Path, payload: dict) -> None:
@@ -405,6 +405,15 @@ def _prepare_metrics(metrics: dict | None) -> dict:
             except Exception:
                 prepared[key] = str(value)
     return prepared
+
+
+def _get_eval_metric(metrics: dict[str, Any], key: str) -> Any:
+    """Return an evaluation metric value, preferring Trainer-prefixed keys."""
+
+    prefixed_key = f"eval_{key}"
+    if prefixed_key in metrics:
+        return metrics[prefixed_key]
+    return metrics.get(key)
 
 
 def _print_summary(output_dir: str, train_metrics: dict, eval_metrics: dict | None) -> None:
@@ -477,8 +486,8 @@ def run_training(config: TrainingConfig) -> int:
         "train_loss": train_result.metrics.get("train_loss"),
     }
     if eval_metrics:
-        summary["eval_loss"] = eval_metrics.get("eval_loss")
-        summary["eval_perplexity"] = eval_metrics.get("eval_perplexity")
+        summary["eval_loss"] = _get_eval_metric(eval_metrics, "loss")
+        summary["eval_perplexity"] = _get_eval_metric(eval_metrics, "perplexity")
     summary_path = os.path.join(config.output_dir, "metrics_summary.json")
     with open(summary_path, "w", encoding="utf-8") as fh:
         json.dump(summary, fh, indent=2)

--- a/tests/unit/test_train_metrics_serialization.py
+++ b/tests/unit/test_train_metrics_serialization.py
@@ -1,0 +1,62 @@
+import importlib
+import sys
+import types
+
+import pytest
+import torch
+
+datasets_mod = types.ModuleType("datasets")
+datasets_mod.Dataset = object
+datasets_mod.load_dataset = lambda *a, **k: None
+sys.modules["datasets"] = datasets_mod
+
+peft_mod = types.ModuleType("peft")
+peft_mod.LoraConfig = object
+peft_mod.get_peft_model = lambda *a, **k: None
+peft_mod.prepare_model_for_kbit_training = lambda *a, **k: None
+sys.modules["peft"] = peft_mod
+
+transformers_mod = types.ModuleType("transformers")
+transformers_mod.AutoModelForCausalLM = object
+transformers_mod.AutoTokenizer = object
+transformers_mod.BitsAndBytesConfig = object
+transformers_mod.DataCollatorForLanguageModeling = object
+transformers_mod.Trainer = object
+transformers_mod.TrainingArguments = object
+sys.modules["transformers"] = transformers_mod
+
+train = importlib.import_module("deepthought.train")
+compute_metrics = train.compute_metrics
+_prepare_metrics = train._prepare_metrics
+_get_eval_metric = train._get_eval_metric
+
+
+def test_compute_metrics_returns_neutral_keys():
+    logits = torch.zeros((1, 3, 5))
+    labels = torch.tensor([[1, 2, 3]])
+
+    metrics = compute_metrics((logits, labels))
+
+    assert set(metrics) == {"loss", "perplexity"}
+    assert metrics["perplexity"] == pytest.approx(torch.exp(torch.tensor(metrics["loss"])).item())
+
+
+def test_prepare_metrics_serializes_tensors_and_nested_objects():
+    metrics = {
+        "eval_loss": torch.tensor(1.23),
+        "eval_perplexity": torch.tensor(3.0),
+        "nested": {"a": 1},
+    }
+
+    prepared = _prepare_metrics(metrics)
+
+    assert prepared["eval_loss"] == pytest.approx(1.23)
+    assert prepared["eval_perplexity"] == pytest.approx(3.0)
+    assert isinstance(prepared["nested"], str)
+
+
+def test_get_eval_metric_prefers_prefixed_keys():
+    metrics = {"eval_loss": 0.5, "loss": 1.0}
+
+    assert _get_eval_metric(metrics, "loss") == 0.5
+    assert _get_eval_metric({"loss": 1.0}, "loss") == 1.0


### PR DESCRIPTION
## Summary
- return neutral metric keys from compute_metrics so Trainer applies eval prefixes
- add helper to read prefixed eval metrics when building summaries
- add unit coverage for metric serialization and key handling

## Testing
- pytest tests/unit/test_train_metrics_serialization.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939898cec948326984c2f845a33d356)