### PR TITLE
Extend input payloads with attachment descriptors for perception routing

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -85,6 +85,46 @@ class EventPayload:
 class InputReceivedPayload(EventPayload):
     """Payload for input received events."""
 
+    @dataclass
+    class AttachmentDescriptor(EventPayload):
+        """Normalized descriptor for a message attachment."""
+
+        url: str
+        content_type: Optional[str] = None
+        filename: Optional[str] = None
+        size: Optional[int] = None
+
+        @classmethod
+        def from_dict(
+            cls, data: Dict[str, Any]
+        ) -> "InputReceivedPayload.AttachmentDescriptor | None":
+            if not isinstance(data, dict):
+                return None
+            url = data.get("url")
+            if not isinstance(url, str) or not url.strip():
+                return None
+            content_type = data.get("content_type")
+            if content_type is not None and not isinstance(content_type, str):
+                content_type = None
+            filename = data.get("filename")
+            if filename is not None and not isinstance(filename, str):
+                filename = None
+            raw_size = data.get("size")
+            size: Optional[int] = None
+            if raw_size is not None:
+                try:
+                    parsed_size = int(raw_size)
+                except (TypeError, ValueError):
+                    parsed_size = -1
+                if parsed_size >= 0:
+                    size = parsed_size
+            return cls(
+                url=url.strip(),
+                content_type=content_type,
+                filename=filename,
+                size=size,
+            )
+
     user_input: str
     input_id: Optional[str] = None
     timestamp: Optional[str] = None
@@ -95,6 +135,36 @@ class InputReceivedPayload(EventPayload):
     author_id: Optional[str] = None
     author_name: Optional[str] = None
     author_is_bot: Optional[bool] = None
+    attachments: Optional[list[AttachmentDescriptor]] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "InputReceivedPayload":
+        normalized: Dict[str, Any] = {
+            "user_input": data.get("user_input", ""),
+            "input_id": data.get("input_id"),
+            "timestamp": data.get("timestamp"),
+            "consent": data.get("consent"),
+            "message_id": data.get("message_id"),
+            "channel_id": data.get("channel_id"),
+            "guild_id": data.get("guild_id"),
+            "author_id": data.get("author_id"),
+            "author_name": data.get("author_name"),
+            "author_is_bot": data.get("author_is_bot"),
+        }
+        raw_attachments = data.get("attachments")
+        if isinstance(raw_attachments, list):
+            attachments = [
+                parsed
+                for parsed in (
+                    InputReceivedPayload.AttachmentDescriptor.from_dict(item)
+                    for item in raw_attachments
+                )
+                if parsed is not None
+            ]
+            normalized["attachments"] = attachments or None
+        else:
+            normalized["attachments"] = None
+        return cls(**normalized)
 
 
 @dataclass

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -63,6 +63,21 @@ class DiscordGatewayService(BaseService):
         author = getattr(message, "author", None)
         channel = getattr(message, "channel", None)
         guild = getattr(message, "guild", None)
+        raw_attachments = getattr(message, "attachments", None)
+        attachments = []
+        if isinstance(raw_attachments, (list, tuple)):
+            for attachment in raw_attachments:
+                descriptor = InputReceivedPayload.AttachmentDescriptor.from_dict(
+                    {
+                        "url": getattr(attachment, "url", None),
+                        "content_type": getattr(attachment, "content_type", None),
+                        "filename": getattr(attachment, "filename", None),
+                        "size": getattr(attachment, "size", None),
+                    }
+                )
+                if descriptor is not None:
+                    attachments.append(descriptor)
+
         return InputReceivedPayload(
             user_input=user_text,
             input_id=str(uuid.uuid4()),
@@ -73,6 +88,7 @@ class DiscordGatewayService(BaseService):
             author_id=(str(getattr(author, "id", "")) if getattr(author, "id", None) is not None else None),
             author_name=(getattr(author, "display_name", None) or getattr(author, "name", None)),
             author_is_bot=bool(getattr(author, "bot", False)) if author is not None else None,
+            attachments=attachments or None,
         )
 
     async def handle_discord_message(self, message: Any) -> str | None:

--- a/src/deepthought/services/perception/listener.py
+++ b/src/deepthought/services/perception/listener.py
@@ -26,6 +26,44 @@ logger = logging.getLogger(__name__)
 class PerceptionServiceListener:
     """Subscribe to input events and invoke :class:`PerceptionService`."""
 
+    @staticmethod
+    def _infer_attachment_modality(content_type: str | None, filename: str | None) -> str | None:
+        ctype = (content_type or "").strip().lower()
+        if ctype:
+            major = ctype.split("/", 1)[0]
+            if major in {"image", "audio", "video"}:
+                return major
+
+        name = (filename or "").strip().lower()
+        if not name:
+            return None
+
+        image_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tif", ".tiff"}
+        audio_exts = {".wav", ".mp3", ".m4a", ".ogg", ".flac", ".aac", ".opus"}
+        video_exts = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v"}
+
+        for ext_set, modality in ((image_exts, "image"), (audio_exts, "audio"), (video_exts, "video")):
+            if any(name.endswith(ext) for ext in ext_set):
+                return modality
+        return None
+
+    @classmethod
+    def _attachment_route(
+        cls,
+        attachments: Sequence[InputReceivedPayload.AttachmentDescriptor] | None,
+    ) -> Dict[str, list[Dict[str, Any]]]:
+        routed: Dict[str, list[Dict[str, Any]]] = {"image": [], "audio": [], "video": []}
+        for item in attachments or []:
+            modality = cls._infer_attachment_modality(item.content_type, item.filename)
+            if modality in routed:
+                routed[modality].append({
+                    "url": item.url,
+                    "content_type": item.content_type,
+                    "filename": item.filename,
+                    "size": item.size,
+                })
+        return routed
+
     def __init__(
         self,
         service: PerceptionService,
@@ -120,6 +158,7 @@ class PerceptionServiceListener:
 
             payload_user_input: str | None = None
             payload_input_id: str | None = None
+            attachments: Sequence[InputReceivedPayload.AttachmentDescriptor] | None = None
             try:
                 payload = InputReceivedPayload.from_dict(raw)
             except Exception:
@@ -128,6 +167,9 @@ class PerceptionServiceListener:
             else:
                 payload_input_id = payload.input_id
                 payload_user_input = payload.user_input
+                attachments = payload.attachments
+
+            routed_attachments = self._attachment_route(attachments)
 
             message_id = (
                 payload_input_id
@@ -153,9 +195,21 @@ class PerceptionServiceListener:
                 "audio_path": raw.get("audio_path"),
                 "video_path": raw.get("video_path"),
             }
+            if kwargs["audio_path"] is None and routed_attachments["audio"]:
+                kwargs["audio_path"] = routed_attachments["audio"][0]["url"]
+            if kwargs["video_path"] is None and routed_attachments["video"]:
+                kwargs["video_path"] = routed_attachments["video"][0]["url"]
             if isinstance(consent, dict):
                 kwargs["audio_opt_in"] = consent.get("audio")
                 kwargs["video_opt_in"] = consent.get("video")
+
+            provenance = kwargs.get("provenance")
+            if not isinstance(provenance, dict):
+                provenance = {}
+            attachment_refs = {name: values for name, values in routed_attachments.items() if values}
+            if attachment_refs:
+                provenance["attachments"] = attachment_refs
+                kwargs["provenance"] = provenance
 
             if (
                 kwargs.get("text_tokens") is None

--- a/tests/integration/test_perception_listener.py
+++ b/tests/integration/test_perception_listener.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import json
 import sys
 import types
@@ -316,3 +317,54 @@ async def test_listener_skips_asr_when_audio_consent_missing(monkeypatch):
     assert service.run.await_count == 1
     _, kwargs = service.run.await_args
     assert "text_tokens" not in kwargs
+
+@pytest.mark.asyncio
+async def test_listener_routes_attachment_descriptors_to_media_and_provenance(monkeypatch):
+    monkeypatch.setattr(
+        "deepthought.services.perception.listener.PerceptionConfig",
+        lambda: SimpleNamespace(enable_asr_transcription=False, text_hop_size=0.05),
+    )
+
+    service = SimpleNamespace(run=AsyncMock())
+    listener = PerceptionServiceListener(
+        service,
+        FakeNATS(),
+        object(),
+        default_user_id="user",
+    )
+
+    payload = {
+        "message_id": "m6",
+        "user_id": "u6",
+        "user_input": "look and listen",
+        "attachments": [
+            {
+                "url": "https://cdn.test/photo.jpg",
+                "content_type": "image/jpeg",
+                "filename": "photo.jpg",
+                "size": 100,
+            },
+            {
+                "url": "https://cdn.test/voice.mp3",
+                "content_type": "audio/mpeg",
+                "filename": "voice.mp3",
+                "size": 200,
+            },
+            {
+                "url": "https://cdn.test/clip.mp4",
+                "content_type": "video/mp4",
+                "filename": "clip.mp4",
+                "size": 300,
+            },
+            {"url": "", "content_type": "image/png"},
+        ],
+    }
+    msg = SimpleNamespace(data=json.dumps(payload).encode(), ack=AsyncMock(), headers=None)
+
+    await listener._handle(msg)
+
+    msg.ack.assert_awaited_once()
+    _, kwargs = service.run.await_args
+    assert kwargs["audio_path"] == "https://cdn.test/voice.mp3"
+    assert kwargs["video_path"] == "https://cdn.test/clip.mp4"
+    assert kwargs["provenance"]["attachments"]["image"][0]["url"] == "https://cdn.test/photo.jpg"

--- a/tests/unit/eda/test_events_roundtrip.py
+++ b/tests/unit/eda/test_events_roundtrip.py
@@ -3,6 +3,7 @@ from deepthought.eda.events import (
     ModalityEmbeddings,
     PerceptionEmbeddingsEvent,
     PerceptionEmbeddingsPayload,
+    InputReceivedPayload,
 )
 
 
@@ -38,3 +39,23 @@ def test_perception_embeddings_event_from_json_roundtrip():
     assert decoded.payload.modality_mask == payload.modality_mask
     assert decoded.encoders == event.encoders
     assert decoded.provenance == event.provenance
+
+
+def test_input_received_payload_ignores_malformed_attachments():
+    payload = InputReceivedPayload.from_dict(
+        {
+            "user_input": "hello",
+            "attachments": [
+                {"url": "https://x.test/a.png", "content_type": "image/png", "filename": "a.png", "size": 7},
+                {"url": "", "content_type": "image/png"},
+                {"url": "https://x.test/b.mp3", "size": "bad"},
+                "invalid",
+            ],
+        }
+    )
+
+    assert payload.user_input == "hello"
+    assert payload.attachments is not None
+    assert len(payload.attachments) == 2
+    assert payload.attachments[0].size == 7
+    assert payload.attachments[1].size is None

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -80,6 +80,14 @@ async def test_handle_discord_message_publishes_input_received(service):
         author=SimpleNamespace(id=5, name="alice", display_name="Alice", bot=False),
         channel=SimpleNamespace(id=123),
         guild=SimpleNamespace(id=7),
+        attachments=[
+            SimpleNamespace(
+                url="https://cdn.discordapp.com/file.png",
+                content_type="image/png",
+                filename="file.png",
+                size=512,
+            )
+        ],
     )
 
     input_id = await service.handle_discord_message(message)
@@ -90,6 +98,8 @@ async def test_handle_discord_message_publishes_input_received(service):
     assert use_js is True
     assert payload.user_input == "hello"
     assert payload.channel_id == "123"
+    assert payload.attachments is not None
+    assert payload.attachments[0].url == "https://cdn.discordapp.com/file.png"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Add support for message attachments to the input event so perception workers can consume images/audio/video shared via the Discord gateway. 
- Keep backward compatibility by making attachments optional and robustly handling malformed attachment descriptors at schema-level. 
- Ensure perception workers can route attachment media to the correct modality pipelines (image/audio/video) and preserve provenance for downstream processing.

### Description
- Added `AttachmentDescriptor` dataclass and optional `attachments` field to `InputReceivedPayload` in `src/deepthought/eda/events.py`, with a safe `from_dict` parser that validates entries and ignores malformed items. 
- Updated `DiscordGatewayService.build_input_payload` in `src/deepthought/services/discord_gateway_service.py` to normalize `message.attachments` into `AttachmentDescriptor`s before publishing `dtr.input.received`. 
- Extended `PerceptionServiceListener` (`src/deepthought/services/perception/listener.py`) to parse attachment descriptors, infer modality from MIME type or filename extension, route audio/video attachment URLs into `audio_path`/`video_path` when missing, and add routed descriptors to `provenance` for downstream workers. 
- Preserved backward compatibility by making new fields optional and adding defensive parsing so malformed attachments do not crash consumers.

### Testing
- Added/updated unit and integration tests: `tests/unit/services/test_discord_gateway_service.py`, `tests/unit/eda/test_events_roundtrip.py`, and `tests/integration/test_perception_listener.py` to cover gateway mapping, malformed-attachment handling, and perception routing/provenance. 
- Ran targeted tests with `pytest` for the modified test files and they all passed (`14 passed`). 
- Ran lint checks with `ruff` on modified files and they passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e4419228832688fd611b5517d317)