### PR TITLE
Use merged checkpoint for AWQ quantization and guard missing base model path

### DIFF
--- a/src/deepthought/train/__init__.py
+++ b/src/deepthought/train/__init__.py
@@ -459,6 +459,13 @@ def _perform_awq_quantization(config: TrainingConfig, tokenizer) -> dict | None:
             "AWQ quantization requested but no base model path was provided; skipping AWQ",
         )
         return None
+    base_model_path = Path(config.model_path)
+    if not base_model_path.exists():
+        logger.warning(
+            "AWQ quantization requested but base model path %s does not exist; skipping AWQ",
+            base_model_path,
+        )
+        return None
 
     try:
         from awq import AutoAWQForCausalLM
@@ -483,22 +490,29 @@ def _perform_awq_quantization(config: TrainingConfig, tokenizer) -> dict | None:
             logger.warning("Unable to select calibration subset; using full dataset")
             sample_count = len(calibration_dataset) if hasattr(calibration_dataset, "__len__") else sample_count
 
+    logger.info(
+        "Preparing merged checkpoint for AWQ from base model %s with adapters in %s",
+        base_model_path,
+        config.output_dir,
+    )
     try:
-        base_model = AutoModelForCausalLM.from_pretrained(config.model_path, trust_remote_code=True)
+        base_model = AutoModelForCausalLM.from_pretrained(str(base_model_path), trust_remote_code=True)
         peft_model = PeftModel.from_pretrained(base_model, config.output_dir)
         merged_model = peft_model.merge_and_unload()
     except Exception:
         logger.exception(
             "Failed to merge base model from %s with adapters in %s; skipping AWQ quantization",
-            config.model_path,
+            base_model_path,
             config.output_dir,
         )
         return None
 
     with tempfile.TemporaryDirectory(prefix="awq-merged-") as merged_dir:
-        merged_model.save_pretrained(merged_dir)
+        merged_checkpoint_path = os.path.join(merged_dir, "merged")
+        merged_model.save_pretrained(merged_checkpoint_path)
+        logger.info("Merged checkpoint for AWQ saved to %s", merged_checkpoint_path)
         model = AutoAWQForCausalLM.from_pretrained(
-            merged_dir,
+            merged_checkpoint_path,
             safetensors=True,
             trust_remote_code=True,
             device_map="auto",


### PR DESCRIPTION
### Motivation
- Ensure AWQ quantization runs on the actual merged model (base + LoRA adapters) rather than an adapter-only directory.
- Provide clearer guardrails and logging when the base model path is missing or merging fails so AWQ is skipped safely.
- Persist AWQ outputs and metrics unchanged when quantization does run.

### Description
- Validate that `config.model_path` exists early and log + skip AWQ if missing (`Path(config.model_path)` check).
- Load the original base model from `config.model_path`, merge the saved LoRA adapters (`PeftModel.from_pretrained(...).merge_and_unload()`), and save a temporary merged checkpoint under a temp dir subpath (`merged/`) before AWQ.
- Use the temporary merged checkpoint path when calling `AutoAWQForCausalLM.from_pretrained(...)` and log the merged checkpoint location.
- Preserve existing behavior for calibration, quantization config, saving AWQ outputs and writing `awq_results.json`; maintain existing exception handling that skips AWQ when merge fails.

### Testing
- Ran `python -m pytest tests/unit/test_train_awq.py tests/train/test_train_module.py` — test collection errored due to missing system dependency (`ModuleNotFoundError: No module named 'numpy'`).
- Ran `python -m ruff check .` — linter invocation produced repository-wide lint errors (many existing issues), not specific failures caused by this change.
- Confirmed file changes applied and committed locally (`src/deepthought/train/__init__.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945a0057e448326b1cbbe355dc1d431)