### PR TITLE
Add AWQ post-training quantization support

### DIFF
--- a/LLM_Fine_Tuning_Report.md
+++ b/LLM_Fine_Tuning_Report.md
@@ -124,6 +124,15 @@ Follow these steps to execute the fine-tuning process:
 
    Use `--resume` to continue from the latest checkpoint in `./results/lora-adapter`.
 3. **Review metrics** in `./results/lora-adapter/train_results.json`.
+4. **Optionally quantize the adapter with AWQ** by appending flags such as:
+
+   ```bash
+   dtrt finetune --enable-awq --awq-calibration-samples 128 --awq-output-dir ./results/lora-adapter/awq
+   ```
+
+   AWQ writes a quantized copy of the adapter plus `awq_results.json`, and the
+   `metrics_summary.json` file is expanded with the quantized artifact path and
+   quantization settings.
 
 ### Example Metrics
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ Adjust 4-bit quantization behaviour (bits must be either 4 or 8):
 dtrt finetune --bits 4 --no-use-nf4 --use-double-quant --compute-dtype float16
 ```
 
+Enable post-training AWQ quantization of the fine-tuned adapter and write a
+quantized copy of the model (plus `awq_results.json`) alongside the existing
+metric files:
+
+```bash
+dtrt finetune --enable-awq --awq-calibration-samples 128 --awq-output-dir ./results/lora-adapter/awq
+```
+
+You can customise the calibration dataset, bit-width, and group size with
+`--awq-dataset-path`, `--awq-w-bit`, and `--awq-group-size`. The
+`metrics_summary.json` file will include the quantized artifact path when AWQ is
+enabled.
+
 Run ``dtrt finetune --help`` to see all available options.
 
 The CLI is also available as ``dtrt-finetune`` for convenience.

--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -38,6 +38,7 @@ __all__ = [
     "parse_args",
     "main",
     "TrainingConfig",
+    "AWQConfig",
 ]
 
 
@@ -80,6 +81,21 @@ class TrainingConfig:
     use_nf4: bool = True
     use_double_quant: bool = True
     compute_dtype: str = "bfloat16"
+    awq: "AWQConfig" | None = None
+
+
+@dataclass
+class AWQConfig:
+    """Configuration options for post-training AWQ quantization."""
+
+    enabled: bool = False
+    dataset_path: str | None = None
+    output_dir: str | None = None
+    calibration_samples: int = 128
+    q_group_size: int = 128
+    w_bit: int = 4
+    zero_point: bool = True
+    version: str = "GEMM"
 
 
 def _resolve_plugin(group: str, name: str) -> Callable:
@@ -430,6 +446,56 @@ def _print_summary(output_dir: str, train_metrics: dict, eval_metrics: dict | No
     print("\n".join(lines))
 
 
+def _perform_awq_quantization(config: TrainingConfig, tokenizer) -> dict | None:
+    """Optionally run AWQ quantization on the fine-tuned adapter."""
+
+    awq_cfg = config.awq or AWQConfig()
+    if not awq_cfg.enabled:
+        return None
+
+    try:
+        from awq import AutoAWQForCausalLM
+    except Exception as exc:  # pragma: no cover - exercised via tests with mocks
+        raise RuntimeError("AWQ quantization requested but the 'awq' package is not available") from exc
+
+    quant_config = {
+        "zero_point": awq_cfg.zero_point,
+        "q_group_size": awq_cfg.q_group_size,
+        "w_bit": awq_cfg.w_bit,
+        "version": awq_cfg.version,
+    }
+
+    awq_output_dir = awq_cfg.output_dir or os.path.join(config.output_dir, "awq")
+    calibration_path = awq_cfg.dataset_path or config.dataset_path
+    calibration_dataset = hf_load_dataset(calibration_path, split="train")
+    sample_count = awq_cfg.calibration_samples
+    if hasattr(calibration_dataset, "select"):
+        try:
+            calibration_dataset = calibration_dataset.select(range(sample_count))
+        except Exception:
+            logger.warning("Unable to select calibration subset; using full dataset")
+            sample_count = len(calibration_dataset) if hasattr(calibration_dataset, "__len__") else sample_count
+
+    model = AutoAWQForCausalLM.from_pretrained(
+        config.output_dir,
+        safetensors=True,
+        trust_remote_code=True,
+        device_map="auto",
+    )
+    model.quantize(tokenizer, quant_config=quant_config, calib_data=calibration_dataset)
+    model.save_quantized(awq_output_dir)
+
+    awq_metrics = {
+        "awq_output_dir": awq_output_dir,
+        "awq_quant_config": quant_config,
+        "awq_calibration_samples": sample_count,
+    }
+    awq_results_path = os.path.join(config.output_dir, "awq_results.json")
+    _save_json(awq_results_path, awq_metrics)
+    logger.info("AWQ results saved to %s", awq_results_path)
+    return awq_metrics
+
+
 def run_training(config: TrainingConfig) -> int:
     """Execute training using :class:`TrainingConfig`."""
     model, tokenizer = load_model(
@@ -488,6 +554,9 @@ def run_training(config: TrainingConfig) -> int:
     if eval_metrics:
         summary["eval_loss"] = _get_eval_metric(eval_metrics, "loss")
         summary["eval_perplexity"] = _get_eval_metric(eval_metrics, "perplexity")
+    awq_metrics = _perform_awq_quantization(config, tokenizer)
+    if awq_metrics:
+        summary.update(awq_metrics)
     summary_path = os.path.join(config.output_dir, "metrics_summary.json")
     with open(summary_path, "w", encoding="utf-8") as fh:
         json.dump(summary, fh, indent=2)
@@ -500,6 +569,16 @@ def run_training(config: TrainingConfig) -> int:
 
 def run(args: argparse.Namespace) -> int:
     """Execute training using high level helper functions."""
+    awq_cfg = AWQConfig(
+        enabled=args.enable_awq,
+        dataset_path=args.awq_dataset_path,
+        output_dir=args.awq_output_dir,
+        calibration_samples=args.awq_calibration_samples,
+        q_group_size=args.awq_group_size,
+        w_bit=args.awq_w_bit,
+        zero_point=args.awq_zero_point,
+        version=args.awq_version,
+    )
     cfg = TrainingConfig(
         model_path=args.model_path,
         dataset_path=args.dataset_path,
@@ -524,6 +603,7 @@ def run(args: argparse.Namespace) -> int:
         use_nf4=args.use_nf4,
         use_double_quant=args.use_double_quant,
         compute_dtype=args.compute_dtype,
+        awq=awq_cfg,
     )
     return run_training(cfg)
 
@@ -659,6 +739,46 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         default="bfloat16",
         help="Computation dtype for 4-bit layers",
     )
+    parser.add_argument("--enable-awq", action="store_true", help="Enable post-training AWQ quantization")
+    parser.add_argument(
+        "--awq-dataset-path",
+        default=None,
+        help="Dataset path to use for AWQ calibration (defaults to the training dataset)",
+    )
+    parser.add_argument(
+        "--awq-output-dir",
+        default=None,
+        help="Output directory for the quantized model (default: <output_dir>/awq)",
+    )
+    parser.add_argument(
+        "--awq-calibration-samples",
+        type=int,
+        default=128,
+        help="Number of samples to use for AWQ calibration",
+    )
+    parser.add_argument(
+        "--awq-group-size",
+        type=int,
+        default=128,
+        help="Group size for AWQ quantization",
+    )
+    parser.add_argument(
+        "--awq-w-bit",
+        type=int,
+        default=4,
+        help="Bit width for AWQ quantization",
+    )
+    parser.add_argument(
+        "--awq-zero-point",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable zero-point optimization in AWQ quantization",
+    )
+    parser.add_argument(
+        "--awq-version",
+        default="GEMM",
+        help="AWQ kernel version to use (for example, GEMM)",
+    )
     return parser.parse_args(args)
 
 
@@ -683,6 +803,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Estimated VRAM requirement: {vram:.2f} GB")
         if args.estimate_only:
             return 0
+    awq_cfg = AWQConfig(
+        enabled=args.enable_awq,
+        dataset_path=args.awq_dataset_path,
+        output_dir=args.awq_output_dir,
+        calibration_samples=args.awq_calibration_samples,
+        q_group_size=args.awq_group_size,
+        w_bit=args.awq_w_bit,
+        zero_point=args.awq_zero_point,
+        version=args.awq_version,
+    )
     cfg = TrainingConfig(
         model_path=args.model_path,
         dataset_path=args.dataset_path,
@@ -707,6 +837,7 @@ def main(argv: list[str] | None = None) -> int:
         use_nf4=args.use_nf4,
         use_double_quant=args.use_double_quant,
         compute_dtype=args.compute_dtype,
+        awq=awq_cfg,
     )
     return run_training(cfg)
 

--- a/tests/unit/test_train_awq.py
+++ b/tests/unit/test_train_awq.py
@@ -1,0 +1,134 @@
+import importlib
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+
+def _install_stubs():
+    datasets_mod = types.ModuleType("datasets")
+    datasets_mod.Dataset = object
+    datasets_mod.load_dataset = lambda *a, **k: None
+    sys.modules["datasets"] = datasets_mod
+
+    peft_mod = types.ModuleType("peft")
+    peft_mod.LoraConfig = object
+    peft_mod.get_peft_model = lambda *a, **k: None
+    peft_mod.prepare_model_for_kbit_training = lambda *a, **k: None
+    sys.modules["peft"] = peft_mod
+
+    transformers_mod = types.ModuleType("transformers")
+    transformers_mod.AutoModelForCausalLM = object
+    transformers_mod.AutoTokenizer = object
+    transformers_mod.BitsAndBytesConfig = object
+    transformers_mod.DataCollatorForLanguageModeling = object
+    transformers_mod.Trainer = object
+    transformers_mod.TrainingArguments = object
+    sys.modules["transformers"] = transformers_mod
+
+
+_install_stubs()
+train = importlib.import_module("deepthought.train")
+
+
+class _DummyResult:
+    def __init__(self, metrics):
+        self.metrics = metrics
+
+
+def test_run_training_invokes_awq(monkeypatch, tmp_path):
+    trainer = mock.Mock()
+    trainer.train.return_value = _DummyResult({"train_loss": 1.0})
+    trainer.evaluate.return_value = {"eval_loss": 0.5, "eval_perplexity": 2.0}
+    trainer.save_metrics = mock.Mock()
+    trainer.save_model = mock.Mock()
+    trainer.save_state = mock.Mock()
+
+    monkeypatch.setattr(train, "load_model", mock.Mock(return_value=("model", "tokenizer")))
+    monkeypatch.setattr(train, "load_dataset", mock.Mock(return_value=("train", "eval")))
+    monkeypatch.setattr(train, "create_trainer", mock.Mock(return_value=(trainer, None)))
+
+    awq_result = {"awq_output_dir": str(tmp_path / "awq"), "awq_quant_config": {"w_bit": 4}}
+    monkeypatch.setattr(train, "_perform_awq_quantization", mock.Mock(return_value=awq_result))
+
+    cfg = train.TrainingConfig(output_dir=str(tmp_path), awq=train.AWQConfig(enabled=True))
+
+    exit_code = train.run_training(cfg)
+
+    assert exit_code == 0
+    train._perform_awq_quantization.assert_called_once_with(cfg, "tokenizer")
+    summary_path = tmp_path / "metrics_summary.json"
+    assert summary_path.exists()
+    summary = summary_path.read_text()
+    assert "awq_output_dir" in summary
+
+
+def test_perform_awq_quantization_writes_results(monkeypatch, tmp_path):
+    class DummyDataset:
+        def __init__(self, size: int = 5):
+            self.size = size
+            self.selected = None
+
+        def select(self, items):
+            self.selected = list(items)
+            return self
+
+        def __len__(self):
+            return self.size
+
+    dummy_dataset = DummyDataset(size=10)
+
+    class DummyAWQModel:
+        last_instance = None
+
+        @classmethod
+        def from_pretrained(cls, model_dir, **kwargs):
+            inst = cls()
+            inst.loaded = (model_dir, kwargs)
+            cls.last_instance = inst
+            return inst
+
+        def quantize(self, tokenizer, quant_config, calib_data):
+            self.quantize_call = (tokenizer, quant_config, calib_data)
+
+        def save_quantized(self, output_dir):
+            self.saved_dir = output_dir
+
+    awq_mod = types.SimpleNamespace(AutoAWQForCausalLM=DummyAWQModel)
+    monkeypatch.setitem(sys.modules, "awq", awq_mod)
+    monkeypatch.setattr(train, "hf_load_dataset", lambda *a, **k: dummy_dataset)
+
+    cfg = train.TrainingConfig(
+        output_dir=str(tmp_path),
+        dataset_path="dummy/calibration",
+        awq=train.AWQConfig(
+            enabled=True,
+            calibration_samples=3,
+            q_group_size=64,
+            w_bit=3,
+            zero_point=False,
+            version="TEST",
+        ),
+    )
+
+    tokenizer = object()
+    result = train._perform_awq_quantization(cfg, tokenizer)
+
+    assert result["awq_output_dir"] == str(tmp_path / "awq")
+    assert result["awq_quant_config"] == {
+        "zero_point": False,
+        "q_group_size": 64,
+        "w_bit": 3,
+        "version": "TEST",
+    }
+    assert result["awq_calibration_samples"] == 3
+
+    awq_results_path = tmp_path / "awq_results.json"
+    assert awq_results_path.exists()
+
+    instance = DummyAWQModel.last_instance
+    assert instance.saved_dir == str(tmp_path / "awq")
+    assert instance.quantize_call[0] is tokenizer
+    assert isinstance(instance.quantize_call[2], DummyDataset)
+    assert instance.quantize_call[2].selected == [0, 1, 2]

--- a/tests/unit/test_train_main.py
+++ b/tests/unit/test_train_main.py
@@ -1,9 +1,34 @@
 import importlib
+import sys
+import types
 from unittest import mock
 
 import pytest
 
-pytest.importorskip("torch")
+
+def _install_stubs():
+    datasets_mod = types.ModuleType("datasets")
+    datasets_mod.Dataset = object
+    datasets_mod.load_dataset = lambda *a, **k: None
+    sys.modules["datasets"] = datasets_mod
+
+    peft_mod = types.ModuleType("peft")
+    peft_mod.LoraConfig = object
+    peft_mod.get_peft_model = lambda *a, **k: None
+    peft_mod.prepare_model_for_kbit_training = lambda *a, **k: None
+    sys.modules["peft"] = peft_mod
+
+    transformers_mod = types.ModuleType("transformers")
+    transformers_mod.AutoModelForCausalLM = object
+    transformers_mod.AutoTokenizer = object
+    transformers_mod.BitsAndBytesConfig = object
+    transformers_mod.DataCollatorForLanguageModeling = object
+    transformers_mod.Trainer = object
+    transformers_mod.TrainingArguments = object
+    sys.modules["transformers"] = transformers_mod
+
+
+_install_stubs()
 train = importlib.import_module("deepthought.train")
 
 


### PR DESCRIPTION
## Summary
- add AWQ configuration and CLI flags to optionally run AWQ post-training quantization for fine-tuned adapters
- emit AWQ artifact metadata alongside existing metrics and document the new workflow in README and LLM_Fine_Tuning_Report
- add unit tests that stub the AWQ pipeline and ensure the configuration is wired into training

## Testing
- pytest tests/unit/test_train_awq.py tests/unit/test_train_main.py tests/unit/test_train_metrics_serialization.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415f836a5c8326b4b2a524aacaf904)