### PR TITLE
Wire ContextAssembler into orchestrator DAG, register service, and document required event flow

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,18 @@ The project follows an event driven architecture built on NATS/JetStream. Compon
 
 A canonical service-to-subject wiring reference (including durable consumers and required environment variables) is maintained in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
+### Required orchestration DAG
+
+For the default orchestrator profile, the following event chain is **required**. If any publish/subscribe edge is removed, the runtime graph becomes disconnected and response generation will stall.
+
+1. `INPUT_RECEIVED` is published by `discord_gateway` and consumed by `context_assembler`.
+2. `MEMORY_RETRIEVED` is published by `cognitive_core` and consumed by `context_assembler`.
+3. Social context must come from either `SOCIAL_UPDATED` (from `social_graph`) **or** `SOCIAL_SIGNALS_RETRIEVED` (from alternative social providers) and be consumed by `context_assembler`.
+4. `PERCEPTION_INTERPRET_RETRIEVED` is published by `perception_interpret` and consumed by `context_assembler`.
+5. `CONTEXT_ASSEMBLED` is published by `context_assembler` and consumed by `llm_remote` (or another LLM responder).
+
+Operators should treat this as a deployment invariant and verify that each required subject has at least one publisher and one subscriber before startup.
+
 ```mermaid
 sequenceDiagram
     participant User

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -6,12 +6,13 @@
 services:
   - discord_gateway
   - cognitive_core
-  - llm_remote
-  - selector
   # Optional services (enable as needed)
   - social_graph
   - perception
   - perception_interpret
+  - context_assembler
+  - llm_remote
+  - selector
 
 service_bindings:
   discord_gateway:
@@ -74,13 +75,13 @@ service_bindings:
         jetstream: true
 
   llm_remote:
-    description: HTTP-backed responder that turns memory into candidates.
+    description: HTTP-backed responder that turns assembled context into candidates.
     env:
       - NATS_URL
       - LLM_ENDPOINT
     subscribe:
-      - subject: dtr.memory.retrieved.v1  # legacy alias: dtr.memory.retrieved
-        event_subject: EventSubjects.MEMORY_RETRIEVED
+      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+        event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: llm_remote_service
         required_reliability: true
@@ -116,7 +117,10 @@ service_bindings:
         jetstream: true
         durable: social_graph_service
         required_reliability: true
-    publish: []
+    publish:
+      - subject: dtr.social.updated
+        event_subject: EventSubjects.SOCIAL_UPDATED
+        jetstream: true
 
   perception:
     optional: true
@@ -160,6 +164,41 @@ service_bindings:
     publish:
       - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
         event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
+        jetstream: true
+
+  context_assembler:
+    description: Assemble provider outputs into a single LLM-ready context payload.
+    env:
+      - NATS_URL
+    subscribe:
+      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+        durable: context_assembler_input
+        required_reliability: true
+      - subject: dtr.memory.retrieved.v1  # legacy alias: dtr.memory.retrieved
+        event_subject: EventSubjects.MEMORY_RETRIEVED
+        jetstream: true
+        durable: context_assembler_memory
+        required_reliability: true
+      - subject: dtr.social.updated
+        event_subject: EventSubjects.SOCIAL_UPDATED
+        jetstream: true
+        durable: context_assembler_social
+        required_reliability: true
+      - subject: dtr.social.signals.retrieved.v1  # legacy alias: dtr.social.signals.retrieved
+        event_subject: EventSubjects.SOCIAL_SIGNALS_RETRIEVED
+        jetstream: true
+        durable: context_assembler_social_signals
+        required_reliability: false
+      - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
+        event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
+        jetstream: true
+        durable: context_assembler_perception
+        required_reliability: true
+    publish:
+      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+        event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
 
 environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ planning = "deepthought.services.planning_service:PlanningService"
 reasoning = "deepthought.services.reasoning_service:ReasoningService"
 discord_gateway = "deepthought.services.discord_gateway_service:DiscordGatewayService"
 perception_interpret = "deepthought.services.perception_interpret_service:PerceptionInterpretService"
+context_assembler = "deepthought.services.context_assembler_service:ContextAssemblerService"
 
 
 

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
     "SelectorService",
     "DiscordGatewayService",
     "PerceptionInterpretService",
+    "ContextAssemblerService",
     "manipulation_score",
 ]
 
@@ -44,6 +45,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "SelectorService": ("selector_service", "SelectorService"),
     "DiscordGatewayService": ("discord_gateway_service", "DiscordGatewayService"),
     "PerceptionInterpretService": ("perception_interpret_service", "PerceptionInterpretService"),
+    "ContextAssemblerService": ("context_assembler_service", "ContextAssemblerService"),
     "manipulation_score": ("manipulative_detection", "manipulation_score"),
 }
 


### PR DESCRIPTION
### Motivation

- Ensure assembled context from memory/social/perception providers is produced before LLM responders run by inserting a `context_assembler` service into the canonical orchestrator profile. 
- Make the `ContextAssemblerService` discoverable by the orchestrator and operators and prevent accidental deployment of a disconnected event graph.

### Description

- Added `context_assembler` to the default `services` list in `examples/orchestrator.yml` and positioned it after memory/social/perception providers and before `llm_remote`/`selector`.
- Explicitly declared publish/subscribe bindings for `INPUT_RECEIVED`, `MEMORY_RETRIEVED`, `SOCIAL_UPDATED`/`SOCIAL_SIGNALS_RETRIEVED`, `PERCEPTION_INTERPRET_RETRIEVED`, and `CONTEXT_ASSEMBLED` in `examples/orchestrator.yml`, and switched `llm_remote` to subscribe to `CONTEXT_ASSEMBLED`.
- Exported `ContextAssemblerService` via the lazy imports in `src/deepthought/services/__init__.py` and registered the entry point in `pyproject.toml` so the service is discoverable to the orchestrator/plugin loader.
- Documented the required orchestration DAG as an operator invariant in `docs/architecture.md` to warn operators to verify publisher/subscriber edges before startup.

### Testing

- Ran `python -m pytest tests/integration/test_context_assembler_service.py tests/integration/test_orchestrate_two_services.py` which reported `3 passed, 1 skipped`.
- Ran `python -m ruff check src/deepthought/services/__init__.py src/deepthought/services/context_assembler_service.py` which returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a853288ce08326b57a72ea13453ba0)