### PR TITLE
Add graph-memory subsystem and integrate with CognitiveCoreService

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -14,6 +14,7 @@ from .vector_store import (
     create_vector_store,
 )
 from .fact_extractor import (
+    extract_typed_fact_triples_from_turn,
     build_user_fact_context,
     extract_and_store_user_facts,
     extract_user_facts,
@@ -32,6 +33,7 @@ __all__ = [
     "TieredMemory",
     "create_memory_backend",
     "build_user_fact_context",
+    "extract_typed_fact_triples_from_turn",
     "extract_and_store_user_facts",
     "extract_user_facts",
     "format_user_facts_for_prompt",

--- a/src/deepthought/memory/fact_extractor.py
+++ b/src/deepthought/memory/fact_extractor.py
@@ -103,6 +103,84 @@ def extract_user_facts(message: str) -> dict[str, Any]:
     return facts
 
 
+def extract_typed_fact_triples_from_turn(
+    *,
+    user_id: str,
+    message: str,
+    timestamp: str,
+    source_id: str,
+) -> list[dict[str, Any]]:
+    """Extract typed triples+attributes from a single conversation turn."""
+
+    facts = extract_user_facts(message)
+    triples: list[dict[str, Any]] = []
+    if "nickname" in facts:
+        triples.append(
+            {
+                "subject_id": str(user_id),
+                "subject_type": "user",
+                "predicate": "has_nickname",
+                "object_id": f"nickname:{facts['nickname'].lower()}",
+                "object_type": "nickname",
+                "object_value": str(facts["nickname"]),
+                "attributes": {"source_id": source_id, "timestamp": timestamp},
+                "confidence": 0.92,
+                "fact_type": "profile",
+            }
+        )
+    for hobby in facts.get("hobbies", []):
+        triples.append(
+            {
+                "subject_id": str(user_id),
+                "subject_type": "user",
+                "predicate": "likes_hobby",
+                "object_id": f"hobby:{str(hobby).lower()}",
+                "object_type": "hobby",
+                "object_value": str(hobby),
+                "attributes": {"source_id": source_id, "timestamp": timestamp},
+                "confidence": 0.8,
+                "fact_type": "preference",
+            }
+        )
+    favorites = facts.get("favorites", {})
+    if isinstance(favorites, Mapping):
+        for category, value in favorites.items():
+            values = value if isinstance(value, list) else [value]
+            for item in values:
+                triples.append(
+                    {
+                        "subject_id": str(user_id),
+                        "subject_type": "user",
+                        "predicate": "favorite",
+                        "object_id": f"favorite:{category}:{str(item).lower()}",
+                        "object_type": "favorite",
+                        "object_value": str(item),
+                        "attributes": {
+                            "category": category,
+                            "source_id": source_id,
+                            "timestamp": timestamp,
+                        },
+                        "confidence": 0.83,
+                        "fact_type": "preference",
+                    }
+                )
+    if message.strip():
+        triples.append(
+            {
+                "subject_id": str(user_id),
+                "subject_type": "user",
+                "predicate": "mentioned",
+                "object_id": None,
+                "object_type": "utterance",
+                "object_value": message.strip(),
+                "attributes": {"source_id": source_id, "timestamp": timestamp},
+                "confidence": 0.55,
+                "fact_type": "utterance",
+            }
+        )
+    return triples
+
+
 def _merge_list(existing: Iterable[str] | None, incoming: Iterable[str]) -> list[str]:
     merged = list(dict.fromkeys([*(existing or []), *incoming]))
     return [item for item in merged if item]

--- a/src/deepthought/memory/graph/__init__.py
+++ b/src/deepthought/memory/graph/__init__.py
@@ -1,0 +1,29 @@
+from .adapters import CypherGraphMemoryStore, InMemoryGraphMemoryStore
+from .migration import migrate_sqlite_memories_to_graph
+from .pipeline import ingest_conversation_turns
+from .retrieval import retrieve_topic_context, retrieve_user_context
+from .store import (
+    GraphEntity,
+    GraphEvidence,
+    GraphFact,
+    GraphMemoryStore,
+    GraphRelation,
+    Provenance,
+    TemporalValidity,
+)
+
+__all__ = [
+    "GraphMemoryStore",
+    "GraphEntity",
+    "GraphRelation",
+    "GraphFact",
+    "GraphEvidence",
+    "Provenance",
+    "TemporalValidity",
+    "CypherGraphMemoryStore",
+    "InMemoryGraphMemoryStore",
+    "ingest_conversation_turns",
+    "retrieve_user_context",
+    "retrieve_topic_context",
+    "migrate_sqlite_memories_to_graph",
+]

--- a/src/deepthought/memory/graph/adapters.py
+++ b/src/deepthought/memory/graph/adapters.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+from ...graph.connector import GraphConnector, Neo4jConnector
+from .store import GraphEntity, GraphEvidence, GraphFact, GraphMemoryStore, GraphRelation
+
+
+class CypherGraphMemoryStore(GraphMemoryStore):
+    """Neo4j/Memgraph graph-memory adapter backed by Cypher queries."""
+
+    def __init__(self, connector: GraphConnector | Neo4jConnector) -> None:
+        self._connector = connector
+
+    def upsert_entity(self, entity: GraphEntity) -> None:
+        self._connector.execute(
+            "MERGE (e:Entity {id: $entity_id}) "
+            "SET e.type = $entity_type, e.label = $label, e.attributes = $attributes, "
+            "e.confidence = $confidence, e.valid_from = $valid_from, e.valid_to = $valid_to, "
+            "e.provenance = $provenance",
+            {
+                "entity_id": entity.entity_id,
+                "entity_type": entity.entity_type,
+                "label": entity.label,
+                "attributes": entity.attributes,
+                "confidence": entity.confidence,
+                "valid_from": entity.temporal.valid_from,
+                "valid_to": entity.temporal.valid_to,
+                "provenance": asdict(entity.provenance),
+            },
+        )
+
+    def upsert_relation(self, relation: GraphRelation) -> None:
+        self._connector.execute(
+            "MERGE (s:Entity {id: $source_id}) "
+            "MERGE (t:Entity {id: $target_id}) "
+            "MERGE (s)-[r:RELATION {type: $relation_type}]->(t) "
+            "SET r.attributes = $attributes, r.confidence = $confidence, "
+            "r.valid_from = $valid_from, r.valid_to = $valid_to, r.provenance = $provenance",
+            {
+                "source_id": relation.source_id,
+                "target_id": relation.target_id,
+                "relation_type": relation.relation_type,
+                "attributes": relation.attributes,
+                "confidence": relation.confidence,
+                "valid_from": relation.temporal.valid_from,
+                "valid_to": relation.temporal.valid_to,
+                "provenance": asdict(relation.provenance),
+            },
+        )
+
+    def upsert_fact(self, fact: GraphFact) -> None:
+        self._connector.execute(
+            "MERGE (s:Entity {id: $subject_id}) "
+            "MERGE (f:Fact {id: $fact_id}) "
+            "SET f.predicate = $predicate, f.fact_type = $fact_type, f.attributes = $attributes, "
+            "f.confidence = $confidence, f.valid_from = $valid_from, f.valid_to = $valid_to, "
+            "f.provenance = $provenance, f.object_value = $object_value "
+            "MERGE (s)-[:HAS_FACT]->(f)",
+            {
+                "subject_id": fact.subject_id,
+                "fact_id": fact.fact_id,
+                "predicate": fact.predicate,
+                "fact_type": fact.fact_type,
+                "attributes": fact.attributes,
+                "confidence": fact.confidence,
+                "valid_from": fact.temporal.valid_from,
+                "valid_to": fact.temporal.valid_to,
+                "provenance": asdict(fact.provenance),
+                "object_value": fact.object_value,
+            },
+        )
+        if fact.object_id:
+            self._connector.execute(
+                "MERGE (o:Entity {id: $object_id}) "
+                "MERGE (f:Fact {id: $fact_id}) "
+                "MERGE (f)-[:ABOUT]->(o)",
+                {"object_id": fact.object_id, "fact_id": fact.fact_id},
+            )
+
+    def retrieve_user_evidence(self, user_id: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        rows = self._connector.execute(
+            "MATCH (u:Entity {id: $user_id})-[:HAS_FACT]->(f:Fact) "
+            "OPTIONAL MATCH (f)-[:ABOUT]->(o:Entity) "
+            "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
+            "o.id AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
+            "f.attributes AS attributes, f.valid_from AS valid_from "
+            "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
+            {"user_id": user_id, "limit": limit},
+        )
+        return _rows_to_evidence(rows)
+
+    def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        rows = self._connector.execute(
+            "MATCH (f:Fact) "
+            "WHERE toLower(f.predicate) CONTAINS toLower($topic) "
+            "OR toLower(coalesce(f.object_value, '')) CONTAINS toLower($topic) "
+            "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
+            "NULL AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
+            "f.attributes AS attributes, f.valid_from AS valid_from "
+            "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
+            {"topic": topic, "limit": limit},
+        )
+        return _rows_to_evidence(rows)
+
+
+class InMemoryGraphMemoryStore(GraphMemoryStore):
+    """Local fallback adapter used in tests and development."""
+
+    def __init__(self) -> None:
+        self.entities: dict[str, GraphEntity] = {}
+        self.relations: dict[tuple[str, str, str], GraphRelation] = {}
+        self.facts: dict[str, GraphFact] = {}
+
+    def upsert_entity(self, entity: GraphEntity) -> None:
+        self.entities[entity.entity_id] = entity
+
+    def upsert_relation(self, relation: GraphRelation) -> None:
+        self.relations[(relation.source_id, relation.relation_type, relation.target_id)] = relation
+
+    def upsert_fact(self, fact: GraphFact) -> None:
+        self.facts[fact.fact_id] = fact
+
+    def retrieve_user_evidence(self, user_id: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        out = [
+            _fact_to_evidence(f)
+            for f in self.facts.values()
+            if f.subject_id == user_id or f.object_id == user_id
+        ]
+        return _rank_and_dedup(out, limit)
+
+    def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        topic_l = topic.lower()
+        out = []
+        for fact in self.facts.values():
+            hay = " ".join(
+                [
+                    fact.predicate.lower(),
+                    str(fact.object_value or "").lower(),
+                    str(fact.attributes.get("topic", "")).lower(),
+                ]
+            )
+            if topic_l in hay:
+                out.append(_fact_to_evidence(fact))
+        return _rank_and_dedup(out, limit)
+
+
+def _rows_to_evidence(rows: Sequence[Any]) -> list[GraphEvidence]:
+    evidences = []
+    for row in rows:
+        evidence_id = _row_get(row, "evidence_id", "")
+        predicate = _row_get(row, "predicate", "fact")
+        object_value = _row_get(row, "object_value", "")
+        confidence = float(_row_get(row, "confidence", 0.5) or 0.5)
+        provenance = _row_get(row, "provenance", {}) or {}
+        attrs = _row_get(row, "attributes", {}) or {}
+        summary = f"{predicate}: {object_value}".strip()
+        evidences.append(
+            GraphEvidence(
+                evidence_id=str(evidence_id),
+                summary=summary,
+                entity_id=_row_get(row, "object_id"),
+                relation_type=predicate,
+                score=_score(confidence, attrs),
+                confidence=confidence,
+                provenance=_prov_from_any(provenance),
+                attributes=attrs,
+            )
+        )
+    return _rank_and_dedup(evidences, limit=len(evidences))
+
+
+def _prov_from_any(raw: Any):
+    from .store import Provenance
+
+    if isinstance(raw, dict):
+        return Provenance(
+            source=str(raw.get("source", "unknown")),
+            source_id=raw.get("source_id"),
+            observed_at=raw.get("observed_at"),
+        )
+    return Provenance(source="unknown")
+
+
+def _row_get(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _fact_to_evidence(fact: GraphFact) -> GraphEvidence:
+    summary = fact.object_value or fact.object_id or ""
+    return GraphEvidence(
+        evidence_id=fact.fact_id,
+        summary=f"{fact.predicate}: {summary}",
+        entity_id=fact.object_id,
+        relation_type=fact.predicate,
+        score=_score(fact.confidence, fact.attributes),
+        confidence=fact.confidence,
+        provenance=fact.provenance,
+        attributes=fact.attributes,
+    )
+
+
+def _score(confidence: float, attrs: dict[str, Any]) -> float:
+    recency_boost = 0.0
+    observed = attrs.get("observed_at") or attrs.get("timestamp")
+    if observed:
+        try:
+            delta = datetime.now(timezone.utc) - datetime.fromisoformat(str(observed).replace("Z", "+00:00"))
+            recency_boost = max(0.0, 1.0 - min(delta.days / 365.0, 1.0)) * 0.1
+        except Exception:
+            recency_boost = 0.0
+    return round(float(confidence) + recency_boost, 6)
+
+
+def _rank_and_dedup(evidences: Sequence[GraphEvidence], limit: int) -> list[GraphEvidence]:
+    dedup: dict[str, GraphEvidence] = {}
+    for item in evidences:
+        key = item.summary.strip().lower()
+        prev = dedup.get(key)
+        if prev is None or item.score > prev.score:
+            dedup[key] = item
+    ranked = sorted(dedup.values(), key=lambda x: (x.score, x.confidence), reverse=True)
+    return ranked[:limit]

--- a/src/deepthought/memory/graph/migration.py
+++ b/src/deepthought/memory/graph/migration.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from ..fact_extractor import extract_typed_fact_triples_from_turn
+from .pipeline import ingest_conversation_turns
+from .store import GraphMemoryStore
+
+
+def migrate_sqlite_memories_to_graph(sqlite_path: str, store: GraphMemoryStore) -> dict[str, Any]:
+    """Move rows from SQLite ``memories`` into graph facts with provenance tags."""
+
+    conn = sqlite3.connect(sqlite_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT user_id, topic, memory, sentiment_score, timestamp FROM memories ORDER BY timestamp ASC"
+    ).fetchall()
+    conn.close()
+
+    turns = []
+    for row in rows:
+        turns.append(
+            {
+                "user_id": str(row["user_id"] or "anonymous"),
+                "text": str(row["memory"] or ""),
+                "timestamp": str(row["timestamp"] or ""),
+                "input_id": f"sqlite-memory:{row['user_id']}:{row['timestamp']}",
+            }
+        )
+        if row["topic"]:
+            triples = extract_typed_fact_triples_from_turn(
+                user_id=str(row["user_id"] or "anonymous"),
+                message=f"My favorite topic is {row['topic']}",
+                timestamp=str(row["timestamp"] or ""),
+                source_id=f"sqlite-topic:{row['user_id']}:{row['timestamp']}",
+            )
+            for triple in triples:
+                turns.append(
+                    {
+                        "user_id": triple["subject_id"],
+                        "text": f"{triple['predicate']} {triple.get('object_value')}",
+                        "timestamp": str(row["timestamp"] or ""),
+                        "input_id": f"sqlite-derived:{triple['subject_id']}:{triple['predicate']}",
+                    }
+                )
+
+    upserts = ingest_conversation_turns(turns, store)
+    return {"rows_read": len(rows), "graph_upserts": upserts}

--- a/src/deepthought/memory/graph/pipeline.py
+++ b/src/deepthought/memory/graph/pipeline.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Iterable, Sequence
+
+from ..fact_extractor import extract_typed_fact_triples_from_turn
+from .store import GraphEntity, GraphFact, GraphMemoryStore, GraphRelation, Provenance, TemporalValidity, utc_now_iso
+
+
+def ingest_conversation_turns(
+    turns: Sequence[dict[str, Any]],
+    store: GraphMemoryStore,
+    *,
+    default_user_id: str = "anonymous",
+) -> int:
+    """Extract typed triples from turns and write entities/relations/facts."""
+
+    upserts = 0
+    for turn in turns:
+        user_id = str(turn.get("user_id") or default_user_id)
+        text = str(turn.get("text") or "")
+        timestamp = str(turn.get("timestamp") or utc_now_iso())
+        source_id = str(turn.get("input_id") or turn.get("id") or _stable_id(user_id, text, timestamp))
+
+        triples = extract_typed_fact_triples_from_turn(user_id=user_id, message=text, timestamp=timestamp, source_id=source_id)
+        for triple in triples:
+            subject = GraphEntity(
+                entity_id=triple["subject_id"],
+                entity_type=triple.get("subject_type", "user"),
+                label=triple.get("subject_label", triple["subject_id"]),
+                attributes={"last_seen": timestamp},
+                provenance=Provenance(source="conversation_turn", source_id=source_id, observed_at=timestamp),
+                confidence=float(triple.get("confidence", 0.7)),
+            )
+            store.upsert_entity(subject)
+
+            obj_id = triple.get("object_id")
+            if obj_id:
+                store.upsert_entity(
+                    GraphEntity(
+                        entity_id=obj_id,
+                        entity_type=triple.get("object_type", "topic"),
+                        label=triple.get("object_label", obj_id),
+                        attributes=triple.get("object_attributes", {}),
+                        provenance=subject.provenance,
+                        confidence=float(triple.get("confidence", 0.7)),
+                    )
+                )
+                store.upsert_relation(
+                    GraphRelation(
+                        source_id=triple["subject_id"],
+                        relation_type=triple["predicate"],
+                        target_id=obj_id,
+                        attributes=triple.get("attributes", {}),
+                        provenance=subject.provenance,
+                        confidence=float(triple.get("confidence", 0.7)),
+                        temporal=TemporalValidity(valid_from=timestamp),
+                    )
+                )
+            fact_id = _stable_id(triple["subject_id"], triple["predicate"], str(obj_id or triple.get("object_value")))
+            store.upsert_fact(
+                GraphFact(
+                    fact_id=fact_id,
+                    subject_id=triple["subject_id"],
+                    predicate=triple["predicate"],
+                    object_id=obj_id,
+                    object_value=triple.get("object_value"),
+                    fact_type=triple.get("fact_type", "profile"),
+                    attributes={**triple.get("attributes", {}), "timestamp": timestamp},
+                    provenance=subject.provenance,
+                    confidence=float(triple.get("confidence", 0.7)),
+                    temporal=TemporalValidity(valid_from=timestamp),
+                )
+            )
+            upserts += 1
+    return upserts
+
+
+def _stable_id(*parts: Iterable[str] | str) -> str:
+    joined = "|".join(str(p) for p in parts)
+    return hashlib.sha1(joined.encode("utf-8")).hexdigest()

--- a/src/deepthought/memory/graph/retrieval.py
+++ b/src/deepthought/memory/graph/retrieval.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from .store import GraphEvidence, GraphMemoryStore
+
+
+def retrieve_user_context(store: GraphMemoryStore, user_id: str, *, limit: int = 8) -> list[GraphEvidence]:
+    return _rank_dedup(store.retrieve_user_evidence(user_id, limit=limit), limit)
+
+
+def retrieve_topic_context(store: GraphMemoryStore, topic: str, *, limit: int = 8) -> list[GraphEvidence]:
+    return _rank_dedup(store.retrieve_topic_evidence(topic, limit=limit), limit)
+
+
+def _rank_dedup(items: Sequence[GraphEvidence], limit: int) -> list[GraphEvidence]:
+    dedup: dict[str, GraphEvidence] = {}
+    for item in items:
+        key = item.summary.strip().lower()
+        prev = dedup.get(key)
+        if prev is None or item.score > prev.score:
+            dedup[key] = item
+    ranked = sorted(dedup.values(), key=lambda i: (i.score, i.confidence), reverse=True)
+    return ranked[:limit]

--- a/src/deepthought/memory/graph/store.py
+++ b/src/deepthought/memory/graph/store.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol, Sequence
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source: str
+    source_id: str | None = None
+    observed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class TemporalValidity:
+    valid_from: str | None = None
+    valid_to: str | None = None
+
+
+@dataclass(frozen=True)
+class GraphEntity:
+    entity_id: str
+    entity_type: str
+    label: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    provenance: Provenance = field(default_factory=lambda: Provenance(source="unknown"))
+    confidence: float = 1.0
+    temporal: TemporalValidity = field(default_factory=TemporalValidity)
+
+
+@dataclass(frozen=True)
+class GraphRelation:
+    source_id: str
+    relation_type: str
+    target_id: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+    provenance: Provenance = field(default_factory=lambda: Provenance(source="unknown"))
+    confidence: float = 1.0
+    temporal: TemporalValidity = field(default_factory=TemporalValidity)
+
+
+@dataclass(frozen=True)
+class GraphFact:
+    fact_id: str
+    subject_id: str
+    predicate: str
+    object_id: str | None = None
+    object_value: str | None = None
+    fact_type: str = "observation"
+    attributes: dict[str, Any] = field(default_factory=dict)
+    provenance: Provenance = field(default_factory=lambda: Provenance(source="unknown"))
+    confidence: float = 1.0
+    temporal: TemporalValidity = field(default_factory=TemporalValidity)
+
+
+@dataclass(frozen=True)
+class GraphEvidence:
+    evidence_id: str
+    summary: str
+    entity_id: str | None
+    relation_type: str | None
+    score: float
+    confidence: float
+    provenance: Provenance
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class GraphMemoryStore(Protocol):
+    def upsert_entity(self, entity: GraphEntity) -> None:
+        ...
+
+    def upsert_relation(self, relation: GraphRelation) -> None:
+        ...
+
+    def upsert_fact(self, fact: GraphFact) -> None:
+        ...
+
+    def retrieve_user_evidence(self, user_id: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        ...
+
+    def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+        ...

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -19,6 +19,13 @@ from ..eda.events import (
     PerceptionEmbeddingsPayload,
 )
 from ..memory import create_memory_backend
+from ..memory.graph import (
+    CypherGraphMemoryStore,
+    InMemoryGraphMemoryStore,
+    ingest_conversation_turns,
+    retrieve_topic_context,
+    retrieve_user_context,
+)
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..perception.social_perception import analyze as analyze_social
@@ -72,6 +79,23 @@ class CognitiveCoreService(BaseService):
         self._search = search
         self._top_k = self._settings.memory_top_k
         self._input_enrichment = InputEnrichmentService()
+        self._graph_memory = self._build_graph_memory_store()
+
+    def _build_graph_memory_store(self):
+        backend = (self._settings.graph_backend or "").lower()
+        if backend in {"memgraph", "neo4j"}:
+            try:
+                graph_backend = getattr(self._memory, "graph_backend", None)
+                connector = None
+                if hasattr(graph_backend, "_dal"):
+                    connector = getattr(getattr(graph_backend, "_dal", None), "_connector", None)
+                elif graph_backend is not None and hasattr(graph_backend, "_connector"):
+                    connector = getattr(graph_backend, "_connector", None)
+                if connector is not None:
+                    return CypherGraphMemoryStore(connector)
+            except Exception:
+                logger.warning("Falling back to in-memory graph store", exc_info=True)
+        return InMemoryGraphMemoryStore()
 
     @classmethod
     def from_config(
@@ -191,11 +215,27 @@ class CognitiveCoreService(BaseService):
             )
             await self._db.adjust_affinity(resolved_user_id, delta)
 
+            ingest_conversation_turns(
+                [
+                    {
+                        "user_id": resolved_user_id,
+                        "text": user_input,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "input_id": input_id,
+                    }
+                ],
+                self._graph_memory,
+                default_user_id=str(resolved_user_id),
+            )
+
             mem_facts = self.retrieve_context(user_input)
             db_facts = await self._db_context()
+            graph_user_evidence = retrieve_user_context(self._graph_memory, str(resolved_user_id), limit=self._top_k)
+            graph_topic_evidence = retrieve_topic_context(self._graph_memory, user_input, limit=self._top_k)
+            graph_facts = [ev.summary for ev in [*graph_user_evidence, *graph_topic_evidence]]
             facts: List[str] = []
             seen = set()
-            for item in mem_facts + db_facts:
+            for item in mem_facts + db_facts + graph_facts:
                 if item not in seen:
                     seen.add(item)
                     facts.append(item)

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -276,6 +276,7 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload.input_id == "x"
     assert "hello" in sent_payload.retrieved_knowledge["facts"]
+    assert service._graph_memory.retrieve_user_evidence("anonymous", limit=5)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_graph_memory_subsystem.py
+++ b/tests/unit/test_graph_memory_subsystem.py
@@ -1,0 +1,69 @@
+import sqlite3
+
+from deepthought.memory.fact_extractor import extract_typed_fact_triples_from_turn
+from deepthought.memory.graph import (
+    InMemoryGraphMemoryStore,
+    ingest_conversation_turns,
+    migrate_sqlite_memories_to_graph,
+    retrieve_topic_context,
+    retrieve_user_context,
+)
+
+
+def test_extract_typed_fact_triples_from_turn():
+    triples = extract_typed_fact_triples_from_turn(
+        user_id="u1",
+        message="Call me Ace. I enjoy hiking and chess. My favorite color is blue.",
+        timestamp="2024-01-01T00:00:00+00:00",
+        source_id="turn-1",
+    )
+
+    predicates = {t["predicate"] for t in triples}
+    assert "has_nickname" in predicates
+    assert "likes_hobby" in predicates
+    assert "favorite" in predicates
+
+
+def test_ingest_and_retrieve_dedup_ranked():
+    store = InMemoryGraphMemoryStore()
+    ingest_conversation_turns(
+        [
+            {"user_id": "u1", "text": "I like chess", "timestamp": "2024-01-01T00:00:00+00:00", "input_id": "a"},
+            {
+                "user_id": "u1",
+                "text": "My favorite game is chess",
+                "timestamp": "2024-01-02T00:00:00+00:00",
+                "input_id": "b",
+            },
+        ],
+        store,
+    )
+
+    user_ctx = retrieve_user_context(store, "u1", limit=10)
+    topic_ctx = retrieve_topic_context(store, "chess", limit=10)
+
+    assert user_ctx
+    assert topic_ctx
+    assert len({e.summary for e in topic_ctx}) == len(topic_ctx)
+    assert topic_ctx[0].score >= topic_ctx[-1].score
+
+
+def test_migrate_sqlite_memories_to_graph(tmp_path):
+    db_path = tmp_path / "migrate.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE memories (user_id TEXT, topic TEXT, memory TEXT, sentiment_score REAL, timestamp DATETIME)"
+    )
+    conn.execute(
+        "INSERT INTO memories (user_id, topic, memory, sentiment_score, timestamp) VALUES (?, ?, ?, ?, ?)",
+        ("u1", "books", "Call me Ace", 0.7, "2024-01-01T00:00:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    store = InMemoryGraphMemoryStore()
+    stats = migrate_sqlite_memories_to_graph(str(db_path), store)
+
+    assert stats["rows_read"] == 1
+    assert stats["graph_upserts"] >= 1
+    assert retrieve_user_context(store, "u1", limit=5)


### PR DESCRIPTION
### Motivation
- Provide a structured graph-memory layer to capture typed entities/relations/facts with provenance, temporal validity and confidence for richer long-term memory and context retrieval. 
- Support Neo4j/Memgraph backends while keeping a lightweight in-memory fallback for tests and local development. 
- Extract typed facts from conversation turns and surface ranked, deduplicated evidence for user- and topic-centric retrieval to improve prompt/context building. 

### Description
- Introduces a graph-memory API and canonical records in `src/deepthought/memory/graph/` including `store.py` (types + `GraphMemoryStore`), `adapters.py` ( `CypherGraphMemoryStore` and `InMemoryGraphMemoryStore`), `pipeline.py` (ingest conversation turns -> upserts), `retrieval.py` (user/topic retrieval + ranking/dedup), and `migration.py` (SQLite `memories` -> graph). 
- Extends `src/deepthought/memory/fact_extractor.py` with `extract_typed_fact_triples_from_turn` to emit typed triples, attributes, confidence and a fallback `mentioned` fact. 
- Wires graph-memory into `CognitiveCoreService` so `_handle_input` now calls `ingest_conversation_turns` to write graph facts and reads graph context via `retrieve_user_context`/`retrieve_topic_context` before publishing `MemoryRetrieved` events. 
- Exposes the new extractor in `src/deepthought/memory/__init__.py` and adds focused unit tests in `tests/unit/test_graph_memory_subsystem.py` and a small assertion update in the cognitive-core service unit test. 

### Testing
- Ran `pytest -q tests/test_fact_extractor.py tests/unit/test_graph_memory_subsystem.py tests/unit/services/test_cognitive_core_service.py` and resolved an initial missing dependency by installing `aiosqlite`, after which the test suite completed successfully (`10 passed`). 
- Ran `flake8` after installing `flake8` and linted `src/deepthought/memory/fact_extractor.py src/deepthought/memory/graph src/deepthought/services/cognitive_core_service.py tests/unit/test_graph_memory_subsystem.py tests/unit/services/test_cognitive_core_service.py` with no reported issues. 
- Unit tests exercise typed extraction, ingestion/upsert logic, ranking/dedup retrieval, SQLite migration, and the CognitiveCoreService integration, all of which passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a834977ae48326ad61abf6fd6f7150)