### PR TITLE
Add ContextAssemblerService and migrate responders to dtr.context.assembled

### DIFF
--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -13,6 +13,12 @@ class CanonicalSubjects:
 
     INPUT_RECEIVED = "dtr.input.received.v1"
     MEMORY_RETRIEVED = "dtr.memory.retrieved.v1"
+    MEMORY_RETRIEVAL_REQUESTED = "dtr.memory.retrieval.requested.v1"
+    SOCIAL_SIGNALS_REQUESTED = "dtr.social.signals.requested.v1"
+    PERCEPTION_INTERPRET_REQUESTED = "dtr.perception.interpret.requested.v1"
+    SOCIAL_SIGNALS_RETRIEVED = "dtr.social.signals.retrieved.v1"
+    PERCEPTION_INTERPRET_RETRIEVED = "dtr.perception.interpret.retrieved.v1"
+    CONTEXT_ASSEMBLED = "dtr.context.assembled.v1"
     RESPONSE_CANDIDATES = "dtr.response.candidates.v1"
     RESPONSE_RANKED = "dtr.response.ranked.v1"
     PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings.v1"
@@ -23,6 +29,12 @@ class CanonicalSubjects:
 LEGACY_SUBJECT_MAP: Dict[str, str] = {
     "dtr.input.received": CanonicalSubjects.INPUT_RECEIVED,
     "dtr.memory.retrieved": CanonicalSubjects.MEMORY_RETRIEVED,
+    "dtr.memory.retrieval.requested": CanonicalSubjects.MEMORY_RETRIEVAL_REQUESTED,
+    "dtr.social.signals.requested": CanonicalSubjects.SOCIAL_SIGNALS_REQUESTED,
+    "dtr.perception.interpret.requested": CanonicalSubjects.PERCEPTION_INTERPRET_REQUESTED,
+    "dtr.social.signals.retrieved": CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED,
+    "dtr.perception.interpret.retrieved": CanonicalSubjects.PERCEPTION_INTERPRET_RETRIEVED,
+    "dtr.context.assembled": CanonicalSubjects.CONTEXT_ASSEMBLED,
     "dtr.response.candidates": CanonicalSubjects.RESPONSE_CANDIDATES,
     "dtr.response.ranked": CanonicalSubjects.RESPONSE_RANKED,
     "dtr.perception.embeddings": CanonicalSubjects.PERCEPTION_EMBEDDINGS,

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -28,6 +28,12 @@ class EventSubjects:
 
     # Memory events
     MEMORY_RETRIEVED = CanonicalSubjects.MEMORY_RETRIEVED
+    MEMORY_RETRIEVAL_REQUESTED = CanonicalSubjects.MEMORY_RETRIEVAL_REQUESTED
+    SOCIAL_SIGNALS_REQUESTED = CanonicalSubjects.SOCIAL_SIGNALS_REQUESTED
+    PERCEPTION_INTERPRET_REQUESTED = CanonicalSubjects.PERCEPTION_INTERPRET_REQUESTED
+    SOCIAL_SIGNALS_RETRIEVED = CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED
+    PERCEPTION_INTERPRET_RETRIEVED = CanonicalSubjects.PERCEPTION_INTERPRET_RETRIEVED
+    CONTEXT_ASSEMBLED = CanonicalSubjects.CONTEXT_ASSEMBLED
 
     # LLM events
     RESPONSE_GENERATED = "dtr.llm.response_generated"
@@ -188,6 +194,31 @@ class MemoryRetrievedPayload(EventPayload):
     channel_context: Optional[str] = None
     recent_turn_summary: Optional[str] = None
     timestamp: Optional[str] = None
+
+
+@dataclass
+class ContextAssembledPayload(EventPayload):
+    """Canonical payload for fully assembled responder context."""
+
+    input_id: str
+    user_input: str
+    conversation_window: list[Dict[str, Any]] = field(default_factory=list)
+    retrieved_facts: list[str] = field(default_factory=list)
+    social_signals: Dict[str, Any] = field(default_factory=dict)
+    multimodal_interpretations: Dict[str, Any] = field(default_factory=dict)
+    confidence: Dict[str, Any] = field(default_factory=dict)
+    user_id: Optional[str] = None
+    author_id: Optional[str] = None
+    author_name: Optional[str] = None
+    channel_id: Optional[str] = None
+    channel_context: Optional[str] = None
+    recent_turn_summary: Optional[str] = None
+    timestamp: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ContextAssembledPayload":
+        data = decode_payload(EventSubjects.CONTEXT_ASSEMBLED, data)
+        return cls(**data)
 
 
 @dataclass

--- a/src/deepthought/modules/llm_base.py
+++ b/src/deepthought/modules/llm_base.py
@@ -98,13 +98,13 @@ class BaseLLM(ABC):
             prompt = persona_desc.strip() + "\n" + prompt
         return prompt
 
-    async def _handle_memory_event(self, msg: Msg) -> None:
-        """Common handler for MEMORY_RETRIEVED events."""
+    async def _handle_context_event(self, msg: Msg) -> None:
+        """Common handler for CONTEXT_ASSEMBLED events."""
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
-                raise ValueError("MemoryRetrieved payload must be a dict")
+                raise ValueError("ContextAssembled payload must be a dict")
             input_id = data.get("input_id")
             author_id = data.get("author_id")
             if not isinstance(author_id, str):
@@ -120,24 +120,13 @@ class BaseLLM(ABC):
             target_id = data.get("target_id")
             if not isinstance(target_id, str):
                 target_id = None
-            knowledge = data.get("retrieved_knowledge")
-            if not isinstance(input_id, str) or not isinstance(knowledge, dict):
-                raise ValueError("Invalid memory payload fields")
-
-            facts = knowledge.get("facts")
+            facts = data.get("retrieved_facts")
             if not isinstance(facts, list):
-                logger.error("retrieved_knowledge missing facts list for input_id %s", input_id)
-                if hasattr(msg, "nak") and callable(msg.nak):
-                    try:
-                        await msg.nak()
-                    except Exception:
-                        logger.error("Failed to NAK message", exc_info=True)
-                elif hasattr(msg, "ack") and callable(msg.ack):
-                    try:
-                        await msg.ack()
-                    except Exception:
-                        logger.error("Failed to ack message after error", exc_info=True)
-                return
+                knowledge = data.get("retrieved_knowledge")
+                if isinstance(knowledge, dict):
+                    facts = knowledge.get("facts")
+            if not isinstance(input_id, str) or not isinstance(facts, list):
+                raise ValueError("Invalid MemoryRetrieved payload fields")
 
             logger.info("%s received memory event ID %s", self.__class__.__name__, input_id)
 
@@ -207,7 +196,7 @@ class BaseLLM(ABC):
                 )
             await msg.ack()
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error("Invalid MemoryRetrieved payload: %s", e, exc_info=True)
+            logger.error("Invalid ContextAssembled payload: %s", e, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
@@ -231,6 +220,10 @@ class BaseLLM(ABC):
                     await msg.ack()
                 except nats.errors.Error:
                     logger.error("Failed to ack message after error", exc_info=True)
+
+    async def _handle_memory_event(self, msg: Msg) -> None:
+        """Backward-compatible alias for legacy tests and producers."""
+        await self._handle_context_event(msg)
 
     async def _handle_reward_event(self, msg: Msg) -> None:
         """Store rewards published on ``agent.reward``."""

--- a/src/deepthought/modules/llm_basic.py
+++ b/src/deepthought/modules/llm_basic.py
@@ -43,8 +43,8 @@ class BasicLLM(BaseLLM):
             return False
         try:
             await self._subscriber.subscribe(
-                subject=EventSubjects.MEMORY_RETRIEVED,
-                handler=self._handle_memory_event,
+                subject=EventSubjects.CONTEXT_ASSEMBLED,
+                handler=self._handle_context_event,
                 use_jetstream=True,
                 durable=durable_name,
             )
@@ -54,7 +54,7 @@ class BasicLLM(BaseLLM):
                 use_jetstream=True,
                 durable=f"{durable_name}_reward",
             )
-            logger.info("BasicLLM subscribed to %s", EventSubjects.MEMORY_RETRIEVED)
+            logger.info("BasicLLM subscribed to %s", EventSubjects.CONTEXT_ASSEMBLED)
             return True
         except nats.errors.Error as e:
             logger.error("BasicLLM failed to subscribe: %s", e, exc_info=True)

--- a/src/deepthought/modules/llm_prod.py
+++ b/src/deepthought/modules/llm_prod.py
@@ -52,8 +52,8 @@ class ProductionLLM(BaseLLM):
             return False
         try:
             await self._subscriber.subscribe(
-                subject=EventSubjects.MEMORY_RETRIEVED,
-                handler=self._handle_memory_event,
+                subject=EventSubjects.CONTEXT_ASSEMBLED,
+                handler=self._handle_context_event,
                 use_jetstream=True,
                 durable=durable_name,
             )
@@ -63,7 +63,7 @@ class ProductionLLM(BaseLLM):
                 use_jetstream=True,
                 durable=f"{durable_name}_reward",
             )
-            logger.info("ProductionLLM subscribed to %s", EventSubjects.MEMORY_RETRIEVED)
+            logger.info("ProductionLLM subscribed to %s", EventSubjects.CONTEXT_ASSEMBLED)
             return True
         except nats.errors.Error as e:
             logger.error("ProductionLLM failed to subscribe: %s", e, exc_info=True)

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -13,7 +13,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
-from ..eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
+from ..eda.events import ContextAssembledPayload, EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from ..pipeline.dspy_pipeline import build_qa_pipeline
@@ -28,13 +28,17 @@ def _normalized_optional_text(value: object) -> str | None:
     return normalized if normalized else None
 
 
-def _extract_memory_facts(retrieved: object) -> list[str]:
+def _extract_memory_facts(data: dict[str, object]) -> list[str]:
+    facts = data.get("retrieved_facts")
+    if isinstance(facts, list):
+        return [str(fact) for fact in facts]
+    retrieved = data.get("retrieved_knowledge")
     if not isinstance(retrieved, dict):
         return []
-    facts = retrieved.get("facts")
-    if not isinstance(facts, list):
+    fallback_facts = retrieved.get("facts")
+    if not isinstance(fallback_facts, list):
         return []
-    return [str(fact) for fact in facts]
+    return [str(fact) for fact in fallback_facts]
 
 
 def _build_generation_prompt(
@@ -103,31 +107,38 @@ class RemoteLLM:
                 raise ValueError("Invalid generate response")
             return text
 
-    async def _handle_memory_event(self, msg: Msg) -> None:
+    async def _handle_context_event(self, msg: Msg) -> None:
         input_id = "unknown"
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
-                raise ValueError("MemoryRetrieved payload must be a dict")
-            input_id = data.get("input_id")
-            author_id = data.get("author_id")
-            if not isinstance(author_id, str):
-                author_id = None
-            user_id = data.get("user_id")
-            if not isinstance(user_id, str):
-                user_id = None
+                raise ValueError("ContextAssembled payload must be a dict")
+            if "retrieved_facts" in data:
+                payload = ContextAssembledPayload.from_dict(data)
+                input_id = payload.input_id
+                user_input = _normalized_optional_text(payload.user_input)
+                author_id = payload.author_id
+                user_id = payload.user_id
+                channel_id = payload.channel_id
+                author_name = _normalized_optional_text(payload.author_name)
+                channel_context = _normalized_optional_text(payload.channel_context)
+                recent_turn_summary = _normalized_optional_text(payload.recent_turn_summary)
+                facts = [str(item) for item in payload.retrieved_facts]
+            else:
+                input_id = data.get("input_id")
+                author_id = data.get("author_id") if isinstance(data.get("author_id"), str) else None
+                user_id = data.get("user_id") if isinstance(data.get("user_id"), str) else None
+                channel_id = data.get("channel_id") if isinstance(data.get("channel_id"), str) else None
+                user_input = _normalized_optional_text(data.get("user_input"))
+                author_name = _normalized_optional_text(data.get("author_name"))
+                channel_context = _normalized_optional_text(data.get("channel_context"))
+                recent_turn_summary = _normalized_optional_text(data.get("recent_turn_summary"))
+                facts = _extract_memory_facts(data)
+
             if author_id is None:
                 author_id = user_id
-            channel_id = data.get("channel_id")
-            if not isinstance(channel_id, str):
-                channel_id = None
-            user_input = _normalized_optional_text(data.get("user_input"))
             if user_input is None:
-                raise ValueError("MemoryRetrieved payload missing required non-empty user_input")
-            author_name = _normalized_optional_text(data.get("author_name"))
-            channel_context = _normalized_optional_text(data.get("channel_context"))
-            recent_turn_summary = _normalized_optional_text(data.get("recent_turn_summary"))
-            facts = _extract_memory_facts(data.get("retrieved_knowledge", {}))
+                raise ValueError("ContextAssembled payload missing required non-empty user_input")
             prompt = _build_generation_prompt(
                 user_input=user_input,
                 facts=facts,
@@ -173,12 +184,12 @@ class RemoteLLM:
             return False
         try:
             await self._subscriber.subscribe(
-                subject=EventSubjects.MEMORY_RETRIEVED,
-                handler=self._handle_memory_event,
+                subject=EventSubjects.CONTEXT_ASSEMBLED,
+                handler=self._handle_context_event,
                 use_jetstream=True,
                 durable=durable_name,
             )
-            logger.info("RemoteLLM subscribed to %s", EventSubjects.MEMORY_RETRIEVED)
+            logger.info("RemoteLLM subscribed to %s", EventSubjects.CONTEXT_ASSEMBLED)
             return True
         except nats.errors.Error as e:
             logger.error("RemoteLLM failed to subscribe: %s", e, exc_info=True)

--- a/src/deepthought/modules/llm_stub.py
+++ b/src/deepthought/modules/llm_stub.py
@@ -39,14 +39,14 @@ class LLMStub:
         self._persona_descriptions = get_settings().persona_descriptions
         logger.info("LLMStub initialized (JetStream enabled).")
 
-    async def _handle_memory_event(self, msg: Msg) -> None:
-        """Handles MemoryRetrieved event from JetStream."""
+    async def _handle_context_event(self, msg: Msg) -> None:
+        """Handles ContextAssembled event from JetStream."""
         input_id = "unknown"
         data = None
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
-                raise ValueError(f"Unexpected MemoryRetrieved payload format: {type(data)}")
+                raise ValueError(f"Unexpected ContextAssembled payload format: {type(data)}")
             input_id = data.get("input_id")
             author_id = data.get("author_id")
             if not isinstance(author_id, str):
@@ -62,30 +62,18 @@ class LLMStub:
             target_id = data.get("target_id")
             if not isinstance(target_id, str):
                 target_id = None
-            retrieved = data.get("retrieved_knowledge")
-            if not isinstance(input_id, str) or retrieved is None:
-                raise ValueError("Invalid memory payload fields")
-            if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
-                knowledge = retrieved.get("retrieved_knowledge", {})
-            elif isinstance(retrieved, dict):
-                knowledge = retrieved
-            else:
-                logger.error("retrieved_knowledge is not a dict for input_id %s", input_id)
-                if hasattr(msg, "nak") and callable(msg.nak):
-                    try:
-                        await msg.nak()
-                    except Exception:
-                        logger.error("Failed to NAK message", exc_info=True)
-                elif hasattr(msg, "ack") and callable(msg.ack):
-                    try:
-                        await msg.ack()
-                    except Exception:
-                        logger.error("Failed to ack message after error", exc_info=True)
-                return
-
-            facts = knowledge.get("facts")
+            facts = data.get("retrieved_facts")
             if not isinstance(facts, list):
-                logger.error("retrieved_knowledge missing facts list for input_id %s", input_id)
+                retrieved = data.get("retrieved_knowledge")
+                if isinstance(retrieved, dict) and "retrieved_knowledge" in retrieved:
+                    knowledge = retrieved.get("retrieved_knowledge", {})
+                elif isinstance(retrieved, dict):
+                    knowledge = retrieved
+                else:
+                    knowledge = {}
+                facts = knowledge.get("facts")
+            if not isinstance(input_id, str) or not isinstance(facts, list):
+                logger.error("context payload missing facts list for input_id %s", input_id)
                 if hasattr(msg, "nak") and callable(msg.nak):
                     try:
                         await msg.nak()
@@ -98,7 +86,7 @@ class LLMStub:
                         logger.error("Failed to ack message after error", exc_info=True)
                 return
 
-            logger.info(f"LLMStub received memory event ID {input_id}")
+            logger.info(f"LLMStub received context event ID {input_id}")
 
             await asyncio.sleep(0.5)  # Simulate work
 
@@ -160,7 +148,7 @@ class LLMStub:
                 # Do not ack/nak on failure; leave to message broker
 
         except (json.JSONDecodeError, ValueError) as e:
-            logger.error(f"Invalid MemoryRetrieved payload: {e}", exc_info=True)
+            logger.error(f"Invalid ContextAssembled payload: {e}", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 try:
                     await msg.nak()
@@ -175,6 +163,10 @@ class LLMStub:
         except Exception as e:
             logger.error(f"Error in LLMStub handler: {e}", exc_info=True)
             # Do not ack/nak on unexpected errors
+
+    async def _handle_memory_event(self, msg: Msg) -> None:
+        """Backward-compatible alias for legacy producers and tests."""
+        await self._handle_context_event(msg)
 
     async def _handle_reward_event(self, msg: Msg) -> None:
         """Store rewards published on ``agent.reward``."""
@@ -195,7 +187,7 @@ class LLMStub:
 
     async def start_listening(self, durable_name: str = "llm_stub_listener") -> bool:
         """
-        Starts the NATS subscriber to listen for MEMORY_RETRIEVED events.
+        Starts the NATS subscriber to listen for CONTEXT_ASSEMBLED events.
 
         Args:
             durable_name: Optional name for the durable consumer. Defaults to "llm_stub_listener".
@@ -208,10 +200,10 @@ class LLMStub:
             return False
 
         try:
-            logger.info(f"LLMStub subscribing to {EventSubjects.MEMORY_RETRIEVED}...")
+            logger.info(f"LLMStub subscribing to {EventSubjects.CONTEXT_ASSEMBLED}...")
             await self._subscriber.subscribe(
-                subject=EventSubjects.MEMORY_RETRIEVED,
-                handler=self._handle_memory_event,
+                subject=EventSubjects.CONTEXT_ASSEMBLED,
+                handler=self._handle_context_event,
                 use_jetstream=True,
                 durable=durable_name,
             )
@@ -221,7 +213,7 @@ class LLMStub:
                 use_jetstream=True,
                 durable=f"{durable_name}_reward",
             )
-            logger.info(f"LLMStub successfully subscribed to {EventSubjects.MEMORY_RETRIEVED}.")
+            logger.info(f"LLMStub successfully subscribed to {EventSubjects.CONTEXT_ASSEMBLED}.")
             return True
         except nats.errors.Error as e:
             logger.error(f"LLMStub failed to subscribe: {e}", exc_info=True)

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import ContextAssembledPayload, EventSubjects
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingAssembly:
+    request: dict[str, Any]
+    provider_payloads: dict[str, dict[str, Any]] = field(default_factory=dict)
+    published: bool = False
+    event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+class ContextAssemblerService:
+    """Assemble contextual data from memory/social/perception providers."""
+
+    _PROVIDER_ORDER = ("memory", "social", "perception")
+
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        *,
+        wait_window_seconds: float = 0.2,
+    ) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._wait_window_seconds = max(0.01, wait_window_seconds)
+        self._pending: dict[str, _PendingAssembly] = {}
+        self._lock = asyncio.Lock()
+
+    async def _publish_fanout_requests(self, payload: dict[str, Any]) -> None:
+        fanout_payload = {
+            "input_id": payload.get("input_id"),
+            "user_input": payload.get("user_input"),
+            "user_id": payload.get("user_id"),
+            "author_id": payload.get("author_id"),
+            "channel_id": payload.get("channel_id"),
+            "author_name": payload.get("author_name"),
+            "timestamp": payload.get("timestamp"),
+        }
+        await self._publisher.publish(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, fanout_payload, use_jetstream=True)
+        await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_REQUESTED, fanout_payload, use_jetstream=True)
+        await self._publisher.publish(EventSubjects.PERCEPTION_INTERPRET_REQUESTED, fanout_payload, use_jetstream=True)
+
+    async def _handle_input_received(self, msg: Msg) -> None:
+        try:
+            payload = json.loads(msg.data.decode())
+            if not isinstance(payload, dict):
+                raise ValueError("Input payload must be an object")
+            input_id = payload.get("input_id")
+            user_input = payload.get("user_input")
+            if not isinstance(input_id, str) or not isinstance(user_input, str):
+                raise ValueError("Input payload missing required fields")
+
+            pending = _PendingAssembly(request=payload)
+            async with self._lock:
+                self._pending[input_id] = pending
+
+            await self._publish_fanout_requests(payload)
+            asyncio.create_task(self._await_and_publish(input_id))
+            await msg.ack()
+        except Exception:
+            logger.exception("Failed to process input event in ContextAssemblerService")
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_provider_response(self, msg: Msg, provider_name: str) -> None:
+        try:
+            payload = json.loads(msg.data.decode())
+            if not isinstance(payload, dict):
+                raise ValueError("Provider payload must be an object")
+            input_id = payload.get("input_id")
+            if not isinstance(input_id, str):
+                raise ValueError("Provider payload missing input_id")
+
+            async with self._lock:
+                pending = self._pending.get(input_id)
+                if pending is not None and not pending.published:
+                    pending.provider_payloads[provider_name] = payload
+                    pending.event.set()
+            await msg.ack()
+        except Exception:
+            logger.exception("Failed to process provider response for %s", provider_name)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    def _build_context_payload(self, input_id: str, pending: _PendingAssembly, elapsed: float) -> ContextAssembledPayload:
+        request = pending.request
+        memory_payload = pending.provider_payloads.get("memory", {})
+        retrieved = memory_payload.get("retrieved_knowledge", {})
+        facts = retrieved.get("facts") if isinstance(retrieved, dict) else []
+        if not isinstance(facts, list):
+            facts = []
+
+        social_payload = pending.provider_payloads.get("social", {})
+        social_signals = social_payload.get("social_signals", social_payload)
+        if not isinstance(social_signals, dict):
+            social_signals = {}
+
+        perception_payload = pending.provider_payloads.get("perception", {})
+        multimodal = perception_payload.get("multimodal_interpretations", perception_payload)
+        if not isinstance(multimodal, dict):
+            multimodal = {}
+
+        conversation_window = request.get("conversation_window")
+        if not isinstance(conversation_window, list):
+            conversation_window = []
+
+        completed = [name for name in self._PROVIDER_ORDER if name in pending.provider_payloads]
+        missing = [name for name in self._PROVIDER_ORDER if name not in pending.provider_payloads]
+        confidence = {
+            "provider_coverage": len(completed) / len(self._PROVIDER_ORDER),
+            "completed_providers": completed,
+            "missing_providers": missing,
+            "window_ms": int(self._wait_window_seconds * 1000),
+            "elapsed_ms": int(elapsed * 1000),
+            "partial": bool(missing),
+        }
+
+        return ContextAssembledPayload(
+            input_id=input_id,
+            user_input=str(request.get("user_input", "")),
+            conversation_window=conversation_window,
+            retrieved_facts=[str(f) for f in facts],
+            social_signals=social_signals,
+            multimodal_interpretations=multimodal,
+            confidence=confidence,
+            user_id=request.get("user_id"),
+            author_id=request.get("author_id"),
+            author_name=request.get("author_name"),
+            channel_id=request.get("channel_id"),
+            channel_context=request.get("channel_context"),
+            recent_turn_summary=request.get("recent_turn_summary"),
+            timestamp=request.get("timestamp") or datetime.now(timezone.utc).isoformat(),
+        )
+
+    async def _await_and_publish(self, input_id: str) -> None:
+        started = asyncio.get_running_loop().time()
+        deadline = started + self._wait_window_seconds
+        while asyncio.get_running_loop().time() < deadline:
+            async with self._lock:
+                pending = self._pending.get(input_id)
+                if pending is None or pending.published:
+                    return
+                if len(pending.provider_payloads) == len(self._PROVIDER_ORDER):
+                    break
+            await asyncio.sleep(0.005)
+
+        async with self._lock:
+            pending = self._pending.get(input_id)
+            if pending is None or pending.published:
+                return
+            pending.published = True
+            elapsed = asyncio.get_running_loop().time() - started
+            payload = self._build_context_payload(input_id, pending, elapsed)
+            del self._pending[input_id]
+
+        await self._publisher.publish(EventSubjects.CONTEXT_ASSEMBLED, payload, use_jetstream=True)
+
+    async def start(self, durable_name: str = "context_assembler") -> bool:
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.INPUT_RECEIVED,
+                handler=self._handle_input_received,
+                use_jetstream=True,
+                durable=f"{durable_name}_input",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.MEMORY_RETRIEVED,
+                handler=lambda msg: self._handle_provider_response(msg, "memory"),
+                use_jetstream=True,
+                durable=f"{durable_name}_memory",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.SOCIAL_SIGNALS_RETRIEVED,
+                handler=lambda msg: self._handle_provider_response(msg, "social"),
+                use_jetstream=True,
+                durable=f"{durable_name}_social",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,
+                handler=lambda msg: self._handle_provider_response(msg, "perception"),
+                use_jetstream=True,
+                durable=f"{durable_name}_perception",
+            )
+            return True
+        except nats.errors.Error:
+            logger.exception("Failed to start ContextAssemblerService")
+            return False
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -1,0 +1,137 @@
+import asyncio
+import json
+
+import pytest
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.context_assembler_service import ContextAssemblerService
+
+
+class DummyNATS:
+    is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class RecordingPublisher:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.calls.append((subject, payload, use_jetstream, timeout))
+
+
+class RecordingSubscriber:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+
+    async def subscribe(self, **kwargs):
+        self.calls.append(kwargs)
+        return True
+
+    async def unsubscribe_all(self):
+        return None
+
+
+class DummyMsg:
+    def __init__(self, payload: dict):
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+        self.nacked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.nacked = True
+
+
+@pytest.mark.asyncio
+async def test_race_safe_assembly_collects_all_providers(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.12)
+
+    input_msg = DummyMsg(
+        {
+            "input_id": "i-race",
+            "user_input": "hello",
+            "author_id": "u1",
+            "conversation_window": [{"role": "user", "text": "earlier"}],
+        }
+    )
+    await svc._handle_input_received(input_msg)
+
+    async def send_memory():
+        await asyncio.sleep(0.01)
+        await svc._handle_provider_response(
+            DummyMsg({"input_id": "i-race", "retrieved_knowledge": {"facts": ["f2", "f1"]}}),
+            "memory",
+        )
+
+    async def send_social():
+        await asyncio.sleep(0.03)
+        await svc._handle_provider_response(
+            DummyMsg({"input_id": "i-race", "social_signals": {"tone": "neutral"}}),
+            "social",
+        )
+
+    async def send_perception():
+        await asyncio.sleep(0.02)
+        await svc._handle_provider_response(
+            DummyMsg({"input_id": "i-race", "multimodal_interpretations": {"image": "none"}}),
+            "perception",
+        )
+
+    await asyncio.gather(send_social(), send_memory(), send_perception())
+    await asyncio.sleep(0.06)
+
+    assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    assert len(assembled) == 1
+    payload = assembled[0][1]
+    assert payload.input_id == "i-race"
+    assert payload.retrieved_facts == ["f2", "f1"]
+    assert payload.social_signals == {"tone": "neutral"}
+    assert payload.multimodal_interpretations == {"image": "none"}
+    assert payload.confidence["partial"] is False
+    assert payload.confidence["completed_providers"] == ["memory", "social", "perception"]
+
+
+@pytest.mark.asyncio
+async def test_partial_result_when_provider_missing_is_deterministic(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.05)
+
+    input_msg = DummyMsg({"input_id": "i-partial", "user_input": "hello"})
+    await svc._handle_input_received(input_msg)
+
+    await svc._handle_provider_response(
+        DummyMsg({"input_id": "i-partial", "retrieved_knowledge": {"facts": ["f1"]}}),
+        "memory",
+    )
+    await svc._handle_provider_response(
+        DummyMsg({"input_id": "i-partial", "social_signals": {"sentiment": 0.7}}),
+        "social",
+    )
+
+    await asyncio.sleep(0.08)
+
+    assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    assert len(assembled) == 1
+    payload = assembled[0][1]
+    assert payload.input_id == "i-partial"
+    assert payload.retrieved_facts == ["f1"]
+    assert payload.social_signals == {"sentiment": 0.7}
+    assert payload.multimodal_interpretations == {}
+    assert payload.confidence["partial"] is True
+    assert payload.confidence["missing_providers"] == ["perception"]
+    assert payload.confidence["completed_providers"] == ["memory", "social"]

--- a/tests/unit/modules/test_llm_basic.py
+++ b/tests/unit/modules/test_llm_basic.py
@@ -184,7 +184,7 @@ async def test_handle_memory_event_missing_facts(monkeypatch, caplog):
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("missing facts" in r.getMessage() for r in caplog.records)
+    assert any("Invalid ContextAssembled payload" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -198,7 +198,7 @@ async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("missing facts" in r.getMessage() for r in caplog.records)
+    assert any("Invalid ContextAssembled payload" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/test_llm_prod.py
+++ b/tests/unit/modules/test_llm_prod.py
@@ -3,7 +3,6 @@ import importlib.util
 import logging
 import sys
 import types
-from datetime import datetime, timezone
 from types import SimpleNamespace
 
 import pytest
@@ -11,7 +10,7 @@ import pytest
 if importlib.util.find_spec("nats") is None:
     pytest.skip("nats not installed", allow_module_level=True)
 
-from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload
+from deepthought.eda.events import MemoryRetrievedPayload
 
 
 class DummyNATS:
@@ -176,7 +175,7 @@ async def test_handle_memory_event_missing_facts(monkeypatch, caplog):
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("missing facts" in r.getMessage() for r in caplog.records)
+    assert any("Invalid ContextAssembled payload" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -190,7 +189,7 @@ async def test_handle_memory_event_facts_not_list(monkeypatch, caplog):
     assert msg.nacked
     pub = llm._publisher
     assert not pub.published
-    assert any("missing facts" in r.getMessage() for r in caplog.records)
+    assert any("Invalid ContextAssembled payload" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -15,7 +15,7 @@ sys.modules[spec.name] = llm_remote
 assert spec.loader is not None
 spec.loader.exec_module(llm_remote)
 
-from deepthought.eda.events import EventSubjects, MemoryRetrievedPayload  # noqa: E402
+from deepthought.eda.events import ContextAssembledPayload, EventSubjects  # noqa: E402
 
 
 class DummyNATS:
@@ -118,7 +118,7 @@ class DummyMsg:
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_publishes(monkeypatch):
+async def test_handle_context_event_publishes(monkeypatch):
     llm = create_llm(monkeypatch)
 
     async def fake_generate(self, prompt):
@@ -126,10 +126,10 @@ async def test_handle_memory_event_publishes(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="42")
+    payload = ContextAssembledPayload(input_id="42", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.acked
     pub = llm._publisher
@@ -173,7 +173,7 @@ async def test_generate_malformed_json(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_timeout(monkeypatch):
+async def test_handle_context_event_timeout(monkeypatch):
     llm = create_llm(monkeypatch)
 
     async def fake_generate(self, prompt):
@@ -181,17 +181,17 @@ async def test_handle_memory_event_timeout(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="99")
+    payload = ContextAssembledPayload(input_id="99", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.nacked
     assert not msg.acked
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_bad_json(monkeypatch):
+async def test_handle_context_event_bad_json(monkeypatch):
     llm = create_llm(monkeypatch)
 
     async def fake_generate(self, prompt):
@@ -199,10 +199,10 @@ async def test_handle_memory_event_bad_json(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="88")
+    payload = ContextAssembledPayload(input_id="88", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.nacked
     assert not msg.acked
@@ -233,7 +233,7 @@ async def test_generate_http_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_http_error(monkeypatch):
+async def test_handle_context_event_http_error(monkeypatch):
     llm = create_llm(monkeypatch)
 
     async def fake_generate(self, prompt):
@@ -246,17 +246,17 @@ async def test_handle_memory_event_http_error(monkeypatch):
 
     monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, user_input="hello", input_id="77")
+    payload = ContextAssembledPayload(input_id="77", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.nacked
     assert not msg.acked
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_with_mock_session(monkeypatch):
+async def test_handle_context_event_with_mock_session(monkeypatch):
     mock_response = AsyncMock()
     mock_response.__aenter__.return_value = mock_response
     mock_response.__aexit__.return_value = False
@@ -268,10 +268,10 @@ async def test_handle_memory_event_with_mock_session(monkeypatch):
 
     llm = create_llm(monkeypatch, session)
 
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["fact"]}, user_input="hello", input_id="55")
+    payload = ContextAssembledPayload(input_id="55", user_input="hello", retrieved_facts=["fact"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.acked
     assert llm._publisher.published
@@ -315,12 +315,12 @@ def test_build_generation_prompt_without_optional_hints():
 
 
 @pytest.mark.asyncio
-async def test_handle_memory_event_missing_user_input_naks(monkeypatch):
+async def test_handle_context_event_missing_user_input_naks(monkeypatch):
     llm = create_llm(monkeypatch)
-    payload = MemoryRetrievedPayload(retrieved_knowledge={"facts": ["f1"]}, input_id="no-input")
+    payload = ContextAssembledPayload(input_id="no-input", user_input="", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
 
-    await llm._handle_memory_event(msg)
+    await llm._handle_context_event(msg)
 
     assert msg.nacked
     assert not msg.acked

--- a/tests/unit/modules/test_llm_stub.py
+++ b/tests/unit/modules/test_llm_stub.py
@@ -106,26 +106,26 @@ async def test_handle_memory_event_non_dict_retrieved(monkeypatch, caplog):
     stub = create_stub(monkeypatch)
     payload = MemoryRetrievedPayload(retrieved_knowledge="oops", input_id="xyz")
     msg = DummyMsg(payload.to_json())
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         await stub._handle_memory_event(msg)
 
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
-    assert any("not a dict" in r.getMessage() for r in caplog.records)
+    assert any("missing facts list" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio
 async def test_handle_memory_event_payload_not_dict(monkeypatch, caplog):
     stub = create_stub(monkeypatch)
     msg = DummyMsg(json.dumps(["not", "dict"]))
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         await stub._handle_memory_event(msg)
 
     assert msg.nacked
     pub = stub._publisher
     assert not pub.published
-    assert any("Unexpected MemoryRetrieved payload format" in r.getMessage() for r in caplog.records)
+    assert any("Unexpected ContextAssembled payload format" in r.getMessage() for r in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Introduce a canonical assembly point that gathers memory, social and perception signals for each user input and presents a single, deterministic context payload to responders.
- Decouple responders from directly subscribing to memory retrieval events so retrieval can be fanned-out, correlated, and bounded with a partial-result policy.
- Provide a clear schema (`ContextAssembledPayload`) and subjects for internal retrieval requests/responses to make integrations and testing deterministic.

### Description
- Added a new `ContextAssemblerService` (`src/deepthought/services/context_assembler_service.py`) that subscribes to `dtr.input.received`, fans out retrieval requests to memory/social/perception providers, correlates provider responses by `input_id` within a bounded wait window, and publishes a single `dtr.context.assembled.v1` `ContextAssembledPayload` containing user message, conversation window, retrieved facts, social signals, multimodal interpretations, and confidence/partial-result metadata.
- Extended EDA contracts/events (`src/deepthought/eda/contracts/__init__.py`, `src/deepthought/eda/events.py`) with new canonical subjects (`MEMORY_RETRIEVAL_REQUESTED`, `SOCIAL_SIGNALS_REQUESTED`, `PERCEPTION_INTERPRET_REQUESTED`, `SOCIAL_SIGNALS_RETRIEVED`, `PERCEPTION_INTERPRET_RETRIEVED`, `CONTEXT_ASSEMBLED`) and added `ContextAssembledPayload` dataclass.
- Refactored LLM responders to consume only `dtr.context.assembled`:
  - `llm_remote` updated to parse `ContextAssembledPayload` and build prompts from canonical fields (`src/deepthought/modules/llm_remote.py`).
  - `llm_base`, `llm_basic`, `llm_prod`, and `llm_stub` updated to handle `CONTEXT_ASSEMBLED` (with compatibility aliases for `_handle_memory_event` so legacy producers/tests remain functional).
- Added integration tests to verify race-safe assembly and deterministic partial-result behavior when a provider is late or missing (`tests/integration/test_context_assembler_service.py`).
- Updated unit tests for LLM modules to expect and exercise the new assembled-context flow (`tests/unit/modules/*_llm*.py`).

### Testing
- Ran linter: `ruff check` on modified sources and tests; results: no issues.
- Ran targeted test suite: `pytest -q tests/integration/test_context_assembler_service.py tests/unit/modules/test_llm_remote.py tests/unit/modules/test_llm_basic.py tests/unit/modules/test_llm_prod.py tests/unit/modules/test_llm_stub.py` and all tests passed: `35 passed`.
- Smoke-tested modified modules via the unit tests exercising backward-compatible aliases and new `ContextAssembledPayload` parsing; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8308bfe0083269aad6a0f06942bd0)