### PR TITLE
Add PerceptionInterpretService and integrate with ContextAssembler

### DIFF
--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -11,6 +11,7 @@ services:
   # Optional services (enable as needed)
   - social_graph
   - perception
+  - perception_interpret
 
 service_bindings:
   discord_gateway:
@@ -138,6 +139,27 @@ service_bindings:
     publish:
       - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
         event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
+        jetstream: true
+
+  perception_interpret:
+    optional: true
+    description: Convert cached perception embeddings into compact prompt interpretations.
+    env:
+      - NATS_URL
+    subscribe:
+      - subject: dtr.perception.interpret.requested.v1  # legacy alias: dtr.perception.interpret.requested
+        event_subject: EventSubjects.PERCEPTION_INTERPRET_REQUESTED
+        jetstream: true
+        durable: perception_interpret_requests
+        required_reliability: true
+      - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
+        event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
+        jetstream: true
+        durable: perception_interpret_embeddings
+        required_reliability: false
+    publish:
+      - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
+        event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
         jetstream: true
 
 environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ reward_manager = "deepthought.motivate.reward_manager:RewardManager"
 planning = "deepthought.services.planning_service:PlanningService"
 reasoning = "deepthought.services.reasoning_service:ReasoningService"
 discord_gateway = "deepthought.services.discord_gateway_service:DiscordGatewayService"
+perception_interpret = "deepthought.services.perception_interpret_service:PerceptionInterpretService"
 
 
 

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "ReasoningService",
     "SelectorService",
     "DiscordGatewayService",
+    "PerceptionInterpretService",
     "manipulation_score",
 ]
 
@@ -42,6 +43,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ReasoningService": ("reasoning_service", "ReasoningService"),
     "SelectorService": ("selector_service", "SelectorService"),
     "DiscordGatewayService": ("discord_gateway_service", "DiscordGatewayService"),
+    "PerceptionInterpretService": ("perception_interpret_service", "PerceptionInterpretService"),
     "manipulation_score": ("manipulative_detection", "manipulation_score"),
 }
 

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -54,6 +54,7 @@ class ContextAssemblerService:
             "channel_id": payload.get("channel_id"),
             "author_name": payload.get("author_name"),
             "timestamp": payload.get("timestamp"),
+            "attachments": payload.get("attachments"),
         }
         await self._publisher.publish(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, fanout_payload, use_jetstream=True)
         await self._publisher.publish(EventSubjects.PERCEPTION_INTERPRET_REQUESTED, fanout_payload, use_jetstream=True)

--- a/src/deepthought/services/perception_interpret_service.py
+++ b/src/deepthought/services/perception_interpret_service.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import nats
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import EventSubjects, PerceptionEmbeddingsEvent
+from ..eda.publisher import Publisher
+from ..eda.subscriber import Subscriber
+
+logger = logging.getLogger(__name__)
+
+
+class PerceptionInterpretService:
+    """Convert perception payloads into compact prompt-ready interpretations."""
+
+    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+        self._publisher = Publisher(nats_client, js_context)
+        self._subscriber = Subscriber(nats_client, js_context)
+        self._embeddings_by_input_id: dict[str, dict[str, Any]] = {}
+
+    @staticmethod
+    def _attachment_summary(attachments: Any) -> str | None:
+        if not isinstance(attachments, list) or not attachments:
+            return None
+        counts: dict[str, int] = {}
+        for raw_attachment in attachments:
+            if not isinstance(raw_attachment, dict):
+                continue
+            content_type = raw_attachment.get("content_type")
+            if isinstance(content_type, str) and "/" in content_type:
+                media_type = content_type.split("/", maxsplit=1)[0].strip().lower()
+            else:
+                media_type = "file"
+            counts[media_type] = counts.get(media_type, 0) + 1
+        if not counts:
+            return None
+        parts = [f"{media}:{count}" for media, count in sorted(counts.items())]
+        return f"attachments[{', '.join(parts)}]"
+
+    @staticmethod
+    def _embedding_summary(embeddings_payload: dict[str, Any]) -> dict[str, str]:
+        raw_modalities = embeddings_payload.get("by_modality")
+        modalities = raw_modalities if isinstance(raw_modalities, dict) else {}
+        raw_modality_conf = embeddings_payload.get("modality_confidence")
+        modality_conf = raw_modality_conf if isinstance(raw_modality_conf, dict) else {}
+
+        summaries: dict[str, str] = {}
+        for modality_name, modality_payload in modalities.items():
+            if not isinstance(modality_payload, dict):
+                continue
+            vectors = modality_payload.get("embeddings")
+            span_count = len(modality_payload.get("spans") or [])
+            vector_count = len(vectors) if isinstance(vectors, list) else 0
+            dim = 0
+            if vector_count and isinstance(vectors[0], list):
+                dim = len(vectors[0])
+            confidence = modality_conf.get(modality_name)
+            conf_text = (
+                f", conf={float(confidence):.2f}"
+                if isinstance(confidence, (int, float))
+                else ""
+            )
+            summaries[str(modality_name)] = (
+                f"{modality_name}: {vector_count} vectors"
+                f" @dim{dim}, spans={span_count}{conf_text}"
+            )
+        return summaries
+
+    async def _handle_embeddings(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
+                raise ValueError("Embeddings payload must be an object")
+            event = PerceptionEmbeddingsEvent.from_dict(data)
+            payload = event.payload
+            if payload is None or not payload.input_id:
+                await msg.ack()
+                return
+            self._embeddings_by_input_id[payload.input_id] = {
+                "confidence": payload.confidence,
+                "modality_confidence": payload.modality_confidence,
+                "by_modality": {
+                    name: {
+                        "spans": mod.spans,
+                        "embeddings": mod.embeddings,
+                    }
+                    for name, mod in payload.by_modality.items()
+                },
+            }
+            await msg.ack()
+        except Exception:
+            logger.exception("Failed to process PERCEPTION_EMBEDDINGS")
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_interpret_request(self, msg: Msg) -> None:
+        try:
+            payload = json.loads(msg.data.decode())
+            if not isinstance(payload, dict):
+                raise ValueError("Interpret request payload must be an object")
+            input_id = payload.get("input_id")
+            if not isinstance(input_id, str):
+                raise ValueError("Interpret request missing input_id")
+
+            cached = self._embeddings_by_input_id.get(input_id, {})
+            modality_summaries = self._embedding_summary(cached)
+            attachments_summary = self._attachment_summary(payload.get("attachments"))
+
+            compact_lines: list[str] = []
+            if modality_summaries:
+                compact_lines.extend(modality_summaries.values())
+            if attachments_summary:
+                compact_lines.append(attachments_summary)
+            if not compact_lines:
+                compact_lines.append("no multimodal signals")
+
+            out_payload = {
+                "input_id": input_id,
+                "multimodal_interpretations": {
+                    "summary": " | ".join(compact_lines),
+                    "by_modality": modality_summaries,
+                    "attachments": attachments_summary,
+                },
+            }
+            await self._publisher.publish(
+                EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,
+                out_payload,
+                use_jetstream=True,
+            )
+            await msg.ack()
+        except Exception:
+            logger.exception("Failed to process PERCEPTION_INTERPRET_REQUESTED")
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def start(self, durable_name: str = "perception_interpret_service") -> bool:
+        try:
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_EMBEDDINGS,
+                handler=self._handle_embeddings,
+                use_jetstream=True,
+                durable=f"{durable_name}_embeddings",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.PERCEPTION_INTERPRET_REQUESTED,
+                handler=self._handle_interpret_request,
+                use_jetstream=True,
+                durable=f"{durable_name}_requests",
+            )
+            return True
+        except nats.errors.Error:
+            logger.exception("Failed to start PerceptionInterpretService")
+            return False
+
+    async def stop(self) -> None:
+        await self._subscriber.unsubscribe_all()
+
+    async def __aenter__(self) -> "PerceptionInterpretService":
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.stop()

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -135,3 +135,93 @@ async def test_partial_result_when_provider_missing_is_deterministic(monkeypatch
     assert payload.confidence["partial"] is True
     assert payload.confidence["missing_providers"] == ["perception"]
     assert payload.confidence["completed_providers"] == ["memory", "social"]
+
+
+@pytest.mark.asyncio
+async def test_context_assembler_merges_perception_interpretations_within_wait_window(monkeypatch):
+    import deepthought.services.context_assembler_service as ca_mod
+    import deepthought.services.perception_interpret_service as pi_mod
+
+    class InMemoryBus:
+        def __init__(self):
+            self.handlers = {}
+            self.published = []
+
+        async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+            self.published.append((subject, payload, use_jetstream, timeout))
+            for handler in self.handlers.get(subject, []):
+                await handler(DummyMsg(payload))
+
+    class BusSubscriber:
+        def __init__(self, _nats, _js):
+            self.calls = []
+
+        async def subscribe(self, **kwargs):
+            self.calls.append(kwargs)
+            bus.handlers.setdefault(kwargs["subject"], []).append(kwargs["handler"])
+            return True
+
+        async def unsubscribe_all(self):
+            return None
+
+    bus = InMemoryBus()
+
+    monkeypatch.setattr(ca_mod, "Publisher", lambda *_args, **_kwargs: bus)
+    monkeypatch.setattr(ca_mod, "Subscriber", BusSubscriber)
+    monkeypatch.setattr(pi_mod, "Publisher", lambda *_args, **_kwargs: bus)
+    monkeypatch.setattr(pi_mod, "Subscriber", BusSubscriber)
+
+    context_service = ca_mod.ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.08)
+    perception_service = pi_mod.PerceptionInterpretService(DummyNATS(), DummyJS())
+    await context_service.start()
+    await perception_service.start()
+
+    await bus.publish(
+        EventSubjects.PERCEPTION_EMBEDDINGS,
+        {
+            "event": EventSubjects.PERCEPTION_EMBEDDINGS,
+            "version": 1,
+            "payload": {
+                "message_id": "m-1",
+                "user_id": "u-1",
+                "input_id": "i-embed",
+                "confidence": 0.77,
+                "modality_confidence": {"image": 0.71},
+                "by_modality": {
+                    "image": {
+                        "spans": [[0, 400]],
+                        "embeddings": [[0.1, 0.2, 0.3]],
+                        "encoders": [],
+                    }
+                },
+            },
+        },
+    )
+
+    await bus.publish(
+        EventSubjects.INPUT_RECEIVED,
+        {
+            "input_id": "i-embed",
+            "user_input": "look at this",
+            "attachments": [{"url": "https://example.test/a.png", "content_type": "image/png"}],
+        },
+    )
+
+    await bus.publish(
+        EventSubjects.MEMORY_RETRIEVED,
+        {"input_id": "i-embed", "retrieved_knowledge": {"facts": ["fact-a"]}},
+    )
+    await bus.publish(
+        EventSubjects.SOCIAL_UPDATED,
+        {"input_id": "i-embed", "social_signals": {"tone": "positive"}},
+    )
+
+    await asyncio.sleep(0.12)
+
+    assembled = [item for item in bus.published if item[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    assert len(assembled) == 1
+    payload = assembled[0][1]
+    assert payload.input_id == "i-embed"
+    assert payload.multimodal_interpretations["by_modality"]["image"].startswith("image: 1 vectors")
+    assert "attachments[image:1]" in payload.multimodal_interpretations["summary"]
+    assert payload.confidence["partial"] is False


### PR DESCRIPTION
### Motivation
- Provide a lightweight service that maps cached perception embeddings and message attachments into compact, prompt-friendly textual interpretations for use in context assembly and downstream prompts.
- Ensure ContextAssembler can include perception interpretations (including attachment summaries) when assembling responder context within the configured wait window.

### Description
- Added `PerceptionInterpretService` (`src/deepthought/services/perception_interpret_service.py`) which subscribes to `EventSubjects.PERCEPTION_INTERPRET_REQUESTED` and optionally caches `EventSubjects.PERCEPTION_EMBEDDINGS` by `input_id`, computes modality and attachment summaries, and publishes normalized interpretation payloads to `EventSubjects.PERCEPTION_INTERPRET_RETRIEVED`.
- Extended `ContextAssemblerService` fanout request payload to include `attachments` so the interpretation service can incorporate attachment metadata into summaries (`src/deepthought/services/context_assembler_service.py`).
- Registered the new service for lazy import in `deepthought.services` and added an entry-point and orchestration wiring in `pyproject.toml` and `examples/orchestrator.yml` so it can be started by the orchestrator.
- Added an integration test that wires a ContextAssembler and the new PerceptionInterpretService over an in-memory bus to validate that perception interpretations (including attachment-derived summary) are merged into the assembled context within the wait window (`tests/integration/test_context_assembler_service.py`).

### Testing
- Ran linting on modified files with `flake8` (files: `src/deepthought/services/perception_interpret_service.py`, `src/deepthought/services/context_assembler_service.py`, `src/deepthought/services/__init__.py`, `tests/integration/test_context_assembler_service.py`); no lint errors reported.
- Ran integration tests with `pytest -q tests/integration/test_context_assembler_service.py` and observed `3 passed` (all tests in that file passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8502f39008326b3143cd6e339946c)