### PR TITLE
Refactor social graph input handling and identity resolution

### DIFF
--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -25,6 +25,7 @@ from ..perception.social_perception import analyze as analyze_social
 from ..search import OfflineSearch
 from .base import BaseService
 from .db_manager import DBManager
+from .input_enrichment_service import InputEnrichmentService
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +71,7 @@ class CognitiveCoreService(BaseService):
                     search = OfflineSearch(db_path)
         self._search = search
         self._top_k = self._settings.memory_top_k
+        self._input_enrichment = InputEnrichmentService()
 
     @classmethod
     def from_config(
@@ -166,38 +168,15 @@ class CognitiveCoreService(BaseService):
         input_id = "unknown"
         start = time.perf_counter()
         try:
-            data = json.loads(msg.data.decode())
-            if not isinstance(data, dict):
-                raise ValueError("InputReceived payload must be a dict")
-            input_id = data.get("input_id")
-            user_input = data.get("user_input")
-            headers = getattr(msg, "headers", None)
-            def _normalized_identifier(value: object) -> str | None:
-                if not isinstance(value, str):
-                    return None
-                normalized = value.strip()
-                return normalized or None
-
-            user_id = _normalized_identifier(data.get("user_id"))
-            if user_id is None and headers:
-                user_id = _normalized_identifier(headers.get("user_id"))
-
-            author_id = _normalized_identifier(data.get("author_id"))
-            if author_id is None:
-                author_id = user_id
-            channel_id = data.get("channel_id")
-            if not isinstance(channel_id, str):
-                channel_id = None
-            if channel_id is None and headers:
-                channel_id = headers.get("channel_id")
-            if not isinstance(channel_id, str):
-                channel_id = None
-
-            if not isinstance(input_id, str) or not isinstance(user_input, str):
-                raise ValueError("Invalid input payload fields")
+            enriched = self._input_enrichment.parse_input_received(msg)
+            input_id = enriched.input_id
+            user_input = enriched.user_input
+            user_id = enriched.user_id
+            author_id = enriched.author_id
+            channel_id = enriched.channel_id
             logger.info("CognitiveCoreService received input %s", input_id)
 
-            resolved_user_id = author_id or user_id or "anonymous"
+            resolved_user_id = enriched.resolved_user_id
             self._memory.store_interaction(user_input)
             await self._db.store_memory(resolved_user_id, user_input)
             await self._db.log_interaction(resolved_user_id, None)

--- a/src/deepthought/services/input_enrichment_service.py
+++ b/src/deepthought/services/input_enrichment_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Mapping
+
+from nats.aio.msg import Msg
+
+
+@dataclass(frozen=True)
+class EnrichedInputPayload:
+    """Normalized INPUT_RECEIVED payload values shared by services."""
+
+    input_id: str
+    user_input: str
+    user_id: str | None
+    author_id: str | None
+    channel_id: str | None
+
+    @property
+    def resolved_user_id(self) -> str:
+        return self.author_id or self.user_id or "anonymous"
+
+
+class InputEnrichmentService:
+    """Parse and normalize INPUT_RECEIVED payloads from NATS messages."""
+
+    @staticmethod
+    def _normalized_identifier(value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    def parse_input_received(self, msg: Msg) -> EnrichedInputPayload:
+        data = json.loads(msg.data.decode())
+        if not isinstance(data, dict):
+            raise ValueError("InputReceived payload must be a dict")
+
+        input_id = data.get("input_id")
+        user_input = data.get("user_input")
+        if not isinstance(input_id, str) or not isinstance(user_input, str):
+            raise ValueError("Invalid input payload fields")
+
+        headers = getattr(msg, "headers", None)
+        if headers is not None and not isinstance(headers, Mapping):
+            headers = None
+
+        user_id = self._normalized_identifier(data.get("user_id"))
+        if user_id is None and headers:
+            user_id = self._normalized_identifier(headers.get("user_id"))
+
+        author_id = self._normalized_identifier(data.get("author_id"))
+        if author_id is None and headers:
+            author_id = self._normalized_identifier(headers.get("author_id"))
+        if author_id is None:
+            author_id = user_id
+
+        channel_id = data.get("channel_id")
+        if not isinstance(channel_id, str):
+            channel_id = None
+        if channel_id is None and headers:
+            channel_id = headers.get("channel_id")
+        if not isinstance(channel_id, str):
+            channel_id = None
+
+        return EnrichedInputPayload(
+            input_id=input_id,
+            user_input=user_input,
+            user_id=user_id,
+            author_id=author_id,
+            channel_id=channel_id,
+        )
+

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+import json
 import logging
 from typing import Optional
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
-from .cognitive_core_service import CognitiveCoreService
 
+from ..perception.social_perception import analyze as analyze_social
 from ..eda.events import EventSubjects
 from .base import BaseService
 from .db_manager import DBManager
 from .persona_manager import PersonaManager
+from .input_enrichment_service import InputEnrichmentService
 from .prism_adapter import PrismAdapter
 from .social_graph_memory import SocialGraphMemory
 
@@ -27,8 +29,8 @@ class SocialGraphService(BaseService):
         js_context: Optional[JetStreamContext] = None,
         db_manager: Optional[DBManager] = None,
         persona_manager: Optional[PersonaManager] = None,
-        cognitive_core: CognitiveCoreService | None = None,
         prism_adapter: Optional[PrismAdapter] = None,
+        input_enrichment: InputEnrichmentService | None = None,
         *,
         nats_url: str | None = None,
         connect_retries: int = 1,
@@ -44,18 +46,49 @@ class SocialGraphService(BaseService):
         self._db = db_manager or DBManager()
         self._memory = SocialGraphMemory(self._db)
         self._persona = persona_manager or PersonaManager(self._db)
-        if cognitive_core is None:
-            raise ValueError("cognitive_core service is required")
-        self._core = cognitive_core
         self._prism = prism_adapter or PrismAdapter(self._memory)
+        self._input_enrichment = input_enrichment or InputEnrichmentService()
 
     async def _handle_input(self, msg: Msg) -> None:
         """Process an INPUT_RECEIVED message."""
         try:
-            await self._core._handle_input(msg)
-            await self._persona.get_persona("user", None)
+            enriched = self._input_enrichment.parse_input_received(msg)
+            logger.info("SocialGraphService received input %s", enriched.input_id)
+            try:
+                perception = analyze_social(enriched.user_input)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error("Failed to analyze social perception: %s", exc, exc_info=True)
+                perception = {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0}
+
+            resolved_user_id = enriched.resolved_user_id
+            await self._db.store_memory(
+                resolved_user_id,
+                json.dumps(perception),
+                topic="social_perception",
+            )
+            delta = perception.get("flirtation", 0.0) - (
+                perception.get("avoidance", 0.0) + perception.get("manipulation", 0.0)
+            )
+            await self._db.adjust_affinity(resolved_user_id, delta)
+            await self._persona.get_persona(
+                resolved_user_id,
+                None,
+                channel_id=enriched.channel_id,
+            )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except (json.JSONDecodeError, ValueError):
+            logger.error("Invalid InputReceived payload for social graph", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
         except Exception:  # pragma: no cover - defensive
             logger.error("Failed to handle input", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+            elif hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
 
     async def start(self, durable_name: str = "social_graph_service") -> bool:
         self._subscriptions.clear()

--- a/tests/integration/test_social_graph_affinity.py
+++ b/tests/integration/test_social_graph_affinity.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 import types
 from types import SimpleNamespace
@@ -42,35 +41,32 @@ async def test_affinity_changes_after_processing(tmp_path, monkeypatch):
     db = DBManager(str(tmp_path / "sg.db"))
     await db.init_db()
     pm = PersonaManager(db, friendly=1, playful=1)
-    core = CognitiveCoreService(None, None, Settings(), memory=DummyMemory(), db=db)
     async def _noop(*a, **k):
         return None
-    core._publisher = SimpleNamespace(publish=_noop)
-    core._subscriber = SimpleNamespace()
 
-    svc = SocialGraphService(db_manager=db, persona_manager=pm, cognitive_core=core)
+    svc = SocialGraphService(db_manager=db, persona_manager=pm)
     svc._publisher = SimpleNamespace(publish=_noop)
     svc._subscriber = SimpleNamespace()
 
-    import deepthought.services.cognitive_core_service as ccsvc
+    import deepthought.services.social_graph_service as sgsvc
     monkeypatch.setattr(
-        ccsvc, "analyze_social", lambda _t: {"flirtation": 0.6, "avoidance": 0.2, "manipulation": 0.0}
+        sgsvc, "analyze_social", lambda _t: {"flirtation": 0.6, "avoidance": 0.2, "manipulation": 0.0}
     )
     pos = DummyMsg(InputReceivedPayload(user_input="I love this", input_id="1"))
     await svc._handle_input(pos)
     assert pos.acked
-    assert await db.get_affinity("user") == 2
-    assert await pm.get_persona("user") == "friendly"
+    assert await db.get_affinity("anonymous") == 1
+    assert await pm.get_persona("anonymous") == "friendly"
 
     monkeypatch.setattr(
-        ccsvc, "analyze_social", lambda _t: {"flirtation": 0.0, "avoidance": 0.4, "manipulation": 0.3}
+        sgsvc, "analyze_social", lambda _t: {"flirtation": 0.0, "avoidance": 0.4, "manipulation": 0.3}
     )
     neg = DummyMsg(InputReceivedPayload(user_input="I hate this", input_id="2"))
     await svc._handle_input(neg)
-    assert await db.get_affinity("user") == 2
-    assert await pm.get_persona("user") == "friendly"
+    assert await db.get_affinity("anonymous") == 0
+    assert await pm.get_persona("anonymous") == "snarky"
 
-    memories = await db.recall_user("user")
+    memories = await db.recall_user("anonymous")
     topics = [t for t, _ in memories]
     assert topics.count("social_perception") == 2
 
@@ -79,25 +75,24 @@ async def test_affinity_changes_after_processing(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cognitive_core_affinity_with_mocked_perception(tmp_path, monkeypatch):
-    sp_mod = types.ModuleType("deepthought.perception.social_perception")
-    sp_mod.analyze = lambda _t: {"flirtation": 0.6, "avoidance": 0.1, "manipulation": 0.0}
-    monkeypatch.setitem(sys.modules, "deepthought.perception.social_perception", sp_mod)
-
-    import deepthought.services.cognitive_core_service as cognitive_core_service
-    importlib.reload(cognitive_core_service)
-    CognitiveCoreService = cognitive_core_service.CognitiveCoreService
-    Settings = cognitive_core_service.Settings
-
     db = DBManager(str(tmp_path / "core.db"))
     await db.init_db()
     svc = CognitiveCoreService(None, None, Settings(), memory=DummyMemory(), db=db)
-    svc._publisher = SimpleNamespace(publish=lambda *a, **k: None)
+    import deepthought.services.cognitive_core_service as ccsvc
+    monkeypatch.setattr(
+        ccsvc, "analyze_social", lambda _t: {"flirtation": 0.6, "avoidance": 0.1, "manipulation": 0.0}
+    )
+
+    async def _noop(*a, **k):
+        return None
+
+    svc._publisher = SimpleNamespace(publish=_noop)
     svc._subscriber = SimpleNamespace()
 
     msg = DummyMsg(InputReceivedPayload(user_input="hello", input_id="1"))
     await svc._handle_input(msg)
 
     assert msg.acked
-    assert await db.get_affinity("user") == 2
+    assert await db.get_affinity("anonymous") == 2
 
     await db.close()

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -291,8 +291,7 @@ async def test_handle_input_prefers_payload_user_id_over_header(monkeypatch):
     service._publisher = DummyPublisher()
     service._subscriber = DummySubscriber()
 
-    payload = InputReceivedPayload(user_input="hello", input_id="x", user_id="payload-user")
-    msg = DummyMsg(payload.to_json())
+    msg = DummyMsg(json.dumps({"user_input": "hello", "input_id": "x", "user_id": "payload-user"}))
     msg.headers = {"user_id": "header-user"}
 
     await service._handle_input(msg)

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -1,0 +1,71 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought.eda.events import InputReceivedPayload
+from deepthought.services import social_graph_service
+from deepthought.services.db_manager import DBManager
+from deepthought.services.persona_manager import PersonaManager
+from deepthought.services.social_graph_service import SocialGraphService
+
+
+class DummyMsg:
+    def __init__(self, payload: str, headers=None):
+        self.data = payload.encode()
+        self.headers = headers or {}
+        self.acked = False
+        self.naked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.naked = True
+
+
+@pytest.mark.asyncio
+async def test_handle_input_resolves_identity_from_payload_and_headers(tmp_path, monkeypatch):
+    db = DBManager(str(tmp_path / "sg.db"))
+    await db.init_db()
+    pm = PersonaManager(db, friendly=1, playful=1)
+
+    monkeypatch.setattr(
+        social_graph_service,
+        "analyze_social",
+        lambda _text: {"flirtation": 0.6, "avoidance": 0.1, "manipulation": 0.0},
+    )
+
+    service = SocialGraphService(db_manager=db, persona_manager=pm)
+    service._publisher = SimpleNamespace()
+    service._subscriber = SimpleNamespace()
+
+    payload = InputReceivedPayload(user_input="hello", input_id="1", author_id="author-42")
+    msg = DummyMsg(payload.to_json(), headers={"user_id": "header-user", "channel_id": "chan-1"})
+
+    await service._handle_input(msg)
+
+    assert msg.acked
+    assert not msg.naked
+    assert await db.get_affinity("author-42") == 1
+    assert await pm.get_persona("author-42", channel_id="chan-1") == "friendly"
+    topics = [topic for topic, _ in await db.recall_user("author-42")]
+    assert "social_perception" in topics
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_handle_input_invalid_payload_naks(tmp_path):
+    db = DBManager(str(tmp_path / "sg.db"))
+    await db.init_db()
+    pm = PersonaManager(db)
+    service = SocialGraphService(db_manager=db, persona_manager=pm)
+
+    msg = DummyMsg(json.dumps({"input_id": "missing-user-input"}))
+    await service._handle_input(msg)
+
+    assert msg.naked
+    assert not msg.acked
+
+    await db.close()


### PR DESCRIPTION
### Motivation
- Avoid hidden side-effects and private handler coupling by making `SocialGraphService` process `INPUT_RECEIVED` messages independently and preserve the true author/user identity when updating social memory and persona state.
- Centralize parsing/enrichment of `INPUT_RECEIVED` payloads so multiple services share a single, explicit preprocessing contract.
- Keep ACK/NAK handling local to the social graph flow to prevent unexpected behavior when other services fail or change.

### Description
- Added a new shared `InputEnrichmentService` and `EnrichedInputPayload` to parse and normalize `INPUT_RECEIVED` payloads (payload + headers) and provide a `resolved_user_id` fallback chain (`author_id` → `user_id` → `"anonymous"`) in `src/deepthought/services/input_enrichment_service.py`.
- Removed the direct call from `SocialGraphService` into `CognitiveCoreService._handle_input` and refactored `SocialGraphService._handle_input` to use the enrichment service, run social perception, store `social_perception` memory, adjust affinity using the resolved user id, and lookup persona with the resolved id; ACK/NAK handling is now local to this handler (`src/deepthought/services/social_graph_service.py`).
- Updated `CognitiveCoreService` to reuse `InputEnrichmentService` for parsing `INPUT_RECEIVED` messages and to use the same resolved user id semantics for memory, perception, affinity and published `MemoryRetrieved` payloads (`src/deepthought/services/cognitive_core_service.py`).
- Added unit tests for `SocialGraphService` identity resolution and ACK/NAK behavior and adjusted integration tests to align with the new identity/affinity semantics (`tests/unit/services/test_social_graph_service.py`, updated `tests/unit/services/test_cognitive_core_service.py` and `tests/integration/test_social_graph_affinity.py`).

### Testing
- Ran `pytest -q tests/unit/services/test_social_graph_service.py tests/unit/services/test_cognitive_core_service.py tests/integration/test_social_graph_affinity.py` and all tests passed (`8 passed`).
- Ran `flake8` on the modified modules (`src/deepthought/services/social_graph_service.py`, `src/deepthought/services/cognitive_core_service.py`, `src/deepthought/services/input_enrichment_service.py`, and related tests) with no lint failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e18927408326b4273cdaa65d7f39)