### PR TITLE
Normalize cognitive-core user IDs and add multi-user isolation tests

### DIFF
--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -172,14 +172,19 @@ class CognitiveCoreService(BaseService):
             input_id = data.get("input_id")
             user_input = data.get("user_input")
             headers = getattr(msg, "headers", None)
-            author_id = data.get("author_id")
-            if not isinstance(author_id, str):
-                author_id = None
-            user_id = data.get("user_id")
-            if not isinstance(user_id, str):
-                user_id = None
+            def _normalized_identifier(value: object) -> str | None:
+                if not isinstance(value, str):
+                    return None
+                normalized = value.strip()
+                return normalized or None
+
+            user_id = _normalized_identifier(data.get("user_id"))
+            if user_id is None and headers:
+                user_id = _normalized_identifier(headers.get("user_id"))
+
+            author_id = _normalized_identifier(data.get("author_id"))
             if author_id is None:
-                author_id = user_id or (headers.get("user_id") if headers else None)
+                author_id = user_id
             channel_id = data.get("channel_id")
             if not isinstance(channel_id, str):
                 channel_id = None
@@ -192,7 +197,7 @@ class CognitiveCoreService(BaseService):
                 raise ValueError("Invalid input payload fields")
             logger.info("CognitiveCoreService received input %s", input_id)
 
-            resolved_user_id = author_id or "user"
+            resolved_user_id = author_id or user_id or "anonymous"
             self._memory.store_interaction(user_input)
             await self._db.store_memory(resolved_user_id, user_input)
             await self._db.log_interaction(resolved_user_id, None)

--- a/tests/test_relationship_persistence.py
+++ b/tests/test_relationship_persistence.py
@@ -22,3 +22,20 @@ async def test_relationship_persistence(tmp_path):
     assert stats["b_to_a"]["count"] == 1
     await mem2.close()
 
+
+
+@pytest.mark.asyncio
+async def test_memory_persistence_isolated_per_user(tmp_path):
+    db_path = tmp_path / "sg.db"
+    db = DBManager(str(db_path))
+
+    await db.store_memory("user-a", "alpha fact", topic="bio")
+    await db.store_memory("user-b", "beta fact", topic="bio")
+
+    a_rows = await db.recall_user("user-a")
+    b_rows = await db.recall_user("user-b")
+
+    assert [memory for _, memory in a_rows] == ["alpha fact"]
+    assert [memory for _, memory in b_rows] == ["beta fact"]
+
+    await db.close()

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -197,20 +197,26 @@ class DummyMemory:
 class DummyDB:
     def __init__(self):
         self.memories = []
+        self.memory_user_ids = []
         self.interactions = 0
+        self.interaction_user_ids = []
         self.affinity = 0.0
+        self.affinity_user_ids = []
         self.perceptions = []
 
     async def store_memory(self, user_id, memory, topic="", sentiment_score=None):
+        self.memory_user_ids.append(user_id)
         if topic == "social_perception":
             self.perceptions.append(json.loads(memory))
         else:
             self.memories.append(memory)
 
     async def log_interaction(self, user_id, target_id=None, sentiment_score=None):
+        self.interaction_user_ids.append(user_id)
         self.interactions += 1
 
     async def adjust_affinity(self, user_id, delta):
+        self.affinity_user_ids.append(user_id)
         self.affinity += delta
 
     async def recall_user(self, user_id, limit=None):
@@ -270,6 +276,59 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"
     assert "hello" in sent_payload.retrieved_knowledge["facts"]
+
+
+@pytest.mark.asyncio
+async def test_handle_input_prefers_payload_user_id_over_header(monkeypatch):
+    memory = DummyMemory()
+    db = DummyDB()
+    monkeypatch.setattr(
+        cognitive_core_service,
+        "analyze_social",
+        lambda text: {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0},
+    )
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload = InputReceivedPayload(user_input="hello", input_id="x", user_id="payload-user")
+    msg = DummyMsg(payload.to_json())
+    msg.headers = {"user_id": "header-user"}
+
+    await service._handle_input(msg)
+
+    assert msg.acked
+    assert db.memory_user_ids == ["payload-user", "payload-user"]
+    assert db.interaction_user_ids == ["payload-user"]
+    assert db.affinity_user_ids == ["payload-user"]
+
+
+@pytest.mark.asyncio
+async def test_handle_input_uses_header_user_id_then_anonymous(monkeypatch):
+    memory = DummyMemory()
+    db = DummyDB()
+    monkeypatch.setattr(
+        cognitive_core_service,
+        "analyze_social",
+        lambda text: {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0},
+    )
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    payload_with_header = InputReceivedPayload(user_input="hello", input_id="x")
+    msg_with_header = DummyMsg(payload_with_header.to_json())
+    msg_with_header.headers = {"user_id": "header-user"}
+    await service._handle_input(msg_with_header)
+
+    payload_without_user = InputReceivedPayload(user_input="hi", input_id="y")
+    msg_without_user = DummyMsg(payload_without_user.to_json())
+    await service._handle_input(msg_without_user)
+
+    assert msg_with_header.acked
+    assert msg_without_user.acked
+    assert db.interaction_user_ids == ["header-user", "anonymous"]
+    assert db.affinity_user_ids == ["header-user", "anonymous"]
 
 
 class DummyStore:


### PR DESCRIPTION
### Motivation
- Ensure the cognitive core consistently attributes stored memories, interactions and affinity adjustments to the correct user identifier and avoid using a literal default like `"user"` that can hide multi-user isolation problems.
- Prefer explicit `user_id` supplied in the payload and fall back to message `headers` only when needed, using `"anonymous"` only when no identifier is available.
- Add tests proving that facts for one user are not returned for another to prevent regressions in user-scoped persistence.

### Description
- In `CognitiveCoreService._handle_input` added a helper `_normalized_identifier` to normalize and validate candidate IDs, and changed extraction to prefer `data["user_id"]` then `msg.headers["user_id"]` as a fallback.
- Replaced the literal fallback `"user"` with `author_id or user_id or "anonymous"` and ensured that this resolved ID is used for `store_memory`, `log_interaction`, and `adjust_affinity` calls.
- Expanded the cognitive-core unit test double (`DummyDB`) to record which user IDs are passed to persistence/interaction/affinity calls and added tests in `tests/unit/services/test_cognitive_core_service.py` that assert payload precedence, header fallback, and anonymous fallback behaviors.
- Added `tests/test_relationship_persistence.py::test_memory_persistence_isolated_per_user` to assert that `DBManager.recall_user` isolates memories by `user_id` (user A facts do not appear under user B).

### Testing
- Ran targeted pytest including `pytest -q tests/unit/services/test_cognitive_core_service.py tests/test_relationship_persistence.py tests/test_user_graph_decay.py` and observed an unrelated failure in `tests/test_user_graph_decay.py::test_edge_decay` due to a precision-sensitive assertion; this failure appears pre-existing and unrelated to the user-id handling changes.
- Running the modified test set for the two files (`tests/unit/services/test_cognitive_core_service.py` and `tests/test_relationship_persistence.py`) in this environment produced skips for two tests (environment/import-related skips), and the added cognitive-core tests exercise the new resolution logic when run in a full test environment.
- Ran `ruff check` on the modified files and observed pre-existing lint issues (module-level import ordering and unused imports) reported in `tests/unit/services/test_cognitive_core_service.py` that are unrelated to the implemented logic changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989dc5e103883268f86afdaa2b02d98)