### PR TITLE
Update holiday status when project tags change

### DIFF
--- a/src/deepthought/plugins/projects_board.py
+++ b/src/deepthought/plugins/projects_board.py
@@ -1771,14 +1771,16 @@ class ProjectsBoard(commands.Cog):
         now = datetime.now(UTC)
         new_tag_names = [tag.name for tag in applied_tags]
         canonical_priority = self._priority_from_tags(new_tag_names)
+        new_holiday = self._is_holiday_project(record.due_date, new_tag_names)
         await self._execute(
             """
             UPDATE projects
-            SET tags = ?, priority = ?, updated_at = ?
+            SET tags = ?, priority = ?, holiday = ?, updated_at = ?
             WHERE project_id = ?
             """,
             json.dumps(new_tag_names) if applied_tags else None,
             canonical_priority,
+            int(new_holiday),
             self._serialize_datetime(now),
             project_id,
         )
@@ -1808,14 +1810,16 @@ class ProjectsBoard(commands.Cog):
         now = datetime.now(UTC)
         new_tag_names = [tag.name for tag in applied_tags]
         canonical_project_type = self._project_type_from_tags(new_tag_names)
+        new_holiday = self._is_holiday_project(record.due_date, new_tag_names)
         await self._execute(
             """
             UPDATE projects
-            SET tags = ?, project_type = ?, updated_at = ?
+            SET tags = ?, project_type = ?, holiday = ?, updated_at = ?
             WHERE project_id = ?
             """,
             json.dumps(new_tag_names) if applied_tags else None,
             canonical_project_type,
+            int(new_holiday),
             self._serialize_datetime(now),
             project_id,
         )
@@ -1836,15 +1840,17 @@ class ProjectsBoard(commands.Cog):
         now = datetime.now(UTC)
         canonical_priority = self._priority_from_tags(new_tag_names)
         canonical_project_type = self._project_type_from_tags(new_tag_names)
+        new_holiday = self._is_holiday_project(record.due_date, new_tag_names)
         await self._execute(
             """
             UPDATE projects
-            SET tags = ?, priority = ?, project_type = ?, updated_at = ?
+            SET tags = ?, priority = ?, project_type = ?, holiday = ?, updated_at = ?
             WHERE project_id = ?
             """,
             json.dumps(new_tag_names) if applied_tags else None,
             canonical_priority,
             canonical_project_type,
+            int(new_holiday),
             self._serialize_datetime(now),
             record.project_id,
         )
@@ -2002,7 +2008,11 @@ class ProjectsBoard(commands.Cog):
         self._board_filters[message_id] = holiday_flag
 
         filtered_records = (
-            [record for record in records if record.holiday]
+            [
+                record
+                for record in records
+                if self._is_holiday_project(record.due_date, record.tags)
+            ]
             if holiday_flag
             else list(records)
         )


### PR DESCRIPTION
### Motivation
- Ensure the `holiday` flag stored in SQLite reflects the dynamic holiday predicate computed from both `due_date` and tag aliases so the DB remains authoritative after tag/priority/type updates.
- Make the holiday-only board filter use the same dynamic predicate (due date + tag aliases) to avoid relying on stale `record.holiday` values.

### Description
- Recompute holiday using `self._is_holiday_project(record.due_date, new_tag_names)` in `_set_project_priority`, `_set_project_type`, and `_persist_tag_update` and persist the `holiday` column in the `projects` table update statements.
- Update the holiday-only filter in `_update_index_embed` to select records with `if self._is_holiday_project(record.due_date, record.tags)` instead of checking `record.holiday`.
- Ensure thread tag edits remain applied to Discord threads after the DB update by preserving existing behavior around `thread.edit(applied_tags=...)`.

### Testing
- Ran `python -m pytest`, which failed during collection due to missing runtime dependencies (e.g. `aiosqlite`, `rdflib`, `discord`) and other environment-specific runtime errors, so tests did not complete successfully.
- Ran `python -m ruff check src`, which reported existing linting errors (numerous `E402` and other issues) unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69481ed1268083268892990edea9ff40)