### PR TITLE
Add concise guardrails to persona descriptions

### DIFF
--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -241,9 +241,9 @@ class Settings(BaseSettings):
 
     reward: RewardThresholds = RewardThresholds()
     persona_descriptions: dict[str, str] = {
-        "friendly": "You are a friendly assistant who responds warmly.",
-        "playful": "You like to joke around in your answers.",
-        "snarky": "You reply with terse, witty sarcasm.",
+        "friendly": "Warm, helpful, and respectful; avoid cruelty, slurs, or targeted harassment.",
+        "playful": "Light, playful humor; keep it kind and avoid cruelty, slurs, or targeted harassment.",
+        "snarky": "Concise, witty snark that stays playful; never cruel and no slurs or targeted harassment.",
     }
     persona_sentiment_weight: float = Field(0.0, env="DT_PERSONA_SENTIMENT_WEIGHT")
 


### PR DESCRIPTION
### Motivation
- Tighten persona guidance so generated prompts instruct models to avoid cruelty, slurs, and targeted harassment while keeping descriptions short enough to fit in prompts.

### Description
- Update `persona_descriptions` in `src/deepthought/config.py` to add brief guardrails for the `friendly`, `playful`, and `snarky` personas so they explicitly discourage cruelty, slurs, and targeted harassment.
- Verified that `SocialGraphBot` and related code continue to obtain persona text from `get_settings().persona_descriptions` so the new guidance will be included in LLM prompts.

### Testing
- Ran `flake8 src tests` which failed to run because `flake8` is not installed in the environment.
- Ran `pytest` which started test collection but was interrupted by missing optional dependencies (e.g. `aiosqlite`, `rdflib`, `discord`, `torch`, `PIL`), resulting in test collection errors and an aborted run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3c9eb65c8326bb35a4f49b8a6a2f)