### PR TITLE
Add persona manager persistence tests

### DIFF
--- a/tests/test_persona_manager_persistence.py
+++ b/tests/test_persona_manager_persistence.py
@@ -1,0 +1,38 @@
+import pytest
+
+from deepthought.services import DBManager, PersonaManager
+
+
+@pytest.mark.asyncio
+async def test_persona_traits_persist_across_manager_instances(tmp_path):
+    db_path = tmp_path / "sg.db"
+    db_manager = DBManager(str(db_path))
+    pm = PersonaManager(db_manager, friendly=5, playful=2)
+    user = "u1"
+
+    await pm.update_personality(user, {"friendly": 5})
+    assert await pm.get_persona(user) == "friendly"
+    await db_manager.close()
+
+    fresh_manager = DBManager(str(db_path))
+    fresh_pm = PersonaManager(fresh_manager, friendly=5, playful=2)
+
+    assert await fresh_pm.get_persona(user) == "friendly"
+    await fresh_manager.close()
+
+
+@pytest.mark.asyncio
+async def test_persona_flips_with_traits_and_affinity(tmp_path):
+    db_manager = DBManager(str(tmp_path / "sg.db"))
+    pm = PersonaManager(db_manager, friendly=5, playful=2)
+    user = "u2"
+
+    assert await pm.get_persona(user) == "snarky"
+
+    await pm.update_personality(user, {"friendly": 4})
+    assert await pm.get_persona(user) == "snarky"
+
+    await db_manager.adjust_affinity(user, 1)
+    assert await pm.get_persona(user) == "friendly"
+
+    await db_manager.close()


### PR DESCRIPTION
### Motivation
- Ensure personality traits persisted via the DB are correctly loaded by new PersonaManager instances backed by the same SQLite database.
- Verify persona selection respects the combination of persisted traits and affinity scores to flip personas as expected.

### Description
- Add `tests/test_persona_manager_persistence.py` containing two async tests that use a temp SQLite DB via `DBManager` and `PersonaManager`.
- Test `test_persona_traits_persist_across_manager_instances` persists traits with `update_personality`, reopens the DB with a fresh `PersonaManager`, and asserts the same persona is returned.
- Test `test_persona_flips_with_traits_and_affinity` validates that partial trait values combined with an affinity adjustment cause the persona to flip according to thresholds.

### Testing
- Ran `pytest tests/test_persona_manager_persistence.py` and observed `2 passed` (tests succeeded with minor runtime warnings).
- Attempted to run `flake8 src tests` but the `flake8` command was not available in the environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69679ead889483268c427f68a234ff25)