### PR TITLE
Add configurable toxicity classifier and enforce outbound response filtering

### DIFF
--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -154,12 +154,16 @@ class BaseLLM(ABC):
             else:
                 response_text = generated.strip()
 
-            if self._response_filter_enabled and not self._response_filter.is_safe(response_text):
-                logger.warning(
-                    "Response filtered for input_id %s; using fallback response",
-                    input_id,
-                )
-                response_text = self._response_filter_fallback
+            if self._response_filter_enabled:
+                sanitized = self._response_filter.sanitize(response_text)
+                if sanitized is None:
+                    logger.warning(
+                        "Response filtered for input_id %s; using fallback response",
+                        input_id,
+                    )
+                    response_text = self._response_filter_fallback
+                else:
+                    response_text = sanitized
 
             payload = ResponseGeneratedPayload(
                 final_response=response_text,

--- a/src/deepthought/services/moderation.py
+++ b/src/deepthought/services/moderation.py
@@ -1,7 +1,8 @@
 import logging
 import os
 import re
-from typing import Iterable, Mapping, MutableMapping, Sequence, Tuple
+from importlib import import_module
+from typing import Callable, Iterable, Mapping, MutableMapping, Sequence, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ TOXICITY_CHECK_ENABLED = os.getenv("MODERATION_TOXICITY_ENABLED", "true").lower(
     "yes",
 }
 TOXICITY_THRESHOLD = float(os.getenv("MODERATION_TOXICITY_THRESHOLD", "0.6"))
+TOXICITY_CLASSIFIER_PATH = os.getenv("MODERATION_TOXICITY_CLASSIFIER", "")
 
 # Lightweight toxicity lexicon with severity weights. Users can add terms via
 # ``MODERATION_PROFANITY_LIST``, using comma-separated entries. Each entry can
@@ -71,6 +73,45 @@ DEFAULT_TOXICITY_TERMS: Mapping[str, float] = {
     "piece of": 0.6,
     "kill yourself": 1.0,
 }
+
+ToxicityClassifier = Callable[[str], object]
+
+
+def _load_toxicity_classifier(path: str) -> ToxicityClassifier:
+    module_path, _, attr_name = path.rpartition(":")
+    if not module_path or not attr_name:
+        raise ValueError("Toxicity classifier path must be in 'module:attribute' format")
+    module = import_module(module_path)
+    classifier = getattr(module, attr_name)
+    if not callable(classifier):
+        raise TypeError(f"Toxicity classifier {path!r} is not callable")
+    return classifier
+
+
+def _parse_classifier_result(result: object) -> Tuple[float | None, Sequence[str]]:
+    matches: list[str] = []
+    score: float | None = None
+    score_value: object | None = None
+    matches_value: object | None = None
+    if isinstance(result, tuple) and len(result) == 2:
+        score_value, matches_value = result
+    elif isinstance(result, Mapping):
+        score_value = result.get("score") or result.get("toxicity") or result.get("value")
+        matches_value = result.get("matches") or result.get("terms") or result.get("labels")
+    else:
+        score_value = result
+    try:
+        if score_value is not None:
+            score = float(score_value)
+    except (TypeError, ValueError):
+        score = None
+    if isinstance(matches_value, str):
+        matches = [matches_value]
+    elif isinstance(matches_value, Sequence) and not isinstance(matches_value, (str, bytes)):
+        matches = [str(item) for item in matches_value if item]
+    if score is not None:
+        score = max(0.0, min(score, 1.0))
+    return score, matches
 
 
 def _parse_weighted_terms(raw_terms: str) -> MutableMapping[str, float]:
@@ -103,6 +144,16 @@ def _build_toxicity_terms() -> MutableMapping[str, float]:
 
 TOXICITY_TERMS: Mapping[str, float] = _build_toxicity_terms()
 _MAX_TOXICITY_WEIGHT = max(TOXICITY_TERMS.values(), default=1.0)
+_TOXICITY_CLASSIFIER: ToxicityClassifier | None = None
+if TOXICITY_CLASSIFIER_PATH:
+    try:
+        _TOXICITY_CLASSIFIER = _load_toxicity_classifier(TOXICITY_CLASSIFIER_PATH)
+    except Exception:
+        logger.warning(
+            "Unable to load toxicity classifier %s; falling back to lexicon scoring",
+            TOXICITY_CLASSIFIER_PATH,
+            exc_info=True,
+        )
 
 
 def evaluate_toxicity(
@@ -113,6 +164,16 @@ def evaluate_toxicity(
     """Return a toxicity score and matched terms for ``text``."""
     if not isinstance(text, str):
         return 0.0, []
+    if _TOXICITY_CLASSIFIER is not None:
+        try:
+            score, matches = _parse_classifier_result(_TOXICITY_CLASSIFIER(text))
+            if score is not None:
+                return score, matches
+        except Exception:
+            logger.warning(
+                "Toxicity classifier failed; falling back to lexicon scoring",
+                exc_info=True,
+            )
     lexicon = terms or TOXICITY_TERMS
     lowered = text.lower()
     matches: list[str] = []

--- a/src/deepthought/services/response_filter.py
+++ b/src/deepthought/services/response_filter.py
@@ -50,6 +50,24 @@ class ResponseFilter:
     toxicity_threshold: float | None = moderation.TOXICITY_THRESHOLD
     toxicity_terms: Mapping[str, float] | None = None
 
+    def _log_decision(
+        self,
+        *,
+        allowed: bool,
+        reason: str,
+        text: str,
+        details: Mapping[str, object] | None = None,
+    ) -> None:
+        if not moderation.MODERATION_LOG_DECISIONS:
+            return
+        logger.info(
+            "Response filter decision: allowed=%s reason=%s details=%s text_preview=%s",
+            allowed,
+            reason,
+            {} if details is None else details,
+            text[:160].replace("\n", " "),
+        )
+
     def is_safe(self, text: str) -> bool:
         sanitized = self.sanitize(text)
         return sanitized is not None
@@ -65,19 +83,37 @@ class ResponseFilter:
             pattern = re.compile(
                 "|".join(re.escape(term) for term in self.denylist), re.IGNORECASE
             )
+            matches = pattern.findall(sanitized)
 
             def _sub(match: re.Match[str]) -> str:
                 return self.replacement
 
             sanitized = pattern.sub(_sub, sanitized)
+            if matches:
+                self._log_decision(
+                    allowed=True,
+                    reason="denylist_replace",
+                    text=sanitized,
+                    details={"matches": sorted({match.lower() for match in matches})},
+                )
 
         if self.classifier is not None:
             try:
                 if not self.classifier(sanitized):
+                    self._log_decision(
+                        allowed=False,
+                        reason="classifier_blocked",
+                        text=sanitized,
+                    )
                     return None
             except Exception:
                 logger.warning(
                     "Response classifier failed; treating as unsafe", exc_info=True
+                )
+                self._log_decision(
+                    allowed=False,
+                    reason="classifier_error",
+                    text=sanitized,
                 )
                 return None
 
@@ -91,7 +127,27 @@ class ResponseFilter:
                     score,
                     matches,
                 )
+                self._log_decision(
+                    allowed=False,
+                    reason="toxicity_blocked",
+                    text=sanitized,
+                    details={
+                        "score": round(score, 3),
+                        "threshold": self.toxicity_threshold,
+                        "matches": list(matches),
+                    },
+                )
                 return None
+            self._log_decision(
+                allowed=True,
+                reason="toxicity_checked",
+                text=sanitized,
+                details={
+                    "score": round(score, 3),
+                    "threshold": self.toxicity_threshold,
+                    "matches": list(matches),
+                },
+            )
 
         return sanitized
 


### PR DESCRIPTION
### Motivation
- Integrate a configurable toxicity classifier (or fall back to a stricter lexicon) so outbound replies can be evaluated with a pluggable scoring model.  
- Ensure outbound responses are sanitized and blocked responses are replaced with a clear fallback reply before being sent.  
- Provide structured logging of moderation decisions for auditability and debugging.  
- Keep the lexicon-based scoring as a robust fallback when no classifier is provided or when the classifier fails.  

### Description
- Added support for loading a toxicity classifier from an import path via the `MODERATION_TOXICITY_CLASSIFIER` environment variable and a helper `_load_toxicity_classifier` in `src/deepthought/services/moderation.py`.  
- Implemented `_parse_classifier_result` and wired the classifier into `evaluate_toxicity` so external classifiers may return `(score, matches)` or mapping-like results, with a lexicon fallback.  
- Extended `ResponseFilter` in `src/deepthought/services/response_filter.py` with decision logging (`_log_decision`), denylist replacement auditing, classifier block/error logging, and toxicity block/checked logs.  
- Enforced sanitized outbound replies in `src/deepthought/modules/llm_base.py` by calling `ResponseFilter.sanitize` and substituting the configured fallback message when `sanitize` returns `None`.  

### Testing
- Ran `python -m pytest` to exercise the test suite, but collection failed due to missing optional runtime dependencies (examples: `aiosqlite`, `rdflib`, `discord`, `PIL`) and environment-specific `torch` issues, so tests were not completed.  
- Attempted `python -m flake8 src/deepthought/services/moderation.py src/deepthought/services/response_filter.py src/deepthought/modules/llm_base.py`, but `flake8` was not installed in the environment so linting was not executed.  
- The changes include defensive fallbacks and extensive logging to make local verification easier when optional classifier or runtime dependencies are available.  
- Recommend running the full test and linter stack in a developer environment with optional dependencies installed and `MODERATION_TOXICITY_CLASSIFIER` configured to validate classifier behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69665c96f4948326a5a577ce933b3000)