### PR TITLE
Add mention-aware replies and update bot tests

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -290,6 +290,13 @@ BOT_CHAT_ENABLED = os.getenv("BOT_CHAT_ENABLED", "false").lower() in {
     "yes",
 }
 
+# Comma-separated list of channel IDs where reply mentions should be suppressed
+NO_MENTION_CHANNEL_IDS = {
+    int(cid)
+    for cid in os.getenv("NO_MENTION_CHANNEL_IDS", "").split(",")
+    if cid.strip().isdigit()
+}
+
 # Literal handshake message exchanged between bots before chatting.
 HANDSHAKE_MESSAGE = "BOT_HANDSHAKE"
 
@@ -355,6 +362,15 @@ async def _generate_text(prompt: str, *, max_new_tokens: int) -> str | None:
         return None
 
 
+def _build_persona_prompt(messages: List[str], persona_desc: str) -> str:
+    """Return a prompt that includes ``persona_desc`` and message history."""
+
+    history = "\n".join(messages)
+    if persona_desc:
+        return f"{persona_desc}\n\n{history}"
+    return history
+
+
 async def generate_idle_response(prompt: str | None = None) -> str | None:
     """Generate a prompt to send when the channel has been idle.
 
@@ -406,6 +422,12 @@ def build_reply_prompt(user_text: str, memory_snippets: list[str]) -> str:
 
 async def generate_contextual_reply(user_text: str, memory_snippets: list[str]) -> str | None:
     prompt = build_reply_prompt(user_text, memory_snippets)
+    return await _generate_text(prompt, max_new_tokens=LLM_REPLY_MAX_NEW_TOKENS)
+
+
+async def generate_llm_reply(prompt: str) -> str | None:
+    """Generate an LLM reply for ``prompt`` using the contextual generator."""
+
     return await _generate_text(prompt, max_new_tokens=LLM_REPLY_MAX_NEW_TOKENS)
 
 
@@ -512,6 +534,32 @@ def log_thought(bot: discord.Client, text: str) -> None:
     except RuntimeError:  # pragma: no cover - no loop available
         return
     loop.create_task(_send_thought(bot, text))
+
+
+def should_reply_with_mention(message: discord.Message) -> bool:
+    """Return ``True`` if a reply to ``message`` should mention the author."""
+
+    channel_id = getattr(getattr(message, "channel", None), "id", None)
+    if channel_id is None:
+        return True
+    return channel_id not in NO_MENTION_CHANNEL_IDS
+
+
+async def reply_to_message(message: discord.Message, reply: str) -> None:
+    """Reply to ``message`` while optionally mentioning the author."""
+
+    mention_author = should_reply_with_mention(message)
+    reply_fn = getattr(message, "reply", None)
+    if callable(reply_fn):
+        await reply_fn(reply, mention_author=mention_author)
+        return
+
+    # Fallback for stub message implementations without ``reply``
+    if mention_author and getattr(message, "author", None) is not None:
+        prefix = f"<@{getattr(message.author, 'id', '')}> "
+        await message.channel.send(f"{prefix}{reply}")
+    else:
+        await message.channel.send(reply)
 
 
 async def emit_refusal(message: discord.Message) -> None:
@@ -1207,7 +1255,7 @@ class SocialGraphBot(commands.Bot):
                 our_message_times.popleft()
             if len(our_message_times) >= MAX_BOT_MESSAGES_PER_INTERVAL:
                 return
-            await message.channel.send(reply)
+            await reply_to_message(message, reply)
             our_message_times.append(discord.utils.utcnow())
             if message.author.bot:
                 last_bot_reply_time = discord.utils.utcnow()
@@ -1235,7 +1283,7 @@ class SocialGraphBot(commands.Bot):
             message.content,
         )
 
-        if hasattr(self, "process_commands"):
+        if hasattr(self, "process_commands") and self.user is not None:
             await self.process_commands(message)
 
     async def _handle_chat_raw(self, msg: Msg) -> None:

--- a/tests/test_autonomy_refusal.py
+++ b/tests/test_autonomy_refusal.py
@@ -54,6 +54,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_bot_cooldown.py
+++ b/tests/test_bot_cooldown.py
@@ -89,6 +89,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_bullying_mock.py
+++ b/tests/test_bullying_mock.py
@@ -55,6 +55,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_deception_memory.py
+++ b/tests/test_deception_memory.py
@@ -60,6 +60,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_deceptive_reply.py
+++ b/tests/test_deceptive_reply.py
@@ -85,6 +85,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_manipulation_trust.py
+++ b/tests/test_manipulation_trust.py
@@ -55,6 +55,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_minimal_reply.py
+++ b/tests/test_minimal_reply.py
@@ -62,6 +62,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_bot_etiquette.py
+++ b/tests/test_multi_bot_etiquette.py
@@ -90,6 +90,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_bot_silence.py
+++ b/tests/test_multi_bot_silence.py
@@ -87,6 +87,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -58,6 +58,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_other_bot_cooldown.py
+++ b/tests/test_other_bot_cooldown.py
@@ -89,6 +89,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_persona_integration.py
+++ b/tests/test_persona_integration.py
@@ -56,6 +56,11 @@ class DummyMessage:
         # Avoid triggering time-based theories by using a fixed hour
         self.created_at = utcnow().replace(hour=1)
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio

--- a/tests/test_reply_rate_limit.py
+++ b/tests/test_reply_rate_limit.py
@@ -58,6 +58,12 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+        self._state = None
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio
@@ -69,6 +75,8 @@ async def test_on_message_rate_limit(monkeypatch, tmp_path):
 
     async def noop(*args, **kwargs):
         return None
+
+    monkeypatch.setattr(sg, "_ensure_nats", noop)
 
     f = asyncio.Future()
     f.set_result((set(), set(), {}))
@@ -89,6 +97,42 @@ async def test_on_message_rate_limit(monkeypatch, tmp_path):
     await bot.on_message(msg2)
 
     assert len(msg1.channel.sent_messages) == 1
+    assert msg1.replies[0]["mention_author"] is True
     assert msg2.channel.sent_messages == []
+
+    await sg.db_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_on_message_no_mention_channels(monkeypatch, tmp_path):
+    monkeypatch.setenv("NO_MENTION_CHANNEL_IDS", "1")
+    sg = reload_sg(monkeypatch)
+    sg.db_manager = sg.DBManager(str(tmp_path / "sg.db"))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(sg, "_ensure_nats", noop)
+
+    f = asyncio.Future()
+    f.set_result((set(), set(), {}))
+    monkeypatch.setattr(sg, "who_is_active", lambda channel: f)
+    monkeypatch.setattr(sg, "send_to_prism", noop)
+    monkeypatch.setattr(sg, "store_theory", noop)
+    monkeypatch.setattr(sg, "queue_deep_reflection", noop)
+    monkeypatch.setattr(sg, "evaluate_triggers", lambda message: [])
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    monkeypatch.setattr(random, "choice", lambda seq: seq[0])
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    msg = DummyMessage("hello")
+    await bot.on_message(msg)
+
+    assert len(msg.channel.sent_messages) == 1
+    assert msg.channel.sent_messages[0] == msg.replies[0]["content"]
+    assert msg.replies[0]["mention_author"] is False
 
     await sg.db_manager.close()

--- a/tests/test_sensitive_moderation.py
+++ b/tests/test_sensitive_moderation.py
@@ -54,6 +54,11 @@ class DummyMessage:
         self.id = message_id
         self.created_at = utcnow()
         self.mentions = []
+        self.replies = []
+
+    async def reply(self, content, mention_author=True):
+        self.replies.append({"content": content, "mention_author": mention_author})
+        await self.channel.send(content, reference=self)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add configurable mention suppression and use a reply helper so bot responses mention authors in group channels
- provide simple persona prompt/LLM reply builders and guard command processing when the bot user is unavailable
- update bot tests with reply-aware dummy messages and new coverage for mention suppression

## Testing
- pytest tests/test_reply_rate_limit.py -vv
- flake8 examples/social_graph_bot.py tests/test_reply_rate_limit.py *(fails: flake8 not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ead871dc88326a829ab9b1f32e9d8)