### PR TITLE
Expand canonical orchestrator service wiring

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,8 @@ This document provides a high level overview of how the main services in **DeepT
 
 The project follows an event driven architecture built on NATS/JetStream. Components publish and subscribe to event subjects defined in `src/deepthought/eda/events.py`.
 
+A canonical service-to-subject wiring reference (including durable consumers and required environment variables) is maintained in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
+
 ```mermaid
 sequenceDiagram
     participant User

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -62,6 +62,10 @@ The orchestrator starts multiple services with a single NATS connection. Each se
      - examples.multi_agent_demo:run_graph
    ```
 
+   For a complete, canonical wiring map (subjects, durable consumer names,
+   and environment variable references), copy from
+   [`examples/orchestrator.yml`](../examples/orchestrator.yml).
+
    `llm_remote` requires the `LLM_ENDPOINT` variable pointing to a running
    `/generate` endpoint.
 

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -1,2 +1,150 @@
+# Canonical orchestrator wiring for DeepThought-ReThought.
+# `dtrt orchestrate` currently reads only the top-level `services` list;
+# the `service_bindings` and `environment` sections are runtime documentation
+# for operators and deployment automation.
+
 services:
-  - knowledge_graph
+  - discord_gateway
+  - cognitive_core
+  - llm_remote
+  - selector
+  # Optional services (enable as needed)
+  - social_graph
+  - perception
+
+service_bindings:
+  discord_gateway:
+    description: Bridge Discord I/O to NATS.
+    env:
+      - NATS_URL
+      - DISCORD_TOKEN
+    subscribe:
+      - subject: dtr.response.ranked
+        event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+        durable: discord_gateway_response_ranked
+        required_reliability: true
+    publish:
+      - subject: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+
+  cognitive_core:
+    description: Unified memory + retrieval + social signal persistence.
+    env:
+      - NATS_URL
+      - DT_MEMORY_DB
+      - DT_SOCIAL_GRAPH_DB
+      - DT_SEARCH_DB
+    subscribe:
+      - subject: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+        durable: cognitive_core_listener
+        required_reliability: true
+      - subject: dtr.perception.embeddings
+        event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
+        jetstream: true
+        durable: cognitive_core_listener_perception_fused
+        required_reliability: true
+      - subject: dtr.perception.image_embeddings
+        event_subject: EventSubjects.PERCEPTION_IMAGE_EMBED
+        jetstream: true
+        durable: cognitive_core_listener_perception_image
+        required_reliability: true
+      - subject: dtr.perception.audio_embeddings
+        event_subject: EventSubjects.PERCEPTION_AUDIO_EMBED
+        jetstream: true
+        durable: cognitive_core_listener_perception_audio
+        required_reliability: true
+      - subject: dtr.perception.video_embeddings
+        event_subject: EventSubjects.PERCEPTION_VIDEO_EMBED
+        jetstream: true
+        durable: cognitive_core_listener_perception_video
+        required_reliability: true
+      - subject: dtr.bdi.intention
+        event_subject: EventSubjects.BDI_INTENTION
+        jetstream: true
+        durable: cognitive_core_listener_bdi
+        required_reliability: true
+    publish:
+      - subject: dtr.memory.retrieved
+        event_subject: EventSubjects.MEMORY_RETRIEVED
+        jetstream: true
+
+  llm_remote:
+    description: HTTP-backed responder that turns memory into candidates.
+    env:
+      - NATS_URL
+      - LLM_ENDPOINT
+    subscribe:
+      - subject: dtr.memory.retrieved
+        event_subject: EventSubjects.MEMORY_RETRIEVED
+        jetstream: true
+        durable: llm_remote_service
+        required_reliability: true
+    publish:
+      - subject: dtr.response.candidates
+        event_subject: EventSubjects.RESPONSE_CANDIDATES
+        jetstream: true
+
+  selector:
+    description: Rank response candidates and emit a final response.
+    env:
+      - NATS_URL
+    subscribe:
+      - subject: dtr.response.candidates
+        event_subject: EventSubjects.RESPONSE_CANDIDATES
+        jetstream: true
+        durable: selector_service
+        required_reliability: true
+    publish:
+      - subject: dtr.response.ranked
+        event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+
+  social_graph:
+    optional: true
+    description: Track affinity and persona context from user input.
+    env:
+      - NATS_URL
+      - DT_SOCIAL_GRAPH_DB
+    subscribe:
+      - subject: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+        durable: social_graph_service
+        required_reliability: true
+    publish: []
+
+  perception:
+    optional: true
+    description: Multimodal perception extraction and embedding publisher.
+    env:
+      - NATS_URL
+      - PERCEPTION_REQUIRE_CONSENT
+      - PERCEPTION_MODEL_PATH
+    subscribe:
+      - subject: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+        durable: perception_listener
+        required_reliability: true
+      - subject: dtr.perception.extract
+        event_subject: EventSubjects.PERCEPTION_EXTRACT
+        jetstream: true
+        durable: perception-extract-listener
+        required_reliability: true
+    publish:
+      - subject: dtr.perception.embeddings
+        event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
+        jetstream: true
+
+environment:
+  NATS_URL: ${NATS_URL:-nats://localhost:4222}
+  DISCORD_TOKEN: ${DISCORD_TOKEN:-}
+  LLM_ENDPOINT: ${LLM_ENDPOINT:-http://localhost:8000/generate}
+  DT_MEMORY_DB: ${DT_MEMORY_DB:-./data/memory.db}
+  DT_SOCIAL_GRAPH_DB: ${DT_SOCIAL_GRAPH_DB:-./data/social_graph.db}
+  DT_SEARCH_DB: ${DT_SEARCH_DB:-./examples/data/sample_docs.json}
+  PERCEPTION_MODEL_PATH: ${PERCEPTION_MODEL_PATH:-}


### PR DESCRIPTION
### Motivation

- Provide a single canonical orchestrator wiring file that fully documents core services, their NATS subjects and JetStream durable consumer names, and required environment variables to make deployment wiring explicit and consistent with runtime code.
- Ensure quickstart and architecture docs point to the canonical spec so operators and CI use the same runtime wiring reference.

### Description

- Added an expanded `examples/orchestrator.yml` that lists core services (`discord_gateway`, `cognitive_core`, `llm_remote`, `selector`) and optional services (`social_graph`, `perception`) and documents `service_bindings` and `environment` entries. 
- For each service the file documents subscribe/publish subjects using the existing `EventSubjects` naming (concrete subject strings are provided), includes JetStream-backed subscriptions and durable consumer names for reliability, and enumerates required environment variables (NATS URL, Discord token, `LLM_ENDPOINT`, DB paths, perception model path, etc.).
- Cross-linked the new canonical file from `docs/orchestrator_quickstart.md` and `docs/architecture.md` so documentation and runtime wiring remain aligned.
- Kept `services:` top-level list compatible with existing `dtrt orchestrate` loader while adding runtime documentation for operators.

### Testing

- Verified `examples/orchestrator.yml` parses as YAML with `python -c 'import yaml; yaml.safe_load(...)'` (succeeds). 
- Ran the orchestrator unit tests with `pytest -q tests/unit/test_orchestrator.py`, which failed in this environment with `ModuleNotFoundError: No module named 'pyperplan'` (3 tests failed) due to a missing optional runtime dependency unrelated to the YAML/docs changes. 
- No linter failures were introduced by the documentation and YAML edits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e8387d408326a939a79adfae3af2)