### PR TITLE
Refactor runtime to canonical provider request/response choreography

### DIFF
--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -39,10 +39,10 @@ service_bindings:
       - DT_SOCIAL_GRAPH_DB
       - DT_SEARCH_DB
     subscribe:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
-        event_subject: EventSubjects.INPUT_RECEIVED
+      - subject: dtr.memory.retrieval.requested.v1  # legacy alias: dtr.memory.retrieval.requested
+        event_subject: EventSubjects.MEMORY_RETRIEVAL_REQUESTED
         jetstream: true
-        durable: cognitive_core_listener
+        durable: cognitive_core_memory_requests
         required_reliability: true
       - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
         event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
@@ -112,14 +112,14 @@ service_bindings:
       - NATS_URL
       - DT_SOCIAL_GRAPH_DB
     subscribe:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
-        event_subject: EventSubjects.INPUT_RECEIVED
+      - subject: dtr.social.signals.requested.v1  # legacy alias: dtr.social.signals.requested
+        event_subject: EventSubjects.SOCIAL_SIGNALS_REQUESTED
         jetstream: true
-        durable: social_graph_service
+        durable: social_graph_requests
         required_reliability: true
     publish:
-      - subject: dtr.social.updated
-        event_subject: EventSubjects.SOCIAL_UPDATED
+      - subject: dtr.social.signals.retrieved.v1  # legacy alias: dtr.social.signals.retrieved
+        event_subject: EventSubjects.SOCIAL_SIGNALS_RETRIEVED
         jetstream: true
 
   perception:
@@ -181,16 +181,11 @@ service_bindings:
         jetstream: true
         durable: context_assembler_memory
         required_reliability: true
-      - subject: dtr.social.updated
-        event_subject: EventSubjects.SOCIAL_UPDATED
-        jetstream: true
-        durable: context_assembler_social
-        required_reliability: true
       - subject: dtr.social.signals.retrieved.v1  # legacy alias: dtr.social.signals.retrieved
         event_subject: EventSubjects.SOCIAL_SIGNALS_RETRIEVED
         jetstream: true
-        durable: context_assembler_social_signals
-        required_reliability: false
+        durable: context_assembler_social
+        required_reliability: true
       - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
         event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
         jetstream: true

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -375,7 +375,7 @@ class CognitiveCoreService(BaseService):
     async def start(self, durable_name: str = "cognitive_core_listener") -> bool:
         self._subscriptions.clear()
         self.add_subscription(
-            subject=EventSubjects.INPUT_RECEIVED,
+            subject=EventSubjects.MEMORY_RETRIEVAL_REQUESTED,
             handler=self._handle_input,
             use_jetstream=True,
             durable=durable_name,
@@ -400,7 +400,7 @@ class CognitiveCoreService(BaseService):
         )
         started = await super().start()
         if started:
-            logger.info("CognitiveCoreService subscribed to %s", EventSubjects.INPUT_RECEIVED)
+            logger.info("CognitiveCoreService subscribed to %s", EventSubjects.MEMORY_RETRIEVAL_REQUESTED)
         return started
 
     async def stop(self) -> None:

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -57,6 +57,7 @@ class ContextAssemblerService:
             "attachments": payload.get("attachments"),
         }
         await self._publisher.publish(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, fanout_payload, use_jetstream=True)
+        await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_REQUESTED, fanout_payload, use_jetstream=True)
         await self._publisher.publish(EventSubjects.PERCEPTION_INTERPRET_REQUESTED, fanout_payload, use_jetstream=True)
 
     async def _handle_input_received(self, msg: Msg) -> None:
@@ -189,7 +190,7 @@ class ContextAssemblerService:
                 durable=f"{durable_name}_memory",
             )
             await self._subscriber.subscribe(
-                subject=EventSubjects.SOCIAL_UPDATED,
+                subject=EventSubjects.SOCIAL_SIGNALS_RETRIEVED,
                 handler=lambda msg: self._handle_provider_response(msg, "social"),
                 use_jetstream=True,
                 durable=f"{durable_name}_social",

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -50,7 +50,7 @@ class SocialGraphService(BaseService):
         self._input_enrichment = input_enrichment or InputEnrichmentService()
 
     async def _handle_input(self, msg: Msg) -> None:
-        """Process an INPUT_RECEIVED message."""
+        """Process a SOCIAL_SIGNALS_REQUESTED message."""
         try:
             enriched = self._input_enrichment.parse_input_received(msg)
             logger.info("SocialGraphService received input %s", enriched.input_id)
@@ -88,7 +88,7 @@ class SocialGraphService(BaseService):
                     "persona": persona,
                 },
             }
-            await self._publisher.publish(EventSubjects.SOCIAL_UPDATED, social_snapshot, use_jetstream=True)
+            await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_RETRIEVED, social_snapshot, use_jetstream=True)
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except (json.JSONDecodeError, ValueError):
@@ -107,7 +107,7 @@ class SocialGraphService(BaseService):
     async def start(self, durable_name: str = "social_graph_service") -> bool:
         self._subscriptions.clear()
         self.add_subscription(
-            subject=EventSubjects.INPUT_RECEIVED,
+            subject=EventSubjects.SOCIAL_SIGNALS_REQUESTED,
             handler=self._handle_input,
             use_jetstream=True,
             durable=durable_name,

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -212,7 +212,7 @@ async def test_context_assembler_merges_perception_interpretations_within_wait_w
         {"input_id": "i-embed", "retrieved_knowledge": {"facts": ["fact-a"]}},
     )
     await bus.publish(
-        EventSubjects.SOCIAL_UPDATED,
+        EventSubjects.SOCIAL_SIGNALS_RETRIEVED,
         {"input_id": "i-embed", "social_signals": {"tone": "positive"}},
     )
 

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -61,7 +61,7 @@ async def test_handle_input_resolves_identity_from_payload_and_headers(tmp_path,
     assert "social_perception" in topics
     assert len(service._publisher.calls) == 1
     event_subject, payload, _, _ = service._publisher.calls[0]
-    assert event_subject == EventSubjects.SOCIAL_UPDATED
+    assert event_subject == EventSubjects.SOCIAL_SIGNALS_RETRIEVED
     assert payload["input_id"] == "1"
     assert payload["social_signals"]["affinity"] == 1
     assert payload["social_signals"]["persona"] == "friendly"


### PR DESCRIPTION
### Motivation
- Unify the runtime pipeline so providers receive canonical request subjects and return canonical retrieved subjects for consistent assembly behavior.
- Prevent duplicate direct pipelines that bypass the context assembler and standardize durable consumer names in the orchestrator wiring.

### Description
- `ContextAssemblerService` now fanouts `INPUT_RECEIVED` into canonical request subjects by publishing `MEMORY_RETRIEVAL_REQUESTED`, `SOCIAL_SIGNALS_REQUESTED`, and `PERCEPTION_INTERPRET_REQUESTED` while still subscribing to `INPUT_RECEIVED` as the trigger.  
- `ContextAssemblerService.start()` subscriptions updated to consume canonical retrieved subjects only (`MEMORY_RETRIEVED`, `SOCIAL_SIGNALS_RETRIEVED`, `PERCEPTION_INTERPRET_RETRIEVED`) instead of legacy direct signals.  
- `CognitiveCoreService` now subscribes to `MEMORY_RETRIEVAL_REQUESTED` (instead of `INPUT_RECEIVED`) and continues to publish `MEMORY_RETRIEVED`.  
- `SocialGraphService` now subscribes to `SOCIAL_SIGNALS_REQUESTED` and publishes `SOCIAL_SIGNALS_RETRIEVED` (replacing `SOCIAL_UPDATED` on the active path).  
- `examples/orchestrator.yml` updated to match canonical subjects and durable consumer names and to remove duplicate context-assembler social subscriptions.  
- Tests updated to assert the canonical social retrieval subject where applicable.

### Testing
- Ran static checks with `ruff check --isolated src/deepthought/services/context_assembler_service.py src/deepthought/services/cognitive_core_service.py src/deepthought/services/social_graph_service.py tests/integration/test_context_assembler_service.py tests/unit/services/test_social_graph_service.py` and it passed.  
- Verified syntax by compiling targets with `python -m compileall src/deepthought/services/context_assembler_service.py src/deepthought/services/cognitive_core_service.py src/deepthought/services/social_graph_service.py tests/integration/test_context_assembler_service.py tests/unit/services/test_social_graph_service.py`, which succeeded.  
- Attempted to run `pytest -q tests/integration/test_context_assembler_service.py tests/unit/services/test_social_graph_service.py` but execution was blocked in this environment first by a `pyproject.toml` parse error and subsequently by an environment import issue (`torch.from_numpy` unavailable while loading `tests/conftest.py`), so full pytest pass could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90a864ce483268a8dc6c9f122eb0b)