### PR TITLE
Use pairwise affinity/relationship for persona selection and pass target_id through LLM pipeline

### DIFF
--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -84,6 +84,9 @@ class BaseLLM(ABC):
             user_id = data.get("user_id")
             if not isinstance(user_id, str):
                 user_id = None
+            target_id = data.get("target_id") or (msg.headers.get("target_id") if msg.headers else None)
+            if not isinstance(target_id, str):
+                target_id = None
             knowledge = data.get("retrieved_knowledge")
             if not isinstance(input_id, str) or not isinstance(knowledge, dict):
                 raise ValueError("Invalid memory payload fields")
@@ -109,7 +112,7 @@ class BaseLLM(ABC):
             if self._persona_manager is not None:
                 try:
                     persona_id = user_id if user_id is not None else input_id
-                    persona_desc = await self._persona_manager.get_description(int(persona_id))
+                    persona_desc = await self._persona_manager.get_description(persona_id, target_id)
                 except Exception:
                     logger.error("Persona selection failed", exc_info=True)
 

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -51,6 +51,9 @@ class LLMStub:
             user_id = data.get("user_id")
             if not isinstance(user_id, str):
                 user_id = None
+            target_id = data.get("target_id") or (msg.headers.get("target_id") if msg.headers else None)
+            if not isinstance(target_id, str):
+                target_id = None
             retrieved = data.get("retrieved_knowledge")
             if not isinstance(input_id, str) or retrieved is None:
                 raise ValueError("Invalid memory payload fields")
@@ -96,7 +99,7 @@ class LLMStub:
             if self._persona_manager is not None:
                 try:
                     persona_id = user_id if user_id is not None else input_id
-                    persona_desc = await self._persona_manager.get_description(int(persona_id))
+                    persona_desc = await self._persona_manager.get_description(persona_id, target_id)
                 except Exception:
                     logger.error("Persona selection failed", exc_info=True)
             # Use timezone-aware UTC timestamps

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -7,7 +7,11 @@ from .db_manager import DBManager
 
 
 class PersonaManager:
-    """Select prompts based on user affinity."""
+    """Select prompts based on user affinity and pairwise relationships.
+
+    When a ``target_id`` is unavailable, persona selection falls back to
+    per-user affinity/trust scores instead of pairwise relationship data.
+    """
 
     def __init__(
         self,
@@ -47,26 +51,36 @@ class PersonaManager:
         current = self._personality.setdefault(uid, {})
         current.update(traits)
 
-    async def get_persona(self, user_id: int) -> str:
+    async def get_persona(self, user_id: int | str, target_id: int | str | None = None) -> str:
         if self._init_task is not None:
             await self._init_task
             self._init_task = None
-        score = await self._db.get_mutual_affinity(user_id)
         traits = self._personality.get(str(user_id), {})
+        if target_id is None:
+            score = await self._db.get_mutual_affinity(user_id)
+        else:
+            relationship = await self._db.get_relationship_type(user_id, target_id)
+            if relationship == "friend":
+                return "friendly"
+            if relationship == "rival":
+                return "snarky"
+            score = await self._db.get_pair_mutual_affinity(user_id, target_id)
         if score + traits.get("friendly", 0) >= self._friendly:
             return "friendly"
         if score + traits.get("playful", 0) >= self._playful:
             return "playful"
         return "snarky"
 
-    async def choose_prompt(self, user_id: int, prompts: dict[str, list[str]]) -> str:
-        persona = await self.get_persona(user_id)
+    async def choose_prompt(
+        self, user_id: int | str, prompts: dict[str, list[str]], target_id: int | str | None = None
+    ) -> str:
+        persona = await self.get_persona(user_id, target_id)
         options = prompts.get(persona) or prompts.get("default") or []
         if not options:
             return ""
         return random.choice(options)
 
-    async def get_description(self, user_id: int) -> str:
+    async def get_description(self, user_id: int | str, target_id: int | str | None = None) -> str:
         """Return a persona description for ``user_id`` if available."""
-        persona = await self.get_persona(user_id)
+        persona = await self.get_persona(user_id, target_id)
         return self._descriptions.get(persona, "")

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -53,7 +53,7 @@ class SocialGraphService(BaseService):
         """Process an INPUT_RECEIVED message."""
         try:
             await self._core._handle_input(msg)
-            await self._persona.get_persona("user")
+            await self._persona.get_persona("user", None)
         except Exception:  # pragma: no cover - defensive
             logger.error("Failed to handle input", exc_info=True)
 


### PR DESCRIPTION
### Motivation
- Make persona selection sensitive to the relationship between the user and a target/bot by consulting pairwise data when available.
- Prefer explicit relationship status (`friend`/`rival`) to force persona choices in clear cases.
- Preserve existing behavior when no `target_id` is present by falling back to per-user affinity/trust scores.
- Propagate `target_id` through the LLM prompt construction path so persona selection can use pairwise info when available.

### Description
- Change `PersonaManager.get_persona` to accept `user_id, target_id` and use `DBManager.get_pair_mutual_affinity` or `get_relationship_type` to select `friendly`/`playful`/`snarky`, with documented fallback to `get_mutual_affinity` when `target_id` is `None`.
- Update `PersonaManager.choose_prompt` and `get_description` to accept an optional `target_id` and pass it into `get_persona`.
- Extract `target_id` from incoming memory events and pass it to `get_description` in `src/deepthought/modules/llm_base.py` and `src/deepthought/modules/llm_stub.py` so persona selection has access to pair context.
- Adjust the social graph service call site to call `get_persona` with a `None` `target_id` fallback when invoked outside pair context.

### Testing
- Ran `pytest`; collection failed due to missing optional/environment dependencies (e.g. `aiosqlite`, `rdflib`, `discord`) and unrelated runtime issues in this environment, so tests did not complete successfully.
- Attempted `flake8` but it was not available in the environment, so linting was not executed.
- Behavior was validated locally by inspecting updated call sites to ensure `target_id` is threaded through `get_description`/`get_persona`.
- No automated tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482344c8f48326b74c9766673a0fac)