### PR TITLE
Migrate services to RESPONSE_CANDIDATES/RESPONSE_RANKED lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Clients can then connect using the `NATS_TLS_CERT` and `NATS_TLS_KEY` environmen
 
 ## Recording Event Traces
 
-Use `tools/record.py` to capture `INPUT_RECEIVED` and `RESPONSE_GENERATED` events:
+Use `tools/record.py` to capture `INPUT_RECEIVED`, `RESPONSE_CANDIDATES`, and `RESPONSE_RANKED` events:
 ```bash
 python tools/record.py --output traces.jsonl
 ```
@@ -899,14 +899,15 @@ For the comprehensive plan outlining each phase, see [docs/discord_bot_phase_rep
 Two lightweight reference modules show how components can interact through NATS:
 
 * **BasicMemory** -- subscribes to `INPUT_RECEIVED` events, stores each user input in a local `memory.json` file and then publishes a `MEMORY_RETRIEVED` event containing the most recent entries.
-* **BasicLLM** -- listens for `MEMORY_RETRIEVED`, runs a small language model to generate a reply, and publishes `RESPONSE_GENERATED`. This module requires the optional heavy dependencies `transformers` and `torch`.
+* **BasicLLM** -- listens for `MEMORY_RETRIEVED`, runs a small language model to generate one or more reply candidates, and publishes `RESPONSE_CANDIDATES`. A selector then publishes `RESPONSE_RANKED` for delivery. This module requires the optional heavy dependencies `transformers` and `torch`.
 
 ### Example Workflow
 
 1. The `InputHandler` emits an `INPUT_RECEIVED` event when it receives a message.
 2. `BasicMemory` logs the text to `memory.json` and publishes a `MEMORY_RETRIEVED` event with the last few inputs.
-3. `BasicLLM` generates a response from those facts and publishes a `RESPONSE_GENERATED` event.
-4. The `OutputHandler` (or another consumer) can then deliver the response to the user.
+3. `BasicLLM` generates response candidates from those facts and publishes a `RESPONSE_CANDIDATES` event.
+4. A selector consumes candidates and publishes `RESPONSE_RANKED`.
+5. The `OutputHandler` (or another consumer) can then deliver the ranked response to the user.
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,20 +24,23 @@ Operators should treat this as a deployment invariant and verify that each requi
 sequenceDiagram
     participant User
     participant Bot
-    participant CognitiveCoreService
+    participant ContextAssembler
     participant LLM
+    participant Selector
 
     User->>Bot: Message
     Bot->>NATS: INPUT_RECEIVED
-    NATS->>CognitiveCoreService: INPUT_RECEIVED
-    CognitiveCoreService->>LLM: Query
-    LLM-->>CognitiveCoreService: Response
-    CognitiveCoreService->>NATS: RESPONSE_GENERATED
-    NATS->>Bot: RESPONSE_GENERATED
+    NATS->>ContextAssembler: INPUT_RECEIVED (+ provider outputs)
+    ContextAssembler->>NATS: CONTEXT_ASSEMBLED
+    NATS->>LLM: CONTEXT_ASSEMBLED
+    LLM->>NATS: RESPONSE_CANDIDATES
+    NATS->>Selector: RESPONSE_CANDIDATES
+    Selector->>NATS: RESPONSE_RANKED
+    NATS->>Bot: RESPONSE_RANKED
     Bot-->>User: Reply
 ```
 
-The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events, retrieves knowledge from the `CognitiveCoreService` and ultimately receives a `RESPONSE_GENERATED` message containing the model output.
+The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the responder publishes `RESPONSE_CANDIDATES` and the selector picks the winner.
 
 ## Unified CognitiveCoreService
 
@@ -50,7 +53,7 @@ augment memory with local documents.
 When an `INPUT_RECEIVED` event arrives the service stores the text in each
 backend, queries for relevant context and publishes `MEMORY_RETRIEVED`. Downstream
 services subscribe to this subject and may then respond with
-`RESPONSE_GENERATED` or other events.
+`RESPONSE_CANDIDATES` and `RESPONSE_RANKED` (or other downstream events).
 
 ```python
 from deepthought.eda.events import EventSubjects

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -13,6 +13,7 @@ services:
   - context_assembler
   - llm_remote
   - selector
+  - reasoning
 
 service_bindings:
   discord_gateway:
@@ -103,6 +104,30 @@ service_bindings:
     publish:
       - subject: dtr.response.ranked.v1  # legacy alias: dtr.response.ranked
         event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+
+  reasoning:
+    optional: true
+    description: Infer and re-inject structured facts from ranked responses and candidates.
+    env:
+      - NATS_URL
+    subscribe:
+      - subject: dtr.response.ranked.v1  # legacy aliases: dtr.response.ranked, dtr.llm.response_generated
+        event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+        durable: reasoning_service_ranked
+        required_reliability: false
+      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+        event_subject: EventSubjects.RESPONSE_CANDIDATES
+        jetstream: true
+        durable: reasoning_service_candidates
+        required_reliability: false
+    publish:
+      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+        event_subject: EventSubjects.INPUT_RECEIVED
+        jetstream: true
+      - subject: dtr.warning
+        event_subject: EventSubjects.WARNING
         jetstream: true
 
   social_graph:

--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -37,6 +37,7 @@ LEGACY_SUBJECT_MAP: Dict[str, str] = {
     "dtr.context.assembled": CanonicalSubjects.CONTEXT_ASSEMBLED,
     "dtr.response.candidates": CanonicalSubjects.RESPONSE_CANDIDATES,
     "dtr.response.ranked": CanonicalSubjects.RESPONSE_RANKED,
+    "dtr.llm.response_generated": CanonicalSubjects.RESPONSE_RANKED,
     "dtr.perception.embeddings": CanonicalSubjects.PERCEPTION_EMBEDDINGS,
     "dtr.perception.extract": CanonicalSubjects.PERCEPTION_EXTRACT,
     "dtr.social.perception": CanonicalSubjects.SOCIAL_PERCEPTION,

--- a/src/deepthought/harness/trace.py
+++ b/src/deepthought/harness/trace.py
@@ -110,8 +110,11 @@ class TraceRecorder:
     async def _handle_input(self, msg: Msg) -> None:
         await self._append("INPUT_RECEIVED", msg)
 
-    async def _handle_response(self, msg: Msg) -> None:
-        await self._append("RESPONSE_GENERATED", msg)
+    async def _handle_response_ranked(self, msg: Msg) -> None:
+        await self._append("RESPONSE_RANKED", msg)
+
+    async def _handle_response_candidates(self, msg: Msg) -> None:
+        await self._append("RESPONSE_CANDIDATES", msg)
 
     async def _handle_chat_raw(self, msg: Msg) -> None:
         await self._append_raw("CHAT_RAW", msg)
@@ -125,10 +128,16 @@ class TraceRecorder:
                 durable=f"{durable_name}_input",
             )
             await self._subscriber.subscribe(
-                subject=EventSubjects.RESPONSE_GENERATED,
-                handler=self._handle_response,
+                subject=EventSubjects.RESPONSE_RANKED,
+                handler=self._handle_response_ranked,
                 use_jetstream=True,
-                durable=f"{durable_name}_response",
+                durable=f"{durable_name}_ranked",
+            )
+            await self._subscriber.subscribe(
+                subject=EventSubjects.RESPONSE_CANDIDATES,
+                handler=self._handle_response_candidates,
+                use_jetstream=True,
+                durable=f"{durable_name}_candidates",
             )
             await self._subscriber.subscribe(
                 subject=EventSubjects.CHAT_RAW,

--- a/src/deepthought/services/reasoning_service.py
+++ b/src/deepthought/services/reasoning_service.py
@@ -10,8 +10,13 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 from rdflib import Namespace
 
-from ..eda.events import (EventSubjects, InputReceivedPayload,
-                          ResponseGeneratedPayload, WarningPayload)
+from ..eda.events import (
+    EventSubjects,
+    InputReceivedPayload,
+    ResponseCandidatesPayload,
+    ResponseRankedPayload,
+    WarningPayload,
+)
 from ..ontology import OntologyManager
 from .base import BaseService
 
@@ -58,56 +63,78 @@ class ReasoningService(BaseService):
             )
         return triples
 
-    async def _handle_response(self, msg: Msg) -> None:
+    async def _analyze_response_text(self, response_text: str) -> None:
+        triples = self._extract_triples(response_text)
+        if not triples:
+            return
+        self._ontology.add_triples(triples)
+        facts = self._ontology.infer_facts()
+        if not facts:
+            return
+        valid, contradictions = self._ontology.verify_triples(facts)
+        if contradictions:
+            warn = WarningPayload(message="Contradictory facts", facts=contradictions)
+            await self._publisher.publish(
+                EventSubjects.WARNING,
+                warn,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+        if valid:
+            text = "; ".join(" ".join(t) for t in valid)
+            out = InputReceivedPayload(user_input=text, input_id=str(uuid4()))
+            await self._publisher.publish(
+                EventSubjects.INPUT_RECEIVED,
+                out,
+                use_jetstream=True,
+                timeout=10.0,
+            )
+
+    async def _handle_ranked_response(self, msg: Msg) -> None:
         try:
             data = json.loads(msg.data.decode())
-            payload = ResponseGeneratedPayload.from_dict(data)
-            triples = self._extract_triples(payload.final_response)
-            if triples:
-                self._ontology.add_triples(triples)
-                facts = self._ontology.infer_facts()
-                if facts:
-                    valid, contradictions = self._ontology.verify_triples(facts)
-                    if contradictions:
-                        warn = WarningPayload(
-                            message="Contradictory facts", facts=contradictions
-                        )
-                        await self._publisher.publish(
-                            EventSubjects.WARNING,
-                            warn,
-                            use_jetstream=True,
-                            timeout=10.0,
-                        )
-                    if valid:
-                        text = "; ".join(" ".join(t) for t in valid)
-                        out = InputReceivedPayload(
-                            user_input=text, input_id=str(uuid4())
-                        )
-                        await self._publisher.publish(
-                            EventSubjects.INPUT_RECEIVED,
-                            out,
-                            use_jetstream=True,
-                            timeout=10.0,
-                        )
+            payload = ResponseRankedPayload.from_dict(data)
+            await self._analyze_response_text(payload.final_response)
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception as exc:  # pragma: no cover - defensive
-            logger.error("Failed to process RESPONSE_GENERATED: %s", exc, exc_info=True)
+            logger.error("Failed to process RESPONSE_RANKED: %s", exc, exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_response_candidates(self, msg: Msg) -> None:
+        try:
+            data = json.loads(msg.data.decode())
+            payload = ResponseCandidatesPayload.from_dict(data)
+            for candidate in payload.candidates:
+                await self._analyze_response_text(candidate.text)
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to process RESPONSE_CANDIDATES: %s", exc, exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):
                 await msg.nak()
 
     async def start(self, durable_name: str = "reasoning_service") -> bool:
         self._subscriptions.clear()
         self.add_subscription(
-            subject=EventSubjects.RESPONSE_GENERATED,
-            handler=self._handle_response,
+            subject=EventSubjects.RESPONSE_RANKED,
+            handler=self._handle_ranked_response,
             use_jetstream=True,
-            durable=durable_name,
+            durable=f"{durable_name}_ranked",
+        )
+        self.add_subscription(
+            subject=EventSubjects.RESPONSE_CANDIDATES,
+            handler=self._handle_response_candidates,
+            use_jetstream=True,
+            durable=f"{durable_name}_candidates",
         )
         started = await super().start()
         if started:
             logger.info(
-                "ReasoningService subscribed to %s", EventSubjects.RESPONSE_GENERATED
+                "ReasoningService subscribed to %s and %s",
+                EventSubjects.RESPONSE_RANKED,
+                EventSubjects.RESPONSE_CANDIDATES,
             )
 
         return started

--- a/tests/unit/services/test_reasoning_service.py
+++ b/tests/unit/services/test_reasoning_service.py
@@ -56,7 +56,11 @@ owlready2.World.get_ontology = lambda self, iri: types.SimpleNamespace(
     load=lambda fileobj=None: types.SimpleNamespace(individuals=lambda: [])
 )
 
-from deepthought.eda.events import EventSubjects, ResponseGeneratedPayload
+from deepthought.eda.events import (
+    EventSubjects,
+    ResponseCandidatesPayload,
+    ResponseRankedPayload,
+)
 from deepthought.services.reasoning_service import ReasoningService
 
 
@@ -107,9 +111,9 @@ async def test_handle_response_publishes_facts(monkeypatch):
     svc._publisher = DummyPublisher()
     svc._subscriber = DummySubscriber()
 
-    payload = ResponseGeneratedPayload(final_response="A is B", input_id="1")
+    payload = ResponseRankedPayload(final_response="A is B", input_id="1")
     msg = DummyMsg(payload.to_json())
-    await svc._handle_response(msg)
+    await svc._handle_ranked_response(msg)
 
     assert msg.acked
     # Ontology stubs may produce no inferred facts
@@ -134,9 +138,9 @@ async def test_handle_response_emits_input_event(monkeypatch):
     svc._publisher = DummyPublisher()
     svc._subscriber = DummySubscriber()
 
-    payload = ResponseGeneratedPayload(final_response="A is B", input_id="1")
+    payload = ResponseRankedPayload(final_response="A is B", input_id="1")
     msg = DummyMsg(payload.to_json())
-    await svc._handle_response(msg)
+    await svc._handle_ranked_response(msg)
 
     assert msg.acked
     assert svc._publisher.published
@@ -144,6 +148,32 @@ async def test_handle_response_emits_input_event(monkeypatch):
     assert subj == EventSubjects.INPUT_RECEIVED
     assert out.user_input == "A B C"
 
+
+
+
+@pytest.mark.asyncio
+async def test_handle_candidates_emits_input_event(monkeypatch):
+    class DummyOntology:
+        def add_triples(self, triples):
+            pass
+
+        def infer_facts(self):
+            return [("A", "B", "C")]
+
+        def verify_triples(self, triples):
+            return triples, []
+
+    svc = ReasoningService(DummyNATS(), DummyJS(), ontology=DummyOntology())
+    svc._publisher = DummyPublisher()
+    svc._subscriber = DummySubscriber()
+
+    payload = ResponseCandidatesPayload(candidates=[{"text": "A is B", "confidence": 0.8}])
+    msg = DummyMsg(payload.to_json())
+    await svc._handle_response_candidates(msg)
+
+    assert msg.acked
+    subjects = [s for s, _ in svc._publisher.published]
+    assert EventSubjects.INPUT_RECEIVED in subjects
 
 def test_extract_triples_simple():
     svc = ReasoningService(DummyNATS(), DummyJS())
@@ -182,9 +212,9 @@ async def test_warning_on_contradiction(monkeypatch):
     svc._publisher = DummyPublisher()
     svc._subscriber = DummySubscriber()
 
-    payload = ResponseGeneratedPayload(final_response="X is Y", input_id="1")
+    payload = ResponseRankedPayload(final_response="X is Y", input_id="1")
     msg = DummyMsg(payload.to_json())
-    await svc._handle_response(msg)
+    await svc._handle_ranked_response(msg)
 
     assert msg.acked
     subjects = [s for s, _ in svc._publisher.published]


### PR DESCRIPTION
### Motivation
- Move services off the legacy per-responder `RESPONSE_GENERATED` subject and converge on a single response lifecycle where responders emit `RESPONSE_CANDIDATES` and a selector emits `RESPONSE_RANKED` for delivery.
- Ensure reasoning and tracing components can analyze both pre-selection candidates and final ranked responses while preserving compatibility for older publishers.

### Description
- Updated `ReasoningService` to stop subscribing to `RESPONSE_GENERATED` and instead subscribe to `EventSubjects.RESPONSE_RANKED` and `EventSubjects.RESPONSE_CANDIDATES`, adding a shared `_analyze_response_text` helper and handlers `_handle_ranked_response` and `_handle_response_candidates` that infer triples and publish `INPUT_RECEIVED`/`WARNING` follow-ups as appropriate (file: `src/deepthought/services/reasoning_service.py`).
- Updated `TraceRecorder` to record and subscribe to `RESPONSE_RANKED` and `RESPONSE_CANDIDATES` (replacing the legacy generated-response subscription) and to write corresponding event labels into traces (file: `src/deepthought/harness/trace.py`).
- Added a compatibility mapping for the legacy subject `dtr.llm.response_generated` to canonical `dtr.response.ranked.v1` in `eda/contracts` so legacy publishers still normalize to the canonical subject (file: `src/deepthought/eda/contracts/__init__.py`).
- Aligned documentation and orchestration examples to the candidates→ranked lifecycle and added optional `reasoning` wiring to `examples/orchestrator.yml`, plus matching changes in `docs/architecture.md` and `README.md` to describe the new flow.
- Updated unit tests for `ReasoningService` to exercise the new ranked/candidates handlers and candidate-path coverage (`tests/unit/services/test_reasoning_service.py`).

### Testing
- Ran `python -m compileall -q` on the modified modules and confirmed they compile cleanly (`src/deepthought/services/reasoning_service.py`, `src/deepthought/harness/trace.py`, `src/deepthought/eda/contracts/__init__.py`, updated tests) which passed.
- Attempted linting with `ruff` and `pytest` for the unit files, but both were blocked by a repo-level `pyproject.toml` parse error (duplicate key) that prevents `ruff`/`pytest` from running in this environment; this is unrelated to the functional code changes and should be resolved in CI/operator environment.
- Updated and committed changes (including the unit test updates) so CI can run the full test/lint suite once the `pyproject.toml` issue is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90f70777883269aa1e9c455662a20)