### PR TITLE
Add response safety filtering with configurable denylist and classifier

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -119,6 +119,20 @@ def _build_env_overrides() -> dict[str, object]:
         _set(("vector_use_gpu",), vector_gpu)
     _set(("graph_backend",), os.getenv("DT_GRAPH_BACKEND"))
 
+    response_filter_enabled = _coerce_bool(os.getenv("DT_RESPONSE_FILTER_ENABLED"))
+    if response_filter_enabled is not None:
+        _set(("response_filter_enabled",), response_filter_enabled)
+    _set(("response_filter_classifier",), os.getenv("DT_RESPONSE_FILTER_CLASSIFIER"))
+    _set(("response_filter_fallback_message",), os.getenv("DT_RESPONSE_FILTER_FALLBACK_MESSAGE"))
+    response_filter_denylist_raw = os.getenv("DT_RESPONSE_FILTER_DENYLIST")
+    if response_filter_denylist_raw:
+        try:
+            parsed = json.loads(response_filter_denylist_raw)
+        except json.JSONDecodeError:
+            parsed = [item.strip() for item in response_filter_denylist_raw.split(",")]
+        if isinstance(parsed, list):
+            _set(("response_filter_denylist",), parsed)
+
     _set(("db", "host"), os.getenv("DT_DB__HOST"))
     db_port = _coerce_int(os.getenv("DT_DB__PORT"))
     if db_port is not None:
@@ -223,6 +237,14 @@ class Settings(BaseSettings):
         "playful": "You like to joke around in your answers.",
         "snarky": "You reply with terse, witty sarcasm.",
     }
+
+    response_filter_enabled: bool = Field(True, env="DT_RESPONSE_FILTER_ENABLED")
+    response_filter_denylist: list[str] = Field(default_factory=list, env="DT_RESPONSE_FILTER_DENYLIST")
+    response_filter_classifier: str | None = Field(None, env="DT_RESPONSE_FILTER_CLASSIFIER")
+    response_filter_fallback_message: str = Field(
+        "I'm sorry, I can't assist with that.",
+        env="DT_RESPONSE_FILTER_FALLBACK_MESSAGE",
+    )
 
     model_config = SettingsConfigDict(env_prefix="DT_", env_nested_delimiter="__")
 

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -14,6 +14,7 @@ from ..config import get_settings
 from ..eda.events import EventSubjects, ResponseGeneratedPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from ..services.response_filter import build_response_filter
 
 logger = logging.getLogger(__name__)
 
@@ -48,10 +49,17 @@ class BaseLLM(ABC):
         self._subscriber = subscriber
         self._tokenizer = tokenizer
         self._model = model
-        buffer_size = reward_buffer_size or get_settings().reward.buffer_size
+        settings = get_settings()
+        buffer_size = reward_buffer_size or settings.reward.buffer_size
         self._recent_rewards: Deque[float] = deque(maxlen=buffer_size)
         self._persona_manager = persona_manager
-        self._persona_descriptions = get_settings().persona_descriptions
+        self._persona_descriptions = settings.persona_descriptions
+        self._response_filter_enabled = settings.response_filter_enabled
+        self._response_filter_fallback = settings.response_filter_fallback_message
+        self._response_filter = build_response_filter(
+            settings.response_filter_denylist,
+            settings.response_filter_classifier,
+        )
 
     @abstractmethod
     async def start_listening(self, durable_name: str = "llm_listener") -> bool:
@@ -128,6 +136,13 @@ class BaseLLM(ABC):
                 response_text = generated[len(prompt) :].strip()  # noqa: E203
             else:
                 response_text = generated.strip()
+
+            if self._response_filter_enabled and not self._response_filter.is_safe(response_text):
+                logger.warning(
+                    "Response filtered for input_id %s; using fallback response",
+                    input_id,
+                )
+                response_text = self._response_filter_fallback
 
             payload = ResponseGeneratedPayload(
                 final_response=response_text,

--- a/src/deepthought/services/response_filter.py
+++ b/src/deepthought/services/response_filter.py
@@ -1,0 +1,76 @@
+"""Lightweight response filtering utilities."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+Classifier = Callable[[str], bool]
+
+
+def _normalize_denylist(denylist: Iterable[str]) -> tuple[str, ...]:
+    cleaned: list[str] = []
+    for phrase in denylist:
+        if not isinstance(phrase, str):
+            continue
+        normalized = phrase.strip().lower()
+        if normalized:
+            cleaned.append(normalized)
+    return tuple(cleaned)
+
+
+def load_classifier(classifier_path: str) -> Classifier:
+    """Load a classifier callable from ``module:attribute`` notation."""
+    module_path, _, attr_name = classifier_path.rpartition(":")
+    if not module_path or not attr_name:
+        raise ValueError("Classifier path must be in 'module:attribute' format")
+    module = import_module(module_path)
+    classifier = getattr(module, attr_name)
+    if not callable(classifier):
+        raise TypeError(f"Classifier {classifier_path!r} is not callable")
+    return classifier
+
+
+@dataclass(frozen=True)
+class ResponseFilter:
+    """Check responses against a denylist and optional classifier."""
+
+    denylist: tuple[str, ...] = ()
+    classifier: Classifier | None = None
+
+    def is_safe(self, text: str) -> bool:
+        if not isinstance(text, str):
+            return False
+        lowered = text.lower()
+        if self.denylist and any(phrase in lowered for phrase in self.denylist):
+            return False
+        if self.classifier is None:
+            return True
+        try:
+            return bool(self.classifier(text))
+        except Exception:
+            logger.warning("Response classifier failed; treating as unsafe", exc_info=True)
+            return False
+
+
+def build_response_filter(
+    denylist: Iterable[str] | None = None,
+    classifier_path: str | None = None,
+) -> ResponseFilter:
+    """Construct a response filter for the configured inputs."""
+    normalized = _normalize_denylist(denylist or [])
+    classifier: Classifier | None = None
+    if classifier_path:
+        try:
+            classifier = load_classifier(classifier_path)
+        except Exception:
+            logger.warning(
+                "Unable to load response classifier %s",
+                classifier_path,
+                exc_info=True,
+            )
+    return ResponseFilter(denylist=normalized, classifier=classifier)


### PR DESCRIPTION
### Motivation

- Provide a lightweight, configurable safety filter to screen generated LLM responses before they are published.
- Allow teams to opt into denylist and/or classifier-based checks and supply a safe fallback when responses are unsafe.
- Centralize filter configuration via settings and environment variables for easy deployment control.

### Description

- Add `src/deepthought/services/response_filter.py` implementing a `ResponseFilter` with denylist normalization, optional `module:attr` classifier loading, and a `build_response_filter` helper.
- Wire the filter into `src/deepthought/modules/llm_base.py` by constructing the filter in `__init__` and running generated `response_text` through it in `_handle_memory_event`, replacing unsafe text with a fallback and logging a warning.
- Add new settings and environment-variable handling in `src/deepthought/config.py` for `response_filter_enabled`, `response_filter_denylist`, `response_filter_classifier`, and `response_filter_fallback_message`, including parsing of a JSON or comma-separated denylist.

### Testing

- Ran `pytest`, which executed test collection but failed during collection with 27 errors related to missing optional dependencies (examples: `aiosqlite`, `rdflib`, `discord`) and environment-specific issues with `torch`/`PIL`.
- Attempted `flake8`, but the command was not available in the environment so linting was not executed.
- Unit-level behavior of the new filter was implemented to avoid hard runtime dependencies (classifier loading is optional and failures are logged and treated as unsafe).
- Manual sanity-checked that the LLM handler uses the configured fallback message and logs a warning when the filter rejects a response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69482517f3008326b28093122b65baa0)