### PR TITLE
Handle AWQ quantization with merged base model

### DIFF
--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import logging
 import os
+import tempfile
 from pathlib import Path
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Tuple
@@ -15,7 +16,7 @@ from importlib import metadata
 import torch
 from datasets import Dataset
 from datasets import load_dataset as hf_load_dataset
-from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training
+from peft import LoraConfig, PeftModel, get_peft_model, prepare_model_for_kbit_training
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
@@ -453,6 +454,12 @@ def _perform_awq_quantization(config: TrainingConfig, tokenizer) -> dict | None:
     if not awq_cfg.enabled:
         return None
 
+    if not config.model_path:
+        logger.warning(
+            "AWQ quantization requested but no base model path was provided; skipping AWQ",
+        )
+        return None
+
     try:
         from awq import AutoAWQForCausalLM
     except Exception as exc:  # pragma: no cover - exercised via tests with mocks
@@ -476,14 +483,28 @@ def _perform_awq_quantization(config: TrainingConfig, tokenizer) -> dict | None:
             logger.warning("Unable to select calibration subset; using full dataset")
             sample_count = len(calibration_dataset) if hasattr(calibration_dataset, "__len__") else sample_count
 
-    model = AutoAWQForCausalLM.from_pretrained(
-        config.output_dir,
-        safetensors=True,
-        trust_remote_code=True,
-        device_map="auto",
-    )
-    model.quantize(tokenizer, quant_config=quant_config, calib_data=calibration_dataset)
-    model.save_quantized(awq_output_dir)
+    try:
+        base_model = AutoModelForCausalLM.from_pretrained(config.model_path, trust_remote_code=True)
+        peft_model = PeftModel.from_pretrained(base_model, config.output_dir)
+        merged_model = peft_model.merge_and_unload()
+    except Exception:
+        logger.exception(
+            "Failed to merge base model from %s with adapters in %s; skipping AWQ quantization",
+            config.model_path,
+            config.output_dir,
+        )
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="awq-merged-") as merged_dir:
+        merged_model.save_pretrained(merged_dir)
+        model = AutoAWQForCausalLM.from_pretrained(
+            merged_dir,
+            safetensors=True,
+            trust_remote_code=True,
+            device_map="auto",
+        )
+        model.quantize(tokenizer, quant_config=quant_config, calib_data=calibration_dataset)
+        model.save_quantized(awq_output_dir)
 
     awq_metrics = {
         "awq_output_dir": awq_output_dir,

--- a/tests/unit/test_train_awq.py
+++ b/tests/unit/test_train_awq.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -14,6 +15,7 @@ def _install_stubs():
 
     peft_mod = types.ModuleType("peft")
     peft_mod.LoraConfig = object
+    peft_mod.PeftModel = object
     peft_mod.get_peft_model = lambda *a, **k: None
     peft_mod.prepare_model_for_kbit_training = lambda *a, **k: None
     sys.modules["peft"] = peft_mod
@@ -79,6 +81,33 @@ def test_perform_awq_quantization_writes_results(monkeypatch, tmp_path):
 
     dummy_dataset = DummyDataset(size=10)
 
+    class DummyBaseModel:
+        def save_pretrained(self, save_dir):
+            Path(save_dir).mkdir(parents=True, exist_ok=True)
+            (Path(save_dir) / "model.bin").write_text("weights")
+
+    class DummyMergedModel(DummyBaseModel):
+        pass
+
+    class DummyAutoModel:
+        last_loaded = None
+
+        @classmethod
+        def from_pretrained(cls, model_dir, **kwargs):
+            cls.last_loaded = (model_dir, kwargs)
+            return DummyBaseModel()
+
+    class DummyPeftModel:
+        last_loaded = None
+
+        @classmethod
+        def from_pretrained(cls, base_model, adapter_dir):
+            cls.last_loaded = (base_model, adapter_dir)
+            return cls()
+
+        def merge_and_unload(self):
+            return DummyMergedModel()
+
     class DummyAWQModel:
         last_instance = None
 
@@ -98,8 +127,11 @@ def test_perform_awq_quantization_writes_results(monkeypatch, tmp_path):
     awq_mod = types.SimpleNamespace(AutoAWQForCausalLM=DummyAWQModel)
     monkeypatch.setitem(sys.modules, "awq", awq_mod)
     monkeypatch.setattr(train, "hf_load_dataset", lambda *a, **k: dummy_dataset)
+    monkeypatch.setattr(train, "AutoModelForCausalLM", DummyAutoModel)
+    monkeypatch.setattr(train, "PeftModel", DummyPeftModel)
 
     cfg = train.TrainingConfig(
+        model_path="/base/model",
         output_dir=str(tmp_path),
         dataset_path="dummy/calibration",
         awq=train.AWQConfig(
@@ -132,3 +164,21 @@ def test_perform_awq_quantization_writes_results(monkeypatch, tmp_path):
     assert instance.quantize_call[0] is tokenizer
     assert isinstance(instance.quantize_call[2], DummyDataset)
     assert instance.quantize_call[2].selected == [0, 1, 2]
+    assert "awq-merged-" in instance.loaded[0]
+    assert DummyPeftModel.last_loaded[1] == str(tmp_path)
+    assert DummyAutoModel.last_loaded[0] == "/base/model"
+
+
+def test_perform_awq_quantization_skips_without_base_model_path(caplog):
+    tokenizer = object()
+    cfg = train.TrainingConfig(
+        output_dir="/tmp/output",
+        awq=train.AWQConfig(enabled=True),
+        model_path=None,
+    )
+
+    with caplog.at_level("WARNING"):
+        result = train._perform_awq_quantization(cfg, tokenizer)
+
+    assert result is None
+    assert any("no base model path" in message for message in caplog.messages)


### PR DESCRIPTION
## Summary
- merge the base model with trained LoRA adapters into a temporary checkpoint before running AWQ
- guard AWQ against missing base paths or merge failures with clear logging while preserving training outputs
- update AWQ unit tests to cover merged checkpoint usage and missing-base-model handling

## Testing
- python -m pytest tests/unit/test_train_awq.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694420aa984c832686ab91b4ed94afee)