### PR TITLE
Add response candidate selection pipeline and ranked output events

### DIFF
--- a/src/deepthought/eda/__init__.py
+++ b/src/deepthought/eda/__init__.py
@@ -8,8 +8,9 @@ the message broker.
 
 from .events import (CodeGeneratedPayload, CodeTemplatePayload, EventPayload,
                      EventSubjects, InputReceivedPayload,
-                     MemoryRetrievedPayload, ResponseGeneratedPayload,
-                     WarningPayload)
+                     MemoryRetrievedPayload, ResponseCandidate,
+                     ResponseCandidatesPayload, ResponseGeneratedPayload,
+                     ResponseRankedPayload, WarningPayload)
 from .publisher import Publisher
 from .subscriber import Subscriber
 
@@ -19,6 +20,9 @@ __all__ = [
     "InputReceivedPayload",
     "MemoryRetrievedPayload",
     "ResponseGeneratedPayload",
+    "ResponseCandidate",
+    "ResponseCandidatesPayload",
+    "ResponseRankedPayload",
     "WarningPayload",
     "CodeTemplatePayload",
     "CodeGeneratedPayload",

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -26,6 +26,8 @@ class EventSubjects:
 
     # LLM events
     RESPONSE_GENERATED = "dtr.llm.response_generated"
+    RESPONSE_CANDIDATES = "dtr.response.candidates"
+    RESPONSE_RANKED = "dtr.response.ranked"
 
     # Perception events
     PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings"
@@ -108,6 +110,76 @@ class ResponseGeneratedPayload(EventPayload):
     user_id: Optional[str] = None
     timestamp: Optional[str] = None
     confidence: Optional[float] = None
+
+
+@dataclass
+class ResponseCandidate(EventPayload):
+    """A single candidate response produced by a responder."""
+
+    text: str
+    confidence: float = 0.0
+    source: Optional[str] = None
+    safety_passed: Optional[bool] = None
+
+
+@dataclass
+class ResponseCandidatesPayload(EventPayload):
+    """Payload for candidate response arrays produced by responders."""
+
+    candidates: list[ResponseCandidate]
+    input_id: Optional[str] = None
+    user_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ResponseCandidatesPayload":
+        raw_candidates = data.get("candidates") or []
+        candidates = [
+            candidate
+            if isinstance(candidate, ResponseCandidate)
+            else ResponseCandidate(**candidate)
+            for candidate in raw_candidates
+            if isinstance(candidate, (dict, ResponseCandidate))
+        ]
+        return cls(
+            candidates=candidates,
+            input_id=data.get("input_id"),
+            user_id=data.get("user_id"),
+            timestamp=data.get("timestamp"),
+        )
+
+
+@dataclass
+class ResponseRankedPayload(EventPayload):
+    """Payload for final response chosen from candidate responses."""
+
+    final_response: str
+    input_id: Optional[str] = None
+    user_id: Optional[str] = None
+    timestamp: Optional[str] = None
+    confidence: Optional[float] = None
+    source: Optional[str] = None
+    candidates: list[ResponseCandidate] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ResponseRankedPayload":
+        raw_candidates = data.get("candidates") or []
+        candidates = [
+            candidate
+            if isinstance(candidate, ResponseCandidate)
+            else ResponseCandidate(**candidate)
+            for candidate in raw_candidates
+            if isinstance(candidate, (dict, ResponseCandidate))
+        ]
+        return cls(
+            final_response=data["final_response"],
+            input_id=data.get("input_id"),
+            user_id=data.get("user_id"),
+            timestamp=data.get("timestamp"),
+            confidence=data.get("confidence"),
+            source=data.get("source"),
+            candidates=candidates,
+        )
 
 
 @dataclass

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -11,7 +11,7 @@ import torch
 from nats.aio.msg import Msg
 
 from ..config import get_settings
-from ..eda.events import EventSubjects, ResponseGeneratedPayload
+from ..eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..services.response_filter import build_response_filter
@@ -165,24 +165,30 @@ class BaseLLM(ABC):
                 else:
                     response_text = sanitized
 
-            payload = ResponseGeneratedPayload(
-                final_response=response_text,
+            payload = ResponseCandidatesPayload(
+                candidates=[
+                    ResponseCandidate(
+                        text=response_text,
+                        confidence=0.5,
+                        source=self.__class__.__name__,
+                        safety_passed=True,
+                    )
+                ],
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
-                confidence=0.5,
             )
             if self._publisher is not None:
                 await self._publisher.publish(
-                    EventSubjects.RESPONSE_GENERATED,
+                    EventSubjects.RESPONSE_CANDIDATES,
                     payload,
                     use_jetstream=True,
                     timeout=10.0,
                 )
-                logger.info("%s published RESPONSE_GENERATED for %s", self.__class__.__name__, input_id)
+                logger.info("%s published RESPONSE_CANDIDATES for %s", self.__class__.__name__, input_id)
             else:
                 logger.warning(
-                    "Cannot publish RESPONSE_GENERATED for %s - publisher not initialized",
+                    "Cannot publish RESPONSE_CANDIDATES for %s - publisher not initialized",
                     input_id,
                 )
             await msg.ack()

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -13,7 +13,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..eda.events import EventSubjects, ResponseGeneratedPayload
+from ..eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..pipeline.dspy_pipeline import build_qa_pipeline
@@ -72,15 +72,21 @@ class RemoteLLM:
                 prompt = "Response:"
             logger.info("RemoteLLM generating for %s", input_id)
             response = await self._generate(prompt)
-            payload = ResponseGeneratedPayload(
-                final_response=response,
+            payload = ResponseCandidatesPayload(
+                candidates=[
+                    ResponseCandidate(
+                        text=response,
+                        confidence=0.9,
+                        source="RemoteLLM",
+                        safety_passed=True,
+                    )
+                ],
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=None,
-                confidence=0.9,
             )
             await self._publisher.publish(
-                EventSubjects.RESPONSE_GENERATED,
+                EventSubjects.RESPONSE_CANDIDATES,
                 payload,
                 use_jetstream=True,
                 timeout=10.0,

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -13,7 +13,7 @@ from nats.js.client import JetStreamContext
 
 # Assuming eda modules are in parent dir relative to modules dir
 from ..config import get_settings
-from ..eda.events import EventSubjects, ResponseGeneratedPayload
+from ..eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 
@@ -107,34 +107,40 @@ class LLMStub:
             response = (
                 f"{intro}Based on: {facts_str}, this is a stub response. [TS: {datetime.now(timezone.utc).isoformat()}]"
             )
-            payload = ResponseGeneratedPayload(
-                final_response=response,
+            payload = ResponseCandidatesPayload(
+                candidates=[
+                    ResponseCandidate(
+                        text=response,
+                        confidence=0.95,
+                        source="LLMStub",
+                        safety_passed=True,
+                    )
+                ],
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),
-                confidence=0.95,
             )
 
-            logger.info(f"LLMStub: Publishing RESPONSE_GENERATED for input_id: {input_id}")
+            logger.info(f"LLMStub: Publishing RESPONSE_CANDIDATES for input_id: {input_id}")
             try:
                 await self._publisher.publish(
-                    EventSubjects.RESPONSE_GENERATED,
+                    EventSubjects.RESPONSE_CANDIDATES,
                     payload,
                     use_jetstream=True,
                     timeout=10.0,
                 )
-                logger.debug(f"LLMStub: Successfully published RESPONSE_GENERATED for {input_id}")
+                logger.debug(f"LLMStub: Successfully published RESPONSE_CANDIDATES for {input_id}")
                 await msg.ack()
                 logger.debug(f"LLMStub: Acked message for {input_id} in LLMStub")
             except nats.errors.TimeoutError as e:
                 logger.error(
-                    f"LLMStub: Timeout publishing RESPONSE_GENERATED for {input_id}: {e}",
+                    f"LLMStub: Timeout publishing RESPONSE_CANDIDATES for {input_id}: {e}",
                     exc_info=True,
                 )
                 # Do not ack/nak on failure; leave to message broker
             except Exception as e:
                 logger.error(
-                    f"LLMStub: Failed to publish RESPONSE_GENERATED for {input_id}: {e}",
+                    f"LLMStub: Failed to publish RESPONSE_CANDIDATES for {input_id}: {e}",
                     exc_info=True,
                 )
                 # Do not ack/nak on failure; leave to message broker

--- a/src/deepthought/modules/output_handler.py
+++ b/src/deepthought/modules/output_handler.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class OutputHandler:
-    """Subscribes to ResponseGenerated via JetStream and handles output."""
+    """Subscribes to ranked responses via JetStream and handles output."""
 
     def __init__(
         self,
@@ -34,13 +34,13 @@ class OutputHandler:
         logger.info("OutputHandler initialized (JetStream enabled).")
 
     async def _handle_response_event(self, msg: Msg) -> None:
-        """Handles ResponseGenerated event from JetStream."""
+        """Handles ranked response events from JetStream."""
         input_id = "unknown"
         data = None
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
-                raise ValueError("ResponseGenerated payload must be a dict")
+                raise ValueError("ResponseRanked payload must be a dict")
             input_id = data.get("input_id")
             final_response = data.get("final_response")
             if not isinstance(input_id, str) or not isinstance(final_response, str):
@@ -62,7 +62,7 @@ class OutputHandler:
             logger.debug(f"Acked message for {input_id} in OutputHandler")
 
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error(f"Invalid ResponseGenerated payload: {e}", exc_info=True)
+            logger.error(f"Invalid ResponseRanked payload: {e}", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
@@ -89,7 +89,7 @@ class OutputHandler:
 
     async def start_listening(self, durable_name: str = "output_handler_listener") -> bool:
         """
-        Starts the NATS subscriber to listen for RESPONSE_GENERATED events.
+        Starts the NATS subscriber to listen for RESPONSE_RANKED events.
 
         Args:
             durable_name: Optional name for the durable consumer. Defaults to "output_handler_listener".
@@ -102,14 +102,14 @@ class OutputHandler:
             return False
 
         try:
-            logger.info(f"OutputHandler subscribing to {EventSubjects.RESPONSE_GENERATED}...")
+            logger.info(f"OutputHandler subscribing to {EventSubjects.RESPONSE_RANKED}...")
             await self._subscriber.subscribe(
-                subject=EventSubjects.RESPONSE_GENERATED,
+                subject=EventSubjects.RESPONSE_RANKED,
                 handler=self._handle_response_event,
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info(f"OutputHandler successfully subscribed to {EventSubjects.RESPONSE_GENERATED}.")
+            logger.info(f"OutputHandler successfully subscribed to {EventSubjects.RESPONSE_RANKED}.")
             return True
         except nats.errors.Error as e:
             logger.error(f"OutputHandler failed to subscribe: {e}", exc_info=True)

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "SocialGraphService",
     "PlanningService",
     "ReasoningService",
+    "SelectorService",
     "manipulation_score",
 ]
 
@@ -38,6 +39,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SocialGraphService": ("social_graph_service", "SocialGraphService"),
     "PlanningService": ("planning_service", "PlanningService"),
     "ReasoningService": ("reasoning_service", "ReasoningService"),
+    "SelectorService": ("selector_service", "SelectorService"),
     "manipulation_score": ("manipulative_detection", "manipulation_score"),
 }
 

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import (
+    EventSubjects,
+    ResponseCandidate,
+    ResponseCandidatesPayload,
+    ResponseRankedPayload,
+)
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class SelectorService:
+    """Select the best candidate response and publish a ranked result."""
+
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        safety_filter: Optional[Callable[[ResponseCandidate], bool]] = None,
+    ) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._safety_filter = safety_filter
+
+    def _rank_candidates(self, candidates: list[ResponseCandidate]) -> list[ResponseCandidate]:
+        filtered = [c for c in candidates if (self._safety_filter(c) if self._safety_filter else c.safety_passed is not False)]
+        return sorted(filtered, key=lambda c: c.confidence, reverse=True)
+
+    async def _handle_candidates_event(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("ResponseCandidates payload must be a dict")
+            payload = ResponseCandidatesPayload.from_dict(data)
+            ranked_candidates = self._rank_candidates(payload.candidates)
+            if not ranked_candidates:
+                await msg.ack()
+                logger.warning("SelectorService received empty candidates for input_id=%s", payload.input_id)
+                return
+
+            selected = ranked_candidates[0]
+            ranked_payload = ResponseRankedPayload(
+                final_response=selected.text,
+                input_id=payload.input_id,
+                user_id=payload.user_id,
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                confidence=selected.confidence,
+                source=selected.source,
+                candidates=ranked_candidates,
+            )
+            await self._publisher.publish(
+                EventSubjects.RESPONSE_RANKED,
+                ranked_payload,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+            await msg.ack()
+        except (json.JSONDecodeError, ValueError):
+            logger.error("Invalid response candidates payload", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("SelectorService failed to process candidates", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def start(self, durable_name: str = "selector_service") -> bool:
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.RESPONSE_CANDIDATES,
+                handler=self._handle_candidates_event,
+                use_jetstream=True,
+                durable=durable_name,
+            )
+            return True
+        except nats.errors.Error:
+            logger.error("SelectorService failed to subscribe", exc_info=True)
+            return False
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()

--- a/tests/integration/test_selector_service_flow.py
+++ b/tests/integration/test_selector_service_flow.py
@@ -1,0 +1,87 @@
+import pytest
+
+from deepthought.eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
+from deepthought.services.selector_service import SelectorService
+
+
+class DummyNATS:
+    is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class RecordingSubscriber:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    async def subscribe(self, **kwargs):
+        self.calls.append(kwargs)
+        return True
+
+    async def unsubscribe_all(self):
+        return None
+
+
+class RecordingPublisher:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.calls.append((subject, payload, use_jetstream))
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+@pytest.mark.asyncio
+async def test_start_uses_durable_and_subject(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = SelectorService(DummyNATS(), DummyJS())
+    ok = await svc.start(durable_name="selector_durable")
+    assert ok is True
+    assert svc._subscriber.calls[0]["subject"] == EventSubjects.RESPONSE_CANDIDATES
+    assert svc._subscriber.calls[0]["durable"] == "selector_durable"
+    assert svc._subscriber.calls[0]["use_jetstream"] is True
+
+
+@pytest.mark.asyncio
+async def test_candidates_publish_and_ack(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = SelectorService(DummyNATS(), DummyJS())
+    payload = ResponseCandidatesPayload(
+        input_id="i-1",
+        candidates=[
+            ResponseCandidate(text="low", confidence=0.2),
+            ResponseCandidate(text="high", confidence=0.9),
+        ],
+    )
+    msg = DummyMsg(payload.to_json())
+
+    await svc._handle_candidates_event(msg)
+
+    assert msg.acked
+    assert not msg.nacked
+    subject, ranked_payload, use_jetstream = svc._publisher.calls[0]
+    assert subject == EventSubjects.RESPONSE_RANKED
+    assert use_jetstream is True
+    assert ranked_payload.final_response == "high"

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -46,6 +46,7 @@ class DummySubscriber:
 class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
+        self.headers = None
         self.acked = False
         self.nacked = False
 
@@ -151,9 +152,9 @@ async def test_handle_memory_event(monkeypatch):
     pub = llm._publisher
     assert pub.published
     subject, sent_payload = pub.published[0]
-    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert subject == EventSubjects.RESPONSE_CANDIDATES
     assert sent_payload.input_id == "abc"
-    assert sent_payload.final_response == "generated"
+    assert sent_payload.candidates[0].text == "generated"
     ts = sent_payload.timestamp
     assert datetime.fromisoformat(ts).tzinfo == timezone.utc
 

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -1,6 +1,5 @@
 import asyncio
 import importlib.util
-import json
 import sys
 from unittest.mock import AsyncMock, MagicMock
 
@@ -16,7 +15,7 @@ sys.modules[spec.name] = llm_remote
 assert spec.loader is not None
 spec.loader.exec_module(llm_remote)
 
-from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload
+from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload  # noqa: E402
 
 
 class DummyNATS:
@@ -107,6 +106,7 @@ async def test_generate_posts(monkeypatch):
 class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
+        self.headers = None
         self.acked = False
         self.nacked = False
 
@@ -135,8 +135,8 @@ async def test_handle_memory_event_publishes(monkeypatch):
     pub = llm._publisher
     assert pub.published
     subject, sent_payload = pub.published[0]
-    assert subject == EventSubjects.RESPONSE_GENERATED
-    assert sent_payload.final_response == "answer"
+    assert subject == EventSubjects.RESPONSE_CANDIDATES
+    assert sent_payload.candidates[0].text == "answer"
     assert sent_payload.input_id == "42"
 
 
@@ -276,8 +276,8 @@ async def test_handle_memory_event_with_mock_session(monkeypatch):
     assert msg.acked
     assert llm._publisher.published
     subject, sent_payload = llm._publisher.published[0]
-    assert subject == EventSubjects.RESPONSE_GENERATED
-    assert sent_payload.final_response == "resp"
+    assert subject == EventSubjects.RESPONSE_CANDIDATES
+    assert sent_payload.candidates[0].text == "resp"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -48,6 +48,7 @@ class DummySubscriber:
 class DummyMsg:
     def __init__(self, data):
         self.data = data.encode()
+        self.headers = None
         self.acked = False
         self.nacked = False
 
@@ -81,7 +82,7 @@ async def test_handle_memory_success(monkeypatch, knowledge):
     pub = stub._publisher
     assert pub.published
     subject, sent_payload = pub.published[0]
-    assert subject == EventSubjects.RESPONSE_GENERATED
+    assert subject == EventSubjects.RESPONSE_CANDIDATES
     assert sent_payload.input_id == "abc"
     # Timestamp should be timezone-aware UTC
     ts = sent_payload.timestamp

--- a/tests/unit/modules/test_output_handler.py
+++ b/tests/unit/modules/test_output_handler.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("nats")
 
 import deepthought.modules.output_handler as output_handler
-from deepthought.eda.events import ResponseGeneratedPayload
+from deepthought.eda.events import ResponseRankedPayload
 
 
 class DummyNATS:
@@ -56,7 +56,7 @@ async def test_handle_response_success(monkeypatch):
         received["resp"] = resp
 
     handler = create_handler(monkeypatch, cb)
-    payload = ResponseGeneratedPayload(final_response="ok", input_id="42")
+    payload = ResponseRankedPayload(final_response="ok", input_id="42")
     msg = DummyMsg(payload.to_json())
     await handler._handle_response_event(msg)
 
@@ -102,7 +102,7 @@ async def test_cache_limit(monkeypatch):
     handler = create_handler(monkeypatch, max_responses=2)
 
     for i in range(3):
-        payload = ResponseGeneratedPayload(final_response=f"r{i}", input_id=str(i))
+        payload = ResponseRankedPayload(final_response=f"r{i}", input_id=str(i))
         msg = DummyMsg(payload.to_json())
         await handler._handle_response_event(msg)
 
@@ -123,7 +123,7 @@ async def test_handle_response_logs_when_no_callback(monkeypatch, caplog):
         called = True
 
     monkeypatch.setattr("builtins.print", fake_print)
-    payload = ResponseGeneratedPayload(final_response="hello", input_id="99")
+    payload = ResponseRankedPayload(final_response="hello", input_id="99")
     msg = DummyMsg(payload.to_json())
     with caplog.at_level(logging.INFO):
         await handler._handle_response_event(msg)

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -1,0 +1,91 @@
+import json
+
+import pytest
+
+from deepthought.eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
+from deepthought.services.selector_service import SelectorService
+
+
+class DummyNATS:
+    is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self, *args, **kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+class DummySubscriber:
+    def __init__(self, *args, **kwargs):
+        self.subscribed = []
+
+    async def subscribe(self, **kwargs):
+        self.subscribed.append(kwargs)
+
+    async def unsubscribe_all(self):
+        return None
+
+
+class DummyMsg:
+    def __init__(self, data):
+        self.data = data.encode()
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+@pytest.fixture
+def service(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    return SelectorService(DummyNATS(), DummyJS())
+
+
+@pytest.mark.asyncio
+async def test_rank_by_confidence(service):
+    payload = ResponseCandidatesPayload(
+        input_id="1",
+        candidates=[
+            ResponseCandidate(text="low", confidence=0.2),
+            ResponseCandidate(text="high", confidence=0.8),
+        ],
+    )
+    msg = DummyMsg(payload.to_json())
+    await service._handle_candidates_event(msg)
+
+    assert msg.acked
+    assert not msg.nacked
+    subject, ranked = service._publisher.published[0]
+    assert subject == EventSubjects.RESPONSE_RANKED
+    assert ranked.final_response == "high"
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_ack_without_publish(service):
+    payload = ResponseCandidatesPayload(input_id="2", candidates=[])
+    msg = DummyMsg(payload.to_json())
+    await service._handle_candidates_event(msg)
+
+    assert msg.acked
+    assert service._publisher.published == []
+
+
+@pytest.mark.asyncio
+async def test_invalid_payload_nak(service):
+    msg = DummyMsg(json.dumps(["bad"]))
+    await service._handle_candidates_event(msg)
+    assert msg.nacked


### PR DESCRIPTION
### Motivation

- Decouple candidate generation from final selection so multiple responders can publish options and a centralized selector can choose the best reply.
- Provide a durable JetStream-based selector that can rank by confidence and apply safety filters before producing a single final output event.
- Make output/gateway consumers subscribe to a single finalized event to simplify downstream handling.

### Description

- Added new event subjects `dtr.response.candidates` and `dtr.response.ranked` in `src/deepthought/eda/events.py` and introduced payload models `ResponseCandidate`, `ResponseCandidatesPayload`, and `ResponseRankedPayload` with parsing helpers.
- Updated LLM responder modules to publish candidate arrays instead of final text: `src/deepthought/modules/llm_base.py`, `src/deepthought/modules/llm_stub.py`, and `src/deepthought/modules/llm_remote.py` now publish `EventSubjects.RESPONSE_CANDIDATES` with `ResponseCandidatesPayload`.
- Implemented `SelectorService` in `src/deepthought/services/selector_service.py` which subscribes durably to `EventSubjects.RESPONSE_CANDIDATES`, ranks candidates by confidence (with optional safety filtering), and publishes the chosen response to `EventSubjects.RESPONSE_RANKED` using `ResponseRankedPayload`.
- Updated output consumer `src/deepthought/modules/output_handler.py` to subscribe to `EventSubjects.RESPONSE_RANKED` and consume the ranked payload.
- Exposed new event types and the service through package exports (`src/deepthought/eda/__init__.py`, `src/deepthought/services/__init__.py`).
- Added unit and integration tests: `tests/unit/services/test_selector_service.py`, `tests/integration/test_selector_service_flow.py`, and updates to existing LLM/output tests to validate candidate publishing, sorting, empty-candidate handling, and publish/ack semantics.

### Testing

- Ran `ruff` checks on all modified source and test files; linter passed with fixes applied.
- Ran the updated test suite focused on the changed modules with `pytest` (unit and integration tests added/updated): the targeted runs completed successfully (tests passed) with only expected resource warnings (no test failures).
- Executed targeted unit tests for responders, selector, and output handler and verified publish/ack behavior and candidate sorting (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989d6473a308326934106f02977d0e7)