### PR TITLE
Feed retrieved memories into bot reply prompts and label MEMORY_RETRIEVED in LLM prompts

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -326,6 +326,23 @@ def _get_idle_generator():
     return _idle_text_generator
 
 
+async def _generate_text(prompt: str, *, max_new_tokens: int) -> str | None:
+    """Return generated text for ``prompt`` or ``None`` on failure."""
+    try:
+        generator = _get_idle_generator()
+        outputs = await asyncio.to_thread(
+            generator,
+            prompt,
+            max_new_tokens=max_new_tokens,
+            num_return_sequences=1,
+        )
+        text = outputs[0]["generated_text"].strip()
+        return text
+    except Exception:  # pragma: no cover - optional dependency or runtime error
+        logger.exception("Text generation failed")
+        return None
+
+
 async def generate_idle_response(prompt: str | None = None) -> str | None:
     """Generate a prompt to send when the channel has been idle.
 
@@ -333,26 +350,51 @@ async def generate_idle_response(prompt: str | None = None) -> str | None:
     environment variable. ``None`` is returned if generation fails for any
     reason.
     """
-    try:
-        gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
-        if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
-            topics = await get_recent_topics(3)
-            if topics:
-                gen_prompt = ", ".join(topics) + ": " + gen_prompt
+    gen_prompt = prompt or os.getenv("IDLE_GENERATOR_PROMPT", "Say something to spark conversation.")
+    if prompt is None and "IDLE_GENERATOR_PROMPT" not in os.environ:
+        topics = await get_recent_topics(3)
+        if topics:
+            gen_prompt = ", ".join(topics) + ": " + gen_prompt
 
-        generator = _get_idle_generator()
-        outputs = await asyncio.to_thread(
-            generator,
-            gen_prompt,
-            max_new_tokens=20,
-            num_return_sequences=1,
-        )
+    return await _generate_text(gen_prompt, max_new_tokens=20)
 
-        text = outputs[0]["generated_text"].strip()
-        return text
-    except Exception:  # pragma: no cover - optional dependency or runtime error
-        logger.exception("Idle text generation failed")
-        return None
+
+MAX_MEMORY_PROMPT_SNIPPETS = int(os.getenv("MEMORY_PROMPT_SNIPPETS", "5"))
+LLM_REPLY_MAX_NEW_TOKENS = int(os.getenv("LLM_REPLY_MAX_NEW_TOKENS", "40"))
+
+
+def _format_memory_snippets(memories: list[tuple[str, str]], limit: int) -> list[str]:
+    if limit <= 0:
+        return []
+    snippets = []
+    for topic, memory in memories:
+        if not memory or not str(memory).strip():
+            continue
+        entry = f"[{topic}] {memory}" if topic else str(memory)
+        snippets.append(entry.strip())
+    return snippets[-limit:]
+
+
+def build_reply_prompt(user_text: str, memory_snippets: list[str]) -> str:
+    """Assemble a reply prompt with optional memory context."""
+    lines = ["You are a conversational social bot.", "MEMORY_RETRIEVED:"]
+    if memory_snippets:
+        lines.extend(f"- {snippet}" for snippet in memory_snippets)
+    else:
+        lines.append("- (none)")
+    lines.extend(
+        [
+            "Respond naturally and briefly.",
+            f"User: {user_text}",
+            "Bot:",
+        ]
+    )
+    return "\n".join(lines)
+
+
+async def generate_contextual_reply(user_text: str, memory_snippets: list[str]) -> str | None:
+    prompt = build_reply_prompt(user_text, memory_snippets)
+    return await _generate_text(prompt, max_new_tokens=LLM_REPLY_MAX_NEW_TOKENS)
 
 
 # Simple list of phrases considered bullying
@@ -1083,6 +1125,11 @@ class SocialGraphBot(commands.Bot):
         if not reply_limiter.allow(str(message.author.id)):
             return
 
+        memories = await recall_user(message.author.id)
+        memory_snippets = _format_memory_snippets(memories, MAX_MEMORY_PROMPT_SNIPPETS)
+        if memories:
+            logger.info(f"Recalling memories for {message.author.id}: {memories}")
+
         async with message.channel.typing():
             start_time = discord.utils.utcnow()
             await asyncio.sleep(random.uniform(1, 3))
@@ -1095,20 +1142,21 @@ class SocialGraphBot(commands.Bot):
             elif social_scores.get("avoidance", 0) > 0.5:
                 reply = AVOIDANCE_REPLY
             else:
-                reply = None
-                if dominant_emotion:
-                    mode, persona_override = EMOTION_REPLY_MAP.get(dominant_emotion, (None, None))
-                    if mode == "minimal":
-                        reply = random.choice(MINIMAL_REPLIES)
-                    elif mode == "persona":
-                        reply = random.choice(PERSONA_REPLIES.get(persona_override, PERSONA_REPLIES["snarky"]))
+                reply = await generate_contextual_reply(message.content, memory_snippets)
                 if reply is None:
-                    trust = await trust_service.get_trust(message.author.id)
-                    if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
-                        reply = random.choice(MINIMAL_REPLIES)
-                    else:
-                        persona = await self.persona_manager.get_persona(message.author.id)
-                        reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
+                    if dominant_emotion:
+                        mode, persona_override = EMOTION_REPLY_MAP.get(dominant_emotion, (None, None))
+                        if mode == "minimal":
+                            reply = random.choice(MINIMAL_REPLIES)
+                        elif mode == "persona":
+                            reply = random.choice(PERSONA_REPLIES.get(persona_override, PERSONA_REPLIES["snarky"]))
+                    if reply is None:
+                        trust = await trust_service.get_trust(message.author.id)
+                        if trust < MINIMAL_REPLY_THRESHOLD or random.random() < MINIMAL_REPLY_PROB:
+                            reply = random.choice(MINIMAL_REPLIES)
+                        else:
+                            persona = await self.persona_manager.get_persona(message.author.id)
+                            reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             now = discord.utils.utcnow()
             while our_message_times and (now - our_message_times[0]).total_seconds() > BOT_MESSAGE_INTERVAL_SECONDS:
                 our_message_times.popleft()
@@ -1132,10 +1180,6 @@ class SocialGraphBot(commands.Bot):
                 "content": message.content,
             }
         )
-
-        memories = await recall_user(message.author.id)
-        if memories:
-            logger.info(f"Recalling memories for {message.author.id}: {memories}")
 
         for theory, conf in evaluate_triggers(message):
             await store_theory(message.author.id, theory, conf)

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -75,7 +75,11 @@ class BaseLLM(ABC):
         if self._recent_rewards:
             avg = sum(self._recent_rewards) / len(self._recent_rewards)
             reward_part = f"[avg_reward: {avg:.2f}]\n"
-        base = "\n".join(facts) + "\nResponse:" if facts else "Response:"
+        if facts:
+            memory_lines = "\n".join(f"- {fact}" for fact in facts)
+            base = f"MEMORY_RETRIEVED:\n{memory_lines}\nResponse:"
+        else:
+            base = "Response:"
         prompt = reward_part + base
         if persona_desc:
             prompt = persona_desc.strip() + "\n" + prompt

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -65,7 +65,11 @@ class RemoteLLM:
                 user_id = None
             retrieved = data.get("retrieved_knowledge", {})
             facts = retrieved.get("facts", [])
-            prompt = ", ".join(map(str, facts))
+            if facts:
+                memory_lines = "\n".join(f"- {fact}" for fact in map(str, facts))
+                prompt = f"MEMORY_RETRIEVED:\n{memory_lines}\nResponse:"
+            else:
+                prompt = "Response:"
             logger.info("RemoteLLM generating for %s", input_id)
             response = await self._generate(prompt)
             payload = ResponseGeneratedPayload(


### PR DESCRIPTION
### Motivation
- Use recalled user memories to improve the bot's reply generation by providing relevant context to the LLM.
- Ensure LLM prompt assemblies explicitly include a `MEMORY_RETRIEVED` section so downstream LLM modules receive memory context.
- Keep memory usage bounded to avoid prompt bloat by limiting the number of injected snippets via configuration.

### Description
- In `examples/social_graph_bot.py` add `_generate_text`, `generate_contextual_reply`, `_format_memory_snippets`, and `build_reply_prompt`, and integrate `recall_user(...)` to assemble bounded memory snippets for replies.
- Use `MAX_MEMORY_PROMPT_SNIPPETS` and `LLM_REPLY_MAX_NEW_TOKENS` environment-configurable constants to bound memory and reply token usage.
- Update the reply selection flow to try a contextual LLM-generated reply first and fall back to existing persona/minimal logic if generation fails.
- Label memory context in LLM prompt assembly by changing `src/deepthought/modules/llm_base.py` and `src/deepthought/modules/llm_remote.py` to include a `MEMORY_RETRIEVED:` section when facts are present.

### Testing
- Ran `python -m pytest` which failed during collection due to missing environment dependencies (e.g., `aiosqlite`, `rdflib`, `discord`, `PIL`, and Torch-related issues) so no test failures attributable to the changes were observed but the full suite could not run.
- Ran `ruff` (`python -m ruff check .`) which reported many existing lint errors in the repository (unused imports, notebook syntax, and E402 locations) and did not report issues specific to the new logic beyond the repo-wide findings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694836b0fdc48326a0c6e29038fe0f6c)