### PR TITLE
Handle memory write failures in social graph bot message pipeline

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1529,7 +1529,15 @@ class SocialGraphBot(commands.Bot):
                     await self.send_filtered(message.channel, cover_reply)
 
             await self.enqueue_response(message.channel, send_cover_reply)
-            await store_memory(message.author.id, cover_reply, topic="deception")
+            try:
+                await store_memory(message.author.id, cover_reply, topic="deception")
+            except Exception as exc:
+                logger.warning(
+                    "Memory write failed for user_id=%s channel_id=%s in deception flow: %s",
+                    message.author.id,
+                    message.channel.id,
+                    exc,
+                )
             await self._log_interactions(message.author.id, target_ids)
             await publish_input_received(message.content)
             await send_to_prism(
@@ -1554,12 +1562,20 @@ class SocialGraphBot(commands.Bot):
             f"Sentiment score: {sentiment_score:+.2f}, Emotion: {dominant_emotion or 'Neutral'}",
         )
         topic = "message" if abs(sentiment_score) > SENTIMENT_THRESHOLD else ""
-        await store_memory(
-            message.author.id,
-            message.content,
-            topic=topic,
-            sentiment_score=sentiment_score,
-        )
+        try:
+            await store_memory(
+                message.author.id,
+                message.content,
+                topic=topic,
+                sentiment_score=sentiment_score,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Memory write failed for user_id=%s channel_id=%s: %s",
+                message.author.id,
+                message.channel.id,
+                exc,
+            )
         try:
             await extract_and_store_user_facts(
                 message.author.id,
@@ -1568,7 +1584,15 @@ class SocialGraphBot(commands.Bot):
             )
         except Exception:
             logger.exception("Failed to extract user facts")
-        await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        try:
+            await update_sentiment_trend(message.author.id, message.channel.id, sentiment_score)
+        except Exception as exc:
+            logger.warning(
+                "Sentiment trend update failed for user_id=%s channel_id=%s: %s",
+                message.author.id,
+                message.channel.id,
+                exc,
+            )
         if not message.author.bot:
             await _maybe_update_personality_traits(message.author.id, message.content)
         affinity_delta = None


### PR DESCRIPTION
### Motivation
- Prevent transient or validation failures when writing to memory from aborting the message handler and breaking downstream processing such as persona selection, reply generation, and logging.  
- Capture enough context for debugging by logging the exception message together with the `user_id` and `channel_id` when memory writes fail.

### Description
- Wrapped the deception-path `store_memory(...)` call in a `try/except` and log a warning including `user_id`, `channel_id`, and the exception message while continuing the handler.  
- Wrapped the main message-path `store_memory(...)` call in a `try/except` and log the same contextual warning without aborting processing.  
- Wrapped `update_sentiment_trend(...)` in a `try/except` and log a contextual warning on failure so the remainder of the pipeline continues.  
- Changes applied to `examples/social_graph_bot.py` and ensure the handler proceeds even if memory/trend writes fail.

### Testing
- Ran `python -m py_compile examples/social_graph_bot.py`, which succeeded.  
- Ran `python -m pytest -q`, which failed during test collection due to unrelated environment/import issues (missing or incompatible runtime dependencies), so no project tests were attributed to this change.  
- Ran `python -m ruff check examples/social_graph_bot.py`, which reported many pre-existing lint issues in that file that were not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986287a71288326a8f95460ace89479)