### PR TITLE
Ensure memory recall returns newest entries first

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -408,11 +408,13 @@ def _format_memory_snippets(memories: list[tuple[str, str]], limit: int) -> list
         return []
     snippets = []
     for topic, memory in memories:
+        if len(snippets) >= limit:
+            break
         if not memory or not str(memory).strip():
             continue
         entry = f"[{topic}] {memory}" if topic else str(memory)
         snippets.append(entry.strip())
-    return snippets[-limit:]
+    return snippets
 
 
 def _build_memory_hint(memory_snippets: list[str]) -> str:
@@ -420,7 +422,7 @@ def _build_memory_hint(memory_snippets: list[str]) -> str:
 
     if not memory_snippets:
         return ""
-    summary = re.sub(r"\s+", " ", memory_snippets[-1]).strip()
+    summary = re.sub(r"\s+", " ", memory_snippets[0]).strip()
     if len(summary) > 120:
         summary = summary[:117] + "..."
     return f"You mentioned {summary} earlier."
@@ -1290,7 +1292,7 @@ class SocialGraphBot(commands.Bot):
         if not reply_limiter.allow(str(message.author.id)):
             return
 
-        memories = await recall_user(message.author.id)
+        memories = await recall_user(message.author.id, limit=MAX_MEMORY_PROMPT_SNIPPETS)
         memory_snippets = _format_memory_snippets(memories, MAX_MEMORY_PROMPT_SNIPPETS)
         memory_hint = _build_memory_hint(memory_snippets)
         if memories:

--- a/src/deepthought/bot/memory.py
+++ b/src/deepthought/bot/memory.py
@@ -21,8 +21,8 @@ def _db() -> DBManager:
     return _db_manager_getter()
 
 
-async def recall_user(user_id: int):
-    return await _db().recall_user(user_id)
+async def recall_user(user_id: int, limit: int | None = None):
+    return await _db().recall_user(user_id, limit=limit)
 
 
 async def store_memory(

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -115,10 +115,8 @@ class CognitiveCoreService(BaseService):
         return merged
 
     async def _db_context(self) -> List[str]:
-        rows = await self._db.recall_user("user")
-        data = [m[1] for m in rows]
-        start = -self._top_k
-        return data[start:]
+        rows = await self._db.recall_user("user", limit=self._top_k)
+        return [m[1] for m in rows]
 
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -558,13 +558,19 @@ class DBManager:
         )
         await self._db.commit()
 
-    async def recall_user(self, user_id: int):
+    async def recall_user(self, user_id: int, limit: int | None = None):
         await self.connect()
+        if limit is not None and limit <= 0:
+            return []
+
         assert self._db
-        async with self._db.execute(
-            "SELECT topic, memory FROM memories WHERE user_id= ?",
-            (str(user_id),),
-        ) as cur:
+        query = "SELECT topic, memory FROM memories WHERE user_id=? ORDER BY timestamp DESC"
+        params: list[str | int] = [str(user_id)]
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+
+        async with self._db.execute(query, params) as cur:
             return await cur.fetchall()
 
     async def store_memory(

--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -338,7 +338,7 @@ async def test_on_message_includes_memory_hint(tmp_path, monkeypatch, input_even
     monkeypatch.setattr(random, "random", lambda: 0.0)
     monkeypatch.setattr(random, "choice", lambda seq: seq[0])
 
-    async def fake_recall_user(user_id):
+    async def fake_recall_user(user_id, limit=None):
         return [("greeting", "that you enjoy coding challenges")]
 
     monkeypatch.setattr(sg, "recall_user", fake_recall_user)

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -213,7 +213,7 @@ class DummyDB:
     async def adjust_affinity(self, user_id, delta):
         self.affinity += delta
 
-    async def recall_user(self, user_id):
+    async def recall_user(self, user_id, limit=None):
         return [("", m) for m in self.memories]
 
     async def close(self):

--- a/tests/unit/services/test_connector_close.py
+++ b/tests/unit/services/test_connector_close.py
@@ -105,7 +105,7 @@ class DummyDB:
     async def log_interaction(self, *a, **k):
         pass
 
-    async def recall_user(self, user_id):
+    async def recall_user(self, user_id, limit=None):
         return []
 
     async def close(self):

--- a/tests/unit/services/test_db_manager_memories.py
+++ b/tests/unit/services/test_db_manager_memories.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.services.db_manager import DBManager
+
+
+@pytest.mark.asyncio
+async def test_recall_user_returns_newest_first_with_limit(tmp_path):
+    db = DBManager(str(tmp_path / "db.sqlite"))
+    await db.connect()
+    await db.init_db()
+
+    assert db._db
+    await db._db.executemany(
+        "INSERT INTO memories (user_id, topic, memory, sentiment_score, timestamp) VALUES (?, ?, ?, ?, ?)",
+        [
+            ("user", "", "first", None, "2024-01-01T00:00:00Z"),
+            ("user", "", "second", None, "2024-01-02T00:00:00Z"),
+            ("user", "", "third", None, "2024-01-03T00:00:00Z"),
+        ],
+    )
+    await db._db.commit()
+
+    rows = await db.recall_user("user", limit=2)
+
+    assert [row[1] for row in rows] == ["third", "second"]
+
+    await db.close()


### PR DESCRIPTION
## Summary
- order user memory recall by timestamp with an optional limit and propagate the bounded results through memory snippet formatting
- update memory hint generation and persona prompt retrieval to prioritize the freshest interactions
- adjust tests and add a regression check covering recency ordering

## Testing
- pytest tests/unit/services/test_db_manager_memories.py tests/unit/services/test_cognitive_core_service.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd0a81f548326a982a99649167647)