### PR TITLE
Update affinity adjustment to track pairwise state

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -1168,6 +1168,12 @@ class DBManager:
         delta: float,
         target_id: int | None = None,
     ) -> None:
+        """Adjust affinity for a user and optionally update pairwise state.
+
+        When ``target_id`` is provided, this mirrors ``log_interaction`` by
+        updating ``relationships`` (directional) and ``mutual_affinity``
+        (symmetric) rows alongside the global ``affinity`` score.
+        """
         delta_int = self._affinity_delta(delta)
         if not delta_int:
             return
@@ -1181,6 +1187,58 @@ class DBManager:
             """,
             (str(user_id), delta_int, delta_int),
         )
+        if target_id is not None:
+            weight = 1.0
+            w_decay, s_decay = await self.get_decay_params()
+            now = datetime.utcnow()
+            async with self._db.execute(
+                "SELECT interaction_count, sentiment_sum, interaction_weight, last_interaction FROM relationships WHERE source_id=? AND target_id=?",
+                (str(user_id), str(target_id)),
+            ) as cur:
+                row = await cur.fetchone()
+            if row:
+                count, ssum, w, last_ts = row
+                if last_ts:
+                    last_dt = datetime.fromisoformat(str(last_ts))
+                    elapsed = (now - last_dt).total_seconds()
+                    ssum = float(ssum) * (s_decay**elapsed)
+                    w = float(w) * (w_decay**elapsed)
+                count = int(count) + 1
+                ssum += float(delta)
+                w += weight
+                await self._db.execute(
+                    "UPDATE relationships SET interaction_count=?, sentiment_sum=?, interaction_weight=?, last_interaction=CURRENT_TIMESTAMP WHERE source_id=? AND target_id=?",
+                    (count, ssum, w, str(user_id), str(target_id)),
+                )
+            else:
+                await self._db.execute(
+                    "INSERT INTO relationships (source_id, target_id, interaction_count, sentiment_sum, interaction_weight, last_interaction) VALUES (?, ?, 1, ?, ?, CURRENT_TIMESTAMP)",
+                    (str(user_id), str(target_id), float(delta), weight),
+                )
+
+            a, b = sorted((str(user_id), str(target_id)))
+            async with self._db.execute(
+                "SELECT score, interaction_weight, last_interaction FROM mutual_affinity WHERE user_a=? AND user_b=?",
+                (a, b),
+            ) as cur:
+                mrow = await cur.fetchone()
+            if mrow:
+                score, w, last_ts = mrow
+                if last_ts:
+                    last_dt = datetime.fromisoformat(str(last_ts))
+                    elapsed = (now - last_dt).total_seconds()
+                    w = float(w) * (w_decay**elapsed)
+                score = int(score) + delta_int
+                w += weight
+                await self._db.execute(
+                    "UPDATE mutual_affinity SET score=?, interaction_weight=?, last_interaction=CURRENT_TIMESTAMP WHERE user_a=? AND user_b=?",
+                    (score, w, a, b),
+                )
+            else:
+                await self._db.execute(
+                    "INSERT INTO mutual_affinity (user_a, user_b, score, interaction_weight, last_interaction) VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)",
+                    (a, b, delta_int, weight),
+                )
         await self._db.commit()
 
     async def get_affinity(self, user_id: int) -> int:


### PR DESCRIPTION
### Motivation
- Make `adjust_affinity` able to update pairwise state when a `target_id` is provided so callers can incrementally affect both global and pairwise relationship statistics without calling `log_interaction` separately.
- Preserve existing behavior for the global affinity score so existing callers remain compatible.

### Description
- Add a docstring to `adjust_affinity` documenting that supplying a `target_id` will also update directional `relationships` and symmetric `mutual_affinity` rows.
- Mirror the `log_interaction` update logic inside `adjust_affinity` when `target_id` is present, including decay handling from `get_decay_params`, updating `interaction_count`, `sentiment_sum`, `interaction_weight`, and `last_interaction` for `relationships`.
- Update or insert the corresponding `mutual_affinity` row (sorted user pair) using the integer-mapped `delta` and interaction weight, matching `log_interaction` behavior.
- Keep the existing global `affinity` insert-or-update behavior unchanged so callers that only expect global affinity updates are unaffected.

### Testing
- Ran `pytest`, which attempted collection but aborted with errors during import and collection (collected 483 items, halted with 29 errors and 46 skipped) due to missing optional/third-party dependencies such as `aiosqlite`, `rdflib`, `discord`, `PIL` issues, and a `torch` registration runtime error, so the test suite did not complete successfully.
- Ran `flake8`, which was not available in the environment (`command not found`) so linters did not run.
- The modified unit (file `src/deepthought/services/db_manager.py`) was exercised locally via static inspection and committed, but full automated test and lint validation could not be completed in this environment due to the dependency issues above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3c9d9c508326952e1cfce95ec768)