### PR TITLE
Windowed, calibrated aggregation selector with safety hooks and telemetry

### DIFF
--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import asyncio
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Callable, Optional
 
@@ -18,8 +20,21 @@ from ..eda.events import (
 )
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from . import moderation
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _AggregationState:
+    input_id: str
+    candidates: list[ResponseCandidate] = field(default_factory=list)
+    user_id: Optional[str] = None
+    author_id: Optional[str] = None
+    channel_id: Optional[str] = None
+    interaction_policy: Optional[dict] = None
+    opened_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    flush_task: asyncio.Task[None] | None = None
 
 
 class SelectorService:
@@ -30,14 +45,150 @@ class SelectorService:
         nats_client: NATS,
         js_context: JetStreamContext,
         safety_filter: Optional[Callable[[ResponseCandidate], bool]] = None,
+        window_seconds: float = 0.15,
+        early_exit_confidence: float = 0.9,
+        source_confidence_weights: Optional[dict[str, float]] = None,
+        toxicity_guard: Optional[Callable[[ResponseCandidate], bool]] = None,
+        contradiction_checker: Optional[Callable[[ResponseCandidate, list[ResponseCandidate]], bool]] = None,
+        repetition_penalty: Optional[Callable[[ResponseCandidate, list[ResponseCandidate]], float]] = None,
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._safety_filter = safety_filter
+        self._window_seconds = max(0.0, window_seconds)
+        self._early_exit_confidence = early_exit_confidence
+        self._source_confidence_weights = source_confidence_weights or {}
+        self._toxicity_guard = toxicity_guard or self._default_toxicity_guard
+        self._contradiction_checker = contradiction_checker or (lambda _c, _all: True)
+        self._repetition_penalty = repetition_penalty or self._default_repetition_penalty
+        self._pending_by_input: dict[str, _AggregationState] = {}
+        self._aggregation_lock = asyncio.Lock()
 
-    def _rank_candidates(self, candidates: list[ResponseCandidate]) -> list[ResponseCandidate]:
-        filtered = [c for c in candidates if (self._safety_filter(c) if self._safety_filter else c.safety_passed is not False)]
-        return sorted(filtered, key=lambda c: c.confidence, reverse=True)
+    def _default_toxicity_guard(self, candidate: ResponseCandidate) -> bool:
+        score, _ = moderation.evaluate_toxicity(candidate.text)
+        return score < moderation.TOXICITY_THRESHOLD
+
+    def _default_repetition_penalty(
+        self,
+        candidate: ResponseCandidate,
+        all_candidates: list[ResponseCandidate],
+    ) -> float:
+        duplicates = sum(1 for item in all_candidates if item.text.strip().lower() == candidate.text.strip().lower())
+        return min(0.3, max(0, duplicates - 1) * 0.1)
+
+    def _normalized_confidence(self, candidate: ResponseCandidate) -> float:
+        source = (candidate.source or "default").lower()
+        weight = self._source_confidence_weights.get(source, self._source_confidence_weights.get("default", 1.0))
+        return max(0.0, candidate.confidence * weight)
+
+    def _choose_fallback(self, interaction_policy: Optional[dict]) -> tuple[str, str]:
+        policy = interaction_policy or {}
+        if policy.get("ask_clarifying_on_no_safe", True):
+            return (
+                "I don't yet have a safe, reliable answer. Could you clarify what outcome you want?",
+                "clarifying_question",
+            )
+        return ("I want to help, but I need a safer way to answer this request.", "safe_default")
+
+    def _rank_candidates(self, candidates: list[ResponseCandidate]) -> tuple[list[ResponseCandidate], list[dict]]:
+        diagnostics: list[dict] = []
+        scored: list[tuple[float, ResponseCandidate]] = []
+        for candidate in candidates:
+            rejection_reasons: list[str] = []
+            normalized = self._normalized_confidence(candidate)
+            if not (self._safety_filter(candidate) if self._safety_filter else candidate.safety_passed is not False):
+                rejection_reasons.append("safety_filter")
+            if not self._toxicity_guard(candidate):
+                rejection_reasons.append("toxicity")
+            if not self._contradiction_checker(candidate, candidates):
+                rejection_reasons.append("contradiction")
+            penalty = self._repetition_penalty(candidate, candidates)
+            final_score = max(0.0, normalized - penalty)
+            if rejection_reasons:
+                diagnostics.append(
+                    {
+                        "text": candidate.text,
+                        "source": candidate.source,
+                        "confidence": candidate.confidence,
+                        "normalized_confidence": normalized,
+                        "score": final_score,
+                        "rejection_reasons": rejection_reasons,
+                    }
+                )
+                continue
+            scored.append((final_score, candidate))
+            diagnostics.append(
+                {
+                    "text": candidate.text,
+                    "source": candidate.source,
+                    "confidence": candidate.confidence,
+                    "normalized_confidence": normalized,
+                    "score": final_score,
+                    "rejection_reasons": [],
+                }
+            )
+
+        ranked = [candidate for _, candidate in sorted(scored, key=lambda item: item[0], reverse=True)]
+        return ranked, sorted(diagnostics, key=lambda item: item["score"], reverse=True)
+
+    async def _publish_selection(self, state: _AggregationState) -> None:
+        ranked_candidates, diagnostics = self._rank_candidates(state.candidates)
+        fallback_reason = None
+        if ranked_candidates:
+            selected = ranked_candidates[0]
+            final_response = selected.text
+            final_confidence = self._normalized_confidence(selected)
+            final_source = selected.source
+        else:
+            final_response, fallback_reason = self._choose_fallback(state.interaction_policy)
+            final_confidence = 0.0
+            final_source = "selector_fallback"
+
+        ranked_payload = ResponseRankedPayload(
+            final_response=final_response,
+            input_id=state.input_id,
+            user_id=state.author_id or state.user_id,
+            author_id=state.author_id,
+            channel_id=state.channel_id,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            confidence=final_confidence,
+            source=final_source,
+            interaction_policy=state.interaction_policy,
+            candidates=ranked_candidates,
+        )
+        await self._publisher.publish(
+            EventSubjects.RESPONSE_RANKED,
+            ranked_payload,
+            use_jetstream=True,
+            timeout=10.0,
+        )
+
+        telemetry_payload = {
+            "input_id": state.input_id,
+            "chosen_source": final_source,
+            "selected_confidence": final_confidence,
+            "fallback_reason": fallback_reason,
+            "window_seconds": self._window_seconds,
+            "candidate_count": len(state.candidates),
+            "diagnostics": diagnostics,
+        }
+        await self._publisher.publish(
+            "dtr.telemetry.selector_ranking.v1",
+            telemetry_payload,
+            use_jetstream=True,
+            timeout=10.0,
+        )
+
+    async def _flush_input_id(self, input_id: str) -> None:
+        async with self._aggregation_lock:
+            state = self._pending_by_input.pop(input_id, None)
+        if state is None:
+            return
+        await self._publish_selection(state)
+
+    async def _schedule_flush(self, input_id: str) -> None:
+        await asyncio.sleep(self._window_seconds)
+        await self._flush_input_id(input_id)
 
     async def _handle_candidates_event(self, msg: Msg) -> None:
         try:
@@ -45,32 +196,40 @@ class SelectorService:
             if not isinstance(data, dict):
                 raise ValueError("ResponseCandidates payload must be a dict")
             payload = ResponseCandidatesPayload.from_dict(data)
-            ranked_candidates = self._rank_candidates(payload.candidates)
-            if not ranked_candidates:
-                await msg.ack()
-                logger.warning("SelectorService received empty candidates for input_id=%s", payload.input_id)
-                return
+            input_id = payload.input_id or "global"
 
-            selected = ranked_candidates[0]
-            ranked_payload = ResponseRankedPayload(
-                final_response=selected.text,
-                input_id=payload.input_id,
-                user_id=payload.author_id or payload.user_id,
-                author_id=payload.author_id,
-                channel_id=payload.channel_id,
-                timestamp=datetime.now(timezone.utc).isoformat(),
-                confidence=selected.confidence,
-                source=selected.source,
-                interaction_policy=payload.interaction_policy,
-                candidates=ranked_candidates,
-            )
-            await self._publisher.publish(
-                EventSubjects.RESPONSE_RANKED,
-                ranked_payload,
-                use_jetstream=True,
-                timeout=10.0,
-            )
+            async with self._aggregation_lock:
+                state = self._pending_by_input.get(input_id)
+                if state is None:
+                    state = _AggregationState(
+                        input_id=input_id,
+                        user_id=payload.user_id,
+                        author_id=payload.author_id,
+                        channel_id=payload.channel_id,
+                        interaction_policy=payload.interaction_policy,
+                    )
+                    self._pending_by_input[input_id] = state
+
+                state.candidates.extend(payload.candidates)
+                state.user_id = state.user_id or payload.user_id
+                state.author_id = state.author_id or payload.author_id
+                state.channel_id = state.channel_id or payload.channel_id
+                state.interaction_policy = state.interaction_policy or payload.interaction_policy
+
+                ranked_candidates, _ = self._rank_candidates(state.candidates)
+                early_exit = bool(ranked_candidates) and self._normalized_confidence(ranked_candidates[0]) >= self._early_exit_confidence
+                if early_exit:
+                    if state.flush_task and not state.flush_task.done():
+                        state.flush_task.cancel()
+                    flush_now = True
+                else:
+                    flush_now = False
+                    if state.flush_task is None or state.flush_task.done():
+                        state.flush_task = asyncio.create_task(self._schedule_flush(input_id))
+
             await msg.ack()
+            if flush_now:
+                await self._flush_input_id(input_id)
         except (json.JSONDecodeError, ValueError):
             logger.error("Invalid response candidates payload", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
@@ -96,4 +255,9 @@ class SelectorService:
             return False
 
     async def stop(self) -> None:
+        async with self._aggregation_lock:
+            flush_tasks = [state.flush_task for state in self._pending_by_input.values() if state.flush_task and not state.flush_task.done()]
+            self._pending_by_input.clear()
+        for task in flush_tasks:
+            task.cancel()
         await self._subscriber.unsubscribe_all()

--- a/tests/integration/test_selector_service_flow.py
+++ b/tests/integration/test_selector_service_flow.py
@@ -52,7 +52,7 @@ async def test_start_uses_durable_and_subject(monkeypatch):
     monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
     monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
 
-    svc = SelectorService(DummyNATS(), DummyJS())
+    svc = SelectorService(DummyNATS(), DummyJS(), early_exit_confidence=0.0)
     ok = await svc.start(durable_name="selector_durable")
     assert ok is True
     assert svc._subscriber.calls[0]["subject"] == EventSubjects.RESPONSE_CANDIDATES
@@ -67,7 +67,7 @@ async def test_candidates_publish_and_ack(monkeypatch):
     monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
     monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
 
-    svc = SelectorService(DummyNATS(), DummyJS())
+    svc = SelectorService(DummyNATS(), DummyJS(), early_exit_confidence=0.0)
     payload = ResponseCandidatesPayload(
         input_id="i-1",
         candidates=[
@@ -85,3 +85,4 @@ async def test_candidates_publish_and_ack(monkeypatch):
     assert subject == EventSubjects.RESPONSE_RANKED
     assert use_jetstream is True
     assert ranked_payload.final_response == "high"
+    assert svc._publisher.calls[1][0] == "dtr.telemetry.selector_ranking.v1"

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 
 import pytest
@@ -52,7 +53,7 @@ def service(monkeypatch):
 
     monkeypatch.setattr(mod, "Publisher", DummyPublisher)
     monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
-    return SelectorService(DummyNATS(), DummyJS())
+    return SelectorService(DummyNATS(), DummyJS(), window_seconds=0.0, early_exit_confidence=0.0)
 
 
 @pytest.mark.asyncio
@@ -72,6 +73,9 @@ async def test_rank_by_confidence(service):
     subject, ranked = service._publisher.published[0]
     assert subject == EventSubjects.RESPONSE_RANKED
     assert ranked.final_response == "high"
+    telemetry_subject, telemetry_payload = service._publisher.published[1]
+    assert telemetry_subject == "dtr.telemetry.selector_ranking.v1"
+    assert telemetry_payload["chosen_source"] is None
 
 
 @pytest.mark.asyncio
@@ -79,9 +83,11 @@ async def test_empty_candidates_ack_without_publish(service):
     payload = ResponseCandidatesPayload(input_id="2", candidates=[])
     msg = DummyMsg(payload.to_json())
     await service._handle_candidates_event(msg)
+    await asyncio.sleep(0.02)
 
     assert msg.acked
-    assert service._publisher.published == []
+    assert len(service._publisher.published) == 2
+    assert service._publisher.published[0][1].source == "selector_fallback"
 
 
 @pytest.mark.asyncio
@@ -89,3 +95,88 @@ async def test_invalid_payload_nak(service):
     msg = DummyMsg(json.dumps(["bad"]))
     await service._handle_candidates_event(msg)
     assert msg.nacked
+
+
+@pytest.mark.asyncio
+async def test_window_aggregates_candidates_before_flush(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(DummyNATS(), DummyJS(), window_seconds=0.03, early_exit_confidence=0.99)
+
+    msg1 = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="window-1",
+            candidates=[ResponseCandidate(text="one", confidence=0.6)],
+        ).to_json()
+    )
+    msg2 = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="window-1",
+            candidates=[ResponseCandidate(text="two", confidence=0.8)],
+        ).to_json()
+    )
+    await svc._handle_candidates_event(msg1)
+    await svc._handle_candidates_event(msg2)
+    assert svc._publisher.published == []
+
+    await asyncio.sleep(0.05)
+    assert svc._publisher.published[0][1].final_response == "two"
+
+
+@pytest.mark.asyncio
+async def test_unsafe_only_candidates_use_clarifying_fallback(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(
+        DummyNATS(),
+        DummyJS(),
+        early_exit_confidence=0.0,
+        safety_filter=lambda _: False,
+        window_seconds=0.0,
+    )
+
+    msg = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="unsafe-1",
+            candidates=[ResponseCandidate(text="risky", confidence=0.9, source="x")],
+        ).to_json()
+    )
+    await svc._handle_candidates_event(msg)
+    await asyncio.sleep(0.02)
+
+    ranked_payload = svc._publisher.published[0][1]
+    assert ranked_payload.source == "selector_fallback"
+    assert "clarify" in ranked_payload.final_response.lower()
+
+
+@pytest.mark.asyncio
+async def test_source_calibration_changes_ranking(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(
+        DummyNATS(),
+        DummyJS(),
+        early_exit_confidence=0.0,
+        source_confidence_weights={"default": 1.0, "trusted": 1.6},
+    )
+
+    msg = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="cal-1",
+            candidates=[
+                ResponseCandidate(text="base", confidence=0.7, source="default"),
+                ResponseCandidate(text="weighted", confidence=0.5, source="trusted"),
+            ],
+        ).to_json()
+    )
+    await svc._handle_candidates_event(msg)
+
+    assert svc._publisher.published[0][1].final_response == "weighted"
+    diagnostics = svc._publisher.published[1][1]["diagnostics"]
+    assert diagnostics[0]["source"] == "trusted"


### PR DESCRIPTION
### Motivation
- Improve selection quality by aggregating responder candidates per `input_id` over a short, configurable time window so multiple responders can be compared together.
- Make ranking robust by calibrating confidences by responder source and applying semantic/safety reranking checks to avoid toxic, contradictory, or repetitive outputs.
- Provide deterministic fallback behavior and rich telemetry so offline tuning and monitoring of the selector decisions is possible.

### Description
- Replaced one-shot ranking with a windowed aggregator keyed by `input_id` that buffers candidates for `window_seconds` and supports an `early_exit_confidence` early flush. 
- Added source-aware confidence normalization via `source_confidence_weights` and implemented reranking hooks: toxicity guard (default uses `moderation.evaluate_toxicity`), contradiction checker hook, and repetition penalty hook.
- Implemented deterministic fallback behavior that emits either a clarifying question or a safe default based on an `interaction_policy` when no safe candidates remain.
- Emit a telemetry event `dtr.telemetry.selector_ranking.v1` containing chosen source, scores, candidate diagnostics, rejection reasons, window info, and candidate counts; added publishing of both `ResponseRankedPayload` and telemetry per flush.
- Updated/extended tests and integration expectations to cover window aggregation timing, empty candidate lists, unsafe-only lists, and mixed-source calibration.

### Testing
- Ran unit and integration tests via `pytest tests/unit/services/test_selector_service.py tests/integration/test_selector_service_flow.py` and all tests passed (`8 passed`).
- Ran linter checks via `ruff check` on the modified files and there were no issues reported.
- Added and exercised new unit tests that validate multi-candidate timing aggregation, empty candidate fallback, unsafe-only fallback, and source calibration behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a841f02b2c8326a1b180cec2c5b945)