### PR TITLE
Add test for affinity target relationship tracking

### DIFF
--- a/tests/test_affinity_target.py
+++ b/tests/test_affinity_target.py
@@ -1,0 +1,37 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+import aiosqlite
+
+from deepthought.services import DBManager
+
+
+@pytest.mark.asyncio
+async def test_adjust_affinity_with_target_creates_relationship(tmp_path):
+    db_path = tmp_path / "sg.db"
+    db = DBManager(str(db_path))
+    await db.connect()
+    await db.init_db()
+
+    user_a = 101
+    user_b = 202
+    assert await db.get_pair_mutual_affinity(user_a, user_b) == 0.0
+
+    await db.adjust_affinity(user_a, 1.0, target_id=user_b)
+
+    assert await db.get_pair_mutual_affinity(user_a, user_b) != 0.0
+
+    async with aiosqlite.connect(str(db_path)) as conn:
+        async with conn.execute(
+            "SELECT source_id, target_id FROM relationships WHERE source_id=? AND target_id=?",
+            (str(user_a), str(user_b)),
+        ) as cur:
+            row = await cur.fetchone()
+        async with conn.execute(
+            "SELECT source_id FROM relationships WHERE source_id=? AND target_id=?",
+            (str(user_b), str(user_a)),
+        ) as cur:
+            reverse_row = await cur.fetchone()
+
+    assert row == (str(user_a), str(user_b))
+    assert reverse_row is None


### PR DESCRIPTION
### Motivation
- Add coverage to ensure `adjust_affinity` with a `target_id` updates the pairwise `mutual_affinity` and creates a directional row in `relationships` so pairwise tracking is validated.

### Description
- Add `tests/test_affinity_target.py` which initializes a `DBManager` with a temp DB, calls `adjust_affinity(user_a, 1.0, target_id=user_b)`, asserts `get_pair_mutual_affinity(user_a, user_b)` changes from `0.0` and inspects the `relationships` table to confirm a directional `(source_id, target_id)` row exists and the reverse entry does not.

### Testing
- Ran `pytest -q tests/test_affinity_target.py` which reported `1 skipped` because the `aiosqlite` optional dependency was not available in the environment.
- Ran `flake8 tests/test_affinity_target.py` which could not run because the `flake8` command is not present in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3e4e1dac83268baaa5bbb7d14eda)