### PR TITLE
Add user fact retrieval to CognitiveCoreService and use in persona prompts

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -61,7 +61,7 @@ from deepthought.goal_scheduler import GoalScheduler
 from deepthought.perception.emotion_detection import detect_emotions
 from deepthought.perception.social_perception import analyze as analyze_social
 from deepthought.plugins.projects_board import DEFAULT_HOLIDAY_LOCALE, ProjectsBoard
-from deepthought.services import PersonaManager, TrustService
+from deepthought.services import CognitiveCoreService, PersonaManager, TrustService
 from deepthought.services.db_manager import DBManager
 from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import evaluate_toxicity, get_profanity_list, is_allowed
@@ -417,6 +417,17 @@ def _format_memory_snippets(memories: list[tuple[str, str]], limit: int) -> list
     return snippets
 
 
+def _merge_memory_snippets(primary: list[str], secondary: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen = set()
+    for snippet in primary + secondary:
+        if snippet in seen:
+            continue
+        seen.add(snippet)
+        merged.append(snippet)
+    return merged
+
+
 def _build_memory_hint(memory_snippets: list[str]) -> str:
     """Return a short, user-facing memory hint."""
 
@@ -489,6 +500,7 @@ persona_manager = PersonaManager(
     sentiment_weight=get_settings().persona_sentiment_weight,
 )
 trust_service = TrustService(db_manager)
+_cognitive_core: CognitiveCoreService | None = None
 reply_limiter = UserRateLimiter(1, USER_REPLY_RATE_SECONDS)
 bot_last_messages: dict[int, tuple[str, datetime.datetime]] = {}
 last_bot_reply_time: datetime.datetime | None = None
@@ -503,7 +515,7 @@ bot_reply_times: dict[int, datetime.datetime] = {}
 
 async def init_db(db_path: str | None = None) -> None:
     """Initialize the database, recreating the manager when the path changes."""
-    global db_manager, persona_manager, trust_service, CURRENT_DB_PATH
+    global db_manager, persona_manager, trust_service, CURRENT_DB_PATH, _cognitive_core
 
     target_path = (
         db_path
@@ -524,6 +536,21 @@ async def init_db(db_path: str | None = None) -> None:
     )
     trust_service = TrustService(db_manager)
     CURRENT_DB_PATH = db_manager.db_path
+    _cognitive_core = None
+
+
+def _get_cognitive_core_service() -> CognitiveCoreService | None:
+    global _cognitive_core
+    if _cognitive_core is None:
+        try:
+            _cognitive_core = CognitiveCoreService(
+                settings=get_settings(),
+                db=db_manager,
+            )
+        except Exception:
+            logger.exception("Failed to initialize cognitive core service")
+            return None
+    return _cognitive_core
 
 
 async def send_to_prism(data: dict) -> None:
@@ -1367,7 +1394,20 @@ class SocialGraphBot(commands.Bot):
 
         memories = await recall_user(message.author.id, limit=MAX_MEMORY_PROMPT_SNIPPETS)
         memory_snippets = _format_memory_snippets(memories, MAX_MEMORY_PROMPT_SNIPPETS)
+        retrieved_facts: list[str] = []
+        cognitive_core = _get_cognitive_core_service()
+        if cognitive_core is not None:
+            try:
+                retrieved_facts = await cognitive_core.retrieve_user_facts(
+                    message.author.id,
+                    channel_id=message.channel.id,
+                    prompt=message.content,
+                    limit=MAX_MEMORY_PROMPT_SNIPPETS,
+                )
+            except Exception:
+                logger.exception("Failed to retrieve cognitive core facts")
         memory_hint = _build_memory_hint(memory_snippets)
+        persona_snippets = _merge_memory_snippets(memory_snippets, retrieved_facts)
         if memories:
             logger.info(f"Recalling memories for {message.author.id}: {memories}")
 
@@ -1410,7 +1450,7 @@ class SocialGraphBot(commands.Bot):
                         )
                     except Exception:
                         logger.exception("Persona description lookup failed")
-                    prompt = _build_persona_prompt([message.content], persona_desc, memory_snippets)
+                    prompt = _build_persona_prompt([message.content], persona_desc, persona_snippets)
                     llm_reply = await generate_llm_reply(prompt)
                     if llm_reply:
                         reply = llm_reply

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -114,6 +114,50 @@ class CognitiveCoreService(BaseService):
                 merged.append(item)
         return merged
 
+    async def retrieve_user_facts(
+        self,
+        user_id: str | int,
+        channel_id: str | int | None = None,
+        *,
+        prompt: str | None = None,
+        limit: int | None = None,
+    ) -> List[str]:
+        """Return top facts/snippets for ``user_id`` and ``channel_id``."""
+
+        max_items = self._top_k if limit is None else int(limit)
+        if max_items <= 0:
+            return []
+
+        seed_prompt = prompt
+        if not seed_prompt:
+            seed_parts = []
+            if user_id is not None:
+                seed_parts.append(f"user:{user_id}")
+            if channel_id is not None:
+                seed_parts.append(f"channel:{channel_id}")
+            seed_prompt = " ".join(seed_parts)
+
+        memory_facts = self.retrieve_context(seed_prompt) if seed_prompt else []
+        db_snippets: List[str] = []
+        if self._db is not None and user_id is not None:
+            rows = await self._db.recall_user(user_id, limit=max_items)
+            for topic, memory in rows:
+                if not memory or not str(memory).strip():
+                    continue
+                entry = f"[{topic}] {memory}" if topic else str(memory)
+                db_snippets.append(entry.strip())
+
+        merged: List[str] = []
+        seen = set()
+        for item in memory_facts + db_snippets:
+            if item in seen:
+                continue
+            seen.add(item)
+            merged.append(item)
+            if len(merged) >= max_items:
+                break
+        return merged
+
     async def _db_context(self) -> List[str]:
         rows = await self._db.recall_user("user", limit=self._top_k)
         return [m[1] for m in rows]
@@ -127,7 +171,8 @@ class CognitiveCoreService(BaseService):
                 raise ValueError("InputReceived payload must be a dict")
             input_id = data.get("input_id")
             user_input = data.get("user_input")
-            user_id = data.get("user_id") or (msg.headers.get("user_id") if msg.headers else None)
+            headers = getattr(msg, "headers", None)
+            user_id = data.get("user_id") or (headers.get("user_id") if headers else None)
             if not isinstance(user_id, str):
                 user_id = None
             if not isinstance(input_id, str) or not isinstance(user_input, str):


### PR DESCRIPTION
### Motivation
- Provide a lightweight retrieval API to surface top facts or memory snippets for a given user/channel to improve persona-aware LLM prompts.
- Merge vector/store search results with DB-stored memories so persona prompts have richer context.
- Make the social graph bot include those retrieved facts when building persona prompts so LLM replies can reference more context.
- Handle message header access defensively when processing input events to avoid test/runtime errors with stub messages.

### Description
- Added an async API `retrieve_user_facts` to `src/deepthought/services/cognitive_core_service.py` that merges vector search context with per-user DB memories and respects a `limit` parameter.
- Made header access robust in `_handle_input` by using `headers = getattr(msg, "headers", None)` before reading `user_id`.
- Updated `examples/social_graph_bot.py` to initialize a cached `CognitiveCoreService` helper via `_get_cognitive_core_service`, added `_merge_memory_snippets`, and merged retrieved facts with existing memory snippets before calling `_build_persona_prompt`.
- Reset the cached cognitive core instance when the DB manager is reinitialized so the service uses the current `DBManager`.

### Testing
- Ran `python -m pytest tests/unit/services/test_cognitive_core_service.py`, which passed (2 tests passed).
- Ran `python -m ruff check src examples`, which failed due to pre-existing lint issues in the repository (unused imports and import-order/module-level import placement), not introduced by these changes.
- Unit tests specifically covering the modified `CognitiveCoreService` behavior succeed after the header guard fix.
- No additional automated tests were added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665493001883268162717bed10bbdc)