### PR TITLE
Humanized Discord gateway: interaction policy, threading, and cooldowns

### DIFF
--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -145,6 +145,10 @@ def normalize_legacy_payload(subject: str, payload: Dict[str, Any]) -> Dict[str,
 
 def validate_input_received_payload(data: Dict[str, Any]) -> Dict[str, Any]:
     _expect_type(data, "user_input", str)
+    for optional_text_field in ("message_id", "channel_id", "guild_id", "author_id", "reference_message_id", "thread_id"):
+        value = data.get(optional_text_field)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"Field '{optional_text_field}' must be a string")
     attachments = data.get("attachments")
     if attachments is not None:
         if not isinstance(attachments, list):
@@ -179,6 +183,13 @@ def validate_response_candidates_payload(data: Dict[str, Any]) -> Dict[str, Any]
 
 def validate_response_ranked_payload(data: Dict[str, Any]) -> Dict[str, Any]:
     _expect_type(data, "final_response", str)
+    for optional_text_field in ("reply_to_message_id", "thread_id"):
+        value = data.get(optional_text_field)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"Field '{optional_text_field}' must be a string")
+    policy = data.get("interaction_policy")
+    if policy is not None and not isinstance(policy, dict):
+        raise ValueError("Field 'interaction_policy' must be an object")
     if "candidates" in data:
         validate_response_candidates_payload({"candidates": data["candidates"]})
     return data

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -147,6 +147,8 @@ class InputReceivedPayload(EventPayload):
     author_id: Optional[str] = None
     author_name: Optional[str] = None
     author_is_bot: Optional[bool] = None
+    reference_message_id: Optional[str] = None
+    thread_id: Optional[str] = None
     attachments: Optional[list[AttachmentDescriptor]] = None
 
     @classmethod
@@ -163,6 +165,8 @@ class InputReceivedPayload(EventPayload):
             "author_id": data.get("author_id"),
             "author_name": data.get("author_name"),
             "author_is_bot": data.get("author_is_bot"),
+            "reference_message_id": data.get("reference_message_id"),
+            "thread_id": data.get("thread_id"),
         }
         raw_attachments = data.get("attachments")
         if isinstance(raw_attachments, list):
@@ -253,6 +257,7 @@ class ResponseCandidatesPayload(EventPayload):
     channel_id: Optional[str] = None
     author_id: Optional[str] = None
     timestamp: Optional[str] = None
+    interaction_policy: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ResponseCandidatesPayload":
@@ -272,6 +277,7 @@ class ResponseCandidatesPayload(EventPayload):
             channel_id=data.get("channel_id"),
             author_id=data.get("author_id"),
             timestamp=data.get("timestamp"),
+            interaction_policy=data.get("interaction_policy"),
         )
 
 
@@ -287,6 +293,9 @@ class ResponseRankedPayload(EventPayload):
     timestamp: Optional[str] = None
     confidence: Optional[float] = None
     source: Optional[str] = None
+    reply_to_message_id: Optional[str] = None
+    thread_id: Optional[str] = None
+    interaction_policy: Optional[Dict[str, Any]] = None
     candidates: list[ResponseCandidate] = field(default_factory=list)
 
     @classmethod
@@ -309,6 +318,9 @@ class ResponseRankedPayload(EventPayload):
             timestamp=data.get("timestamp"),
             confidence=data.get("confidence"),
             source=data.get("source"),
+            reply_to_message_id=data.get("reply_to_message_id"),
+            thread_id=data.get("thread_id"),
+            interaction_policy=data.get("interaction_policy"),
             candidates=candidates,
         )
 

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from time import monotonic
+from typing import Any, Awaitable, Callable, Protocol
 
 from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
@@ -12,16 +16,25 @@ from nats.js.client import JetStreamContext
 
 from ..eda.events import EventSubjects, InputReceivedPayload, ResponseRankedPayload
 from .base import BaseService
+from .human_interaction_policy import HumanInteractionPolicy
 
 logger = logging.getLogger(__name__)
 
 
 class _Channel(Protocol):
-    async def send(self, content: str) -> None: ...
+    async def send(self, content: str, **kwargs: Any) -> None: ...
 
 
 class _DiscordClient(Protocol):
     def get_channel(self, channel_id: int) -> _Channel | None: ...
+
+
+@dataclass
+class _PendingRoute:
+    channel_id: str
+    source_message_id: str | None
+    thread_id: str | None
+    author_id: str | None
 
 
 class DiscordGatewayService(BaseService):
@@ -38,6 +51,9 @@ class DiscordGatewayService(BaseService):
         nats_url: str | None = None,
         connect_retries: int = 1,
         connect_timeout: float = 2.0,
+        interaction_policy: HumanInteractionPolicy | None = None,
+        clock: Callable[[], float] = monotonic,
+        sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
     ) -> None:
         super().__init__(
             nats_client,
@@ -47,7 +63,13 @@ class DiscordGatewayService(BaseService):
             connect_timeout=connect_timeout,
         )
         self._discord_client = discord_client
-        self._pending_channels: dict[str, str] = {}
+        self._pending_routes: dict[str, _PendingRoute] = {}
+        self._interaction_policy = interaction_policy or HumanInteractionPolicy()
+        self._clock = clock
+        self._sleep = sleeper
+        self._recent_channel_activity: dict[str, list[float]] = {}
+        self._familiarity_counts: dict[tuple[str, str], int] = {}
+        self._cooldown_until: dict[str, float] = {}
         self.add_subscription(
             response_subject,
             self._handle_ranked_response,
@@ -64,6 +86,8 @@ class DiscordGatewayService(BaseService):
         channel = getattr(message, "channel", None)
         guild = getattr(message, "guild", None)
         raw_attachments = getattr(message, "attachments", None)
+        reference = getattr(message, "reference", None)
+        thread = getattr(message, "thread", None)
         attachments = []
         if isinstance(raw_attachments, (list, tuple)):
             for attachment in raw_attachments:
@@ -88,8 +112,36 @@ class DiscordGatewayService(BaseService):
             author_id=(str(getattr(author, "id", "")) if getattr(author, "id", None) is not None else None),
             author_name=(getattr(author, "display_name", None) or getattr(author, "name", None)),
             author_is_bot=bool(getattr(author, "bot", False)) if author is not None else None,
+            reference_message_id=(
+                str(getattr(reference, "message_id", "")) if getattr(reference, "message_id", None) is not None else None
+            ),
+            thread_id=(str(getattr(thread, "id", "")) if getattr(thread, "id", None) is not None else None),
             attachments=attachments or None,
         )
+
+    def _record_inbound_activity(self, *, channel_id: str | None, author_id: str | None) -> None:
+        now = self._clock()
+        if channel_id:
+            window = [ts for ts in self._recent_channel_activity.get(channel_id, []) if now - ts <= 60.0]
+            window.append(now)
+            self._recent_channel_activity[channel_id] = window
+            if author_id:
+                key = (channel_id, author_id)
+                self._familiarity_counts[key] = self._familiarity_counts.get(key, 0) + 1
+
+    def _estimate_channel_pace(self, channel_id: str | None) -> float:
+        if not channel_id:
+            return 0.0
+        now = self._clock()
+        active = [ts for ts in self._recent_channel_activity.get(channel_id, []) if now - ts <= 60.0]
+        self._recent_channel_activity[channel_id] = active
+        return float(len(active))
+
+    def _estimate_familiarity(self, channel_id: str | None, author_id: str | None) -> float:
+        if not channel_id or not author_id:
+            return 0.0
+        count = self._familiarity_counts.get((channel_id, author_id), 0)
+        return min(count / 8.0, 1.0)
 
     async def handle_discord_message(self, message: Any) -> str | None:
         """Publish human-authored Discord messages as INPUT_RECEIVED events."""
@@ -102,8 +154,14 @@ class DiscordGatewayService(BaseService):
             return None
 
         payload = self.build_input_payload(message)
+        self._record_inbound_activity(channel_id=payload.channel_id, author_id=payload.author_id)
         if payload.input_id and payload.channel_id:
-            self._pending_channels[payload.input_id] = payload.channel_id
+            self._pending_routes[payload.input_id] = _PendingRoute(
+                channel_id=payload.channel_id,
+                source_message_id=payload.message_id,
+                thread_id=payload.thread_id,
+                author_id=payload.author_id,
+            )
 
         await self._publisher.publish(
             EventSubjects.INPUT_RECEIVED,
@@ -113,19 +171,75 @@ class DiscordGatewayService(BaseService):
         )
         return payload.input_id
 
-    async def _send_channel_message(self, channel_id: str, content: str) -> bool:
+    @asynccontextmanager
+    async def _typing_scope(self, channel: _Channel, typing_seconds: float):
+        if typing_seconds <= 0:
+            yield
+            return
+        typing = getattr(channel, "typing", None)
+        if callable(typing):
+            async with typing():
+                await self._sleep(typing_seconds)
+                yield
+            return
+        await self._sleep(typing_seconds)
+        yield
+
+    async def _wait_for_cooldown(self, channel_id: str, author_id: str | None) -> list[str]:
+        now = self._clock()
+        keys = [f"channel:{channel_id}"]
+        if author_id:
+            keys.append(f"user:{author_id}")
+        wait = max([self._cooldown_until.get(key, 0.0) - now for key in keys], default=0.0)
+        if wait > 0:
+            await self._sleep(wait)
+        return keys
+
+    def _set_cooldown(self, keys: list[str], cooldown_seconds: float) -> None:
+        until = self._clock() + cooldown_seconds
+        for key in keys:
+            self._cooldown_until[key] = until
+
+    async def _send_channel_message(
+        self,
+        channel_id: str,
+        *,
+        content: str,
+        reply_to_message_id: str | None,
+        thread_id: str | None,
+        author_id: str | None,
+        interaction_metadata: dict[str, Any] | None,
+    ) -> bool:
         if self._discord_client is None:
             logger.warning("Discord client unavailable; cannot forward ranked response")
             return False
+
+        target_id = thread_id or channel_id
         try:
-            channel = self._discord_client.get_channel(int(channel_id))
+            channel = self._discord_client.get_channel(int(target_id))
         except (TypeError, ValueError):
-            logger.warning("Invalid channel id: %s", channel_id)
+            logger.warning("Invalid channel id: %s", target_id)
             return True
         if channel is None:
-            logger.warning("Channel %s not found", channel_id)
+            logger.warning("Channel %s not found", target_id)
             return True
-        await channel.send(content)
+
+        decision = self._interaction_policy.decide(
+            message_text=content,
+            channel_pace=self._estimate_channel_pace(channel_id),
+            familiarity=self._estimate_familiarity(channel_id, author_id),
+            metadata=interaction_metadata,
+        )
+        cooldown_keys = await self._wait_for_cooldown(channel_id, author_id)
+        if decision.delay_seconds > 0:
+            await self._sleep(decision.delay_seconds)
+
+        send_kwargs: dict[str, Any] = {}
+        if reply_to_message_id is not None:
+            send_kwargs["reference"] = reply_to_message_id
+        async with self._typing_scope(channel, decision.typing_seconds):
+            await channel.send(content, **send_kwargs)
+        self._set_cooldown(cooldown_keys, decision.cooldown_seconds)
         return True
 
     async def _handle_ranked_response(self, msg: Msg) -> None:
@@ -137,18 +251,27 @@ class DiscordGatewayService(BaseService):
             if not payload.final_response:
                 raise ValueError("final_response is required")
 
-            channel_id = payload.channel_id
-            if not channel_id and payload.input_id:
-                channel_id = self._pending_channels.get(payload.input_id)
+            route = self._pending_routes.get(payload.input_id or "") if payload.input_id else None
+            channel_id = payload.channel_id or (route.channel_id if route else None)
+            reply_to_message_id = payload.reply_to_message_id or (route.source_message_id if route else None)
+            thread_id = payload.thread_id or (route.thread_id if route else None)
+            author_id = payload.author_id or (route.author_id if route else None)
             if not channel_id:
                 logger.warning("No channel mapping found for ranked response input_id=%s", payload.input_id)
                 await msg.ack()
                 return
 
-            sent = await self._send_channel_message(channel_id, payload.final_response)
+            sent = await self._send_channel_message(
+                channel_id,
+                content=payload.final_response,
+                reply_to_message_id=reply_to_message_id,
+                thread_id=thread_id,
+                author_id=author_id,
+                interaction_metadata=payload.interaction_policy,
+            )
             if sent:
                 if payload.input_id:
-                    self._pending_channels.pop(payload.input_id, None)
+                    self._pending_routes.pop(payload.input_id, None)
                 await msg.ack()
             elif hasattr(msg, "nak") and callable(msg.nak):
                 await msg.nak()

--- a/src/deepthought/services/human_interaction_policy.py
+++ b/src/deepthought/services/human_interaction_policy.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class InteractionPolicyDecision:
+    delay_seconds: float
+    typing_seconds: float
+    cooldown_seconds: float
+    style_modifiers: list[str] = field(default_factory=list)
+
+
+class HumanInteractionPolicy:
+    """Compute human-like timing and style hints for outbound Discord responses."""
+
+    def __init__(
+        self,
+        *,
+        min_delay_seconds: float = 0.2,
+        max_delay_seconds: float = 4.0,
+        typing_chars_per_second: float = 18.0,
+        max_typing_seconds: float = 6.0,
+    ) -> None:
+        self._min_delay = max(0.0, min_delay_seconds)
+        self._max_delay = max(self._min_delay, max_delay_seconds)
+        self._typing_cps = max(1.0, typing_chars_per_second)
+        self._max_typing = max(0.0, max_typing_seconds)
+
+    def decide(
+        self,
+        *,
+        message_text: str,
+        channel_pace: float,
+        familiarity: float,
+        metadata: dict[str, object] | None = None,
+    ) -> InteractionPolicyDecision:
+        """Return timing and style decisions.
+
+        Args:
+            message_text: message to be sent.
+            channel_pace: estimated messages/minute in channel.
+            familiarity: [0, 1] estimate for how familiar this user/channel is.
+            metadata: optional planner/selector hints that override computed values.
+        """
+
+        text = message_text or ""
+        length_factor = min(len(text) / 240.0, 1.0)
+        pace_factor = min(max(channel_pace, 0.0) / 30.0, 1.0)
+        familiarity_factor = min(max(familiarity, 0.0), 1.0)
+
+        baseline = self._min_delay + (self._max_delay - self._min_delay) * (0.45 * length_factor + 0.35 * pace_factor)
+        baseline *= 1.15 - (0.45 * familiarity_factor)
+        delay_seconds = min(max(baseline, self._min_delay), self._max_delay)
+
+        typing_seconds = min(len(text) / self._typing_cps, self._max_typing)
+        cooldown_seconds = min(3.0, 0.25 + 0.75 * length_factor + 0.5 * pace_factor)
+
+        style_modifiers: list[str] = []
+        if pace_factor > 0.65:
+            style_modifiers.append("concise")
+        if familiarity_factor > 0.70:
+            style_modifiers.append("warm")
+        elif familiarity_factor < 0.25:
+            style_modifiers.append("formal")
+        if len(text) > 300:
+            style_modifiers.append("structured")
+
+        if metadata:
+            raw_delay = metadata.get("delay_seconds")
+            if isinstance(raw_delay, (int, float)):
+                delay_seconds = min(max(float(raw_delay), 0.0), self._max_delay)
+            raw_typing = metadata.get("typing_seconds")
+            if isinstance(raw_typing, (int, float)):
+                typing_seconds = min(max(float(raw_typing), 0.0), self._max_typing)
+            raw_cooldown = metadata.get("cooldown_seconds")
+            if isinstance(raw_cooldown, (int, float)):
+                cooldown_seconds = min(max(float(raw_cooldown), 0.0), 10.0)
+            raw_modifiers = metadata.get("style_modifiers")
+            if isinstance(raw_modifiers, list):
+                style_modifiers = [m for m in raw_modifiers if isinstance(m, str)]
+
+        return InteractionPolicyDecision(
+            delay_seconds=round(delay_seconds, 3),
+            typing_seconds=round(typing_seconds, 3),
+            cooldown_seconds=round(cooldown_seconds, 3),
+            style_modifiers=style_modifiers,
+        )

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -61,6 +61,7 @@ class SelectorService:
                 timestamp=datetime.now(timezone.utc).isoformat(),
                 confidence=selected.confidence,
                 source=selected.source,
+                interaction_policy=payload.interaction_policy,
                 candidates=ranked_candidates,
             )
             await self._publisher.publish(

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -7,6 +7,17 @@ from deepthought.eda.events import EventSubjects, ResponseRankedPayload
 from deepthought.services.discord_gateway_service import DiscordGatewayService
 
 
+class FakeClock:
+    def __init__(self):
+        self.now = 100.0
+
+    def __call__(self):
+        return self.now
+
+    async def sleep(self, seconds: float):
+        self.now += max(0.0, seconds)
+
+
 class DummyNATS:
     is_connected = True
 
@@ -47,29 +58,62 @@ class DummyMsg:
         self.nacked = True
 
 
+class DummyTypingScope:
+    def __init__(self, channel):
+        self._channel = channel
+
+    async def __aenter__(self):
+        self._channel.typing_entries += 1
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
 class DummyChannel:
     def __init__(self):
         self.messages = []
+        self.typing_entries = 0
 
-    async def send(self, content: str):
-        self.messages.append(content)
+    def typing(self):
+        return DummyTypingScope(self)
+
+    async def send(self, content: str, **kwargs):
+        self.messages.append((content, kwargs))
 
 
 class DummyDiscordClient:
     def __init__(self):
         self.channel = DummyChannel()
+        self.thread = DummyChannel()
 
     def get_channel(self, channel_id: int):
-        return self.channel if channel_id == 123 else None
+        if channel_id == 123:
+            return self.channel
+        if channel_id == 999:
+            return self.thread
+        return None
 
 
 @pytest.fixture
-def service(monkeypatch):
+
+def fake_clock():
+    return FakeClock()
+
+
+@pytest.fixture
+
+def service(monkeypatch, fake_clock):
     import deepthought.services.base as base_mod
 
     monkeypatch.setattr(base_mod, "Publisher", DummyPublisher)
     monkeypatch.setattr(base_mod, "Subscriber", DummySubscriber)
-    return DiscordGatewayService(DummyNATS(), DummyJS(), discord_client=DummyDiscordClient())
+    return DiscordGatewayService(
+        DummyNATS(),
+        DummyJS(),
+        discord_client=DummyDiscordClient(),
+        clock=fake_clock,
+        sleeper=fake_clock.sleep,
+    )
 
 
 @pytest.mark.asyncio
@@ -77,6 +121,8 @@ async def test_handle_discord_message_publishes_input_received(service):
     message = SimpleNamespace(
         content="hello",
         id=99,
+        reference=SimpleNamespace(message_id=66),
+        thread=SimpleNamespace(id=999),
         author=SimpleNamespace(id=5, name="alice", display_name="Alice", bot=False),
         channel=SimpleNamespace(id=123),
         guild=SimpleNamespace(id=7),
@@ -98,6 +144,8 @@ async def test_handle_discord_message_publishes_input_received(service):
     assert use_js is True
     assert payload.user_input == "hello"
     assert payload.channel_id == "123"
+    assert payload.reference_message_id == "66"
+    assert payload.thread_id == "999"
     assert payload.attachments is not None
     assert payload.attachments[0].url == "https://cdn.discordapp.com/file.png"
 
@@ -110,15 +158,48 @@ async def test_handle_discord_message_ignores_bots(service):
 
 
 @pytest.mark.asyncio
-async def test_ranked_response_sent_and_acked(service):
-    payload = ResponseRankedPayload(final_response="done", input_id="in-1", channel_id="123")
+async def test_ranked_response_respects_thread_reply_and_policy_override(service, fake_clock):
+    payload = ResponseRankedPayload(
+        final_response="done",
+        input_id="in-1",
+        channel_id="123",
+        thread_id="999",
+        reply_to_message_id="orig-7",
+        interaction_policy={"delay_seconds": 0.4, "typing_seconds": 0.2, "cooldown_seconds": 0.5},
+    )
     msg = DummyMsg(payload.to_json())
 
     await service._handle_ranked_response(msg)
 
     assert msg.acked
     assert not msg.nacked
-    assert service._discord_client.channel.messages == ["done"]
+    assert fake_clock.now == pytest.approx(100.6, abs=0.001)
+    assert service._discord_client.thread.messages == [("done", {"reference": "orig-7"})]
+
+
+@pytest.mark.asyncio
+async def test_ranked_response_applies_cooldown_per_channel(service, fake_clock):
+    first = DummyMsg(
+        ResponseRankedPayload(
+            final_response="first",
+            channel_id="123",
+            interaction_policy={"delay_seconds": 0.0, "typing_seconds": 0.0, "cooldown_seconds": 1.0},
+        ).to_json()
+    )
+    second = DummyMsg(
+        ResponseRankedPayload(
+            final_response="second",
+            channel_id="123",
+            interaction_policy={"delay_seconds": 0.0, "typing_seconds": 0.0, "cooldown_seconds": 1.0},
+        ).to_json()
+    )
+
+    await service._handle_ranked_response(first)
+    before_second = fake_clock.now
+    await service._handle_ranked_response(second)
+
+    assert second.acked
+    assert fake_clock.now - before_second >= 1.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_human_interaction_policy.py
+++ b/tests/unit/services/test_human_interaction_policy.py
@@ -1,0 +1,30 @@
+from deepthought.services.human_interaction_policy import HumanInteractionPolicy
+
+
+def test_policy_delay_bounds_are_clamped():
+    policy = HumanInteractionPolicy(min_delay_seconds=0.2, max_delay_seconds=1.1)
+    low = policy.decide(message_text="hi", channel_pace=0.0, familiarity=1.0)
+    high = policy.decide(message_text="x" * 1000, channel_pace=999.0, familiarity=0.0)
+
+    assert 0.2 <= low.delay_seconds <= 1.1
+    assert 0.2 <= high.delay_seconds <= 1.1
+
+
+def test_policy_metadata_override_is_deterministic():
+    policy = HumanInteractionPolicy(max_typing_seconds=3.0)
+    decision = policy.decide(
+        message_text="hello",
+        channel_pace=5.0,
+        familiarity=0.3,
+        metadata={
+            "delay_seconds": 0.5,
+            "typing_seconds": 5.0,
+            "cooldown_seconds": 2.5,
+            "style_modifiers": ["gentle", "concise"],
+        },
+    )
+
+    assert decision.delay_seconds == 0.5
+    assert decision.typing_seconds == 3.0
+    assert decision.cooldown_seconds == 2.5
+    assert decision.style_modifiers == ["gentle", "concise"]


### PR DESCRIPTION
### Motivation
- Make outbound Discord responses behave more human-like by adding deterministic timing, typing, and style decisions based on message length, channel pace, and user familiarity.
- Preserve contextual reply targets (message references and threads) so replies are routed to the originating conversation context.
- Prevent robotic burst behavior by adding channel/user cooldowns and allowing selector/planner hints to influence tone and timing.

### Description
- Added `HumanInteractionPolicy` to compute `delay_seconds`, `typing_seconds`, `cooldown_seconds`, and `style_modifiers` with metadata overrides (new file `src/deepthought/services/human_interaction_policy.py`).
- Extended EDA payloads to carry routing and policy metadata by adding `reference_message_id`/`thread_id` to `InputReceivedPayload` and adding `interaction_policy`, `reply_to_message_id`, and `thread_id` to candidate/ranked response payloads (`src/deepthought/eda/events.py`) and validated in contracts (`src/deepthought/eda/contracts/__init__.py`).
- Enhanced `DiscordGatewayService` to capture inbound reference/thread context, maintain pending route metadata, estimate channel pace and familiarity, apply policy-decided delay/typing, and enforce per-channel/user cooldowns when sending messages (`src/deepthought/services/discord_gateway_service.py`).
- Propagated `interaction_policy` from `ResponseCandidatesPayload` into `ResponseRankedPayload` in the selector so downstream gateway can apply planner/selector hints (`src/deepthought/services/selector_service.py`).
- Added deterministic unit tests using a fake clock for policy bounds, metadata override determinism, contextual thread/reply routing, and cooldown behavior (`tests/unit/services/test_human_interaction_policy.py` and updated `tests/unit/services/test_discord_gateway_service.py`).

### Testing
- Ran static checks: `ruff check` on modified service, policy, events, contracts, selector, and test files and all checks passed.
- Ran unit tests: `pytest -q tests/unit/services/test_human_interaction_policy.py tests/unit/services/test_discord_gateway_service.py tests/unit/eda/test_event_contracts.py` and all tests passed (17 passed).
- The added tests exercise deterministic fake-clock sleeps and validate delay bounds, metadata overrides, routing to threads/replies, and cooldown enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83dc1947c8326b69cda58852e203f)