### PR TITLE
Add canonical EDA contracts and strict payload validation

### DIFF
--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -1,0 +1,208 @@
+"""Canonical EDA event contracts and migration compatibility helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict
+from uuid import UUID, uuid4
+
+
+class CanonicalSubjects:
+    """Canonical, versioned subject names used by production traffic."""
+
+    INPUT_RECEIVED = "dtr.input.received.v1"
+    MEMORY_RETRIEVED = "dtr.memory.retrieved.v1"
+    RESPONSE_CANDIDATES = "dtr.response.candidates.v1"
+    RESPONSE_RANKED = "dtr.response.ranked.v1"
+    PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings.v1"
+    PERCEPTION_EXTRACT = "dtr.perception.extract.v1"
+    SOCIAL_PERCEPTION = "dtr.social.perception.v1"
+
+
+LEGACY_SUBJECT_MAP: Dict[str, str] = {
+    "dtr.input.received": CanonicalSubjects.INPUT_RECEIVED,
+    "dtr.memory.retrieved": CanonicalSubjects.MEMORY_RETRIEVED,
+    "dtr.response.candidates": CanonicalSubjects.RESPONSE_CANDIDATES,
+    "dtr.response.ranked": CanonicalSubjects.RESPONSE_RANKED,
+    "dtr.perception.embeddings": CanonicalSubjects.PERCEPTION_EMBEDDINGS,
+    "dtr.perception.extract": CanonicalSubjects.PERCEPTION_EXTRACT,
+    "dtr.social.perception": CanonicalSubjects.SOCIAL_PERCEPTION,
+}
+
+
+@dataclass(frozen=True)
+class EventEnvelope:
+    schema_version: str
+    event_id: str
+    trace_id: str
+    causation_id: str | None
+    created_at: str
+    producer: str
+    subject: str
+    payload: Dict[str, Any]
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        subject: str,
+        payload: Dict[str, Any],
+        producer: str,
+        trace_id: str | None = None,
+        causation_id: str | None = None,
+        schema_version: str = "1.0.0",
+    ) -> "EventEnvelope":
+        return cls(
+            schema_version=schema_version,
+            event_id=str(uuid4()),
+            trace_id=trace_id or str(uuid4()),
+            causation_id=causation_id,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            producer=producer,
+            subject=to_canonical_subject(subject),
+            payload=payload,
+        )
+
+
+def _expect_type(data: dict[str, Any], key: str, expected: type, optional: bool = False) -> Any:
+    value = data.get(key)
+    if value is None:
+        if optional:
+            return None
+        raise ValueError(f"Missing required key '{key}'")
+    if not isinstance(value, expected):
+        raise ValueError(f"Field '{key}' must be {expected.__name__}")
+    return value
+
+
+def _expect_uuid(value: str, field_name: str) -> None:
+    try:
+        UUID(value)
+    except (ValueError, TypeError) as exc:
+        raise ValueError(f"Field '{field_name}' must be a valid UUID") from exc
+
+
+def validate_envelope(data: Dict[str, Any]) -> EventEnvelope:
+    schema_version = _expect_type(data, "schema_version", str)
+    event_id = _expect_type(data, "event_id", str)
+    trace_id = _expect_type(data, "trace_id", str)
+    causation_id = _expect_type(data, "causation_id", str, optional=True)
+    created_at = _expect_type(data, "created_at", str)
+    producer = _expect_type(data, "producer", str)
+    subject = _expect_type(data, "subject", str)
+    payload = _expect_type(data, "payload", dict)
+
+    _expect_uuid(event_id, "event_id")
+    _expect_uuid(trace_id, "trace_id")
+    if causation_id is not None:
+        _expect_uuid(causation_id, "causation_id")
+    try:
+        datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("Field 'created_at' must be ISO-8601") from exc
+
+    return EventEnvelope(
+        schema_version=schema_version,
+        event_id=event_id,
+        trace_id=trace_id,
+        causation_id=causation_id,
+        created_at=created_at,
+        producer=producer,
+        subject=to_canonical_subject(subject),
+        payload=payload,
+    )
+
+
+def to_canonical_subject(subject: str) -> str:
+    return LEGACY_SUBJECT_MAP.get(subject, subject)
+
+
+def normalize_legacy_payload(subject: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    canonical = to_canonical_subject(subject)
+    if canonical == CanonicalSubjects.INPUT_RECEIVED and "user_input" not in payload and "text" in payload:
+        payload = {**payload, "user_input": payload["text"]}
+    if canonical == CanonicalSubjects.MEMORY_RETRIEVED and "retrieved_knowledge" not in payload and "memory" in payload:
+        payload = {**payload, "retrieved_knowledge": payload["memory"]}
+    if canonical == CanonicalSubjects.RESPONSE_RANKED and "final_response" not in payload and "response" in payload:
+        payload = {**payload, "final_response": payload["response"]}
+    if canonical == CanonicalSubjects.PERCEPTION_EXTRACT and "text_tokens" not in payload and "tokens" in payload:
+        payload = {**payload, "text_tokens": payload["tokens"]}
+    return payload
+
+
+def validate_input_received_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    _expect_type(data, "user_input", str)
+    attachments = data.get("attachments")
+    if attachments is not None:
+        if not isinstance(attachments, list):
+            raise ValueError("Field 'attachments' must be a list")
+        for idx, item in enumerate(attachments):
+            if not isinstance(item, dict):
+                raise ValueError(f"Attachment at index {idx} must be an object")
+            url = item.get("url")
+            if not isinstance(url, str) or not url.strip():
+                raise ValueError(f"Attachment at index {idx} has invalid url")
+            if "size" in item and item["size"] is not None and not isinstance(item["size"], int):
+                raise ValueError(f"Attachment at index {idx} has invalid size")
+    return data
+
+
+def validate_memory_retrieved_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    _expect_type(data, "retrieved_knowledge", dict)
+    return data
+
+
+def validate_response_candidates_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    candidates = _expect_type(data, "candidates", list)
+    for idx, candidate in enumerate(candidates):
+        if not isinstance(candidate, dict):
+            raise ValueError(f"Candidate at index {idx} must be an object")
+        _expect_type(candidate, "text", str)
+        confidence = candidate.get("confidence", 0.0)
+        if not isinstance(confidence, (float, int)):
+            raise ValueError(f"Candidate at index {idx} has invalid confidence")
+    return data
+
+
+def validate_response_ranked_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    _expect_type(data, "final_response", str)
+    if "candidates" in data:
+        validate_response_candidates_payload({"candidates": data["candidates"]})
+    return data
+
+
+def validate_perception_embeddings_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    _expect_type(data, "message_id", str)
+    _expect_type(data, "user_id", str)
+    if "by_modality" in data and not isinstance(data["by_modality"], dict):
+        raise ValueError("Field 'by_modality' must be an object")
+    return data
+
+
+def validate_perception_extract_payload(data: Dict[str, Any]) -> Dict[str, Any]:
+    _expect_type(data, "message_id", str)
+    _expect_type(data, "user_id", str)
+    tokens = data.get("text_tokens")
+    if tokens is not None and not isinstance(tokens, list):
+        raise ValueError("Field 'text_tokens' must be a list")
+    return data
+
+
+PAYLOAD_VALIDATORS = {
+    CanonicalSubjects.INPUT_RECEIVED: validate_input_received_payload,
+    CanonicalSubjects.MEMORY_RETRIEVED: validate_memory_retrieved_payload,
+    CanonicalSubjects.RESPONSE_CANDIDATES: validate_response_candidates_payload,
+    CanonicalSubjects.RESPONSE_RANKED: validate_response_ranked_payload,
+    CanonicalSubjects.PERCEPTION_EMBEDDINGS: validate_perception_embeddings_payload,
+    CanonicalSubjects.PERCEPTION_EXTRACT: validate_perception_extract_payload,
+}
+
+
+def decode_payload(subject: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    canonical = to_canonical_subject(subject)
+    normalized = normalize_legacy_payload(canonical, payload)
+    validator = PAYLOAD_VALIDATORS.get(canonical)
+    if validator is None:
+        return normalized
+    return validator(normalized)

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -9,6 +9,11 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Optional
 
+from .contracts import (
+    CanonicalSubjects,
+    decode_payload,
+)
+
 
 # Subject naming convention: dtr.<module>.<event_type>
 class EventSubjects:
@@ -19,22 +24,22 @@ class EventSubjects:
     """
 
     # Input events
-    INPUT_RECEIVED = "dtr.input.received"
+    INPUT_RECEIVED = CanonicalSubjects.INPUT_RECEIVED
 
     # Memory events
-    MEMORY_RETRIEVED = "dtr.memory.retrieved"
+    MEMORY_RETRIEVED = CanonicalSubjects.MEMORY_RETRIEVED
 
     # LLM events
     RESPONSE_GENERATED = "dtr.llm.response_generated"
-    RESPONSE_CANDIDATES = "dtr.response.candidates"
-    RESPONSE_RANKED = "dtr.response.ranked"
+    RESPONSE_CANDIDATES = CanonicalSubjects.RESPONSE_CANDIDATES
+    RESPONSE_RANKED = CanonicalSubjects.RESPONSE_RANKED
 
     # Perception events
-    PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings"
+    PERCEPTION_EMBEDDINGS = CanonicalSubjects.PERCEPTION_EMBEDDINGS
     PERCEPTION_IMAGE_EMBED = "dtr.perception.image_embeddings"
     PERCEPTION_AUDIO_EMBED = "dtr.perception.audio_embeddings"
     PERCEPTION_VIDEO_EMBED = "dtr.perception.video_embeddings"
-    PERCEPTION_EXTRACT = "dtr.perception.extract"
+    PERCEPTION_EXTRACT = CanonicalSubjects.PERCEPTION_EXTRACT
 
     # Raw chat message events
     CHAT_RAW = "chat.raw"
@@ -76,7 +81,7 @@ class EventPayload:
     def from_json(cls, json_str: str) -> "EventPayload":
         """Create a payload instance from a JSON string."""
         data = json.loads(json_str)
-        return cls(**data)
+        return cls.from_dict(data)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "EventPayload":
@@ -102,25 +107,22 @@ class InputReceivedPayload(EventPayload):
             cls, data: Dict[str, Any]
         ) -> "InputReceivedPayload.AttachmentDescriptor | None":
             if not isinstance(data, dict):
-                return None
+                raise ValueError("Attachment must be an object")
             url = data.get("url")
             if not isinstance(url, str) or not url.strip():
-                return None
+                raise ValueError("Attachment url must be a non-empty string")
             content_type = data.get("content_type")
             if content_type is not None and not isinstance(content_type, str):
-                content_type = None
+                raise ValueError("Attachment content_type must be a string when provided")
             filename = data.get("filename")
             if filename is not None and not isinstance(filename, str):
-                filename = None
+                raise ValueError("Attachment filename must be a string when provided")
             raw_size = data.get("size")
             size: Optional[int] = None
             if raw_size is not None:
-                try:
-                    parsed_size = int(raw_size)
-                except (TypeError, ValueError):
-                    parsed_size = -1
-                if parsed_size >= 0:
-                    size = parsed_size
+                if not isinstance(raw_size, int) or raw_size < 0:
+                    raise ValueError("Attachment size must be a non-negative integer")
+                size = raw_size
             return cls(
                 url=url.strip(),
                 content_type=content_type,
@@ -142,6 +144,7 @@ class InputReceivedPayload(EventPayload):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "InputReceivedPayload":
+        data = decode_payload(EventSubjects.INPUT_RECEIVED, data)
         normalized: Dict[str, Any] = {
             "user_input": data.get("user_input", ""),
             "input_id": data.get("input_id"),
@@ -157,12 +160,8 @@ class InputReceivedPayload(EventPayload):
         raw_attachments = data.get("attachments")
         if isinstance(raw_attachments, list):
             attachments = [
-                parsed
-                for parsed in (
-                    InputReceivedPayload.AttachmentDescriptor.from_dict(item)
-                    for item in raw_attachments
-                )
-                if parsed is not None
+                InputReceivedPayload.AttachmentDescriptor.from_dict(item)
+                for item in raw_attachments
             ]
             normalized["attachments"] = attachments or None
         else:
@@ -175,6 +174,11 @@ class MemoryRetrievedPayload(EventPayload):
     """Payload for memory retrieved events."""
 
     retrieved_knowledge: Dict[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MemoryRetrievedPayload":
+        normalized = decode_payload(EventSubjects.MEMORY_RETRIEVED, data)
+        return cls(**normalized)
     user_input: Optional[str] = None
     input_id: Optional[str] = None
     user_id: Optional[str] = None
@@ -220,6 +224,7 @@ class ResponseCandidatesPayload(EventPayload):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ResponseCandidatesPayload":
+        data = decode_payload(EventSubjects.RESPONSE_CANDIDATES, data)
         raw_candidates = data.get("candidates") or []
         candidates = [
             candidate
@@ -254,6 +259,7 @@ class ResponseRankedPayload(EventPayload):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ResponseRankedPayload":
+        data = decode_payload(EventSubjects.RESPONSE_RANKED, data)
         raw_candidates = data.get("candidates") or []
         candidates = [
             candidate
@@ -370,6 +376,7 @@ class PerceptionEmbeddingsPayload(EventPayload):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PerceptionEmbeddingsPayload":
+        data = decode_payload(EventSubjects.PERCEPTION_EMBEDDINGS, data)
         raw_by_modality = data.get("by_modality") or {}
         by_modality: Dict[str, ModalityEmbeddings] = {}
         if isinstance(raw_by_modality, dict):
@@ -601,6 +608,7 @@ class PerceptionExtractPayload(EventPayload):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PerceptionExtractPayload":
+        data = decode_payload(EventSubjects.PERCEPTION_EXTRACT, data)
         tokens = cls._parse_tokens(
             data.get("text_tokens") or data.get("tokens")
         )

--- a/tests/unit/eda/test_event_contracts.py
+++ b/tests/unit/eda/test_event_contracts.py
@@ -1,0 +1,74 @@
+import pytest
+
+from deepthought.eda.contracts import (
+    CanonicalSubjects,
+    EventEnvelope,
+    decode_payload,
+    to_canonical_subject,
+    validate_envelope,
+)
+from deepthought.eda.events import (
+    InputReceivedPayload,
+    MemoryRetrievedPayload,
+    PerceptionEmbeddingsPayload,
+    PerceptionExtractPayload,
+    ResponseCandidatesPayload,
+    ResponseRankedPayload,
+)
+
+
+def test_legacy_subject_maps_to_canonical_and_payload_compatibility():
+    payload = decode_payload("dtr.input.received", {"text": "hello"})
+    assert to_canonical_subject("dtr.input.received") == CanonicalSubjects.INPUT_RECEIVED
+    assert payload["user_input"] == "hello"
+
+
+def test_event_envelope_roundtrip_validation():
+    envelope = EventEnvelope.build(
+        subject="dtr.response.ranked",
+        payload={"final_response": "ok"},
+        producer="selector",
+    )
+    validated = validate_envelope(envelope.__dict__)
+    assert validated.subject == CanonicalSubjects.RESPONSE_RANKED
+
+
+@pytest.mark.parametrize(
+    ("payload_type", "raw"),
+    [
+        (InputReceivedPayload, {"user_input": "hi", "attachments": [{"url": "https://a", "size": 2}]}),
+        (MemoryRetrievedPayload, {"retrieved_knowledge": {"k": "v"}}),
+        (ResponseCandidatesPayload, {"candidates": [{"text": "a", "confidence": 0.2}]}),
+        (ResponseRankedPayload, {"final_response": "a", "candidates": [{"text": "a", "confidence": 0.2}]}),
+        (PerceptionEmbeddingsPayload, {"message_id": "m1", "user_id": "u1", "by_modality": {}}),
+        (PerceptionExtractPayload, {"message_id": "m1", "user_id": "u1", "text_tokens": []}),
+    ],
+)
+def test_producer_consumer_schema_roundtrip(payload_type, raw):
+    model = payload_type.from_dict(raw)
+    encoded = model.to_json()
+    decoded = payload_type.from_json(encoded)
+    assert decoded == model
+
+
+def test_invalid_input_payload_fails_safe():
+    with pytest.raises(ValueError):
+        InputReceivedPayload.from_dict(
+            {"user_input": "x", "attachments": [{"url": "", "size": "1"}]}
+        )
+
+
+def test_invalid_envelope_fails_safe():
+    with pytest.raises(ValueError):
+        validate_envelope(
+            {
+                "schema_version": "1.0.0",
+                "event_id": "bad-uuid",
+                "trace_id": "also-bad",
+                "causation_id": None,
+                "created_at": "not-time",
+                "producer": "svc",
+                "subject": "dtr.input.received",
+                "payload": {},
+            }
+        )

--- a/tests/unit/eda/test_events_roundtrip.py
+++ b/tests/unit/eda/test_events_roundtrip.py
@@ -1,3 +1,5 @@
+import pytest
+
 from deepthought.eda.events import (
     EncoderMetadata,
     ModalityEmbeddings,
@@ -41,21 +43,14 @@ def test_perception_embeddings_event_from_json_roundtrip():
     assert decoded.provenance == event.provenance
 
 
-def test_input_received_payload_ignores_malformed_attachments():
-    payload = InputReceivedPayload.from_dict(
-        {
-            "user_input": "hello",
-            "attachments": [
-                {"url": "https://x.test/a.png", "content_type": "image/png", "filename": "a.png", "size": 7},
-                {"url": "", "content_type": "image/png"},
-                {"url": "https://x.test/b.mp3", "size": "bad"},
-                "invalid",
-            ],
-        }
-    )
-
-    assert payload.user_input == "hello"
-    assert payload.attachments is not None
-    assert len(payload.attachments) == 2
-    assert payload.attachments[0].size == 7
-    assert payload.attachments[1].size is None
+def test_input_received_payload_rejects_malformed_attachments():
+    with pytest.raises(ValueError):
+        InputReceivedPayload.from_dict(
+            {
+                "user_input": "hello",
+                "attachments": [
+                    {"url": "https://x.test/a.png", "content_type": "image/png", "filename": "a.png", "size": 7},
+                    {"url": "", "content_type": "image/png"},
+                ],
+            }
+        )


### PR DESCRIPTION
### Motivation
- Provide a single, canonical event-contract surface for production EDA traffic and a clear migration path from legacy subjects/payload shapes.
- Ensure event envelopes carry versioning and trace metadata so producers/consumers can validate provenance and avoid silent coercion.
- Make payload decoding strict so malformed messages fail fast and are easier to debug and migrate.

### Description
- Add a new contract module at `src/deepthought/eda/contracts/__init__.py` defining canonical, versioned subjects (input/memory/response/perception/social), a versioned `EventEnvelope`, a legacy→canonical subject map, payload normalizers, and strict payload validators for requested payload types.
- Wire the contract validators into the existing payload constructors in `src/deepthought/eda/events.py` by calling `decode_payload(...)` in each `from_dict` and switching `from_json` to route through `from_dict` for consistent validation.
- Replace permissive attachment coercion with strict attachment validation that raises `ValueError` on malformed attachment fields instead of silently filtering/coercing.
- Add unit tests at `tests/unit/eda/test_event_contracts.py` and update `tests/unit/eda/test_events_roundtrip.py` to assert producer/consumer roundtrips, legacy→canonical compatibility, envelope validation, and safe failure on invalid inputs.

### Testing
- Ran `pytest tests/unit/eda/test_event_contracts.py tests/unit/eda/test_events_roundtrip.py tests/unit/eda/test_perception_events.py` and all tests passed (`14 passed`).
- Ran linter checks with `ruff check src/deepthought/eda/events.py src/deepthought/eda/contracts/__init__.py tests/unit/eda/test_event_contracts.py tests/unit/eda/test_events_roundtrip.py` and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a82f2bc46c832689050701e4a20199)