### PR TITLE
Add lightweight toxicity moderation and foe-mode severity cap

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -64,7 +64,7 @@ from deepthought.plugins.projects_board import DEFAULT_HOLIDAY_LOCALE, ProjectsB
 from deepthought.services import PersonaManager, TrustService
 from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
-from deepthought.services.moderation import is_allowed
+from deepthought.services.moderation import evaluate_toxicity, is_allowed
 from deepthought.services.scheduler import SchedulerService
 from deepthought.utils import UserRateLimiter
 
@@ -256,6 +256,12 @@ MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
 AVOIDANCE_REPLY = "Take your time; I'm here if you need me."
 REFUSAL_MESSAGE = "I'm sorry, but I can't help with that."
+FOE_MODE_CAP_ENABLED = os.getenv("FOE_MODE_CAP_ENABLED", "true").lower() in {
+    "true",
+    "1",
+    "yes",
+}
+FOE_MODE_MAX_SEVERITY = float(os.getenv("FOE_MODE_MAX_SEVERITY", "0.4"))
 
 # Optional channel for thought logging
 _THOUGHT_CHANNEL = os.getenv("THOUGHT_CHANNEL")
@@ -1088,10 +1094,12 @@ class SocialGraphBot(commands.Bot):
             await asyncio.sleep(random.uniform(1, 3))
             if last_other_bot_message_time and last_other_bot_message_time > start_time:
                 return
+            persona_used = None
             if bullying and not await is_do_not_mock(message.author.id):
                 reply = BULLYING_RESPONSE
             elif social_scores.get("flirtation", 0) > 0.5:
                 reply = random.choice(PERSONA_REPLIES["playful"])
+                persona_used = "playful"
             elif social_scores.get("avoidance", 0) > 0.5:
                 reply = AVOIDANCE_REPLY
             else:
@@ -1101,14 +1109,25 @@ class SocialGraphBot(commands.Bot):
                     if mode == "minimal":
                         reply = random.choice(MINIMAL_REPLIES)
                     elif mode == "persona":
-                        reply = random.choice(PERSONA_REPLIES.get(persona_override, PERSONA_REPLIES["snarky"]))
+                        persona_used = persona_override or "snarky"
+                        reply = random.choice(PERSONA_REPLIES.get(persona_used, PERSONA_REPLIES["snarky"]))
                 if reply is None:
                     trust = await trust_service.get_trust(message.author.id)
                     if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
                         reply = random.choice(MINIMAL_REPLIES)
                     else:
                         persona = await self.persona_manager.get_persona(message.author.id)
+                        persona_used = persona
                         reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+            if FOE_MODE_CAP_ENABLED and persona_used == "snarky":
+                severity, matches = evaluate_toxicity(reply)
+                if severity > FOE_MODE_MAX_SEVERITY:
+                    logger.info(
+                        "Foe-mode cap applied: severity=%s matches=%s",
+                        round(severity, 3),
+                        matches,
+                    )
+                    reply = random.choice(MINIMAL_REPLIES)
             now = discord.utils.utcnow()
             while our_message_times and (now - our_message_times[0]).total_seconds() > BOT_MESSAGE_INTERVAL_SECONDS:
                 our_message_times.popleft()

--- a/src/deepthought/services/moderation.py
+++ b/src/deepthought/services/moderation.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Iterable
+import os
+import re
+from typing import Iterable, Mapping, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -36,11 +38,122 @@ BANNED_PHRASES = [
     *SECRET_REQUEST_PHRASES,
 ]
 
+# Configuration toggles for moderation behavior.
+MODERATION_LOG_DECISIONS = os.getenv("MODERATION_LOG_DECISIONS", "true").lower() in {
+    "true",
+    "1",
+    "yes",
+}
+TOXICITY_CHECK_ENABLED = os.getenv("MODERATION_TOXICITY_ENABLED", "true").lower() in {
+    "true",
+    "1",
+    "yes",
+}
+TOXICITY_THRESHOLD = float(os.getenv("MODERATION_TOXICITY_THRESHOLD", "0.6"))
 
-def is_allowed(text: str, banned_phrases: Iterable[str] | None = None) -> bool:
+# Lightweight toxicity lexicon with severity weights.
+TOXICITY_TERMS: Mapping[str, float] = {
+    "idiot": 0.4,
+    "stupid": 0.4,
+    "loser": 0.4,
+    "dumb": 0.4,
+    "ugly": 0.4,
+    "moron": 0.5,
+    "jerk": 0.5,
+    "shut up": 0.6,
+    "trash": 0.5,
+    "worthless": 0.7,
+    "hate you": 0.7,
+    "piece of": 0.6,
+    "kill yourself": 1.0,
+}
+_MAX_TOXICITY_WEIGHT = max(TOXICITY_TERMS.values(), default=1.0)
+
+
+def evaluate_toxicity(
+    text: str,
+    *,
+    terms: Mapping[str, float] | None = None,
+) -> Tuple[float, Sequence[str]]:
+    """Return a toxicity score and matched terms for ``text``."""
+    if not isinstance(text, str):
+        return 0.0, []
+    lexicon = terms or TOXICITY_TERMS
+    lowered = text.lower()
+    matches: list[str] = []
+    total_weight = 0.0
+    for phrase, weight in lexicon.items():
+        if " " in phrase:
+            found = phrase in lowered
+        else:
+            found = re.search(rf"\b{re.escape(phrase)}\b", lowered) is not None
+        if found:
+            matches.append(phrase)
+            total_weight += weight
+    if not matches:
+        return 0.0, []
+    score = min(1.0, total_weight / (_MAX_TOXICITY_WEIGHT * len(matches)))
+    return score, matches
+
+
+def _log_decision(
+    *,
+    text: str,
+    allowed: bool,
+    banned_matches: Sequence[str],
+    toxicity_score: float | None = None,
+    toxicity_matches: Sequence[str] | None = None,
+    toxicity_threshold: float | None = None,
+) -> None:
+    if not MODERATION_LOG_DECISIONS:
+        return
+    logger.info(
+        "Moderation decision: allowed=%s banned_matches=%s toxicity_score=%s "
+        "toxicity_matches=%s toxicity_threshold=%s text_preview=%s",
+        allowed,
+        list(banned_matches),
+        None if toxicity_score is None else round(toxicity_score, 3),
+        list(toxicity_matches or []),
+        toxicity_threshold,
+        text[:160].replace("\n", " "),
+    )
+
+
+def is_allowed(
+    text: str,
+    banned_phrases: Iterable[str] | None = None,
+    *,
+    check_toxicity: bool | None = None,
+    toxicity_threshold: float | None = None,
+) -> bool:
     """Return ``True`` if ``text`` does not contain any banned phrases."""
     if not isinstance(text, str):
         return False
     phrases = list(banned_phrases) if banned_phrases is not None else BANNED_PHRASES
     lowered = text.lower()
-    return not any(phrase in lowered for phrase in phrases)
+    banned_matches = [phrase for phrase in phrases if phrase in lowered]
+    if banned_matches:
+        _log_decision(
+            text=text,
+            allowed=False,
+            banned_matches=banned_matches,
+        )
+        return False
+    use_toxicity = TOXICITY_CHECK_ENABLED if check_toxicity is None else check_toxicity
+    threshold = TOXICITY_THRESHOLD if toxicity_threshold is None else toxicity_threshold
+    toxicity_score = None
+    toxicity_matches: Sequence[str] = []
+    if use_toxicity:
+        toxicity_score, toxicity_matches = evaluate_toxicity(text)
+        allowed = toxicity_score < threshold
+    else:
+        allowed = True
+    _log_decision(
+        text=text,
+        allowed=allowed,
+        banned_matches=banned_matches,
+        toxicity_score=toxicity_score,
+        toxicity_matches=toxicity_matches,
+        toxicity_threshold=threshold if use_toxicity else None,
+    )
+    return allowed


### PR DESCRIPTION
### Motivation

- Prevent hostile or abusive outputs by extending banned-phrase checks with a lightweight toxicity heuristic.  
- Limit the severity of replies when the bot is operating in a snarky persona to avoid escalating hostility.  
- Make moderation behavior configurable and auditable for easier tuning and post-hoc review.  

### Description

- Add `evaluate_toxicity` lexicon-based scorer, environment toggles (`MODERATION_TOXICITY_ENABLED`, `MODERATION_TOXICITY_THRESHOLD`, `MODERATION_LOG_DECISIONS`) and audit logging to `src/deepthought/services/moderation.py`.  
- Extend `is_allowed` to return decisions based on both banned phrases and toxicity score and to log moderation decisions when enabled.  
- Update `examples/social_graph_bot.py` to import `evaluate_toxicity`, introduce `FOE_MODE_CAP_ENABLED` and `FOE_MODE_MAX_SEVERITY` toggles, track `persona_used`, and apply a severity cap that replaces overly toxic snarky replies with a minimal reply while logging the action.  

### Testing

- Ran `python -m flake8` as a lint step but `flake8` was not installed in the environment so linting did not complete.  
- Ran `pytest` which started test collection but was interrupted by multiple import/collection errors caused by missing optional dependencies (`aiosqlite`, `rdflib`, `discord`, `torch`, `PIL`, `prometheus_client`) so full test execution could not be completed.  
- The moderation logic and bot flow changes are exercised by the modified code paths, but integration/unit tests could not be fully run due to environment gaps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694836b1be2083269990b86a3f349d95)