### PR TITLE
Add configurable moderation and response filtering

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -64,7 +64,8 @@ from deepthought.plugins.projects_board import DEFAULT_HOLIDAY_LOCALE, ProjectsB
 from deepthought.services import PersonaManager, TrustService
 from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
-from deepthought.services.moderation import evaluate_toxicity, is_allowed
+from deepthought.services.moderation import evaluate_toxicity, get_profanity_list, is_allowed
+from deepthought.services.response_filter import build_response_filter
 from deepthought.services.scheduler import SchedulerService
 from deepthought.utils import ResponseQueue, UserRateLimiter
 
@@ -553,6 +554,12 @@ async def _send_thought(bot: discord.Client, text: str) -> None:
     if channel is None:
         logger.warning("Thought channel %s not found", THOUGHT_CHANNEL_ID)
         return
+    if hasattr(bot, "response_filter"):
+        filtered = bot.response_filter.sanitize(text)  # type: ignore[attr-defined]
+        if filtered is None:
+            logger.info("Thought message filtered; not sending")
+            return
+        text = filtered
     try:
         await channel.send(text)
     except Exception as exc:  # pragma: no cover - send failure
@@ -665,10 +672,14 @@ async def process_deep_reflections(bot: discord.Client) -> None:
                     await asyncio.sleep(2)
                     reflection = generate_reflection(prompt)
                     logger.info(f"Posting deep reflection for task {task_id}")
-                    await channel.send(
-                        f"After some thought... {reflection}",
-                        reference=ref,
-                    )
+                    text = f"After some thought... {reflection}"
+                    if hasattr(bot, "response_filter"):
+                        text = bot.response_filter.sanitize(text)  # type: ignore[attr-defined]
+                    if text:
+                        await channel.send(
+                            text,
+                            reference=ref,
+                        )
                 await db_manager.mark_task_done(task_id)
             await assign_themes()
             await asyncio.sleep(REFLECTION_CHECK_SECONDS)
@@ -706,7 +717,10 @@ async def _maybe_post_reminder_to_thread(bot: "SocialGraphBot", message: str) ->
         return
 
     try:
-        await channel.send(message)
+        if hasattr(bot, "response_filter"):
+            message = bot.response_filter.sanitize(message)  # type: ignore[attr-defined]
+        if message:
+            await channel.send(message)
     except Exception:
         logger.debug("Failed to post reminder to thread %s", thread_id)
 
@@ -788,7 +802,9 @@ async def process_thought_commands(bot: "SocialGraphBot") -> None:
                         if msg.author == bot.user:
                             msgs.append(f"{msg.id}: {msg.content}")
                     if msgs:
-                        await message.channel.send("\n".join(reversed(msgs)))
+                        await bot.send_filtered(
+                            message.channel, "\n".join(reversed(msgs))
+                        )
                 elif cmd == "delete" and len(parts) > 2:
                     try:
                         msg_id = int(parts[2])
@@ -818,7 +834,7 @@ async def process_thought_commands(bot: "SocialGraphBot") -> None:
                     rows = await db_manager.list_lies(limit)
                     if rows:
                         lines = [f"{rowid}: {question} -> {reply} (user {uid})" for rowid, uid, question, reply in rows]
-                        await message.channel.send("\n".join(lines))
+                        await bot.send_filtered(message.channel, "\n".join(lines))
                 elif cmd == "delete" and len(parts) > 2:
                     if parts[2].isdigit():
                         rowid = int(parts[2])
@@ -977,10 +993,17 @@ async def monitor_channels(bot: discord.Client, channel_id: int) -> None:
                 async def _send_prompt() -> None:
                     async with channel.typing():
                         await asyncio.sleep(random.uniform(3, 10))
+                        safe_prompt = (
+                            bot.response_filter.sanitize(prompt)
+                            if hasattr(bot, "response_filter")
+                            else prompt
+                        )
+                        if not safe_prompt:
+                            return
                         if respond_to is not None:
-                            await channel.send(prompt, reference=respond_to)
+                            await channel.send(safe_prompt, reference=respond_to)
                         else:
-                            await channel.send(prompt)
+                            await channel.send(safe_prompt)
 
                 enqueue = getattr(bot, "enqueue_response", None)
                 if callable(enqueue):
@@ -1027,6 +1050,9 @@ class SocialGraphBot(commands.Bot):
         self._projects_board: ProjectsBoard | None = None
         self.response_queue = ResponseQueue(
             RESPONSE_QUEUE_COOLDOWN_SECONDS, stale_after=RESPONSE_STALE_SECONDS
+        )
+        self.response_filter = build_response_filter(
+            denylist=get_profanity_list(), toxicity_threshold=FOE_MODE_MAX_SEVERITY
         )
 
     async def setup_hook(self) -> None:
@@ -1084,6 +1110,16 @@ class SocialGraphBot(commands.Bot):
 
         await self.response_queue.enqueue(channel.id, sender)
 
+    def sanitize_response(self, text: str) -> str | None:
+        return self.response_filter.sanitize(text)
+
+    async def send_filtered(self, channel: discord.abc.Messageable, text: str, **kwargs) -> None:
+        sanitized = self.sanitize_response(text)
+        if sanitized is None:
+            logger.info("Response filtered; nothing sent")
+            return
+        await channel.send(sanitized, **kwargs)
+
     async def on_message(self, message: discord.Message) -> None:
         global last_bot_reply_time, last_other_bot_message_time
         if message.author == self.user:
@@ -1135,11 +1171,15 @@ class SocialGraphBot(commands.Bot):
                 await store_lie(message.author.id, message.content, cover_reply)
             else:
                 cover_reply = lie_reply
+            cover_reply = self.sanitize_response(cover_reply) or None
+            if cover_reply is None:
+                logger.info("Cover reply blocked by response filter")
+                return
 
             async def send_cover_reply() -> None:
                 async with message.channel.typing():
                     await asyncio.sleep(random.uniform(1, 3))
-                    await message.channel.send(cover_reply)
+                    await self.send_filtered(message.channel, cover_reply)
 
             await self.enqueue_response(message.channel, send_cover_reply)
             await store_memory(message.author.id, cover_reply, topic="deception")
@@ -1299,8 +1339,12 @@ class SocialGraphBot(commands.Bot):
                 our_message_times.popleft()
             if len(our_message_times) >= MAX_BOT_MESSAGES_PER_INTERVAL:
                 return
+            safe_reply = self.sanitize_response(reply)
+            if safe_reply is None:
+                logger.info("Reply blocked by response filter")
+                return
             async def dispatch_reply() -> None:
-                await message.channel.send(reply)
+                await self.send_filtered(message.channel, safe_reply)
                 our_message_times.append(discord.utils.utcnow())
                 if message.author.bot:
                     global last_bot_reply_time
@@ -1339,8 +1383,14 @@ class SocialGraphBot(commands.Bot):
         text = msg.data.decode()
         channel = self.get_channel(self.monitor_channel_id)
         try:
+            safe_text = self.sanitize_response(text)
+            if safe_text is None:
+                logger.info("CHAT_RAW message blocked by response filter")
+                if hasattr(msg, "ack") and callable(msg.ack):
+                    await msg.ack()
+                return
             if channel is not None:
-                await self.enqueue_response(channel, lambda: channel.send(text))
+                await self.enqueue_response(channel, lambda: self.send_filtered(channel, safe_text))
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:  # pragma: no cover - defensive

--- a/src/deepthought/services/moderation.py
+++ b/src/deepthought/services/moderation.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import re
-from typing import Iterable, Mapping, Sequence, Tuple
+from typing import Iterable, Mapping, MutableMapping, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +51,12 @@ TOXICITY_CHECK_ENABLED = os.getenv("MODERATION_TOXICITY_ENABLED", "true").lower(
 }
 TOXICITY_THRESHOLD = float(os.getenv("MODERATION_TOXICITY_THRESHOLD", "0.6"))
 
-# Lightweight toxicity lexicon with severity weights.
-TOXICITY_TERMS: Mapping[str, float] = {
+# Lightweight toxicity lexicon with severity weights. Users can add terms via
+# ``MODERATION_PROFANITY_LIST``, using comma-separated entries. Each entry can
+# optionally include a weight (``term:weight``). Example::
+#
+#     export MODERATION_PROFANITY_LIST="foobar:0.9,baz"
+DEFAULT_TOXICITY_TERMS: Mapping[str, float] = {
     "idiot": 0.4,
     "stupid": 0.4,
     "loser": 0.4,
@@ -67,6 +71,37 @@ TOXICITY_TERMS: Mapping[str, float] = {
     "piece of": 0.6,
     "kill yourself": 1.0,
 }
+
+
+def _parse_weighted_terms(raw_terms: str) -> MutableMapping[str, float]:
+    parsed: MutableMapping[str, float] = {}
+    for chunk in raw_terms.split(","):
+        if not chunk:
+            continue
+        if ":" in chunk:
+            phrase, _, weight_str = chunk.partition(":")
+            try:
+                weight = float(weight_str)
+            except ValueError:
+                weight = 0.6
+        else:
+            phrase, weight = chunk, 0.6
+        normalized = phrase.strip().lower()
+        if not normalized:
+            continue
+        parsed[normalized] = max(0.1, min(weight, 1.0))
+    return parsed
+
+
+def _build_toxicity_terms() -> MutableMapping[str, float]:
+    configured = os.getenv("MODERATION_PROFANITY_LIST", "")
+    combined: MutableMapping[str, float] = dict(DEFAULT_TOXICITY_TERMS)
+    if configured:
+        combined.update(_parse_weighted_terms(configured))
+    return combined
+
+
+TOXICITY_TERMS: Mapping[str, float] = _build_toxicity_terms()
 _MAX_TOXICITY_WEIGHT = max(TOXICITY_TERMS.values(), default=1.0)
 
 
@@ -94,6 +129,18 @@ def evaluate_toxicity(
         return 0.0, []
     score = min(1.0, total_weight / (_MAX_TOXICITY_WEIGHT * len(matches)))
     return score, matches
+
+
+def get_toxicity_terms() -> Mapping[str, float]:
+    """Return the configured toxicity lexicon."""
+
+    return TOXICITY_TERMS
+
+
+def get_profanity_list() -> Tuple[str, ...]:
+    """Return profanity phrases for outbound filtering or UI hints."""
+
+    return tuple(TOXICITY_TERMS.keys())
 
 
 def _log_decision(

--- a/src/deepthought/services/response_filter.py
+++ b/src/deepthought/services/response_filter.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 from dataclasses import dataclass
 from importlib import import_module
-from typing import Callable, Iterable
+from typing import Callable, Iterable, Mapping
+
+from deepthought.services import moderation
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +29,7 @@ def _normalize_denylist(denylist: Iterable[str]) -> tuple[str, ...]:
 
 def load_classifier(classifier_path: str) -> Classifier:
     """Load a classifier callable from ``module:attribute`` notation."""
+
     module_path, _, attr_name = classifier_path.rpartition(":")
     if not module_path or not attr_name:
         raise ValueError("Classifier path must be in 'module:attribute' format")
@@ -41,28 +46,71 @@ class ResponseFilter:
 
     denylist: tuple[str, ...] = ()
     classifier: Classifier | None = None
+    replacement: str = "***"
+    toxicity_threshold: float | None = moderation.TOXICITY_THRESHOLD
+    toxicity_terms: Mapping[str, float] | None = None
 
     def is_safe(self, text: str) -> bool:
+        sanitized = self.sanitize(text)
+        return sanitized is not None
+
+    def sanitize(self, text: str) -> str | None:
+        """Return sanitized ``text`` or ``None`` if it should be blocked."""
+
         if not isinstance(text, str):
-            return False
-        lowered = text.lower()
-        if self.denylist and any(phrase in lowered for phrase in self.denylist):
-            return False
-        if self.classifier is None:
-            return True
-        try:
-            return bool(self.classifier(text))
-        except Exception:
-            logger.warning("Response classifier failed; treating as unsafe", exc_info=True)
-            return False
+            return None
+
+        sanitized = text
+        if self.denylist:
+            pattern = re.compile(
+                "|".join(re.escape(term) for term in self.denylist), re.IGNORECASE
+            )
+
+            def _sub(match: re.Match[str]) -> str:
+                return self.replacement
+
+            sanitized = pattern.sub(_sub, sanitized)
+
+        if self.classifier is not None:
+            try:
+                if not self.classifier(sanitized):
+                    return None
+            except Exception:
+                logger.warning(
+                    "Response classifier failed; treating as unsafe", exc_info=True
+                )
+                return None
+
+        if self.toxicity_threshold is not None:
+            score, matches = moderation.evaluate_toxicity(
+                sanitized, terms=self.toxicity_terms
+            )
+            if score >= self.toxicity_threshold:
+                logger.info(
+                    "Blocked response due to toxicity score %.3f and matches %s",
+                    score,
+                    matches,
+                )
+                return None
+
+        return sanitized
 
 
 def build_response_filter(
     denylist: Iterable[str] | None = None,
     classifier_path: str | None = None,
+    *,
+    replacement: str = "***",
+    toxicity_threshold: float | None = None,
+    toxicity_terms: Mapping[str, float] | None = None,
 ) -> ResponseFilter:
     """Construct a response filter for the configured inputs."""
-    normalized = _normalize_denylist(denylist or [])
+
+    env_denylist = os.getenv("RESPONSE_FILTER_DENYLIST", "")
+    configured_denylist = _normalize_denylist(
+        env_denylist.split(",") if env_denylist else []
+    )
+    normalized = _normalize_denylist(denylist or ()) + configured_denylist
     classifier: Classifier | None = None
     if classifier_path:
         try:
@@ -73,4 +121,12 @@ def build_response_filter(
                 classifier_path,
                 exc_info=True,
             )
-    return ResponseFilter(denylist=normalized, classifier=classifier)
+    return ResponseFilter(
+        denylist=normalized,
+        classifier=classifier,
+        replacement=replacement,
+        toxicity_threshold=toxicity_threshold
+        if toxicity_threshold is not None
+        else moderation.TOXICITY_THRESHOLD,
+        toxicity_terms=toxicity_terms or moderation.get_toxicity_terms(),
+    )

--- a/tests/test_sensitive_moderation.py
+++ b/tests/test_sensitive_moderation.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import random
 
 import pytest
@@ -10,6 +11,8 @@ sg = pytest.importorskip("examples.social_graph_bot")
 if not hasattr(sg, "TrustService"):
     pytest.skip("social_graph_bot optional dependencies not installed", allow_module_level=True)
 from deepthought.services import DBManager
+from deepthought.services import moderation
+from deepthought.services.response_filter import build_response_filter
 
 
 class DummyAuthor:
@@ -116,4 +119,38 @@ async def test_refuses_secret_key_request(tmp_path, monkeypatch, input_events):
     await bot.on_message(message)
 
     assert message.channel.sent_messages == [sg.REFUSAL_MESSAGE]
+    await sg.db_manager.close()
+
+
+def test_custom_profanity_terms(monkeypatch):
+    monkeypatch.setenv("MODERATION_PROFANITY_LIST", "zonk:0.9,blorp")
+    importlib.reload(moderation)
+
+    score, matches = moderation.evaluate_toxicity("you are such a zonk")
+    assert score > 0.0
+    assert "zonk" in matches
+
+    monkeypatch.delenv("MODERATION_PROFANITY_LIST", raising=False)
+    importlib.reload(moderation)
+
+
+@pytest.mark.asyncio
+async def test_outbound_response_filter(monkeypatch, tmp_path, input_events):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    sg.trust_service = sg.TrustService(sg.db_manager)
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    bot = sg.SocialGraphBot(monitor_channel_id=1)
+    bot.response_filter = build_response_filter(
+        denylist=("spoiler",), replacement="[clean]", toxicity_threshold=0.5
+    )
+    channel = DummyChannel(channel_id=99)
+
+    await bot.send_filtered(channel, "you are worthless and a spoiler")
+    assert channel.sent_messages == []
+
+    await bot.send_filtered(channel, "no spoiler here")
+    assert channel.sent_messages == ["no [clean] here"]
+
     await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- allow moderation toxicity lexicon to be extended via configuration and expose helper accessors
- enhance response filtering utilities to sanitize outbound messages and integrate them into the social graph bot
- add moderation tests covering configurable profanity and outbound response filtering

## Testing
- pytest tests/test_sensitive_moderation.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bc27e17d88326bf6c9ab5b3131893)