### PR TITLE
Set persona prior to LLM generation and preserve FOE_MODE cap

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1700,6 +1700,13 @@ class SocialGraphBot(commands.Bot):
                         )
                     except Exception:
                         logger.exception("Persona description lookup failed")
+                    try:
+                        persona_used = await self.persona_manager.get_persona(
+                            message.author.id, channel_id=message.channel.id
+                        )
+                    except Exception:
+                        logger.exception("Persona lookup failed")
+                        persona_used = "snarky"
                     prompt = _build_persona_prompt(
                         [message.content],
                         persona_desc,
@@ -1712,10 +1719,7 @@ class SocialGraphBot(commands.Bot):
                         reply = llm_reply
                         reply_from_llm = True
                     else:
-                        persona = await self.persona_manager.get_persona(
-                            message.author.id, channel_id=message.channel.id
-                        )
-                        persona_used = persona
+                        persona = persona_used or "snarky"
                         reply = random.choice(PERSONA_REPLIES.get(persona, PERSONA_REPLIES["snarky"]))
             if reply and not reply_from_llm:
                 if memory_hint:


### PR DESCRIPTION
### Motivation

- Ensure the persona is known before invoking the LLM so the FOE/`snarky` toxicity cap can be applied consistently even when the reply is generated by the LLM.
- Reuse the resolved persona for fallback replies to avoid double lookups and keep deterministic behavior when persona lookup fails.
- Preserve the existing sanitized reply and enqueue flow so capped replies still pass through `sanitize_response` and the response queue.

### Description

- Call `await self.persona_manager.get_persona(...)` before `generate_llm_reply(...)` and store the result in `persona_used`, with a try/except that defaults to `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3e4841cc8326b7b0be4fc43a22fc)