### PR TITLE
Add Discord gateway runtime and CLI command

### DIFF
--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -243,6 +243,16 @@ def _cmd_perception_delete_user(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_run_discord_gateway(args: argparse.Namespace) -> int:
+    if not args.token:
+        raise SystemExit("DISCORD_TOKEN is required (use --token or set DISCORD_TOKEN)")
+
+    from ..runtime.discord_gateway_app import run_discord_gateway
+
+    asyncio.run(run_discord_gateway(token=args.token, nats_url=args.nats_url))
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     from ..services.perception.config import PerceptionConfig
 
@@ -372,6 +382,14 @@ def _build_parser() -> argparse.ArgumentParser:
     perception_delete.add_argument("--user-id", required=True)
     perception_delete.add_argument("--nats-url", default=PerceptionConfig().nats_url)
     perception_delete.set_defaults(func=_cmd_perception_delete_user)
+
+    run_p = sub.add_parser("run", description="Run runtime applications")
+    run_sub = run_p.add_subparsers(dest="run_cmd")
+
+    run_discord_gateway = run_sub.add_parser("discord-gateway", description="Run the Discord gateway runtime")
+    run_discord_gateway.add_argument("--token", default=os.getenv("DISCORD_TOKEN", ""))
+    run_discord_gateway.add_argument("--nats-url", default=os.getenv("NATS_URL", "nats://localhost:4222"))
+    run_discord_gateway.set_defaults(func=_cmd_run_discord_gateway)
 
     init_p = sub.add_parser("init")
     init_sub = init_p.add_subparsers(dest="target")

--- a/src/deepthought/runtime/__init__.py
+++ b/src/deepthought/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime entrypoints for long-running DeepThought applications."""
+
+from .discord_gateway_app import DiscordGatewayRuntime, run_discord_gateway
+
+__all__ = ["DiscordGatewayRuntime", "run_discord_gateway"]

--- a/src/deepthought/runtime/discord_gateway_app.py
+++ b/src/deepthought/runtime/discord_gateway_app.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from ..services.discord_gateway_service import DiscordGatewayService
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordGatewayRuntime:
+    """Owns Discord and NATS lifecycle for the Discord gateway application."""
+
+    def __init__(
+        self,
+        *,
+        token: str,
+        nats_url: str,
+        gateway_factory: Callable[..., DiscordGatewayService] = DiscordGatewayService,
+        discord_client_factory: Callable[[Any], Any] | None = None,
+        intents_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self._token = token
+        self._nats_url = nats_url
+        self._gateway_factory = gateway_factory
+        self._discord_client_factory = discord_client_factory
+        self._intents_factory = intents_factory
+        self._gateway: DiscordGatewayService | None = None
+        self._client: Any | None = None
+
+    @staticmethod
+    def _should_route_message(message: Any) -> bool:
+        author = getattr(message, "author", None)
+        return not bool(getattr(author, "bot", False))
+
+    def _build_intents(self) -> Any:
+        if self._intents_factory is not None:
+            return self._intents_factory()
+
+        import discord
+
+        intents = discord.Intents.default()
+        intents.guilds = True
+        intents.messages = True
+        intents.message_content = True
+        return intents
+
+    def _build_discord_client(self, intents: Any) -> Any:
+        if self._discord_client_factory is not None:
+            return self._discord_client_factory(intents)
+
+        import discord
+
+        return discord.Client(intents=intents)
+
+    async def run(self) -> None:
+        intents = self._build_intents()
+        client = self._build_discord_client(intents)
+        gateway = self._gateway_factory(discord_client=client, nats_url=self._nats_url)
+
+        self._client = client
+        self._gateway = gateway
+
+        @client.event
+        async def on_message(message: Any) -> None:
+            if not self._should_route_message(message):
+                return
+            await gateway.handle_discord_message(message)
+
+        try:
+            started = await gateway.start()
+            if not started:
+                raise RuntimeError("Failed to start DiscordGatewayService")
+            await client.start(self._token)
+        finally:
+            if getattr(client, "is_closed", lambda: True)() is False:
+                await client.close()
+            await gateway.stop()
+
+
+async def run_discord_gateway(*, token: str, nats_url: str) -> None:
+    runtime = DiscordGatewayRuntime(token=token, nats_url=nats_url)
+    await runtime.run()
+
+
+def main(*, token: str, nats_url: str) -> int:
+    asyncio.run(run_discord_gateway(token=token, nats_url=nats_url))
+    return 0

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -146,9 +146,6 @@ class DiscordGatewayService(BaseService):
     async def handle_discord_message(self, message: Any) -> str | None:
         """Publish human-authored Discord messages as INPUT_RECEIVED events."""
 
-        author = getattr(message, "author", None)
-        if getattr(author, "bot", False):
-            return None
         if not self._publisher:
             logger.warning("DiscordGatewayService publisher unavailable; dropping message")
             return None

--- a/tests/unit/runtime/test_discord_gateway_app.py
+++ b/tests/unit/runtime/test_discord_gateway_app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deepthought.runtime.discord_gateway_app import DiscordGatewayRuntime
+
+
+class FakeGateway:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+        self.stopped = False
+        self.messages = []
+
+    async def start(self) -> bool:
+        self.started = True
+        return True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    async def handle_discord_message(self, message):
+        self.messages.append(message)
+
+
+class FakeClient:
+    def __init__(self, intents):
+        self.intents = intents
+        self._events = {}
+        self.started_with = None
+        self.closed = False
+
+    def event(self, fn):
+        self._events[fn.__name__] = fn
+        return fn
+
+    async def start(self, token: str):
+        self.started_with = token
+
+    async def close(self):
+        self.closed = True
+
+    def is_closed(self) -> bool:
+        return self.closed
+
+
+@pytest.mark.asyncio
+async def test_runtime_bootstraps_gateway_and_client_lifecycle():
+    fake_gateway: FakeGateway | None = None
+
+    def gateway_factory(**kwargs):
+        nonlocal fake_gateway
+        fake_gateway = FakeGateway(**kwargs)
+        return fake_gateway
+
+    fake_client: FakeClient | None = None
+
+    def client_factory(intents):
+        nonlocal fake_client
+        fake_client = FakeClient(intents)
+        return fake_client
+
+    runtime = DiscordGatewayRuntime(
+        token="discord-token",
+        nats_url="nats://example:4222",
+        gateway_factory=gateway_factory,
+        discord_client_factory=client_factory,
+        intents_factory=lambda: object(),
+    )
+
+    await runtime.run()
+
+    assert fake_gateway is not None
+    assert fake_client is not None
+    assert fake_gateway.started is True
+    assert fake_gateway.stopped is True
+    assert fake_client.started_with == "discord-token"
+    assert fake_client.closed is True
+    assert fake_gateway.kwargs["nats_url"] == "nats://example:4222"
+    assert fake_gateway.kwargs["discord_client"] is fake_client
+
+
+@pytest.mark.asyncio
+async def test_runtime_routes_human_messages_only():
+    fake_gateway: FakeGateway | None = None
+
+    def gateway_factory(**kwargs):
+        nonlocal fake_gateway
+        fake_gateway = FakeGateway(**kwargs)
+        return fake_gateway
+
+    class RoutingClient(FakeClient):
+        async def start(self, token: str):
+            await super().start(token)
+            on_message = self._events["on_message"]
+            await on_message(SimpleNamespace(author=SimpleNamespace(bot=False), content="hi"))
+            await on_message(SimpleNamespace(author=SimpleNamespace(bot=True), content="ignore"))
+
+    runtime = DiscordGatewayRuntime(
+        token="discord-token",
+        nats_url="nats://example:4222",
+        gateway_factory=gateway_factory,
+        discord_client_factory=lambda intents: RoutingClient(intents),
+        intents_factory=lambda: object(),
+    )
+
+    await runtime.run()
+
+    assert fake_gateway is not None
+    assert [m.content for m in fake_gateway.messages] == ["hi"]

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -155,13 +155,6 @@ async def test_handle_discord_message_publishes_input_received(service):
 
 
 @pytest.mark.asyncio
-async def test_handle_discord_message_ignores_bots(service):
-    message = SimpleNamespace(content="ignore", author=SimpleNamespace(bot=True))
-    assert await service.handle_discord_message(message) is None
-    assert service._publisher.published == []
-
-
-@pytest.mark.asyncio
 async def test_ranked_response_respects_thread_reply_and_policy_override(service, fake_clock):
     payload = ResponseRankedPayload(
         final_response="done",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+from deepthought.cli import _build_parser
+
 
 def _run_dtrt(
     tmp_path: Path, *args: str, env: dict[str, str] | None = None
@@ -189,8 +191,6 @@ def test_init_service_demo_start_stop(tmp_path: Path) -> None:
     asyncio.run(main())
 
 
-from deepthought.cli import _build_parser
-
 
 def test_parse_finetune_args():
     parser = _build_parser()
@@ -313,3 +313,20 @@ def test_finetune_estimate_vram(tmp_path: Path, monkeypatch) -> None:
         "--estimate-vram",
     )
     assert "Estimated VRAM requirement" in result.stdout
+
+
+def test_parse_run_discord_gateway():
+    parser = _build_parser()
+    args = parser.parse_args(["run", "discord-gateway", "--token", "abc", "--nats-url", "nats://x:4222"])
+    assert args.command == "run"
+    assert args.run_cmd == "discord-gateway"
+    assert args.token == "abc"
+    assert args.nats_url == "nats://x:4222"
+    assert args.func.__name__ == "_cmd_run_discord_gateway"
+
+
+def test_run_discord_gateway_requires_token():
+    parser = _build_parser()
+    args = parser.parse_args(["run", "discord-gateway", "--token", ""])
+    with pytest.raises(SystemExit, match="DISCORD_TOKEN is required"):
+        args.func(args)


### PR DESCRIPTION
### Motivation
- Provide a dedicated runtime that configures Discord intents, instantiates the Discord client, wires `on_message` to the gateway service, and manages clean startup/shutdown of both NATS and the Discord client.
- Centralize `author.bot` filtering in the runtime layer so the service no longer needs to duplicate bot-filter logic and message routing can be tested without a live Discord connection.
- Expose a convenient CLI entrypoint for running the gateway process and add focused tests to validate bootstrapping and routing behavior.

### Description
- Added `src/deepthought/runtime/discord_gateway_app.py` which implements `DiscordGatewayRuntime`, configures intents (`guilds`, `messages`, `message_content`), builds the Discord client, wires `on_message` to call `DiscordGatewayService.handle_discord_message`, and manages lifecycle (start/stop) for both client and gateway.
- Exported runtime symbols in `src/deepthought/runtime/__init__.py` and added a CLI handler `_cmd_run_discord_gateway` plus a `dtrt run discord-gateway` subcommand in `src/deepthought/cli/__init__.py` that accepts `--token` and `--nats-url` and validates the token.
- Centralized bot filtering in the runtime via `DiscordGatewayRuntime._should_route_message` and removed the `author.bot` early return from `DiscordGatewayService.handle_discord_message` so the check is not reimplemented ad hoc.
- Added unit tests `tests/unit/runtime/test_discord_gateway_app.py`, updated `tests/unit/services/test_discord_gateway_service.py` to align with centralized filtering, and extended `tests/unit/test_cli.py` with parser and validation tests for the new `run discord-gateway` command.

### Testing
- Ran targeted pytest for the new runtime, related service tests, and the added CLI tests with `pytest -q -c /dev/null tests/unit/runtime/test_discord_gateway_app.py tests/unit/services/test_discord_gateway_service.py tests/unit/test_cli.py::test_parse_run_discord_gateway tests/unit/test_cli.py::test_run_discord_gateway_requires_token` and observed all tests passing (`12 passed`).
- Ran the same set of tests (including the three files) with `-c /dev/null` and saw the targeted suite pass (`12 passed`).
- Ran the linter with `ruff check --isolated` on the modified runtime/cli/service files and the new tests and observed no issues.
- Note: running the entire repository test matrix or `ruff` without `--isolated` in this environment surfaced unrelated repository-level TOML parsing problems (duplicate key in `pyproject.toml`) that are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a31a1c6c8326993dd5f668d8b528)