### PR TITLE
Persist persona traits to DB and update bot to infer traits periodically

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -59,6 +59,7 @@ DECEPTION_REPLY_MODE = bot_deception.DECEPTION_REPLY_MODE
 DYNAMIC_COVER_REPLIES = bot_deception.DYNAMIC_COVER_REPLIES
 from deepthought.goal_scheduler import GoalScheduler
 from deepthought.perception.emotion_detection import detect_emotions
+from deepthought.perception.personality_detection import infer_personality
 from deepthought.perception.social_perception import analyze as analyze_social
 from deepthought.plugins.projects_board import DEFAULT_HOLIDAY_LOCALE, ProjectsBoard
 from deepthought.services import CognitiveCoreService, PersonaManager, TrustService
@@ -601,6 +602,11 @@ last_other_bot_message_time: datetime.datetime | None = None
 # Track handshake completions and per-bot cooldowns
 bot_handshakes: dict[int, datetime.datetime] = {}
 bot_reply_times: dict[int, datetime.datetime] = {}
+_personality_message_buffers: dict[int, deque[str]] = {}
+_personality_message_counts: dict[int, int] = {}
+
+PERSONALITY_TRAIT_UPDATE_EVERY = 5
+PERSONALITY_TRAIT_WINDOW = 12
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -702,6 +708,22 @@ def log_thought(bot: discord.Client, text: str) -> None:
     except RuntimeError:  # pragma: no cover - no loop available
         return
     loop.create_task(_send_thought(bot, text))
+
+
+async def _maybe_update_personality_traits(user_id: int, message_text: str) -> None:
+    buffer = _personality_message_buffers.setdefault(
+        user_id, deque(maxlen=PERSONALITY_TRAIT_WINDOW)
+    )
+    buffer.append(message_text)
+    count = _personality_message_counts.get(user_id, 0) + 1
+    _personality_message_counts[user_id] = count
+    if count % PERSONALITY_TRAIT_UPDATE_EVERY:
+        return
+    traits = infer_personality(list(buffer))
+    try:
+        await persona_manager.update_personality(user_id, traits)
+    except Exception:
+        logger.exception("Failed to update personality traits for user %s", user_id)
 
 
 async def emit_refusal(
@@ -1424,6 +1446,8 @@ class SocialGraphBot(commands.Bot):
             sentiment_score=sentiment_score,
         )
         await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        if not message.author.bot:
+            await _maybe_update_personality_traits(message.author.id, message.content)
         affinity_delta = None
         if sentiment_score >= SENTIMENT_THRESHOLD:
             affinity_delta = AFFINITY_POS_DELTA

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -57,16 +57,22 @@ class PersonaManager:
             asyncio.run(self._db.init_db())
             self._init_task = None
 
-    def update_personality(self, user_id: int, traits: dict[str, float]) -> None:
+    async def update_personality(self, user_id: int, traits: dict[str, float]) -> None:
         """Update stored personality ``traits`` for ``user_id``.
 
         The provided ``traits`` mapping is merged with any existing traits for
-        the user, overwriting values for matching keys.
+        the user, overwriting values for matching keys. Trait maps are stored
+        as JSON dictionaries in the ``user_profiles`` table.
         """
 
+        await self._ensure_initialized()
         uid = str(user_id)
-        current = self._personality.setdefault(uid, {})
-        current.update(traits)
+        current = self._personality.get(uid)
+        if current is None:
+            current = await self._load_user_traits(user_id)
+        current.update(self._normalize_traits(traits))
+        self._personality[uid] = current
+        await self._store_user_traits(user_id, current)
 
     async def get_persona(
         self,
@@ -75,10 +81,11 @@ class PersonaManager:
         *,
         channel_id: int | str | None = None,
     ) -> str:
-        if self._init_task is not None:
-            await self._init_task
-            self._init_task = None
-        traits = self._personality.get(str(user_id), {})
+        await self._ensure_initialized()
+        uid = str(user_id)
+        traits = self._personality.get(uid)
+        if traits is None:
+            traits = await self._load_user_traits(user_id)
         relationship = None
         key = self._state_key(user_id, target_id, channel_id)
         if target_id is None:
@@ -211,3 +218,30 @@ class PersonaManager:
             return 0.0, None
         average_sentiment = sentiment_sum / message_count
         return average_sentiment * self._sentiment_weight, average_sentiment
+
+    async def _ensure_initialized(self) -> None:
+        if self._init_task is not None:
+            await self._init_task
+            self._init_task = None
+
+    async def _load_user_traits(self, user_id: int | str) -> dict[str, float]:
+        profile = await self._db.get_user_profile(user_id)
+        traits = self._normalize_traits(profile)
+        self._personality[str(user_id)] = traits
+        return traits
+
+    async def _store_user_traits(self, user_id: int | str, traits: dict[str, float]) -> None:
+        await self._db.set_user_profile(user_id, traits)
+
+    def _normalize_traits(self, traits: object | None) -> dict[str, float]:
+        if not isinstance(traits, dict):
+            return {}
+        if "traits" in traits and isinstance(traits["traits"], dict):
+            traits = traits["traits"]
+        normalized: dict[str, float] = {}
+        for key, value in traits.items():
+            try:
+                normalized[str(key)] = float(value)
+            except (TypeError, ValueError):
+                continue
+        return normalized

--- a/tests/test_persona_manager_personality.py
+++ b/tests/test_persona_manager_personality.py
@@ -18,11 +18,11 @@ async def test_personality_traits_override_affinity(tmp_path):
     assert await pm.get_persona(user) == "snarky"
 
     # Personality can push persona to friendly
-    pm.update_personality(user, {"friendly": 5})
+    await pm.update_personality(user, {"friendly": 5})
     assert await pm.get_persona(user) == "friendly"
 
     # Updating traits can shift persona again
-    pm.update_personality(user, {"friendly": 0, "playful": 2})
+    await pm.update_personality(user, {"friendly": 0, "playful": 2})
     assert await pm.get_persona(user) == "playful"
 
     await sg.db_manager.close()
@@ -37,7 +37,7 @@ async def test_personality_combines_with_affinity(tmp_path):
     await sg.adjust_affinity(user, 1)
     assert await pm.get_persona(user) == "snarky"
 
-    pm.update_personality(user, {"playful": 1})
+    await pm.update_personality(user, {"playful": 1})
     assert await pm.get_persona(user) == "playful"
 
     await sg.db_manager.close()


### PR DESCRIPTION
### Motivation
- Persist per-user personality trait maps so personas survive restarts and can be shared across components.
- Load traits lazily to avoid extra DB calls and keep an in-memory cache for runtime use.
- Use a simple JSON schema for traits compatible with the existing `user_profiles` table (e.g. `{"friendly": 2.0, "playful": 1.0}`).
- Provide a lightweight integration point in the example bot to infer and persist traits from recent messages on a cadence.

### Description
- Made `PersonaManager.update_personality` asynchronous and persist updates to the DB via `DBManager.set_user_profile` after normalizing the trait map.
- Modified `PersonaManager.get_persona` to lazily load stored traits from `DBManager.get_user_profile` when not cached, and added helpers `._ensure_initialized`, `._load_user_traits`, `._store_user_traits`, and `._normalize_traits`.
- Added a message-buffering cadence to `examples/social_graph_bot.py` that imports `infer_personality` and calls `persona_manager.update_personality` every `PERSONALITY_TRAIT_UPDATE_EVERY` messages using a sliding window of recent messages.
- Updated tests in `tests/test_persona_manager_personality.py` to `await` the new async `update_personality` API.

### Testing
- Ran `python -m pytest tests/test_persona_manager_personality.py`, which completed collection but the test module was skipped due to optional external dependencies (skipped).
- Ran `python -m flake8`, which could not run in this environment because `flake8` is not installed (failure due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966613ceec08326bd009558aee8f577)