### PR TITLE
Add post-ingest fact extraction and user-scoped graph retrieval prioritization

### DIFF
--- a/src/deepthought/memory/fact_extractor.py
+++ b/src/deepthought/memory/fact_extractor.py
@@ -49,6 +49,11 @@ FAVORITE_PATTERNS = [
     ),
 ]
 
+TEMPORAL_EVENT_PATTERNS = [
+    re.compile(r"\b(?:tomorrow|next week|next month|on \w+)\b[^.!?]*", re.IGNORECASE),
+    re.compile(r"\bi\s+(?:will|am going to)\s+([^.!?]+)", re.IGNORECASE),
+]
+
 
 def _split_list(text: str) -> list[str]:
     parts = re.split(r"\s*(?:,|and|&|/)\s*", text.strip())
@@ -178,6 +183,29 @@ def extract_typed_fact_triples_from_turn(
                 "fact_type": "utterance",
             }
         )
+    for pattern in TEMPORAL_EVENT_PATTERNS:
+        match = pattern.search(message)
+        if not match:
+            continue
+        event_text = match.group(0).strip()
+        triples.append(
+            {
+                "subject_id": str(user_id),
+                "subject_type": "user",
+                "predicate": "plans_event",
+                "object_id": None,
+                "object_type": "event",
+                "object_value": event_text,
+                "attributes": {
+                    "source_id": source_id,
+                    "timestamp": timestamp,
+                    "temporal": True,
+                },
+                "confidence": 0.76,
+                "fact_type": "temporal_fact",
+            }
+        )
+        break
     return triples
 
 

--- a/src/deepthought/memory/graph/adapters.py
+++ b/src/deepthought/memory/graph/adapters.py
@@ -86,7 +86,7 @@ class CypherGraphMemoryStore(GraphMemoryStore):
             "OPTIONAL MATCH (f)-[:ABOUT]->(o:Entity) "
             "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
             "o.id AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
-            "f.attributes AS attributes, f.valid_from AS valid_from "
+            "f.attributes AS attributes, f.valid_from AS valid_from, f.fact_type AS fact_type, u.id AS subject_id "
             "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
             {"user_id": user_id, "limit": limit},
         )
@@ -94,12 +94,12 @@ class CypherGraphMemoryStore(GraphMemoryStore):
 
     def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
         rows = self._connector.execute(
-            "MATCH (f:Fact) "
+            "MATCH (s:Entity)-[:HAS_FACT]->(f:Fact) "
             "WHERE toLower(f.predicate) CONTAINS toLower($topic) "
             "OR toLower(coalesce(f.object_value, '')) CONTAINS toLower($topic) "
             "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
             "NULL AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
-            "f.attributes AS attributes, f.valid_from AS valid_from "
+            "f.attributes AS attributes, f.valid_from AS valid_from, f.fact_type AS fact_type, s.id AS subject_id "
             "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
             {"topic": topic, "limit": limit},
         )
@@ -156,6 +156,10 @@ def _rows_to_evidence(rows: Sequence[Any]) -> list[GraphEvidence]:
         confidence = float(_row_get(row, "confidence", 0.5) or 0.5)
         provenance = _row_get(row, "provenance", {}) or {}
         attrs = _row_get(row, "attributes", {}) or {}
+        attrs = dict(attrs)
+        attrs.setdefault("fact_type", _row_get(row, "fact_type", "observation"))
+        attrs.setdefault("subject_id", _row_get(row, "subject_id"))
+        attrs.setdefault("user_scoped", bool(attrs.get("subject_id")))
         summary = f"{predicate}: {object_value}".strip()
         evidences.append(
             GraphEvidence(
@@ -192,6 +196,10 @@ def _row_get(row: Any, key: str, default: Any = None) -> Any:
 
 def _fact_to_evidence(fact: GraphFact) -> GraphEvidence:
     summary = fact.object_value or fact.object_id or ""
+    attrs = dict(fact.attributes)
+    attrs.setdefault("fact_type", fact.fact_type)
+    attrs.setdefault("subject_id", fact.subject_id)
+    attrs.setdefault("user_scoped", True)
     return GraphEvidence(
         evidence_id=fact.fact_id,
         summary=f"{fact.predicate}: {summary}",
@@ -200,7 +208,7 @@ def _fact_to_evidence(fact: GraphFact) -> GraphEvidence:
         score=_score(fact.confidence, fact.attributes),
         confidence=fact.confidence,
         provenance=fact.provenance,
-        attributes=fact.attributes,
+        attributes=attrs,
     )
 
 

--- a/src/deepthought/memory/graph/pipeline.py
+++ b/src/deepthought/memory/graph/pipeline.py
@@ -23,57 +23,82 @@ def ingest_conversation_turns(
         source_id = str(turn.get("input_id") or turn.get("id") or _stable_id(user_id, text, timestamp))
 
         triples = extract_typed_fact_triples_from_turn(user_id=user_id, message=text, timestamp=timestamp, source_id=source_id)
-        for triple in triples:
-            subject = GraphEntity(
-                entity_id=triple["subject_id"],
-                entity_type=triple.get("subject_type", "user"),
-                label=triple.get("subject_label", triple["subject_id"]),
-                attributes={"last_seen": timestamp},
-                provenance=Provenance(source="conversation_turn", source_id=source_id, observed_at=timestamp),
-                confidence=float(triple.get("confidence", 0.7)),
-            )
-            store.upsert_entity(subject)
+        upserts += ingest_fact_triples(triples, store, timestamp=timestamp, source_id=source_id)
+    return upserts
 
-            obj_id = triple.get("object_id")
-            if obj_id:
-                store.upsert_entity(
-                    GraphEntity(
-                        entity_id=obj_id,
-                        entity_type=triple.get("object_type", "topic"),
-                        label=triple.get("object_label", obj_id),
-                        attributes=triple.get("object_attributes", {}),
-                        provenance=subject.provenance,
-                        confidence=float(triple.get("confidence", 0.7)),
-                    )
+
+def ingest_fact_triples(
+    triples: Sequence[dict[str, Any]],
+    store: GraphMemoryStore,
+    *,
+    timestamp: str,
+    source_id: str,
+) -> int:
+    """Write pre-extracted triples into graph entities/relations/facts."""
+
+    upserts = 0
+    for triple in triples:
+        subject = GraphEntity(
+            entity_id=triple["subject_id"],
+            entity_type=triple.get("subject_type", "user"),
+            label=triple.get("subject_label", triple["subject_id"]),
+            attributes={"last_seen": timestamp},
+            provenance=Provenance(source="conversation_turn", source_id=source_id, observed_at=timestamp),
+            confidence=float(triple.get("confidence", 0.7)),
+        )
+        store.upsert_entity(subject)
+
+        obj_id = triple.get("object_id")
+        if not obj_id and triple.get("fact_type") == "temporal_fact" and triple.get("object_value"):
+            obj_id = f"event:{_stable_id(triple['subject_id'], str(triple.get('object_value')))}"
+
+        if obj_id:
+            store.upsert_entity(
+                GraphEntity(
+                    entity_id=obj_id,
+                    entity_type=triple.get("object_type", "topic"),
+                    label=triple.get("object_label", obj_id),
+                    attributes=triple.get("object_attributes", {}),
+                    provenance=subject.provenance,
+                    confidence=float(triple.get("confidence", 0.7)),
                 )
-                store.upsert_relation(
-                    GraphRelation(
-                        source_id=triple["subject_id"],
-                        relation_type=triple["predicate"],
-                        target_id=obj_id,
-                        attributes=triple.get("attributes", {}),
-                        provenance=subject.provenance,
-                        confidence=float(triple.get("confidence", 0.7)),
-                        temporal=TemporalValidity(valid_from=timestamp),
-                    )
-                )
-            fact_id = _stable_id(triple["subject_id"], triple["predicate"], str(obj_id or triple.get("object_value")))
-            store.upsert_fact(
-                GraphFact(
-                    fact_id=fact_id,
-                    subject_id=triple["subject_id"],
-                    predicate=triple["predicate"],
-                    object_id=obj_id,
-                    object_value=triple.get("object_value"),
-                    fact_type=triple.get("fact_type", "profile"),
-                    attributes={**triple.get("attributes", {}), "timestamp": timestamp},
+            )
+            store.upsert_relation(
+                GraphRelation(
+                    source_id=triple["subject_id"],
+                    relation_type=_typed_relation(triple.get("fact_type", "profile"), triple["predicate"]),
+                    target_id=obj_id,
+                    attributes={**triple.get("attributes", {}), "predicate": triple["predicate"]},
                     provenance=subject.provenance,
                     confidence=float(triple.get("confidence", 0.7)),
                     temporal=TemporalValidity(valid_from=timestamp),
                 )
             )
-            upserts += 1
+        fact_id = _stable_id(triple["subject_id"], triple["predicate"], str(obj_id or triple.get("object_value")))
+        store.upsert_fact(
+            GraphFact(
+                fact_id=fact_id,
+                subject_id=triple["subject_id"],
+                predicate=triple["predicate"],
+                object_id=obj_id,
+                object_value=triple.get("object_value"),
+                fact_type=triple.get("fact_type", "profile"),
+                attributes={**triple.get("attributes", {}), "timestamp": timestamp},
+                provenance=subject.provenance,
+                confidence=float(triple.get("confidence", 0.7)),
+                temporal=TemporalValidity(valid_from=timestamp),
+            )
+        )
+        upserts += 1
     return upserts
+
+
+def _typed_relation(fact_type: str, predicate: str) -> str:
+    return {
+        "preference": "preference",
+        "profile": "profile",
+        "temporal_fact": "temporal_fact",
+    }.get(fact_type, predicate)
 
 
 def _stable_id(*parts: Iterable[str] | str) -> str:

--- a/src/deepthought/memory/graph/retrieval.py
+++ b/src/deepthought/memory/graph/retrieval.py
@@ -20,5 +20,14 @@ def _rank_dedup(items: Sequence[GraphEvidence], limit: int) -> list[GraphEvidenc
         prev = dedup.get(key)
         if prev is None or item.score > prev.score:
             dedup[key] = item
-    ranked = sorted(dedup.values(), key=lambda i: (i.score, i.confidence), reverse=True)
+    ranked = sorted(
+        dedup.values(),
+        key=lambda i: (
+            bool(i.attributes.get("user_scoped")),
+            i.confidence >= 0.8,
+            i.score,
+            i.confidence,
+        ),
+        reverse=True,
+    )
     return ranked[:limit]

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -19,6 +19,7 @@ from ..eda.events import (
     PerceptionEmbeddingsPayload,
 )
 from ..memory import create_memory_backend
+from ..memory.fact_extractor import extract_typed_fact_triples_from_turn
 from ..memory.graph import (
     CypherGraphMemoryStore,
     InMemoryGraphMemoryStore,
@@ -26,6 +27,7 @@ from ..memory.graph import (
     retrieve_topic_context,
     retrieve_user_context,
 )
+from ..memory.graph.pipeline import ingest_fact_triples
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..search import OfflineSearch
@@ -203,18 +205,33 @@ class CognitiveCoreService(BaseService):
             self._memory.store_interaction(user_input)
             await self._db.store_memory(resolved_user_id, user_input)
 
+            turn_timestamp = datetime.now(timezone.utc).isoformat()
             ingest_conversation_turns(
                 [
                     {
                         "user_id": resolved_user_id,
                         "text": user_input,
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "timestamp": turn_timestamp,
                         "input_id": input_id,
                     }
                 ],
                 self._graph_memory,
                 default_user_id=str(resolved_user_id),
             )
+
+            extracted_triples = extract_typed_fact_triples_from_turn(
+                user_id=str(resolved_user_id),
+                message=user_input,
+                timestamp=turn_timestamp,
+                source_id=input_id,
+            )
+            if extracted_triples:
+                ingest_fact_triples(
+                    extracted_triples,
+                    self._graph_memory,
+                    timestamp=turn_timestamp,
+                    source_id=input_id,
+                )
 
             mem_facts = self.retrieve_context(user_input)
             db_facts = await self._db_context()

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -307,6 +307,27 @@ async def test_handle_input_uses_header_user_id_then_anonymous():
     assert db.affinity_user_ids == []
 
 
+@pytest.mark.asyncio
+async def test_handle_input_reuses_earlier_user_preferences_in_later_context():
+    memory = DummyMemory()
+    db = DummyDB()
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._top_k = 8
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    first = DummyMsg(json.dumps({"user_input": "My favorite drink is tea", "input_id": "turn-1", "user_id": "u-pref"}))
+    second = DummyMsg(json.dumps({"user_input": "What should I have this evening?", "input_id": "turn-2", "user_id": "u-pref"}))
+
+    await service._handle_input(first)
+    await service._handle_input(second)
+
+    assert first.acked and second.acked
+    _, payload = service._publisher.published[-1]
+    facts = payload.retrieved_knowledge["facts"]
+    assert any("favorite: tea" in fact for fact in facts)
+
+
 class DummyStore:
     def __init__(self) -> None:
         self.upserts: list = []

--- a/tests/unit/test_graph_memory_subsystem.py
+++ b/tests/unit/test_graph_memory_subsystem.py
@@ -13,7 +13,7 @@ from deepthought.memory.graph import (
 def test_extract_typed_fact_triples_from_turn():
     triples = extract_typed_fact_triples_from_turn(
         user_id="u1",
-        message="Call me Ace. I enjoy hiking and chess. My favorite color is blue.",
+        message="Call me Ace. I enjoy hiking and chess. My favorite color is blue. Tomorrow I will practice openings.",
         timestamp="2024-01-01T00:00:00+00:00",
         source_id="turn-1",
     )
@@ -22,6 +22,7 @@ def test_extract_typed_fact_triples_from_turn():
     assert "has_nickname" in predicates
     assert "likes_hobby" in predicates
     assert "favorite" in predicates
+    assert "plans_event" in predicates
 
 
 def test_ingest_and_retrieve_dedup_ranked():
@@ -46,6 +47,42 @@ def test_ingest_and_retrieve_dedup_ranked():
     assert topic_ctx
     assert len({e.summary for e in topic_ctx}) == len(topic_ctx)
     assert topic_ctx[0].score >= topic_ctx[-1].score
+
+
+def test_ingest_assigns_typed_relations_for_fact_types():
+    store = InMemoryGraphMemoryStore()
+    ingest_conversation_turns(
+        [
+            {
+                "user_id": "u1",
+                "text": "My favorite drink is tea. Tomorrow I will run a marathon.",
+                "timestamp": "2024-01-03T00:00:00+00:00",
+                "input_id": "turn-typed",
+            }
+        ],
+        store,
+    )
+
+    relation_types = {rel.relation_type for rel in store.relations.values()}
+    assert "preference" in relation_types
+    assert "temporal_fact" in relation_types
+
+
+def test_topic_retrieval_prioritizes_user_scoped_high_confidence_facts():
+    store = InMemoryGraphMemoryStore()
+    ingest_conversation_turns(
+        [
+            {"user_id": "u1", "text": "My favorite game is chess", "timestamp": "2024-01-04T00:00:00+00:00", "input_id": "h1"},
+            {"user_id": "u2", "text": "chess", "timestamp": "2024-01-01T00:00:00+00:00", "input_id": "l1"},
+        ],
+        store,
+    )
+
+    topic_ctx = retrieve_topic_context(store, "chess", limit=5)
+
+    assert topic_ctx
+    assert topic_ctx[0].attributes.get("user_scoped") is True
+    assert topic_ctx[0].confidence >= topic_ctx[-1].confidence
 
 
 def test_migrate_sqlite_memories_to_graph(tmp_path):


### PR DESCRIPTION
### Motivation
- Allow the CognitiveCore input pipeline to explicitly extract structured user facts (preferences, profile items, temporal events) after ingesting the conversation turn so those facts are stored in the KG and usable for later retrieval and prompt building.
- Persist typed facts with provenance/confidence so retrieval can surface and rank reliable, user-scoped facts ahead of generic/low-confidence matches.

### Description
- Added a post-ingest stage in `CognitiveCoreService._handle_input` that calls `extract_typed_fact_triples_from_turn(...)` and writes triples into the graph via new `ingest_fact_triples(...)` (files changed: `src/deepthought/services/cognitive_core_service.py`, `src/deepthought/memory/graph/pipeline.py`).
- Extended the fact extractor to detect temporal event statements and emit `temporal_fact` triples alongside existing `preference` and `profile` facts (file changed: `src/deepthought/memory/fact_extractor.py`).
- When persisting triples we create typed relation edges (relation types like `preference`, `profile`, `temporal_fact`), synthesize event entities for temporal facts when needed, and include provenance/timestamp/confidence on `GraphEntity`/`GraphFact` objects (file changed: `src/deepthought/memory/graph/pipeline.py`).
- Enriched graph adapter evidence with `fact_type`, `subject_id`, `user_scoped` flags and adjusted ranking in graph retrieval so results prioritize user-scoped and higher-confidence facts when building user/topic context (files changed: `src/deepthought/memory/graph/adapters.py`, `src/deepthought/memory/graph/retrieval.py`).
- Added unit tests that verify temporal/preference facts are extracted and stored with typed relations, that topic retrieval prefers user-scoped/high-confidence evidence, and that user preferences stated in earlier turns reappear in later retrieved context (tests added/updated: `tests/unit/test_graph_memory_subsystem.py`, `tests/unit/services/test_cognitive_core_service.py`).

### Testing
- Ran the targeted unit tests with `pytest -q -c /dev/null tests/unit/services/test_cognitive_core_service.py tests/unit/test_graph_memory_subsystem.py` and all tests in those files passed (`10 passed`).
- Ran the linter with `ruff check --isolated --extend-ignore E402` over the modified files and it passed (`All checks passed!`).
- Graph evidence/ranking changes are covered by the new unit tests which assert typed relation creation and that earlier user preferences surface in later retrieved payloads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a6396b408326af4dd5c136724a41)