### PR TITLE
Incorporate channel sentiment into persona selection

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -483,7 +483,11 @@ ALLOW_DECEPTION = bot_deception.ALLOW_DECEPTION
 DECEPTION_COVER_MESSAGE = bot_deception.DECEPTION_COVER_MESSAGE
 DECEPTION_REPLY_MODE = bot_deception.DECEPTION_REPLY_MODE
 DYNAMIC_COVER_REPLIES = bot_deception.DYNAMIC_COVER_REPLIES
-persona_manager = PersonaManager(db_manager, descriptions=get_settings().persona_descriptions)
+persona_manager = PersonaManager(
+    db_manager,
+    descriptions=get_settings().persona_descriptions,
+    sentiment_weight=get_settings().persona_sentiment_weight,
+)
 trust_service = TrustService(db_manager)
 reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
 bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
@@ -513,7 +517,11 @@ async def init_db(db_path: str | None = None) -> None:
         db_manager = DBManager(target_path)
 
     await db_manager.init_db()
-    persona_manager = PersonaManager(db_manager, descriptions=get_settings().persona_descriptions)
+    persona_manager = PersonaManager(
+        db_manager,
+        descriptions=get_settings().persona_descriptions,
+        sentiment_weight=get_settings().persona_sentiment_weight,
+    )
     trust_service = TrustService(db_manager)
     CURRENT_DB_PATH = db_manager.db_path
 
@@ -1056,7 +1064,11 @@ class SocialGraphBot(commands.Bot):
         self._bg_tasks: list[asyncio.Task] = []
         self.goal_scheduler = GoalScheduler(db_manager)
         self.scheduler_service: SchedulerService | None = None  # noqa: F821 - optional feature
-        self.persona_manager = PersonaManager(db_manager, descriptions=get_settings().persona_descriptions)
+        self.persona_manager = PersonaManager(
+            db_manager,
+            descriptions=get_settings().persona_descriptions,
+            sentiment_weight=get_settings().persona_sentiment_weight,
+        )
         self._subscriber: Subscriber | None = None
         self._projects_board: ProjectsBoard | None = None
         self.response_queue = ResponseQueue(
@@ -1069,7 +1081,11 @@ class SocialGraphBot(commands.Bot):
     async def setup_hook(self) -> None:
         await db_manager.connect()
         await init_db()
-        self.persona_manager = PersonaManager(db_manager, descriptions=get_settings().persona_descriptions)
+        self.persona_manager = PersonaManager(
+            db_manager,
+            descriptions=get_settings().persona_descriptions,
+            sentiment_weight=get_settings().persona_sentiment_weight,
+        )
 
         await _ensure_nats()
         if _nats_client is not None and _js_context is not None:
@@ -1332,7 +1348,9 @@ class SocialGraphBot(commands.Bot):
                 else:
                     persona_desc = ""
                     try:
-                        persona_desc = await self.persona_manager.get_description(message.author.id)
+                        persona_desc = await self.persona_manager.get_description(
+                            message.author.id, channel_id=message.channel.id
+                        )
                     except Exception:
                         logger.exception("Persona description lookup failed")
                     prompt = _build_persona_prompt([message.content], persona_desc, memory_snippets)
@@ -1341,7 +1359,9 @@ class SocialGraphBot(commands.Bot):
                         reply = llm_reply
                         reply_from_llm = True
                     else:
-                        persona = await self.persona_manager.get_persona(message.author.id)
+                        persona = await self.persona_manager.get_persona(
+                            message.author.id, channel_id=message.channel.id
+                        )
                         persona_used = persona
                         reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             if reply and memory_hint and not reply_from_llm:

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -237,6 +237,7 @@ class Settings(BaseSettings):
         "playful": "You like to joke around in your answers.",
         "snarky": "You reply with terse, witty sarcasm.",
     }
+    persona_sentiment_weight: float = Field(0.0, env="DT_PERSONA_SENTIMENT_WEIGHT")
 
     response_filter_enabled: bool = Field(True, env="DT_RESPONSE_FILTER_ENABLED")
     response_filter_denylist: list[str] = Field(default_factory=list, env="DT_RESPONSE_FILTER_DENYLIST")

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -18,11 +18,14 @@ class PersonaManager:
         db_manager: DBManager,
         friendly: int = 5,
         playful: int = 2,
+        *,
+        sentiment_weight: float = 0.0,
         descriptions: dict[str, str] | None = None,
     ) -> None:
         self._db = db_manager
         self._friendly = friendly
         self._playful = playful
+        self._sentiment_weight = sentiment_weight
         self._descriptions = descriptions or {}
         self._personality: dict[str, dict[str, float]] = {}
 
@@ -51,7 +54,13 @@ class PersonaManager:
         current = self._personality.setdefault(uid, {})
         current.update(traits)
 
-    async def get_persona(self, user_id: int | str, target_id: int | str | None = None) -> str:
+    async def get_persona(
+        self,
+        user_id: int | str,
+        target_id: int | str | None = None,
+        *,
+        channel_id: int | str | None = None,
+    ) -> str:
         if self._init_task is not None:
             await self._init_task
             self._init_task = None
@@ -65,6 +74,7 @@ class PersonaManager:
             if relationship == "rival":
                 return "snarky"
             score = await self._db.get_pair_mutual_affinity(user_id, target_id)
+        score += await self._get_sentiment_adjustment(user_id, channel_id)
         if score + traits.get("friendly", 0) >= self._friendly:
             return "friendly"
         if score + traits.get("playful", 0) >= self._playful:
@@ -72,15 +82,40 @@ class PersonaManager:
         return "snarky"
 
     async def choose_prompt(
-        self, user_id: int | str, prompts: dict[str, list[str]], target_id: int | str | None = None
+        self,
+        user_id: int | str,
+        prompts: dict[str, list[str]],
+        target_id: int | str | None = None,
+        *,
+        channel_id: int | str | None = None,
     ) -> str:
-        persona = await self.get_persona(user_id, target_id)
+        persona = await self.get_persona(user_id, target_id, channel_id=channel_id)
         options = prompts.get(persona) or prompts.get("default") or []
         if not options:
             return ""
         return random.choice(options)
 
-    async def get_description(self, user_id: int | str, target_id: int | str | None = None) -> str:
+    async def get_description(
+        self,
+        user_id: int | str,
+        target_id: int | str | None = None,
+        *,
+        channel_id: int | str | None = None,
+    ) -> str:
         """Return a persona description for ``user_id`` if available."""
-        persona = await self.get_persona(user_id, target_id)
+        persona = await self.get_persona(user_id, target_id, channel_id=channel_id)
         return self._descriptions.get(persona, "")
+
+    async def _get_sentiment_adjustment(
+        self, user_id: int | str, channel_id: int | str | None
+    ) -> float:
+        if not channel_id or self._sentiment_weight == 0:
+            return 0.0
+        trend = await self._db.get_sentiment_trend(user_id, channel_id)
+        if not trend:
+            return 0.0
+        sentiment_sum, message_count = trend
+        if not message_count:
+            return 0.0
+        average_sentiment = sentiment_sum / message_count
+        return average_sentiment * self._sentiment_weight

--- a/tests/test_persona_manager_sentiment.py
+++ b/tests/test_persona_manager_sentiment.py
@@ -1,0 +1,28 @@
+import pytest
+
+sg = pytest.importorskip("examples.social_graph_bot")
+if not hasattr(sg, "TrustService"):
+    pytest.skip("social_graph_bot optional dependencies not installed", allow_module_level=True)
+
+pytest.importorskip("nats")
+from deepthought.services import DBManager, PersonaManager
+
+
+@pytest.mark.asyncio
+async def test_persona_flips_with_channel_sentiment(tmp_path):
+    sg.db_manager = DBManager(str(tmp_path / "sg.db"))
+    pm = PersonaManager(sg.db_manager, friendly=3, playful=1, sentiment_weight=4)
+    user = "u1"
+    channel = "c1"
+
+    assert await pm.get_persona(user, channel_id=channel) == "snarky"
+
+    await sg.update_sentiment_trend(user, channel, 0.9)
+    assert await pm.get_persona(user, channel_id=channel) == "friendly"
+
+    for _ in range(5):
+        await sg.update_sentiment_trend(user, channel, -0.9)
+
+    assert await pm.get_persona(user, channel_id=channel) == "snarky"
+
+    await sg.db_manager.close()


### PR DESCRIPTION
## Summary
- use recent per-channel sentiment trends when selecting personas through a configurable sentiment weight
- wire the social graph bot to pass channel context to persona lookups and honor the new sentiment weight setting
- add coverage to ensure persona choices flip as channel sentiment shifts

## Testing
- pytest tests/test_persona_manager.py tests/test_persona_manager_personality.py tests/test_persona_manager_sentiment.py
- flake8 src/deepthought/services/persona_manager.py tests/test_persona_manager_sentiment.py examples/social_graph_bot.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd336d3d4832680ce1ab58750f6ca)