### PR TITLE
Add modality-specific perception embedding subjects and correlation/confidence metadata

### DIFF
--- a/docs/perception_event_migration.md
+++ b/docs/perception_event_migration.md
@@ -1,0 +1,29 @@
+# Perception Event Subject Migration
+
+DeepThought now publishes perception embedding events to both:
+
+- the legacy fused subject: `dtr.perception.embeddings`
+- modality-specific subjects:
+  - `dtr.perception.image_embeddings`
+  - `dtr.perception.audio_embeddings`
+  - `dtr.perception.video_embeddings`
+
+## Backward compatibility
+
+Existing deployments that only subscribe to `dtr.perception.embeddings` continue to receive the full fused payload and do not require immediate changes.
+
+## Correlation and confidence metadata
+
+Perception extract and embedding payloads now carry correlation keys and confidence metadata:
+
+- `input_id` and/or `message_id`
+- `author_id`
+- `channel_id`
+- `confidence`
+- `modality_confidence`
+
+## Subscriber migration guidance
+
+- Consumers that need a unified stream can keep using `dtr.perception.embeddings`.
+- Consumers that only need one modality can subscribe to the corresponding modality subject to reduce downstream fan-in.
+- During migration, subscribing to both fused and modality subjects is supported.

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -31,6 +31,9 @@ class EventSubjects:
 
     # Perception events
     PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings"
+    PERCEPTION_IMAGE_EMBED = "dtr.perception.image_embeddings"
+    PERCEPTION_AUDIO_EMBED = "dtr.perception.audio_embeddings"
+    PERCEPTION_VIDEO_EMBED = "dtr.perception.video_embeddings"
     PERCEPTION_EXTRACT = "dtr.perception.extract"
 
     # Raw chat message events
@@ -353,6 +356,11 @@ class PerceptionEmbeddingsPayload(EventPayload):
 
     message_id: str
     user_id: str
+    input_id: Optional[str] = None
+    author_id: Optional[str] = None
+    channel_id: Optional[str] = None
+    confidence: Optional[float] = None
+    modality_confidence: Dict[str, float] = field(default_factory=dict)
     fused: Optional[list[list[float]]] = None
     spans: list[list[int]] = field(default_factory=list)
     modality_mask: Dict[str, list[bool]] = field(default_factory=dict)
@@ -427,6 +435,19 @@ class PerceptionEmbeddingsPayload(EventPayload):
         return cls(
             message_id=data["message_id"],
             user_id=data["user_id"],
+            input_id=data.get("input_id"),
+            author_id=data.get("author_id"),
+            channel_id=data.get("channel_id"),
+            confidence=(
+                float(data["confidence"])
+                if data.get("confidence") is not None
+                else None
+            ),
+            modality_confidence={
+                str(name): float(value)
+                for name, value in (data.get("modality_confidence") or {}).items()
+                if value is not None
+            },
             fused=fused_vectors,
             spans=spans,
             modality_mask=modality_mask,
@@ -477,6 +498,11 @@ class PerceptionEmbeddingsEvent(EventPayload):
             payload_keys = {
                 "message_id",
                 "user_id",
+                "input_id",
+                "author_id",
+                "channel_id",
+                "confidence",
+                "modality_confidence",
                 "fused",
                 "spans",
                 "modality_mask",
@@ -505,6 +531,11 @@ class PerceptionExtractPayload(EventPayload):
 
     message_id: str
     user_id: str
+    input_id: Optional[str] = None
+    author_id: Optional[str] = None
+    channel_id: Optional[str] = None
+    confidence: Optional[float] = None
+    modality_confidence: Dict[str, float] = field(default_factory=dict)
     text: Optional[str] = None
     text_tokens: Optional[list[list[Any]]] = None
     embeddings: Optional[list[list[float]]] = None
@@ -605,6 +636,19 @@ class PerceptionExtractPayload(EventPayload):
         return cls(
             message_id=data["message_id"],
             user_id=data["user_id"],
+            input_id=data.get("input_id"),
+            author_id=data.get("author_id"),
+            channel_id=data.get("channel_id"),
+            confidence=(
+                float(data["confidence"])
+                if data.get("confidence") is not None
+                else None
+            ),
+            modality_confidence={
+                str(name): float(value)
+                for name, value in (data.get("modality_confidence") or {}).items()
+                if value is not None
+            },
             text=text,
             text_tokens=tokens,
             embeddings=cls._parse_embeddings(data.get("embeddings") or data.get("fused")),
@@ -649,6 +693,11 @@ class PerceptionExtractEvent(EventPayload):
             payload_keys = {
                 "message_id",
                 "user_id",
+                "input_id",
+                "author_id",
+                "channel_id",
+                "confidence",
+                "modality_confidence",
                 "text",
                 "text_tokens",
                 "tokens",

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -312,7 +312,7 @@ class CognitiveCoreService(BaseService):
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:
-            logger.error("Failed to handle PERCEPTION_EMBEDDINGS", exc_info=True)
+            logger.error("Failed to handle perception embedding event", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
@@ -352,12 +352,18 @@ class CognitiveCoreService(BaseService):
             use_jetstream=True,
             durable=durable_name,
         )
-        self.add_subscription(
-            subject=EventSubjects.PERCEPTION_EMBEDDINGS,
-            handler=self._handle_embeddings,
-            use_jetstream=True,
-            durable=f"{durable_name}_perception",
-        )
+        for subject, suffix in (
+            (EventSubjects.PERCEPTION_EMBEDDINGS, "perception_fused"),
+            (EventSubjects.PERCEPTION_IMAGE_EMBED, "perception_image"),
+            (EventSubjects.PERCEPTION_AUDIO_EMBED, "perception_audio"),
+            (EventSubjects.PERCEPTION_VIDEO_EMBED, "perception_video"),
+        ):
+            self.add_subscription(
+                subject=subject,
+                handler=self._handle_embeddings,
+                use_jetstream=True,
+                durable=f"{durable_name}_{suffix}",
+            )
         self.add_subscription(
             subject=EventSubjects.BDI_INTENTION,
             handler=self._handle_intention,

--- a/src/deepthought/services/perception/listener.py
+++ b/src/deepthought/services/perception/listener.py
@@ -186,6 +186,10 @@ class PerceptionServiceListener:
 
             kwargs = {
                 "message_id": message_id,
+                "input_id": raw.get("input_id") or raw.get("message_id") or payload_input_id,
+                "author_id": raw.get("author_id"),
+                "channel_id": raw.get("channel_id"),
+                "confidence": raw.get("confidence"),
                 "user_id": user_id,
                 "spans": raw.get("spans"),
                 "embeddings": raw.get("embeddings"),
@@ -317,6 +321,10 @@ class PerceptionServiceListener:
 
             kwargs: Dict[str, Any] = {
                 "message_id": payload.message_id,
+                "input_id": payload.input_id or payload.message_id,
+                "author_id": payload.author_id,
+                "channel_id": payload.channel_id,
+                "confidence": payload.confidence,
                 "user_id": payload.user_id,
                 "spans": payload.spans,
                 "modality_mask": payload.modality_mask,

--- a/src/deepthought/services/perception/publisher.py
+++ b/src/deepthought/services/perception/publisher.py
@@ -29,6 +29,11 @@ class PerceptionPublisher:
         message_id: str,
         user_id: str,
         *,
+        input_id: str | None = None,
+        author_id: str | None = None,
+        channel_id: str | None = None,
+        confidence: float | None = None,
+        modality_confidence: Mapping[str, float | int] | None = None,
         fused: Sequence[Sequence[float]] | None = None,
         by_modality: Mapping[str, Mapping[str, Any]] | None = None,
         spans: Sequence[Sequence[int]] | None = None,
@@ -104,6 +109,15 @@ class PerceptionPublisher:
         payload = PerceptionEmbeddingsPayload(
             message_id=message_id,
             user_id=user_id,
+            input_id=input_id,
+            author_id=author_id,
+            channel_id=channel_id,
+            confidence=confidence,
+            modality_confidence={
+                name: float(value)
+                for name, value in (modality_confidence or {}).items()
+                if value is not None
+            },
             fused=fused_vectors,
             spans=span_payload,
             modality_mask=modality_mask_payload,
@@ -126,9 +140,25 @@ class PerceptionPublisher:
             payload=payload,
         )
 
-        return await self._publisher.publish(
+        fused_result = await self._publisher.publish(
             EventSubjects.PERCEPTION_EMBEDDINGS,
             event,
             use_jetstream=True,
             retries=retries,
         )
+
+        for modality_name, subject in (
+            ("image", EventSubjects.PERCEPTION_IMAGE_EMBED),
+            ("audio", EventSubjects.PERCEPTION_AUDIO_EMBED),
+            ("video", EventSubjects.PERCEPTION_VIDEO_EMBED),
+        ):
+            if modality_name not in modality_payloads:
+                continue
+            await self._publisher.publish(
+                subject,
+                event,
+                use_jetstream=True,
+                retries=retries,
+            )
+
+        return fused_result

--- a/src/deepthought/services/perception/service.py
+++ b/src/deepthought/services/perception/service.py
@@ -126,6 +126,10 @@ class PerceptionService:
         message_id: str,
         user_id: str,
         *,
+        input_id: str | None = None,
+        author_id: str | None = None,
+        channel_id: str | None = None,
+        confidence: float | None = None,
         spans: Sequence[Sequence[int]] | None = None,
         modality_mask: Dict[str, Sequence[bool]] | None = None,
         contribution_mask: Dict[str, Sequence[bool]] | None = None,
@@ -563,9 +567,25 @@ class PerceptionService:
         if self.user_embeddings is not None and store_embedding is not None and store_embedding.numel() > 0:
             self.user_embeddings.set(user_id, store_embedding)
 
+        modality_confidence: Dict[str, float] = {}
+        total_hops = len(grid_spans or [])
+        for name, payload in modality_payload.items():
+            mask = payload.get("mask") if isinstance(payload, dict) else None
+            if isinstance(mask, list) and mask:
+                modality_confidence[name] = sum(1 for flag in mask if flag) / len(mask)
+            elif total_hops > 0:
+                modality_confidence[name] = min(1.0, len(payload.get("embeddings", [])) / total_hops)
+            else:
+                modality_confidence[name] = 1.0 if payload.get("embeddings") else 0.0
+
         await self.publisher.publish(
             message_id=message_id,
             user_id=user_id,
+            input_id=input_id or message_id,
+            author_id=author_id or user_id,
+            channel_id=channel_id,
+            confidence=confidence if confidence is not None else 1.0,
+            modality_confidence=modality_confidence,
             fused=fused_list,
             by_modality=modality_payload,
             spans=grid_spans,

--- a/tests/test_perception_publisher.py
+++ b/tests/test_perception_publisher.py
@@ -1,4 +1,3 @@
-import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -108,3 +107,40 @@ async def test_perception_publisher_deduplicates_encoders(monkeypatch):
     subject, payload = pub._publisher.publish.call_args[0]
     assert subject == EventSubjects.PERCEPTION_EMBEDDINGS
     assert len(payload.encoders) == 1
+
+
+@pytest.mark.asyncio
+async def test_perception_publisher_emits_modality_subjects_and_correlation(monkeypatch):
+    monkeypatch.setattr(
+        "deepthought.services.perception.publisher.Publisher",
+        DummyPublisher,
+    )
+    pub = PerceptionPublisher(nats_client=object(), js_context=object())
+    await pub.publish(
+        "msg3",
+        "user3",
+        input_id="input-3",
+        author_id="author-3",
+        channel_id="channel-3",
+        confidence=0.91,
+        modality_confidence={"image": 0.8, "audio": 0.7},
+        by_modality={
+            "image": {"spans": [[0, 1]], "embeddings": [[0.1, 0.2]], "encoders": []},
+            "audio": {"spans": [[0, 1]], "embeddings": [[0.3, 0.4]], "encoders": []},
+        },
+    )
+
+    calls = pub._publisher.publish.await_args_list
+    subjects = [call.args[0] for call in calls]
+    assert subjects == [
+        EventSubjects.PERCEPTION_EMBEDDINGS,
+        EventSubjects.PERCEPTION_IMAGE_EMBED,
+        EventSubjects.PERCEPTION_AUDIO_EMBED,
+    ]
+    event = calls[0].args[1]
+    assert event.payload is not None
+    assert event.payload.input_id == "input-3"
+    assert event.payload.author_id == "author-3"
+    assert event.payload.channel_id == "channel-3"
+    assert event.payload.confidence == 0.91
+    assert event.payload.modality_confidence == {"image": 0.8, "audio": 0.7}


### PR DESCRIPTION
### Motivation
- Reduce downstream fan-in by emitting modality-specific perception embedding events while preserving the existing fused channel for backwards compatibility.
- Ensure perception events carry correlation keys and confidence measurements so downstream services can link events to inputs and reason about per-modality reliability.
- Thread correlation/confidence data through the listener -> service -> publisher pipeline and update subscribers to consume modality streams.

### Description
- Added new subjects `PERCEPTION_IMAGE_EMBED`, `PERCEPTION_AUDIO_EMBED`, and `PERCEPTION_VIDEO_EMBED` in `EventSubjects` while keeping `PERCEPTION_EMBEDDINGS` as the fused/legacy channel.
- Extended `PerceptionEmbeddingsPayload` and `PerceptionExtractPayload` with `input_id`, `author_id`, `channel_id`, `confidence`, and `modality_confidence` fields and updated parsing logic in `src/deepthought/eda/events.py`.
- Updated `PerceptionPublisher` to include correlation/confidence fields in the payload and to publish the fused event plus modality-specific events for any present modalities.
- Propagated correlation/confidence arguments through `PerceptionService` and `PerceptionServiceListener`, added a simple per-modality confidence heuristic in the service, and updated `CognitiveCoreService` to subscribe to fused and modality-specific subjects.
- Added documentation `docs/perception_event_migration.md` describing migration/backwards-compatibility behavior and updated tests to validate modality subject fan-out and metadata propagation.

### Testing
- Ran linting with `ruff` on the modified files and the test file; all checks passed.
- Executed unit/integration tests `python -m pytest -q tests/test_perception_publisher.py tests/integration/test_perception_listener.py` and the modified publisher tests passed (12 passed).
- Observed that running a larger integration test set encountered collection errors when optional dependency `aiosqlite` was missing; this is due to unrelated optional components and not the perception changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e5d22e388326af518092d1525b33)