### PR TITLE
Persist relationship status on interactions and expose updater

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -69,6 +69,7 @@ from deepthought.services.manipulative_detection import manipulation_score
 from deepthought.services.moderation import evaluate_toxicity, get_profanity_list, is_allowed
 from deepthought.services.response_filter import build_response_filter
 from deepthought.services.scheduler import SchedulerService
+from deepthought.services.social_graph_memory import SocialGraphMemory
 from deepthought.utils import ResponseQueue, UserRateLimiter
 
 try:
@@ -652,6 +653,7 @@ ALLOW_DECEPTION = bot_deception.ALLOW_DECEPTION
 DECEPTION_COVER_MESSAGE = bot_deception.DECEPTION_COVER_MESSAGE
 DECEPTION_REPLY_MODE = bot_deception.DECEPTION_REPLY_MODE
 DYNAMIC_COVER_REPLIES = bot_deception.DYNAMIC_COVER_REPLIES
+social_graph_memory = SocialGraphMemory(db_manager)
 persona_manager = PersonaManager(
     db_manager,
     descriptions=get_settings().persona_descriptions,
@@ -678,7 +680,7 @@ PERSONALITY_TRAIT_WINDOW = 12
 
 async def init_db(db_path: str | None = None) -> None:
     """Initialize the database, recreating the manager when the path changes."""
-    global db_manager, persona_manager, trust_service, CURRENT_DB_PATH, _cognitive_core
+    global db_manager, persona_manager, trust_service, CURRENT_DB_PATH, _cognitive_core, social_graph_memory
 
     target_path = (
         db_path
@@ -692,6 +694,7 @@ async def init_db(db_path: str | None = None) -> None:
         db_manager = DBManager(target_path)
 
     await db_manager.init_db()
+    social_graph_memory = SocialGraphMemory(db_manager)
     persona_manager = PersonaManager(
         db_manager,
         descriptions=get_settings().persona_descriptions,
@@ -1445,8 +1448,12 @@ class SocialGraphBot(commands.Bot):
         if target_ids:
             for target_id in target_ids:
                 await log_interaction(user_id, target_id, sentiment_score=sentiment_score)
+                await self._update_relationship_status(user_id, target_id)
             return
         await log_interaction(user_id, None, sentiment_score=sentiment_score)
+
+    async def _update_relationship_status(self, user_id: int, target_id: int) -> None:
+        await social_graph_memory.update_relationship_type(str(user_id), str(target_id))
 
     async def on_message(self, message: discord.Message) -> None:
         global last_bot_reply_time, last_other_bot_message_time

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -112,6 +112,10 @@ class SocialGraphMemory:
         elif status == "rival":
             await self._db.update_edge(user_a, user_b, "rival", 1.0)
 
+    async def update_relationship_type(self, user_a: str, user_b: str) -> None:
+        """Public wrapper for updating relationship type between two users."""
+        await self._update_relationship_type(user_a, user_b)
+
     async def get_relationship_status(self, user_a: str, user_b: str) -> str | None:
         return await self._db.get_relationship_type(user_a, user_b)
 


### PR DESCRIPTION
### Motivation

- Ensure relationship status is computed and persisted when an interaction has a `target_id` so relationship-based features (like personas) can observe updates.
- Reuse the existing relationship-type computation flow rather than duplicating logic.
- Make sure the social graph logic uses the same `DBManager` instance already configured for the bot so other services like `PersonaManager.get_persona(...)` can see `relationship_types` immediately.

### Description

- Added a public wrapper `update_relationship_type` that calls the existing `_update_relationship_type` flow in `SocialGraphMemory` to expose the relationship-status update logic for reuse via `SocialGraphMemory.update_relationship_type`.
- Imported and instantiated `SocialGraphMemory` in `examples/social_graph_bot.py` as `social_graph_memory` and passed the shared `db_manager` to it to ensure the same DB is used.
- Wired the bot to call `social_graph_memory.update_relationship_type` for each `target_id` during `_log_interactions` via a small helper `SocialGraphBot._update_relationship_status` so relationship types are updated when interactions are logged.
- Recreate/refresh the `social_graph_memory` instance inside `init_db` when the bot database manager is reinitialized so the social graph always uses the current `DBManager`.

### Testing

- Ran `flake8 src tests` which could not run because `flake8` is not installed in the environment (check CI or developer tooling to verify linting).
- Ran `pytest` which failed during collection due to missing optional dependencies and environment issues (errors included missing `aiosqlite`, `rdflib`, `discord`, `PIL` spec issue, and a Torch runtime registration error), so tests did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3c9c83888326956b39cce7f3e12a)