### PR TITLE
Fix Discord gateway exception flow and add regression tests + CI parse check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         run: pre-commit run --all-files
       - name: Run flake8
         run: flake8 src tests
+      - name: Static parse check for Discord gateway service
+        run: python -m py_compile src/deepthought/services/discord_gateway_service.py
       - env:
           PYTHONPATH: src
         run: pytest --cov=src --cov-report=xml --cov-fail-under=80 -m "not nats"

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -217,7 +217,10 @@ class DiscordGatewayService(BaseService):
         target_id = thread_id or channel_id
         try:
             channel = self._discord_client.get_channel(int(target_id))
-        except (TypeError, ValueError):
+        except TypeError:
+            logger.warning("Invalid channel id type: %s", target_id)
+            return True
+        except ValueError:
             logger.warning("Invalid channel id: %s", target_id)
             return True
         if channel is None:
@@ -243,6 +246,7 @@ class DiscordGatewayService(BaseService):
         return True
 
     async def _handle_ranked_response(self, msg: Msg) -> None:
+        action = "ack"
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
@@ -258,32 +262,33 @@ class DiscordGatewayService(BaseService):
             author_id = payload.author_id or (route.author_id if route else None)
             if not channel_id:
                 logger.warning("No channel mapping found for ranked response input_id=%s", payload.input_id)
-                await msg.ack()
-                return
-
-            sent = await self._send_channel_message(
-                channel_id,
-                content=payload.final_response,
-                reply_to_message_id=reply_to_message_id,
-                thread_id=thread_id,
-                author_id=author_id,
-                interaction_metadata=payload.interaction_policy,
-            )
-            if sent:
-                if payload.input_id:
-                    self._pending_routes.pop(payload.input_id, None)
-                await msg.ack()
-            elif hasattr(msg, "nak") and callable(msg.nak):
-                await msg.nak()
             else:
-                await msg.ack()
-        except (json.JSONDecodeError, ValueError):
+                sent = await self._send_channel_message(
+                    channel_id,
+                    content=payload.final_response,
+                    reply_to_message_id=reply_to_message_id,
+                    thread_id=thread_id,
+                    author_id=author_id,
+                    interaction_metadata=payload.interaction_policy,
+                )
+                if sent:
+                    if payload.input_id:
+                        self._pending_routes.pop(payload.input_id, None)
+                elif hasattr(msg, "nak") and callable(msg.nak):
+                    action = "nak"
+                else:
+                    action = "ack"
+        except json.JSONDecodeError:
             logger.error("Invalid ranked response payload", exc_info=True)
-            if hasattr(msg, "nak") and callable(msg.nak):
-                await msg.nak()
-            elif hasattr(msg, "ack") and callable(msg.ack):
-                await msg.ack()
+            action = "nak"
+        except ValueError:
+            logger.error("Invalid ranked response payload", exc_info=True)
+            action = "nak"
         except Exception:
             logger.error("Failed to handle ranked response", exc_info=True)
-            if hasattr(msg, "nak") and callable(msg.nak):
-                await msg.nak()
+            action = "nak"
+
+        if action == "nak" and hasattr(msg, "nak") and callable(msg.nak):
+            await msg.nak()
+        elif hasattr(msg, "ack") and callable(msg.ack):
+            await msg.ack()

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -50,12 +50,16 @@ class DummyMsg:
         self.data = data.encode()
         self.acked = False
         self.nacked = False
+        self.ack_calls = 0
+        self.nak_calls = 0
 
     async def ack(self):
         self.acked = True
+        self.ack_calls += 1
 
     async def nak(self):
         self.nacked = True
+        self.nak_calls += 1
 
 
 class DummyTypingScope:
@@ -209,3 +213,76 @@ async def test_ranked_response_invalid_payload_naks(service):
     await service._handle_ranked_response(msg)
 
     assert msg.nacked
+    assert msg.nak_calls == 1
+    assert msg.ack_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_send_channel_message_invalid_channel_or_thread_id_returns_true(service):
+    sent_channel = await service._send_channel_message(
+        "not-a-channel-id",
+        content="ignored",
+        reply_to_message_id=None,
+        thread_id=None,
+        author_id=None,
+        interaction_metadata=None,
+    )
+    sent_thread = await service._send_channel_message(
+        "123",
+        content="ignored",
+        reply_to_message_id=None,
+        thread_id="not-a-thread-id",
+        author_id=None,
+        interaction_metadata=None,
+    )
+
+    assert sent_channel is True
+    assert sent_thread is True
+    assert service._discord_client.channel.messages == []
+    assert service._discord_client.thread.messages == []
+
+
+@pytest.mark.asyncio
+async def test_send_channel_message_missing_channel_lookup_returns_true(service):
+    sent = await service._send_channel_message(
+        "321",
+        content="ignored",
+        reply_to_message_id=None,
+        thread_id=None,
+        author_id=None,
+        interaction_metadata=None,
+    )
+
+    assert sent is True
+    assert service._discord_client.channel.messages == []
+
+
+@pytest.mark.asyncio
+async def test_send_channel_message_applies_typing_delay_and_cooldown(service, fake_clock):
+    sent = await service._send_channel_message(
+        "123",
+        content="hello",
+        reply_to_message_id="orig-1",
+        thread_id=None,
+        author_id="42",
+        interaction_metadata={"delay_seconds": 0.4, "typing_seconds": 0.2, "cooldown_seconds": 0.5},
+    )
+
+    assert sent is True
+    assert fake_clock.now == pytest.approx(100.6, abs=0.001)
+    assert service._discord_client.channel.typing_entries == 1
+    assert service._discord_client.channel.messages == [("hello", {"reference": "orig-1"})]
+    assert service._cooldown_until["channel:123"] == pytest.approx(101.1, abs=0.001)
+    assert service._cooldown_until["user:42"] == pytest.approx(101.1, abs=0.001)
+
+
+@pytest.mark.asyncio
+async def test_ranked_response_missing_channel_mapping_acks_once(service):
+    msg = DummyMsg(ResponseRankedPayload(final_response="done", input_id="unknown").to_json())
+
+    await service._handle_ranked_response(msg)
+
+    assert msg.acked is True
+    assert msg.nacked is False
+    assert msg.ack_calls == 1
+    assert msg.nak_calls == 0


### PR DESCRIPTION
### Motivation
- Prevent ambiguous exception handling and duplicated `except` branches in `DiscordGatewayService` that could lead to multiple or missed `ack`/`nak` terminal calls.
- Ensure the send path handles invalid channel/thread IDs deterministically and keeps the control flow simple and auditable.
- Add unit-level regression coverage to prevent the same error pattern from regressing in future changes.

### Description
- Split the combined `except (TypeError, ValueError)` in `_send_channel_message` into separate `TypeError` and `ValueError` branches and added distinct log messages, returning deterministically for invalid ids.
- Refactored `_handle_ranked_response` to drive final acknowledgement via a single `action` variable so that either `ack` or `nak` is invoked exactly once after all exception branches, and added explicit `json.JSONDecodeError` and `ValueError` handlers.
- Added unit tests in `tests/unit/services/test_discord_gateway_service.py` covering invalid channel/thread IDs, missing channel lookup, successful send with typing delay and cooldown behavior, and exactly-once `ack`/`nak` call-count assertions.
- Added a CI static-parse guard to the lint/unit job to run `python -m py_compile src/deepthought/services/discord_gateway_service.py` to catch malformed exception blocks before merge.

### Testing
- Ran `pytest tests/unit/services/test_discord_gateway_service.py` with all unit tests passing (9 passed).
- Ran `python -m py_compile src/deepthought/services/discord_gateway_service.py tests/unit/services/test_discord_gateway_service.py` which succeeded for the service and tests files.
- Local environment did not have `flake8` installed so `flake8` could not be executed here, but the CI job still runs `flake8 src tests` as configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84c59eaac832697f7c727ada79f04)