### PR TITLE
Include user fact context in SocialGraphBot prompts and replies

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -43,6 +43,7 @@ from deepthought.bot.memory import (
     store_theory,
     update_sentiment_trend,
 )
+from deepthought.memory.fact_extractor import build_user_fact_context, extract_and_store_user_facts
 
 # Re-export bot helper functions and configuration values for convenience
 maybe_deceptive_reply = bot_deception.maybe_deceptive_reply
@@ -270,6 +271,7 @@ MINIMAL_REPLY_PROB = float(os.getenv("MINIMAL_REPLY_PROB", "0.05"))
 MINIMAL_REPLIES = ["...", "👍", "No"]
 AVOIDANCE_REPLY = "Take your time; I'm here if you need me."
 REFUSAL_MESSAGE = "I'm sorry, but I can't help with that."
+FACT_CONTEXT_TTL_SECONDS = int(os.getenv("FACT_CONTEXT_TTL_SECONDS", "900"))
 FOE_MODE_CAP_ENABLED = os.getenv("FOE_MODE_CAP_ENABLED", "true").lower() in {
     "true",
     "1",
@@ -455,7 +457,10 @@ def _get_text_adapter() -> LLMTextAdapter:
 
 
 def _build_persona_prompt(
-    messages: List[str], persona_desc: str, memory_snippets: list[str] | None = None
+    messages: List[str],
+    persona_desc: str,
+    memory_snippets: list[str] | None = None,
+    fact_context: str | None = None,
 ) -> str:
     """Return a prompt that includes persona, memory context, and message history."""
 
@@ -466,6 +471,8 @@ def _build_persona_prompt(
     if memory_snippets:
         memory_lines = "\n".join(f"- {snippet}" for snippet in memory_snippets)
         sections.append(f"Memory notes:\n{memory_lines}")
+    if fact_context:
+        sections.append(fact_context)
     sections.append(history)
     return "\n\n".join(sections)
 
@@ -527,6 +534,15 @@ def _build_memory_hint(memory_snippets: list[str]) -> str:
     return f"You mentioned {summary} earlier."
 
 
+def _build_fact_hint(fact_context: str | None) -> str:
+    if not fact_context:
+        return ""
+    summary = re.sub(r"\s+", " ", fact_context).strip()
+    if len(summary) > 120:
+        summary = summary[:117] + "..."
+    return f"Reminder: {summary}"
+
+
 def _append_memory_hint(reply: str, memory_hint: str) -> str:
     """Append memory hint to reply with proper spacing."""
 
@@ -539,13 +555,20 @@ def _append_memory_hint(reply: str, memory_hint: str) -> str:
     return f"{reply}. {memory_hint}"
 
 
-def build_reply_prompt(user_text: str, memory_snippets: list[str]) -> str:
+def build_reply_prompt(
+    user_text: str,
+    memory_snippets: list[str],
+    fact_context: str | None = None,
+) -> str:
     """Assemble a reply prompt with optional memory context."""
     lines = ["You are a conversational social bot.", "MEMORY_RETRIEVED:"]
     if memory_snippets:
         lines.extend(f"- {snippet}" for snippet in memory_snippets)
     else:
         lines.append("- (none)")
+    if fact_context:
+        lines.append("USER_FACTS:")
+        lines.append(fact_context)
     lines.extend(
         [
             "Respond naturally and briefly.",
@@ -556,10 +579,30 @@ def build_reply_prompt(user_text: str, memory_snippets: list[str]) -> str:
     return "\n".join(lines)
 
 
-async def generate_contextual_reply(user_text: str, memory_snippets: list[str]) -> str | None:
-    prompt = build_reply_prompt(user_text, memory_snippets)
+async def generate_contextual_reply(
+    user_text: str,
+    memory_snippets: list[str],
+    fact_context: str | None = None,
+) -> str | None:
+    prompt = build_reply_prompt(user_text, memory_snippets, fact_context)
     adapter = _get_text_adapter()
     return await adapter.generate(prompt, max_new_tokens=LLM_REPLY_MAX_NEW_TOKENS)
+
+
+def _dedupe_fact_context(
+    user_id: int,
+    fact_context: str | None,
+    now: datetime.datetime,
+) -> str | None:
+    if not fact_context:
+        return None
+    cached = fact_context_cache.get(user_id)
+    if cached:
+        cached_fact, cached_time = cached
+        if cached_fact == fact_context and (now - cached_time).total_seconds() < FACT_CONTEXT_TTL_SECONDS:
+            return None
+    fact_context_cache[user_id] = (fact_context, now)
+    return fact_context
 
 
 async def generate_llm_reply(prompt: str) -> str | None:
@@ -601,6 +644,7 @@ last_other_bot_message_time: datetime.datetime | None = None
 # Track handshake completions and per-bot cooldowns
 bot_handshakes: dict[int, datetime.datetime] = {}
 bot_reply_times: dict[int, datetime.datetime] = {}
+fact_context_cache: dict[int, tuple[str, datetime.datetime]] = {}
 
 
 async def init_db(db_path: str | None = None) -> None:
@@ -1423,6 +1467,14 @@ class SocialGraphBot(commands.Bot):
             topic=topic,
             sentiment_score=sentiment_score,
         )
+        try:
+            await extract_and_store_user_facts(
+                message.author.id,
+                message.content,
+                db_manager=db_manager,
+            )
+        except Exception:
+            logger.exception("Failed to extract user facts")
         await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
         affinity_delta = None
         if sentiment_score >= SENTIMENT_THRESHOLD:
@@ -1484,6 +1536,12 @@ class SocialGraphBot(commands.Bot):
 
         memories = await recall_user(message.author.id, limit=MAX_MEMORY_PROMPT_SNIPPETS)
         memory_snippets = _format_memory_snippets(memories, MAX_MEMORY_PROMPT_SNIPPETS)
+        fact_context = None
+        try:
+            raw_fact_context = await build_user_fact_context(message.author.id, db_manager=db_manager)
+            fact_context = _dedupe_fact_context(message.author.id, raw_fact_context, discord.utils.utcnow())
+        except Exception:
+            logger.exception("Failed to build user fact context")
         retrieved_facts: list[str] = []
         cognitive_core = _get_cognitive_core_service()
         if cognitive_core is not None:
@@ -1497,6 +1555,7 @@ class SocialGraphBot(commands.Bot):
             except Exception:
                 logger.exception("Failed to retrieve cognitive core facts")
         memory_hint = _build_memory_hint(memory_snippets)
+        fact_hint = _build_fact_hint(fact_context)
         persona_snippets = _merge_memory_snippets(memory_snippets, retrieved_facts)
         if memories:
             logger.info(f"Recalling memories for {message.author.id}: {memories}")
@@ -1540,7 +1599,12 @@ class SocialGraphBot(commands.Bot):
                         )
                     except Exception:
                         logger.exception("Persona description lookup failed")
-                    prompt = _build_persona_prompt([message.content], persona_desc, persona_snippets)
+                    prompt = _build_persona_prompt(
+                        [message.content],
+                        persona_desc,
+                        persona_snippets,
+                        fact_context=fact_context,
+                    )
                     llm_reply = await generate_llm_reply(prompt)
                     if llm_reply:
                         reply = llm_reply
@@ -1551,8 +1615,11 @@ class SocialGraphBot(commands.Bot):
                         )
                         persona_used = persona
                         reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
-            if reply and memory_hint and not reply_from_llm:
-                reply = _append_memory_hint(reply, memory_hint)
+            if reply and not reply_from_llm:
+                if memory_hint:
+                    reply = _append_memory_hint(reply, memory_hint)
+                if fact_hint:
+                    reply = _append_memory_hint(reply, fact_hint)
             if FOE_MODE_CAP_ENABLED and persona_used == "snarky":
                 severity, matches = evaluate_toxicity(reply)
                 if severity > FOE_MODE_MAX_SEVERITY:


### PR DESCRIPTION
### Motivation

- Surface concise user-fact summaries to the LLM so replies can reflect known user attributes and preferences.
- Persist extracted user facts from incoming messages so future prompts can include that context.
- Avoid repeating the same fact on every reply by caching per-user fact prompts with a TTL.
- Ensure fact context is available both to LLM-generated replies and to fallback persona replies.

### Description

- Added imports for `build_user_fact_context` and `extract_and_store_user_facts` and a new config `FACT_CONTEXT_TTL_SECONDS` with a `fact_context_cache` for TTL-based dedupe.
- Call `extract_and_store_user_facts` after each eligible user message is stored via `store_memory` to persist discovered facts.
- Fetch `build_user_fact_context` during reply construction, run it through `_dedupe_fact_context`, and pass the result into `_build_persona_prompt` and `build_reply_prompt` so the LLM prompt includes `fact_context` when available.
- Added `_build_fact_hint` and appended the fact hint to fallback persona replies (non-LLM replies) alongside existing memory hints.

### Testing

- Ran `python -m pytest`; collection failed due to missing optional dependencies and environment issues (errors for `aiosqlite`, `discord`, `rdflib`, PIL spec issues, and a Torch registration error).  Tests did not complete successfully.
- Ran `python -m flake8`; invocation failed because `flake8` is not installed in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966613c2b48832690081536bd203d70)