### PR TITLE
Propagate user_id in memory and response events and prefer it for persona lookup

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -95,6 +95,7 @@ class MemoryRetrievedPayload(EventPayload):
 
     retrieved_knowledge: Dict[str, Any]
     input_id: Optional[str] = None
+    user_id: Optional[str] = None
     timestamp: Optional[str] = None
 
 
@@ -104,6 +105,7 @@ class ResponseGeneratedPayload(EventPayload):
 
     final_response: str
     input_id: Optional[str] = None
+    user_id: Optional[str] = None
     timestamp: Optional[str] = None
     confidence: Optional[float] = None
 

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -81,6 +81,9 @@ class BaseLLM(ABC):
             if not isinstance(data, dict):
                 raise ValueError("MemoryRetrieved payload must be a dict")
             input_id = data.get("input_id")
+            user_id = data.get("user_id")
+            if not isinstance(user_id, str):
+                user_id = None
             knowledge = data.get("retrieved_knowledge")
             if not isinstance(input_id, str) or not isinstance(knowledge, dict):
                 raise ValueError("Invalid memory payload fields")
@@ -105,7 +108,8 @@ class BaseLLM(ABC):
             persona_desc = ""
             if self._persona_manager is not None:
                 try:
-                    persona_desc = await self._persona_manager.get_description(int(input_id))
+                    persona_id = user_id if user_id is not None else input_id
+                    persona_desc = await self._persona_manager.get_description(int(persona_id))
                 except Exception:
                     logger.error("Persona selection failed", exc_info=True)
 
@@ -125,6 +129,7 @@ class BaseLLM(ABC):
             payload = ResponseGeneratedPayload(
                 final_response=response_text,
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 confidence=0.5,
             )

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -60,6 +60,9 @@ class RemoteLLM:
             if not isinstance(data, dict):
                 raise ValueError("MemoryRetrieved payload must be a dict")
             input_id = data.get("input_id")
+            user_id = data.get("user_id")
+            if not isinstance(user_id, str):
+                user_id = None
             retrieved = data.get("retrieved_knowledge", {})
             facts = retrieved.get("facts", [])
             prompt = ", ".join(map(str, facts))
@@ -68,6 +71,7 @@ class RemoteLLM:
             payload = ResponseGeneratedPayload(
                 final_response=response,
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=None,
                 confidence=0.9,
             )

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -48,6 +48,9 @@ class LLMStub:
             if not isinstance(data, dict):
                 raise ValueError(f"Unexpected MemoryRetrieved payload format: {type(data)}")
             input_id = data.get("input_id")
+            user_id = data.get("user_id")
+            if not isinstance(user_id, str):
+                user_id = None
             retrieved = data.get("retrieved_knowledge")
             if not isinstance(input_id, str) or retrieved is None:
                 raise ValueError("Invalid memory payload fields")
@@ -92,7 +95,8 @@ class LLMStub:
             persona_desc = ""
             if self._persona_manager is not None:
                 try:
-                    persona_desc = await self._persona_manager.get_description(int(input_id))
+                    persona_id = user_id if user_id is not None else input_id
+                    persona_desc = await self._persona_manager.get_description(int(persona_id))
                 except Exception:
                     logger.error("Persona selection failed", exc_info=True)
             # Use timezone-aware UTC timestamps
@@ -103,6 +107,7 @@ class LLMStub:
             payload = ResponseGeneratedPayload(
                 final_response=response,
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 confidence=0.95,
             )

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -46,6 +46,9 @@ class BasicMemory:
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
+            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            if not isinstance(user_id, str):
+                user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Invalid input payload fields")
             logger.info("BasicMemory received input event ID %s", input_id)
@@ -55,6 +58,7 @@ class BasicMemory:
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "basic_memory"},
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -49,6 +49,9 @@ class GraphMemory:
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
+            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            if not isinstance(user_id, str):
+                user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Invalid input payload fields")
             logger.info("GraphMemory received input event ID %s", input_id)
@@ -58,6 +61,7 @@ class GraphMemory:
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "graph_memory"},
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -77,6 +77,9 @@ class KnowledgeGraphMemory:
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
+            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            if not isinstance(user_id, str):
+                user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Invalid input payload fields")
             logger.info("KnowledgeGraphMemory received input %s", input_id)
@@ -88,6 +91,7 @@ class KnowledgeGraphMemory:
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "knowledge_graph"},
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
             await self._publisher.publish(

--- a/src/deepthought/modules/memory_stub.py
+++ b/src/deepthought/modules/memory_stub.py
@@ -36,6 +36,9 @@ class MemoryStub:
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
+            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            if not isinstance(user_id, str):
+                user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Invalid input payload fields")
             logger.info(f"MemoryStub received input event ID {input_id}")
@@ -51,6 +54,7 @@ class MemoryStub:
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"retrieved_knowledge": memory_data},
                 input_id=input_id,
+                user_id=user_id,
                 # Use timezone-aware UTC timestamp
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -129,6 +129,9 @@ class CognitiveCoreService(BaseService):
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
+            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            if not isinstance(user_id, str):
+                user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Invalid input payload fields")
             logger.info("CognitiveCoreService received input %s", input_id)
@@ -158,6 +161,7 @@ class CognitiveCoreService(BaseService):
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "cognitive_core"},
                 input_id=input_id,
+                user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 


### PR DESCRIPTION
### Motivation
- Include the actual user identifier in memory and LLM response events so downstream logic (persona selection, analytics, etc.) can operate on the real user rather than only an input id.
- Ensure memory producers publish `user_id` when available so LLM modules and other consumers receive it.
- Prefer `user_id` for persona selection while keeping `input_id` as a fallback to preserve existing behavior.
- Make event payloads explicit about `user_id` so consumers can safely access it.

### Description
- Added `user_id: Optional[str]` to `MemoryRetrievedPayload` and `ResponseGeneratedPayload` in `src/deepthought/eda/events.py`.
- Extracted `user_id` from incoming messages (and `msg.headers` fallback) in memory producers (`cognitive_core_service`, `memory_basic`, `memory_graph`, `memory_kg`, `memory_stub`) and included it in published `MemoryRetrievedPayload`.
- Threaded `user_id` through LLM handlers (`llm_base`, `llm_stub`, `llm_remote`) and included it in published `ResponseGeneratedPayload`.
- Updated persona lookup to use `payload.user_id` when present and fall back to `input_id` (`persona_id = user_id if user_id is not None else input_id`).

### Testing
- Ran `python -m pytest`, which began collection but failed during collection with 27 errors caused by missing or incompatible environment dependencies (e.g. `aiosqlite`, `rdflib`, `discord`, PIL/torch issues).
- Ran `python -m flake8` but the command failed because `flake8` is not installed in the execution environment (`No module named flake8`).
- No further automated test failures are attributable to the code changes themselves because test execution was blocked by environment dependency errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948213e89a8832698abe6ba64b5b071)