### PR TITLE
Add unit test for reply prompt to check MEMORY_NOTES/GRAPH_FACTS/USER_FACTS

### DIFF
--- a/tests/test_on_message_memory.py
+++ b/tests/test_on_message_memory.py
@@ -65,6 +65,19 @@ class DummyMessage:
         await self.channel.send(content, reference=self)
 
 
+def test_build_reply_prompt_includes_memory_and_fact_sections():
+    prompt = sg.build_reply_prompt(
+        "hello there",
+        ["met at the cafe", "likes chess"],
+        graph_facts=["connected to user 42"],
+        fact_context="enjoys hiking.",
+    )
+
+    assert "MEMORY_NOTES:" in prompt
+    assert "GRAPH_FACTS:" in prompt
+    assert "USER_FACTS:" in prompt
+
+
 @pytest.mark.asyncio
 async def test_on_message_stores_memory(tmp_path, monkeypatch, input_events):
     sg.db_manager = DBManager(str(tmp_path / "sg.db"))


### PR DESCRIPTION
### Motivation
- Ensure the reply prompt builders include memory, graph facts, and user facts sections when those inputs are provided to prevent regressions in prompt formatting.

### Description
- Add `test_build_reply_prompt_includes_memory_and_fact_sections` to `tests/test_on_message_memory.py` that calls `sg.build_reply_prompt` directly and asserts the presence of `MEMORY_NOTES:`, `GRAPH_FACTS:`, and `USER_FACTS:` in the returned prompt string.
- The test passes example `memory_snippets`, `graph_facts`, and a plain `fact_context` string to keep the test pure without instantiating the bot.
- Adjust the test input to provide `fact_context="enjoys hiking."` rather than embedding the `USER_FACTS:` prefix in the argument.

### Testing
- Ran `python -m pytest tests/test_on_message_memory.py` which executed the module but the run reported the module was skipped due to optional dependency checks at import time (result: 1 skipped).
- Attempted to run `flake8` but the command was not available in the execution environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e4097f07c8326b972864ccc88a53f)