### PR TITLE
Scale social graph affinity updates using sentiment strength

### DIFF
--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1597,11 +1597,7 @@ class SocialGraphBot(commands.Bot):
             )
         if not message.author.bot:
             await _maybe_update_personality_traits(message.author.id, message.content)
-        affinity_delta = None
-        if sentiment_score >= SENTIMENT_THRESHOLD:
-            affinity_delta = AFFINITY_POS_DELTA
-        elif sentiment_score <= -SENTIMENT_THRESHOLD:
-            affinity_delta = AFFINITY_NEG_DELTA
+        affinity_delta = DBManager.sentiment_to_affinity_delta(sentiment_score, scale=3.0, cap=3)
         if affinity_delta:
             await adjust_affinity(message.author.id, affinity_delta, target_id=primary_target_id)
 

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -1160,7 +1160,29 @@ class DBManager:
             if value < 0:
                 return AFFINITY_NEG_DELTA
             return 0
-        return int(value)
+        return int(round(float(value)))
+
+    @staticmethod
+    def sentiment_to_affinity_delta(
+        sentiment_score: float,
+        *,
+        scale: float = 3.0,
+        cap: int = 3,
+    ) -> int:
+        """Map sentiment polarity in ``[-1, 1]`` to a small integer affinity step."""
+        if not isinstance(sentiment_score, (int, float)):
+            raise ValueError("sentiment_score must be numeric")
+        if not -1 <= float(sentiment_score) <= 1:
+            raise ValueError("sentiment_score out of range")
+        if scale <= 0:
+            raise ValueError("scale must be positive")
+        if cap < 0:
+            raise ValueError("cap must be non-negative")
+
+        delta = int(round(float(sentiment_score) * scale))
+        if cap:
+            delta = max(-cap, min(cap, delta))
+        return delta
 
     async def adjust_affinity(
         self,

--- a/tests/test_db_manager_affinity_delta.py
+++ b/tests/test_db_manager_affinity_delta.py
@@ -1,0 +1,17 @@
+import pytest
+
+from deepthought.services.db_manager import DBManager
+
+
+def test_sentiment_to_affinity_delta_scales_and_clamps():
+    assert DBManager.sentiment_to_affinity_delta(0.1) == 0
+    assert DBManager.sentiment_to_affinity_delta(0.2) == 1
+    assert DBManager.sentiment_to_affinity_delta(0.9) == 3
+    assert DBManager.sentiment_to_affinity_delta(-0.9) == -3
+
+
+def test_sentiment_to_affinity_delta_validates_input():
+    with pytest.raises(ValueError, match="sentiment_score must be numeric"):
+        DBManager.sentiment_to_affinity_delta("nope")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="sentiment_score out of range"):
+        DBManager.sentiment_to_affinity_delta(1.1)


### PR DESCRIPTION
### Motivation

- Make affinity updates reflect sentiment magnitude rather than only a sign/threshold, so stronger positive/negative messages produce larger affinity steps.
- Provide a safe, validated mapping from a fractional sentiment polarity in [-1, 1] to the small integer steps used by the affinity store.

### Description

- Replaced threshold-only affinity update in `examples/social_graph_bot.py` with a call to `DBManager.sentiment_to_affinity_delta(sentiment_score, scale=3.0, cap=3)` so updates scale with sentiment strength.
- Added `DBManager.sentiment_to_affinity_delta(...)` which validates the input, multiplies by a configurable `scale`, clamps to `[-cap, cap]`, and rounds to an integer.
- Updated `_affinity_delta` to `round` non-normalized float deltas before converting to `int` to avoid truncation surprises.
- Added unit tests in `tests/test_db_manager_affinity_delta.py` covering scaling/clamping behavior and input validation.

### Testing

- Ran `pytest -q tests/test_db_manager_affinity_delta.py`, which passed (2 passed).
- Ran `pytest -q tests/test_affinity_target.py`, which passed (1 passed) with unrelated deprecation warnings.
- Ran `flake8 examples/social_graph_bot.py src/deepthought/services/db_manager.py tests/test_db_manager_affinity_delta.py`, which reported existing lint issues in `examples/social_graph_bot.py` (undefined names / an unused global) that are unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698631f4c3c08326b4435ec7361875a8)