### PR TITLE
Pass target user into persona selection in social_graph_bot

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1550,6 +1550,8 @@ class SocialGraphBot(commands.Bot):
 
             return
 
+        primary_target_id = target_ids[0] if target_ids else None
+
         sentiment_score = analyze_sentiment(message.content)
         emotions = detect_emotions(message.content)
         dominant_emotion, dom_score = (None, 0.0)
@@ -1601,7 +1603,6 @@ class SocialGraphBot(commands.Bot):
         elif sentiment_score <= -SENTIMENT_THRESHOLD:
             affinity_delta = AFFINITY_NEG_DELTA
         if affinity_delta:
-            primary_target_id = target_ids[0] if target_ids else None
             await adjust_affinity(message.author.id, affinity_delta, target_id=primary_target_id)
 
         await db_manager.record_emotion(message.author.id, emotions)
@@ -1720,13 +1721,17 @@ class SocialGraphBot(commands.Bot):
                     persona_desc = ""
                     try:
                         persona_desc = await self.persona_manager.get_description(
-                            message.author.id, channel_id=message.channel.id
+                            message.author.id,
+                            target_id=primary_target_id,
+                            channel_id=message.channel.id,
                         )
                     except Exception:
                         logger.exception("Persona description lookup failed")
                     try:
                         persona_used = await self.persona_manager.get_persona(
-                            message.author.id, channel_id=message.channel.id
+                            message.author.id,
+                            target_id=primary_target_id,
+                            channel_id=message.channel.id,
                         )
                     except Exception:
                         logger.exception("Persona lookup failed")


### PR DESCRIPTION
### Motivation
- Provide persona resolution with explicit target context when a message mentions or replies to another user so friend/rival relationship status can influence persona selection while leaving interaction logging and relationship updates intact.

### Description
- Compute `primary_target_id = target_ids[0] if target_ids else None` early in `on_message` and pass `target_id=primary_target_id` into `PersonaManager.get_description` and `PersonaManager.get_persona`, without changing the existing per-target interaction logging or relationship-status update calls.

### Testing
- Ran `ruff check examples/social_graph_bot.py` which failed due to pre-existing lint issues in the file unrelated to this change.  
- Ran `pytest -q tests/test_persona_manager.py`, `pytest -q tests/test_relationship_inference.py tests/test_persona_manager_sentiment.py`, and `pytest -q tests/test_affinity_target.py`; these tests were skipped in this environment (reported as 1, 2, and 1 skipped respectively).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69862e51a8b08326b9ba0c554b1b1857)