### PR TITLE
Add user fact extractor and prompt helpers

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -13,6 +13,14 @@ from .vector_store import (
     VectorStore,
     create_vector_store,
 )
+from .fact_extractor import (
+    build_user_fact_context,
+    extract_and_store_user_facts,
+    extract_user_facts,
+    format_user_facts_for_prompt,
+    get_user_fact_profile,
+    merge_user_profiles,
+)
 
 __all__ = [
     "HierarchicalMemory",
@@ -23,6 +31,12 @@ __all__ = [
     "SimpleEmbeddingFunction",
     "TieredMemory",
     "create_memory_backend",
+    "build_user_fact_context",
+    "extract_and_store_user_facts",
+    "extract_user_facts",
+    "format_user_facts_for_prompt",
+    "get_user_fact_profile",
+    "merge_user_profiles",
 ]
 
 

--- a/src/deepthought/memory/fact_extractor.py
+++ b/src/deepthought/memory/fact_extractor.py
@@ -1,0 +1,198 @@
+"""Extract and persist user facts for prompt building."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from ..services.db_manager import DBManager
+
+NICKNAME_PATTERNS = [
+    re.compile(
+        r"\b(?:call me|i go by|my nickname is|my nick(?:name)? is|you can call me)\s+(?P<name>[^.!?,]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:i am|i'm)\s+known as\s+(?P<name>[^.!?,]+)",
+        re.IGNORECASE,
+    ),
+]
+
+HOBBY_PATTERNS = [
+    re.compile(
+        r"\bmy hobbies are\s+(?P<hobbies>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bmy hobby is\s+(?P<hobbies>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bi (?:enjoy|love|like)\s+(?P<hobbies>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bin my free time\s+i\s+(?P<hobbies>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+]
+
+FAVORITE_PATTERNS = [
+    re.compile(
+        r"\b(?:my\s+)?favorite\s+(?P<category>[a-zA-Z ]+?)\s+(?:is|are|:)\s*(?P<value>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:my\s+)?favorites\s+(?:are|:)\s*(?P<value>[^.!?]+)",
+        re.IGNORECASE,
+    ),
+]
+
+
+def _split_list(text: str) -> list[str]:
+    parts = re.split(r"\s*(?:,|and|&|/)\s*", text.strip())
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _extract_nickname(message: str) -> str | None:
+    for pattern in NICKNAME_PATTERNS:
+        match = pattern.search(message)
+        if match:
+            name = match.group("name").strip(" \"'")
+            return name or None
+    return None
+
+
+def _extract_hobbies(message: str) -> list[str]:
+    hobbies: list[str] = []
+    for pattern in HOBBY_PATTERNS:
+        match = pattern.search(message)
+        if match:
+            hobbies.extend(_split_list(match.group("hobbies")))
+    return hobbies
+
+
+def _extract_favorites(message: str) -> dict[str, list[str] | str]:
+    favorites: dict[str, list[str] | str] = {}
+    for pattern in FAVORITE_PATTERNS:
+        match = pattern.search(message)
+        if not match:
+            continue
+        if "category" in match.groupdict() and match.group("category"):
+            category = match.group("category").strip().lower()
+            value = match.group("value").strip()
+            favorites[category] = value
+        else:
+            favorites["general"] = _split_list(match.group("value"))
+    return favorites
+
+
+def extract_user_facts(message: str) -> dict[str, Any]:
+    """Extract nickname, hobbies, and favorites from a single message."""
+    nickname = _extract_nickname(message)
+    hobbies = _extract_hobbies(message)
+    favorites = _extract_favorites(message)
+    facts: dict[str, Any] = {}
+    if nickname:
+        facts["nickname"] = nickname
+    if hobbies:
+        facts["hobbies"] = hobbies
+    if favorites:
+        facts["favorites"] = favorites
+    return facts
+
+
+def _merge_list(existing: Iterable[str] | None, incoming: Iterable[str]) -> list[str]:
+    merged = list(dict.fromkeys([*(existing or []), *incoming]))
+    return [item for item in merged if item]
+
+
+def merge_user_profiles(
+    existing: Mapping[str, Any] | list | str | None,
+    updates: Mapping[str, Any],
+) -> dict[str, Any]:
+    profile: dict[str, Any] = {}
+    if isinstance(existing, Mapping):
+        profile.update(existing)
+    elif existing is not None:
+        profile["raw"] = existing
+
+    if "nickname" in updates:
+        profile["nickname"] = updates["nickname"]
+
+    if "hobbies" in updates:
+        profile["hobbies"] = _merge_list(profile.get("hobbies"), updates["hobbies"])
+
+    if "favorites" in updates:
+        favorites = profile.get("favorites")
+        merged_favorites: dict[str, Any] = {}
+        if isinstance(favorites, Mapping):
+            merged_favorites.update(favorites)
+        for key, value in updates["favorites"].items():
+            merged_favorites[key] = value
+        profile["favorites"] = merged_favorites
+
+    return profile
+
+
+async def extract_and_store_user_facts(
+    user_id: int,
+    message: str,
+    db_manager: DBManager | None = None,
+) -> dict[str, Any]:
+    """Extract facts from a message and persist them to ``user_profiles``."""
+    facts = extract_user_facts(message)
+    if not facts:
+        return {}
+    db = db_manager or DBManager()
+    existing = await db.get_user_profile(user_id)
+    merged = merge_user_profiles(existing, facts)
+    await db.set_user_profile(user_id, merged)
+    return facts
+
+
+async def get_user_fact_profile(
+    user_id: int,
+    db_manager: DBManager | None = None,
+) -> dict[str, Any] | None:
+    """Return the stored user fact profile as a dict when possible."""
+    db = db_manager or DBManager()
+    profile = await db.get_user_profile(user_id)
+    if profile is None:
+        return None
+    if isinstance(profile, Mapping):
+        return dict(profile)
+    return {"raw": profile}
+
+
+def format_user_facts_for_prompt(profile: Mapping[str, Any] | None) -> str | None:
+    """Format a stored user profile into a prompt-ready summary."""
+    if not profile:
+        return None
+    parts: list[str] = []
+    nickname = profile.get("nickname")
+    if nickname:
+        parts.append(f"Nickname: {nickname}")
+    hobbies = profile.get("hobbies")
+    if hobbies:
+        if isinstance(hobbies, str):
+            parts.append(f"Hobbies: {hobbies}")
+        else:
+            parts.append(f"Hobbies: {', '.join(hobbies)}")
+    favorites = profile.get("favorites")
+    if isinstance(favorites, Mapping) and favorites:
+        fav_parts = [f"{key}: {value}" for key, value in favorites.items()]
+        parts.append(f"Favorites: {', '.join(fav_parts)}")
+    if not parts:
+        return None
+    return "User facts - " + " | ".join(parts)
+
+
+async def build_user_fact_context(
+    user_id: int,
+    db_manager: DBManager | None = None,
+) -> str | None:
+    """Return a formatted user-fact string for prompt building."""
+    profile = await get_user_fact_profile(user_id, db_manager=db_manager)
+    return format_user_facts_for_prompt(profile)


### PR DESCRIPTION
### Motivation

- Provide utilities to detect simple user facts (nickname, hobbies, favorites) from chat messages and persist them to the `user_profiles` table for use when constructing prompts.
- Centralize parsing and merging logic so detected facts augment existing profiles rather than overwrite unrelated fields.

### Description

- Add `src/deepthought/memory/fact_extractor.py` implementing `extract_user_facts`, `extract_and_store_user_facts`, `merge_user_profiles`, `get_user_fact_profile`, `format_user_facts_for_prompt`, and `build_user_fact_context` using regex patterns to extract nicknames, hobbies, and favorites and persisting via `DBManager.get_user_profile`/`DBManager.set_user_profile`.
- Implement lightweight merging semantics for lists and favorites to avoid duplicates and preserve existing entries.
- Export the new helper functions from the memory package by updating `src/deepthought/memory/__init__.py` so they are available via the `deepthought.memory` API.

### Testing

- Ran `flake8 src tests` but the `flake8` command was not available in the environment so linting could not be completed.
- Ran `pytest` which executed test collection but aborted due to import/collection errors (test collection reported 6 errors during collection, several skipped tests, and warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665493150c8326a6bab460c51e5804)