### PR TITLE
Extend Thanksgiving window through Sunday

### DIFF
--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -85,11 +85,9 @@ def _fourth_thursday(year: int) -> date:
 
 def _is_thanksgiving_window(moment: datetime) -> bool:
     day = _normalize_datetime(moment).date()
-    if day.month != 11:
-        return False
     thanksgiving = _fourth_thursday(day.year)
     window_start = thanksgiving - timedelta(days=3)
-    window_end = thanksgiving + timedelta(days=2)
+    window_end = thanksgiving + timedelta(days=3)
     return window_start <= day <= window_end
 
 
@@ -120,10 +118,10 @@ def _western_easter_date(year: int) -> date:
     h = (19 * a + b - d - g + 15) % 30
     i = c // 4
     k = c % 4
-    l = (32 + 2 * e + 2 * i - h - k) % 7
-    m = (a + 11 * h + 22 * l) // 451
-    month = (h + l - 7 * m + 114) // 31
-    day = ((h + l - 7 * m + 114) % 31) + 1
+    ell = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * ell) // 451
+    month = (h + ell - 7 * m + 114) // 31
+    day = ((h + ell - 7 * m + 114) % 31) + 1
     return date(year, month, day)
 
 

--- a/tests/unit/plugins/test_projects_board_holidays.py
+++ b/tests/unit/plugins/test_projects_board_holidays.py
@@ -74,12 +74,41 @@ async def _create_board(
 @pytest.mark.parametrize(
     "scenario, due_date, expected",
     [
-        ("halloween", datetime(2024, 10, 5, tzinfo=UTC), True),
-        ("thanksgiving", datetime(2024, 11, 27, tzinfo=UTC), True),
-        ("christmas", datetime(2024, 12, 20, tzinfo=UTC), True),
-        ("new-year", datetime(2025, 1, 5, tzinfo=UTC), True),
-        ("valentines", datetime(2025, 2, 14, tzinfo=UTC), True),
-        ("mid-summer", datetime(2024, 7, 15, tzinfo=UTC), False),
+        (
+            "halloween",
+            datetime(2024, 10, 5, tzinfo=UTC),
+            {"US": True, "GB": False},
+        ),
+        (
+            "thanksgiving",
+            datetime(2024, 11, 27, tzinfo=UTC),
+            {"US": True, "GB": False},
+        ),
+        (
+            "thanksgiving-weekend",
+            datetime(2024, 12, 1, tzinfo=UTC),
+            {"US": True, "GB": True},
+        ),
+        (
+            "christmas",
+            datetime(2024, 12, 20, tzinfo=UTC),
+            {"US": True, "GB": True},
+        ),
+        (
+            "new-year",
+            datetime(2025, 1, 5, tzinfo=UTC),
+            {"US": True, "GB": True},
+        ),
+        (
+            "valentines",
+            datetime(2025, 2, 14, tzinfo=UTC),
+            {"US": True, "GB": False},
+        ),
+        (
+            "mid-summer",
+            datetime(2024, 7, 15, tzinfo=UTC),
+            {"US": False, "GB": False},
+        ),
     ],
 )
 async def test_creation_detects_holiday_windows(
@@ -89,7 +118,7 @@ async def test_creation_detects_holiday_windows(
     holiday_locale: str,
     scenario: str,
     due_date: datetime,
-    expected: bool,
+    expected: dict[str, bool],
 ) -> None:
     board = await _create_board(projects_board_module, monkeypatch, tmp_path, holiday_locale=holiday_locale)
     channel = DummyChannel()
@@ -108,10 +137,10 @@ async def test_creation_detects_holiday_windows(
         )
     finally:
         await board._close_db()
-    assert record.holiday is expected
+    assert record.holiday is expected[holiday_locale]
     tag_names = set(record.tags)
     holiday_tag = projects_board_module.HOLIDAY_TAG_NAME
-    assert (holiday_tag in tag_names) is expected
+    assert (holiday_tag in tag_names) is expected[holiday_locale]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/plugins/test_projects_board_reminders.py
+++ b/tests/unit/plugins/test_projects_board_reminders.py
@@ -13,7 +13,11 @@ pytest.importorskip("aiosqlite")
 pytest.importorskip("discord")
 
 from deepthought.goal_scheduler import GoalScheduler
-from deepthought.plugins.projects_board import ProjectRecord, ProjectsBoard
+from deepthought.plugins.projects_board import (
+    ProjectRecord,
+    ProjectsBoard,
+    _is_thanksgiving_window,
+)
 
 sys.modules.pop("examples.social_graph_bot", None)
 sys.path.append(str(Path(__file__).resolve().parents[2] / "src"))
@@ -119,6 +123,57 @@ async def test_queue_goal_scheduler_reminder_single_entry(monkeypatch: pytest.Mo
     assert f"<#{record.thread_id}>" in message
     assert record.due_date.isoformat() in message
     assert f"ID #{record.project_id}" in message
+
+
+@pytest.mark.asyncio
+async def test_queue_goal_scheduler_reminder_honors_extended_thanksgiving_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "deepthought.plugins.projects_board.datetime",
+        _FixedDateTime,
+    )
+    original_now = _FixedDateTime._now
+    _FixedDateTime._now = datetime(2024, 12, 1, 8, 0, tzinfo=UTC)
+    board = ProjectsBoard.__new__(ProjectsBoard)
+    board._scheduler = GoalScheduler()
+
+    holiday_due = datetime(2024, 12, 1, 12, 0, tzinfo=UTC)
+    assert _is_thanksgiving_window(holiday_due)
+
+    record = ProjectRecord(
+        project_id=202,
+        guild_id=999,
+        thread_id=808,
+        name="Holiday Weekend",
+        summary=None,
+        owner_id=None,
+        status="in-progress",
+        due_date=holiday_due,
+        holiday=True,
+        tags=[],
+        priority=None,
+        project_type=None,
+        scheduled_event_id=None,
+        created_at=_FixedDateTime._now - timedelta(days=3),
+        updated_at=_FixedDateTime._now - timedelta(days=2),
+        archived_at=None,
+    )
+
+    reminder_time = holiday_due - timedelta(hours=2)
+    try:
+        board._queue_goal_scheduler_reminder(record, reminder_time)
+
+        queued = board._scheduler.next_goal()
+        assert queued is not None
+        assert board._scheduler.next_goal() is None
+
+        delay_str, message = queued.split(":", 1)
+        assert delay_str == str(int(timedelta(hours=2).total_seconds()))
+        assert f"<#{record.thread_id}>" in message
+        assert record.due_date.isoformat() in message
+    finally:
+        _FixedDateTime._now = original_now
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- extend the Thanksgiving holiday window through the Sunday after the fourth Thursday
- adjust holiday tagging expectations for US and GB locales and add coverage for the extended window
- verify reminder scheduling for projects due during the extended Thanksgiving window

## Testing
- python -m pytest tests/unit/plugins/test_projects_board_holidays.py tests/unit/plugins/test_projects_board_reminders.py
- flake8 src/deepthought/plugins/projects_board.py tests/unit/plugins/test_projects_board_holidays.py tests/unit/plugins/test_projects_board_reminders.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942c98d3d288326b69039364ca72982)