### PR TITLE
Apply sentiment-based affinity deltas before persona selection and add integration test

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1087,6 +1087,13 @@ class SocialGraphBot(commands.Bot):
             sentiment_score=sentiment_score,
         )
         await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        affinity_delta = None
+        if sentiment_score >= SENTIMENT_THRESHOLD:
+            affinity_delta = AFFINITY_POS_DELTA
+        elif sentiment_score <= -SENTIMENT_THRESHOLD:
+            affinity_delta = AFFINITY_NEG_DELTA
+        if affinity_delta:
+            await adjust_affinity(message.author.id, affinity_delta)
 
         await db_manager.record_emotion(message.author.id, emotions)
 

--- a/tests/test_persona_integration.py
+++ b/tests/test_persona_integration.py
@@ -146,3 +146,45 @@ async def test_social_analysis_adjusts_tone(tmp_path, monkeypatch, input_events)
     assert msg2.channel.sent_messages[-1] == sg.AVOIDANCE_REPLY
 
     await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_on_message_updates_affinity_from_sentiment(tmp_path, monkeypatch, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
+    sg.persona_manager = PersonaManager(sg.db_manager)
+
+    async def noop(*args, **kwargs):
+        return None
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "log_interaction", noop)
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+    monkeypatch.setattr(sg.reply_limiter, "allow", lambda _id: True)
+    monkeypatch.setattr(sg, "detect_emotions", lambda _t: {})
+    monkeypatch.setattr(
+        sg,
+        "analyze_social",
+        lambda _t: {"flirtation": 0, "avoidance": 0, "manipulation": 0},
+    )
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+
+    monkeypatch.setattr(sg, "analyze_sentiment", lambda _t: 0.8)
+    msg1 = DummyMessage("you are great")
+    await bot.on_message(msg1)
+    assert await sg.get_affinity(msg1.author.id) == sg.AFFINITY_POS_DELTA
+
+    monkeypatch.setattr(sg, "analyze_sentiment", lambda _t: -0.8)
+    msg2 = DummyMessage("you are terrible", author_id=msg1.author.id, message_id=11)
+    await bot.on_message(msg2)
+    assert await sg.get_affinity(msg2.author.id) == sg.AFFINITY_POS_DELTA + sg.AFFINITY_NEG_DELTA
+
+    await sg.db_manager.close()


### PR DESCRIPTION
### Motivation
- Track social affinity changes based on message sentiment so persona selection reflects recent user tone.
- Apply positive/negative affinity adjustments before choosing a reply persona to ensure replies adapt immediately.
- Persist affinity updates via the existing `DBManager` interface to maintain consistent social state.
- Add an automated integration test to prevent regressions in affinity handling.

### Description
- Compute an `affinity_delta` in `examples/social_graph_bot.py` inside `SocialGraphBot.on_message` using `sentiment_score`, `SENTIMENT_THRESHOLD`, and `AFFINITY_POS_DELTA`/`AFFINITY_NEG_DELTA`.
- Call `await adjust_affinity(message.author.id, affinity_delta)` immediately after `update_sentiment_trend` and before persona selection logic.
- Add `tests/test_persona_integration.py::test_on_message_updates_affinity_from_sentiment` which stubs `analyze_sentiment` for positive and negative messages and asserts `await sg.get_affinity(...)` matches expected deltas.
- Test setup in the new test uses `DBManager` and `PersonaManager` and monkeypatches external side effects to isolate affinity behavior.

### Testing
- Ran `pytest tests/test_persona_integration.py`, but collection skipped the test due to the optional `discord` dependency (result: 0 collected, 1 skipped).
- Attempted `flake8 src tests`, but `flake8` was not available in the environment so linting did not run.
- The integration test is present and designed to assert affinity increments/decrements when `analyze_sentiment` is stubbed to positive/negative values.
- No automated failures were observed in the attempted test run (skip due to optional dependency prevented assertions from executing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9e5b4fb08326841ad1b1cd3222d3)