### PR TITLE
Add social-signals responder and contract tests for update vs retrieval semantics

### DIFF
--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -49,8 +49,8 @@ class SocialGraphService(BaseService):
         self._prism = prism_adapter or PrismAdapter(self._memory)
         self._input_enrichment = input_enrichment or InputEnrichmentService()
 
-    async def _handle_input(self, msg: Msg) -> None:
-        """Process a SOCIAL_SIGNALS_REQUESTED message."""
+    async def _handle_social_signals_requested(self, msg: Msg) -> None:
+        """Respond to SOCIAL_SIGNALS_REQUESTED with context and telemetry events."""
         try:
             enriched = self._input_enrichment.parse_input_received(msg)
             logger.info("SocialGraphService received input %s", enriched.input_id)
@@ -88,6 +88,17 @@ class SocialGraphService(BaseService):
                     "persona": persona,
                 },
             }
+            social_update = {
+                "input_id": enriched.input_id,
+                "user_id": enriched.user_id,
+                "author_id": enriched.author_id,
+                "channel_id": enriched.channel_id,
+                "delta": delta,
+                "affinity": affinity,
+                "persona": persona,
+                "perception": perception,
+            }
+            await self._publisher.publish(EventSubjects.SOCIAL_UPDATED, social_update, use_jetstream=True)
             await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_RETRIEVED, social_snapshot, use_jetstream=True)
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
@@ -104,11 +115,16 @@ class SocialGraphService(BaseService):
             elif hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
 
+
+    async def _handle_input(self, msg: Msg) -> None:
+        """Backward-compatible alias for social signal request handling."""
+        await self._handle_social_signals_requested(msg)
+
     async def start(self, durable_name: str = "social_graph_service") -> bool:
         self._subscriptions.clear()
         self.add_subscription(
             subject=EventSubjects.SOCIAL_SIGNALS_REQUESTED,
-            handler=self._handle_input,
+            handler=self._handle_social_signals_requested,
             use_jetstream=True,
             durable=durable_name,
         )

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -225,3 +225,19 @@ async def test_context_assembler_merges_perception_interpretations_within_wait_w
     assert payload.multimodal_interpretations["by_modality"]["image"].startswith("image: 1 vectors")
     assert "attachments[image:1]" in payload.multimodal_interpretations["summary"]
     assert payload.confidence["partial"] is False
+
+
+@pytest.mark.asyncio
+async def test_context_assembler_uses_social_signals_retrieved_as_social_provider(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.05)
+    started = await svc.start(durable_name="ctx-social-contract")
+
+    assert started is True
+    subjects = [call["subject"] for call in svc._subscriber.calls]
+    assert EventSubjects.SOCIAL_SIGNALS_RETRIEVED in subjects
+    assert EventSubjects.SOCIAL_UPDATED not in subjects

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -59,8 +59,14 @@ async def test_handle_input_resolves_identity_from_payload_and_headers(tmp_path,
     assert await pm.get_persona("author-42", channel_id="chan-1") == "friendly"
     topics = [topic for topic, _ in await db.recall_user("author-42")]
     assert "social_perception" in topics
-    assert len(service._publisher.calls) == 1
-    event_subject, payload, _, _ = service._publisher.calls[0]
+    assert len(service._publisher.calls) == 2
+
+    update_subject, update_payload, _, _ = service._publisher.calls[0]
+    assert update_subject == EventSubjects.SOCIAL_UPDATED
+    assert update_payload["input_id"] == "1"
+    assert update_payload["affinity"] == 1
+
+    event_subject, payload, _, _ = service._publisher.calls[1]
     assert event_subject == EventSubjects.SOCIAL_SIGNALS_RETRIEVED
     assert payload["input_id"] == "1"
     assert payload["social_signals"]["affinity"] == 1
@@ -114,7 +120,42 @@ async def test_each_input_updates_social_state_exactly_once(tmp_path, monkeypatc
     assert len(adjust_calls) == 1
     memories = await db.recall_user("u-1")
     assert [topic for topic, _ in memories].count("social_perception") == 1
-    assert len(service._publisher.calls) == 1
+    assert len(service._publisher.calls) == 2
+    assert service._publisher.calls[0][0] == EventSubjects.SOCIAL_UPDATED
+    assert service._publisher.calls[1][0] == EventSubjects.SOCIAL_SIGNALS_RETRIEVED
     assert service._publisher.calls[0][1]["input_id"] == "in-1"
+    assert service._publisher.calls[1][1]["input_id"] == "in-1"
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_social_contract_update_and_retrieval_semantics(tmp_path, monkeypatch):
+    db = DBManager(str(tmp_path / "sg.db"))
+    await db.init_db()
+    service = SocialGraphService(db_manager=db, persona_manager=PersonaManager(db))
+    service._publisher = RecordingPublisher()
+
+    monkeypatch.setattr(
+        social_graph_service,
+        "analyze_social",
+        lambda _text: {"flirtation": 0.5, "avoidance": 0.2, "manipulation": 0.0},
+    )
+
+    msg = DummyMsg(InputReceivedPayload(user_input="hey", input_id="in-contract", author_id="u-1").to_json())
+    await service._handle_social_signals_requested(msg)
+
+    subjects = [call[0] for call in service._publisher.calls]
+    assert subjects == [EventSubjects.SOCIAL_UPDATED, EventSubjects.SOCIAL_SIGNALS_RETRIEVED]
+
+    updated = service._publisher.calls[0][1]
+    retrieved = service._publisher.calls[1][1]
+    assert updated["input_id"] == "in-contract"
+    assert updated["perception"]["flirtation"] == pytest.approx(0.5)
+    assert "social_signals" not in updated
+
+    assert retrieved["input_id"] == "in-contract"
+    assert retrieved["social_signals"]["perception"]["flirtation"] == pytest.approx(0.5)
+    assert retrieved["social_signals"]["affinity"] == updated["affinity"]
 
     await db.close()


### PR DESCRIPTION
### Motivation
- Make social signal processing emit both a telemetry/state-change event and a separate context response so consumers can rely on a stable context channel keyed by `input_id`.
- Ensure the context assembler treats the retrieval channel as the authoritative provider for social context rather than the telemetry update stream.

### Description
- Introduced `_handle_social_signals_requested` in `SocialGraphService` to process `EventSubjects.SOCIAL_SIGNALS_REQUESTED` and split outputs into `SOCIAL_UPDATED` (telemetry/state change) and `SOCIAL_SIGNALS_RETRIEVED` (context payload keyed by `input_id`).
- Added a backward-compatible `_handle_input` alias that delegates to the new handler and wired `start()` to subscribe the new handler to `SOCIAL_SIGNALS_REQUESTED`.
- Added unit tests in `tests/unit/services/test_social_graph_service.py` to validate both `SOCIAL_UPDATED` and `SOCIAL_SIGNALS_RETRIEVED` emission ordering and content, and an integration contract test in `tests/integration/test_context_assembler_service.py` that asserts `ContextAssemblerService` subscribes to `SOCIAL_SIGNALS_RETRIEVED` (and not `SOCIAL_UPDATED`).

### Testing
- Ran `pytest -q -c pytest.ini tests/integration/test_context_assembler_service.py` which passed with `4 passed`.
- Ran `pytest -q -c pytest.ini tests/unit/services/test_social_graph_service.py tests/integration/test_context_assembler_service.py` which passed with `8 passed`.
- Compiled key modules with `python -m py_compile src/deepthought/services/social_graph_service.py tests/unit/services/test_social_graph_service.py tests/integration/test_context_assembler_service.py` which succeeded.
- Linting tools could not be fully executed in this environment: `flake8` was not installed and `ruff` failed due to an unrelated `pyproject.toml` parse/duplicate-key issue, so lint checks were not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a9813e908326845715a32fee6d61)