### PR TITLE
Implement response queue for social graph bot replies

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -8,7 +8,7 @@ import re
 import uuid
 from collections import deque
 from datetime import timedelta, timezone
-from typing import List, Tuple
+from typing import Awaitable, Callable, List, Tuple
 
 import aiohttp
 
@@ -66,7 +66,7 @@ from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import evaluate_toxicity, is_allowed
 from deepthought.services.scheduler import SchedulerService
-from deepthought.utils import UserRateLimiter
+from deepthought.utils import ResponseQueue, UserRateLimiter
 
 try:
     import discord
@@ -256,6 +256,10 @@ BOT_COOLDOWN_SECONDS = int(os.getenv("BOT_COOLDOWN_SECONDS", "30"))
 OTHER_BOT_COOLDOWN_SECONDS = int(os.getenv("OTHER_BOT_COOLDOWN_SECONDS", "10"))
 BOT_MESSAGE_INTERVAL_SECONDS = int(os.getenv("BOT_MESSAGE_INTERVAL_SECONDS", "60"))
 MAX_BOT_MESSAGES_PER_INTERVAL = int(os.getenv("MAX_BOT_MESSAGES_PER_INTERVAL", "5"))
+RESPONSE_QUEUE_COOLDOWN_SECONDS = float(
+    os.getenv("RESPONSE_QUEUE_COOLDOWN_SECONDS", str(BOT_MESSAGE_INTERVAL_SECONDS))
+)
+RESPONSE_STALE_SECONDS = float(os.getenv("RESPONSE_STALE_SECONDS", "20"))
 MINIMAL_REPLY_THRESHOLD = float(os.getenv("MINIMAL_REPLY_THRESHOLD", "-5"))
 MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
@@ -514,11 +518,21 @@ def log_thought(bot: discord.Client, text: str) -> None:
     loop.create_task(_send_thought(bot, text))
 
 
-async def emit_refusal(message: discord.Message) -> None:
+async def emit_refusal(
+    message: discord.Message,
+    enqueue: Callable[[discord.abc.Messageable, Callable[[], Awaitable[None]]], Awaitable[None]] | None = None,
+) -> None:
     """Send a refusal message to ``message.channel``."""
-    async with message.channel.typing():
-        await asyncio.sleep(random.uniform(1, 3))
-        await message.channel.send(REFUSAL_MESSAGE)
+
+    async def _send_refusal() -> None:
+        async with message.channel.typing():
+            await asyncio.sleep(random.uniform(1, 3))
+            await message.channel.send(REFUSAL_MESSAGE)
+
+    if enqueue is None:
+        await _send_refusal()
+    else:
+        await enqueue(message.channel, _send_refusal)
 
 
 async def publish_input_received(text: str) -> None:
@@ -908,12 +922,19 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 prompt = await generate_idle_response()
                 if not prompt:
                     prompt = random.choice(idle_response_candidates)
-                async with channel.typing():
-                    await asyncio.sleep(random.uniform(3, 10))
-                    if respond_to is not None:
-                        await channel.send(prompt, reference=respond_to)
-                    else:
-                        await channel.send(prompt)
+                async def _send_prompt() -> None:
+                    async with channel.typing():
+                        await asyncio.sleep(random.uniform(3, 10))
+                        if respond_to is not None:
+                            await channel.send(prompt, reference=respond_to)
+                        else:
+                            await channel.send(prompt)
+
+                enqueue = getattr(bot, "enqueue_response", None)
+                if callable(enqueue):
+                    await enqueue(channel, _send_prompt)
+                else:
+                    await _send_prompt()
             await asyncio.sleep(60)
         except asyncio.CancelledError:
             logger.info("monitor_channels cancelled")
@@ -952,6 +973,9 @@ class SocialGraphBot(commands.Bot):
         self.persona_manager = PersonaManager(db_manager, descriptions=get_settings().persona_descriptions)
         self._subscriber: Subscriber | None = None
         self._projects_board: ProjectsBoard | None = None
+        self.response_queue = ResponseQueue(
+            RESPONSE_QUEUE_COOLDOWN_SECONDS, stale_after=RESPONSE_STALE_SECONDS
+        )
 
     async def setup_hook(self) -> None:
         await db_manager.connect()
@@ -1001,6 +1025,13 @@ class SocialGraphBot(commands.Bot):
         """Log basic information once the bot connects."""
         logger.info("Logged in as %s (%s)", self.user.name, self.user.id)
 
+    async def enqueue_response(
+        self, channel: discord.abc.Messageable, sender: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Enqueue a response for ``channel`` while respecting cooldowns."""
+
+        await self.response_queue.enqueue(channel.id, sender)
+
     async def on_message(self, message: discord.Message) -> None:
         global last_bot_reply_time, last_other_bot_message_time
         if message.author == self.user:
@@ -1041,7 +1072,7 @@ class SocialGraphBot(commands.Bot):
                 return
 
         if not is_allowed(message.content):  # noqa: F821 - optional import
-            await emit_refusal(message)
+            await emit_refusal(message, enqueue=self.enqueue_response)
             await trust_service.penalize_banned(message.author.id)
             return
 
@@ -1052,9 +1083,13 @@ class SocialGraphBot(commands.Bot):
                 await store_lie(message.author.id, message.content, cover_reply)
             else:
                 cover_reply = lie_reply
-            async with message.channel.typing():
-                await asyncio.sleep(random.uniform(1, 3))
-                await message.channel.send(cover_reply)
+
+            async def send_cover_reply() -> None:
+                async with message.channel.typing():
+                    await asyncio.sleep(random.uniform(1, 3))
+                    await message.channel.send(cover_reply)
+
+            await self.enqueue_response(message.channel, send_cover_reply)
             await store_memory(message.author.id, cover_reply, topic="deception")
             await log_interaction(message.author.id, message.channel.id)
             await publish_input_received(message.content)
@@ -1207,10 +1242,14 @@ class SocialGraphBot(commands.Bot):
                 our_message_times.popleft()
             if len(our_message_times) >= MAX_BOT_MESSAGES_PER_INTERVAL:
                 return
-            await message.channel.send(reply)
-            our_message_times.append(discord.utils.utcnow())
-            if message.author.bot:
-                last_bot_reply_time = discord.utils.utcnow()
+            async def dispatch_reply() -> None:
+                await message.channel.send(reply)
+                our_message_times.append(discord.utils.utcnow())
+                if message.author.bot:
+                    global last_bot_reply_time
+                    last_bot_reply_time = discord.utils.utcnow()
+
+            await self.enqueue_response(message.channel, dispatch_reply)
 
         # Log the interaction
         await log_interaction(message.author.id, message.channel.id)
@@ -1244,7 +1283,7 @@ class SocialGraphBot(commands.Bot):
         channel = self.get_channel(self.monitor_channel_id)
         try:
             if channel is not None:
-                await channel.send(text)
+                await self.enqueue_response(channel, lambda: channel.send(text))
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:  # pragma: no cover - defensive
@@ -1278,6 +1317,7 @@ class SocialGraphBot(commands.Bot):
             await self._subscriber.unsubscribe_all()
             self._subscriber = None
         await db_manager.close()
+        await self.response_queue.stop()
         global _nats_client, _js_context, _input_publisher, _subscriber
         if _nats_client is not None and not _nats_client.is_closed:
             await _nats_client.close()

--- a/src/deepthought/utils/__init__.py
+++ b/src/deepthought/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers used across the project."""
 
 from .ratelimit import UserRateLimiter
+from .response_queue import ResponseQueue
 
-__all__ = ["UserRateLimiter"]
+__all__ = ["UserRateLimiter", "ResponseQueue"]

--- a/src/deepthought/utils/response_queue.py
+++ b/src/deepthought/utils/response_queue.py
@@ -1,0 +1,98 @@
+"""Async helper for queuing responses per channel with cooldowns."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Deque, Dict, Hashable
+
+logger = logging.getLogger(__name__)
+
+SendCallable = Callable[[], Awaitable[None]]
+
+
+@dataclass
+class _QueuedResponse:
+    created_at: float
+    sender: SendCallable
+
+
+class ResponseQueue:
+    """Maintain per-channel queues for sending responses.
+
+    The queue enforces a cooldown between responses per ``key`` (for example,
+    a Discord channel ID). When multiple responses queue up for a key, stale
+    entries are dropped in favor of newer ones to avoid sending outdated
+    messages.
+    """
+
+    def __init__(self, cooldown: float, *, stale_after: float = 30.0) -> None:
+        self.cooldown = cooldown
+        self.stale_after = stale_after
+        self._queues: Dict[Hashable, Deque[_QueuedResponse]] = {}
+        self._last_sent: Dict[Hashable, float] = {}
+        self._tasks: Dict[Hashable, asyncio.Task] = {}
+        self._lock = asyncio.Lock()
+
+    async def enqueue(self, key: Hashable, sender: SendCallable) -> None:
+        """Queue ``sender`` for ``key`` and start a worker if needed."""
+
+        async with self._lock:
+            queue = self._queues.setdefault(key, deque())
+            queue.append(_QueuedResponse(time.monotonic(), sender))
+            worker = self._tasks.get(key)
+            if worker is None or worker.done():
+                self._tasks[key] = asyncio.create_task(self._run_queue(key))
+
+    async def stop(self) -> None:
+        """Cancel all workers and clear queues."""
+
+        async with self._lock:
+            tasks = list(self._tasks.values())
+            self._tasks.clear()
+            self._queues.clear()
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _run_queue(self, key: Hashable) -> None:
+        while True:
+            async with self._lock:
+                queue = self._queues.get(key)
+                if not queue:
+                    self._tasks.pop(key, None)
+                    return
+
+                now = time.monotonic()
+                while len(queue) > 1 and now - queue[0].created_at > self.stale_after:
+                    queue.popleft()
+
+                if not queue:
+                    continue
+
+                ready_at = self._last_sent.get(key, 0.0) + self.cooldown
+                delay = max(0.0, ready_at - now)
+
+                # Defer sending if still in cooldown.
+                if delay > 0:
+                    # Sleep in short slices so new responses can be checked for staleness.
+                    await asyncio.sleep(min(delay, 1.0))
+                    # If new items were added while sleeping and the head is stale, loop drops it.
+                    continue
+
+                item = queue.popleft()
+
+            # Drop stale items when newer messages exist in the queue.
+            if (time.monotonic() - item.created_at > self.stale_after) and self._queues.get(key):
+                continue
+
+            try:
+                await item.sender()
+            except Exception:  # pragma: no cover - logging best effort
+                logger.warning("Failed to send queued response for %s", key, exc_info=True)
+
+            self._last_sent[key] = time.monotonic()


### PR DESCRIPTION
## Summary
- add a reusable per-channel ResponseQueue helper with cooldown and stale item dropping
- integrate response queue into the social graph bot for idle prompts, refusals, chat replies, and CHAT_RAW events
- ensure queues shut down with the bot lifecycle

## Testing
- python -m pytest *(fails: missing optional dependencies such as datasets/torch and unavailable perception workers in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ead87e8688326a202c44f11bc9079)