### PR TITLE
Enhance RemoteLLM memory-event prompt construction and input validation

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -102,10 +102,14 @@ class MemoryRetrievedPayload(EventPayload):
     """Payload for memory retrieved events."""
 
     retrieved_knowledge: Dict[str, Any]
+    user_input: Optional[str] = None
     input_id: Optional[str] = None
     user_id: Optional[str] = None
     channel_id: Optional[str] = None
     author_id: Optional[str] = None
+    author_name: Optional[str] = None
+    channel_context: Optional[str] = None
+    recent_turn_summary: Optional[str] = None
     timestamp: Optional[str] = None
 
 

--- a/src/deepthought/modules/input_handler.py
+++ b/src/deepthought/modules/input_handler.py
@@ -73,7 +73,11 @@ class InputHandler:
 
                 mem_payload = MemoryRetrievedPayload(
                     retrieved_knowledge={"facts": context, "source": "hierarchical"},
+                    user_input=user_input,
                     input_id=input_id,
+                    channel_id=channel_id,
+                    author_id=author_id,
+                    author_name=author_name,
                     timestamp=datetime.now(timezone.utc).isoformat(),
                 )
 

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -21,6 +21,56 @@ from ..pipeline.dspy_pipeline import build_qa_pipeline
 logger = logging.getLogger(__name__)
 
 
+def _normalized_optional_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if normalized else None
+
+
+def _extract_memory_facts(retrieved: object) -> list[str]:
+    if not isinstance(retrieved, dict):
+        return []
+    facts = retrieved.get("facts")
+    if not isinstance(facts, list):
+        return []
+    return [str(fact) for fact in facts]
+
+
+def _build_generation_prompt(
+    *,
+    user_input: str,
+    facts: list[str],
+    author_name: str | None = None,
+    channel_context: str | None = None,
+    recent_turn_summary: str | None = None,
+) -> str:
+    facts_block = "\n".join(f"- {fact}" for fact in facts) if facts else "- None"
+
+    hints: list[str] = []
+    if author_name:
+        hints.append(f"- Author name: {author_name}")
+    if channel_context:
+        hints.append(f"- Channel context: {channel_context}")
+    if recent_turn_summary:
+        hints.append(f"- Recent turn summary: {recent_turn_summary}")
+    hints_block = "\n".join(hints) if hints else "- None"
+
+    return (
+        "[SYSTEM PERSONA]\n"
+        "You are DeepThought, a conversational assistant.\n"
+        "Respond clearly, ground your answer in retrieved facts when relevant, and avoid inventing details.\n\n"
+        "[RELEVANT FACTS]\n"
+        f"{facts_block}\n\n"
+        "[LATEST USER MESSAGE]\n"
+        f"{user_input}\n\n"
+        "[SOCIAL/PERCEPTION HINTS]\n"
+        f"{hints_block}\n\n"
+        "[TASK]\n"
+        "Generate a helpful response to the user message."
+    )
+
+
 class RemoteLLM:
     """LLM module that calls a remote HTTP endpoint."""
 
@@ -71,13 +121,20 @@ class RemoteLLM:
             channel_id = data.get("channel_id")
             if not isinstance(channel_id, str):
                 channel_id = None
-            retrieved = data.get("retrieved_knowledge", {})
-            facts = retrieved.get("facts", [])
-            if facts:
-                memory_lines = "\n".join(f"- {fact}" for fact in map(str, facts))
-                prompt = f"MEMORY_RETRIEVED:\n{memory_lines}\nResponse:"
-            else:
-                prompt = "Response:"
+            user_input = _normalized_optional_text(data.get("user_input"))
+            if user_input is None:
+                raise ValueError("MemoryRetrieved payload missing required non-empty user_input")
+            author_name = _normalized_optional_text(data.get("author_name"))
+            channel_context = _normalized_optional_text(data.get("channel_context"))
+            recent_turn_summary = _normalized_optional_text(data.get("recent_turn_summary"))
+            facts = _extract_memory_facts(data.get("retrieved_knowledge", {}))
+            prompt = _build_generation_prompt(
+                user_input=user_input,
+                facts=facts,
+                author_name=author_name,
+                channel_context=channel_context,
+                recent_turn_summary=recent_turn_summary,
+            )
             logger.info("RemoteLLM generating for %s", input_id)
             response = await self._generate(prompt)
             payload = ResponseCandidatesPayload(

--- a/src/deepthought/modules/memory_basic.py
+++ b/src/deepthought/modules/memory_basic.py
@@ -57,6 +57,7 @@ class BasicMemory:
             facts = self._memory.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "basic_memory"},
+                user_input=user_input,
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),

--- a/src/deepthought/modules/memory_graph.py
+++ b/src/deepthought/modules/memory_graph.py
@@ -60,6 +60,7 @@ class GraphMemory:
             facts = self._memory.retrieve_context(user_input)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "graph_memory"},
+                user_input=user_input,
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),

--- a/src/deepthought/modules/memory_kg.py
+++ b/src/deepthought/modules/memory_kg.py
@@ -90,6 +90,7 @@ class KnowledgeGraphMemory:
             facts = self.infer_facts()
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "knowledge_graph"},
+                user_input=user_input,
                 input_id=input_id,
                 user_id=user_id,
                 timestamp=datetime.now(timezone.utc).isoformat(),

--- a/src/deepthought/modules/memory_stub.py
+++ b/src/deepthought/modules/memory_stub.py
@@ -53,6 +53,7 @@ class MemoryStub:
             }
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"retrieved_knowledge": memory_data},
+                user_input=user_input,
                 input_id=input_id,
                 user_id=user_id,
                 # Use timezone-aware UTC timestamp

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -222,6 +222,7 @@ class CognitiveCoreService(BaseService):
                     facts.append(item)
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "cognitive_core"},
+                user_input=user_input,
                 input_id=input_id,
                 user_id=author_id or user_id,
                 author_id=author_id,

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -126,7 +126,7 @@ async def test_handle_memory_event_publishes(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="42")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="42")
     msg = DummyMsg(payload.to_json())
 
     await llm._handle_memory_event(msg)
@@ -181,7 +181,7 @@ async def test_handle_memory_event_timeout(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="99")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="99")
     msg = DummyMsg(payload.to_json())
 
     await llm._handle_memory_event(msg)
@@ -199,7 +199,7 @@ async def test_handle_memory_event_bad_json(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="88")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="88")
     msg = DummyMsg(payload.to_json())
 
     await llm._handle_memory_event(msg)
@@ -246,7 +246,7 @@ async def test_handle_memory_event_http_error(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="77")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="77")
     msg = DummyMsg(payload.to_json())
 
     await llm._handle_memory_event(msg)
@@ -268,7 +268,7 @@ async def test_handle_memory_event_with_mock_session(monkeypatch):
 
     llm = create_llm(monkeypatch, session)
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["fact"]}, input_id="55")
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["fact"]}, user_input="hello", input_id="55")
     msg = DummyMsg(payload.to_json())
 
     await llm._handle_memory_event(msg)
@@ -288,3 +288,40 @@ async def test_generate_uses_dspy_pipeline(monkeypatch):
     result = await llm._generate("query")
     assert result == "pipe"
     await llm._session.close()
+
+
+def test_build_generation_prompt_includes_sections():
+    prompt = llm_remote._build_generation_prompt(
+        user_input="How are you?",
+        facts=["Fact A", "Fact B"],
+        author_name="Ada",
+        channel_context="discord/#general",
+        recent_turn_summary="The user asked about status.",
+    )
+
+    assert "[SYSTEM PERSONA]" in prompt
+    assert "[RELEVANT FACTS]" in prompt
+    assert "- Fact A" in prompt
+    assert "[LATEST USER MESSAGE]" in prompt
+    assert "How are you?" in prompt
+    assert "[SOCIAL/PERCEPTION HINTS]" in prompt
+    assert "- Author name: Ada" in prompt
+
+
+def test_build_generation_prompt_without_optional_hints():
+    prompt = llm_remote._build_generation_prompt(user_input="Hi", facts=[])
+    assert "[RELEVANT FACTS]" in prompt
+    assert "- None" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_memory_event_missing_user_input_naks(monkeypatch):
+    llm = create_llm(monkeypatch)
+    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="no-input")
+    msg = DummyMsg(payload.to_json())
+
+    await llm._handle_memory_event(msg)
+
+    assert msg.nacked
+    assert not msg.acked
+    assert not llm._publisher.published


### PR DESCRIPTION
### Motivation
- Ensure the remote LLM consumes the latest user utterance and optional dialogue/context hints from memory events so responses are grounded and safe.
- Replace the ad-hoc memory prompt text with a structured, deterministic prompt format to make generation behavior testable and consistent.
- Fail safely when the upstream memory payload does not include a usable `user_input` to avoid producing ungrounded responses.

### Description
- Extended `MemoryRetrievedPayload` to include `user_input` plus optional metadata fields `author_name`, `channel_context`, and `recent_turn_summary` in `src/deepthought/eda/events.py`.
- Propagated `user_input` (and available author/channel metadata) into `MEMORY_RETRIEVED` publishers across `input_handler`, `memory_basic`, `memory_stub`, `memory_kg`, `memory_graph`, and `cognitive_core_service` so the LLM receives the latest message context.
- Added deterministic helpers in `src/deepthought/modules/llm_remote.py`: `_normalized_optional_text`, `_extract_memory_facts`, and `_build_generation_prompt`, and refactored `RemoteLLM._handle_memory_event` to validate `user_input`, parse optional hints, and build the structured prompt (system persona, relevant facts, latest user message, social/perception hints).
- Kept `ResponseCandidatesPayload` routing fields intact so `input_id`, `author_id`, and `channel_id` are published unchanged.
- Updated `tests/unit/modules/test_llm_remote.py` to include `user_input` in memory payloads and added unit tests for the prompt builder and missing-`user_input` fail-safe.

### Testing
- Ran `pytest -q tests/unit/modules/test_llm_remote.py` and the file's tests passed (`13 passed`).
- Ran `ruff check` across the modified modules and there were no linter issues (`ruff` checks passed).
- A broader selected test run failed collection due to missing optional environment deps in this environment (`aiosqlite`, `rdflib`), so full-suite tests requiring those packages were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e044bf1c832690f7b74b6ee6a93a)