### PR TITLE
Support multi-candidate LLM outputs with calibrated confidence and safety metadata

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,22 @@ sequenceDiagram
 
 The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the responder publishes `RESPONSE_CANDIDATES` and the selector picks the winner.
 
+
+### Candidate schema expectations (`RESPONSE_CANDIDATES`)
+
+`ResponseCandidatesPayload` should carry one or more `ResponseCandidate` entries. Responders are expected to emit multiple candidates when the backend supports sampling or hybrid tool/rule generation.
+
+Each candidate should include:
+
+- `text`: Generated candidate response text.
+- `confidence`: Calibrated `0..1` confidence used by selector ranking.
+- `source`: Candidate origin label (for example `remote_llm:sampling`, `tool`, or `rule`) used by source-specific selector weighting.
+- `safety_passed`: Boolean safety gate result for selector filtering.
+- `confidence_components`: Optional token/model/heuristic component breakdown for diagnostics and calibration audits.
+- `safety_metadata`: Optional policy details (matched terms, policy version, severity) for telemetry and incident triage.
+
+Selectors may down-weight or reject candidates using `source`, `confidence`, and safety fields; producers should keep this metadata stable across versions.
+
 ## Unified CognitiveCoreService
 
 `CognitiveCoreService` combines the vector store, knowledge graph and

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -248,6 +248,8 @@ class ResponseCandidate(EventPayload):
     confidence: float = 0.0
     source: Optional[str] = None
     safety_passed: Optional[bool] = None
+    confidence_components: Dict[str, Any] = field(default_factory=dict)
+    safety_metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 from typing import Optional
 
@@ -89,23 +90,95 @@ class RemoteLLM:
         use_dspy = os.getenv("USE_DSPY", "")
         self._use_dspy = use_dspy.lower() in {"1", "true", "yes", "on"}
         self._qa_pipeline = build_qa_pipeline() if self._use_dspy else None
+        self._num_candidates = max(1, int(os.getenv("LLM_NUM_CANDIDATES", "3")))
+        self._source_name = os.getenv("LLM_SOURCE_NAME", "remote_llm")
 
         logger.info("RemoteLLM initialized with endpoint %s", self._endpoint)
 
-    async def _generate(self, prompt: str) -> str:
+    def _calibrate_confidence(self, candidate: dict[str, object], text: str) -> tuple[float, dict[str, float]]:
+        token_score = 0.0
+        raw_logprob = candidate.get("avg_logprob")
+        if isinstance(raw_logprob, (float, int)):
+            token_score = 1.0 / (1.0 + math.exp(-float(raw_logprob)))
+
+        model_score = 0.0
+        raw_model_score = candidate.get("score")
+        if isinstance(raw_model_score, (float, int)):
+            model_score = max(0.0, min(1.0, float(raw_model_score)))
+
+        length = len(text.split())
+        length_score = min(1.0, max(0.0, length / 32.0))
+        confidence = (0.5 * token_score) + (0.35 * model_score) + (0.15 * length_score)
+        components = {
+            "token_score": round(token_score, 4),
+            "model_score": round(model_score, 4),
+            "length_score": round(length_score, 4),
+        }
+        return round(max(0.0, min(1.0, confidence)), 4), components
+
+    def _evaluate_safety(self, text: str) -> tuple[bool, dict[str, object]]:
+        lowered = text.lower()
+        blocked_terms = ["kill", "bomb", "dox", "self-harm"]
+        matched = [term for term in blocked_terms if term in lowered]
+        return (not matched), {"rule": "keyword_v1", "matched_terms": matched, "severity": "high" if matched else "none"}
+
+    async def _generate_candidates(self, prompt: str) -> list[ResponseCandidate]:
         if self._use_dspy and self._qa_pipeline is not None:
             result = self._qa_pipeline(prompt)
             if not isinstance(result, str):
                 raise ValueError("Invalid DSPy response")
-            return result
+            safe, safety_metadata = self._evaluate_safety(result)
+            confidence, components = self._calibrate_confidence({}, result)
+            return [
+                ResponseCandidate(
+                    text=result,
+                    confidence=confidence,
+                    source=f"{self._source_name}:dspy",
+                    safety_passed=safe,
+                    confidence_components=components,
+                    safety_metadata=safety_metadata,
+                )
+            ]
 
-        async with self._session.post(self._endpoint, json={"text": prompt}) as resp:
+        async with self._session.post(self._endpoint, json={"text": prompt, "n": self._num_candidates}) as resp:
             resp.raise_for_status()
             data = await resp.json()
-            text = data.get("text")
-            if not isinstance(text, str):
-                raise ValueError("Invalid generate response")
-            return text
+            raw_candidates = data.get("candidates") if isinstance(data, dict) else None
+            materialized: list[dict[str, object]]
+            if isinstance(raw_candidates, list) and raw_candidates:
+                materialized = [item for item in raw_candidates if isinstance(item, dict)]
+            else:
+                text = data.get("text") if isinstance(data, dict) else None
+                if not isinstance(text, str):
+                    raise ValueError("Invalid generate response")
+                materialized = [{"text": text}]
+
+            candidates: list[ResponseCandidate] = []
+            for item in materialized[: self._num_candidates]:
+                text = item.get("text")
+                if not isinstance(text, str) or not text.strip():
+                    continue
+                confidence, components = self._calibrate_confidence(item, text)
+                safe, safety_metadata = self._evaluate_safety(text)
+                source = item.get("source") if isinstance(item.get("source"), str) else f"{self._source_name}:sampling"
+                candidates.append(
+                    ResponseCandidate(
+                        text=text,
+                        confidence=confidence,
+                        source=source,
+                        safety_passed=safe,
+                        confidence_components=components,
+                        safety_metadata=safety_metadata,
+                    )
+                )
+
+            if not candidates:
+                raise ValueError("Generate response did not include valid candidates")
+            return candidates
+
+    async def _generate(self, prompt: str) -> str:
+        candidates = await self._generate_candidates(prompt)
+        return candidates[0].text
 
     async def _handle_context_event(self, msg: Msg) -> None:
         input_id = "unknown"
@@ -147,16 +220,9 @@ class RemoteLLM:
                 recent_turn_summary=recent_turn_summary,
             )
             logger.info("RemoteLLM generating for %s", input_id)
-            response = await self._generate(prompt)
+            candidates = await self._generate_candidates(prompt)
             payload = ResponseCandidatesPayload(
-                candidates=[
-                    ResponseCandidate(
-                        text=response,
-                        confidence=0.9,
-                        source="RemoteLLM",
-                        safety_passed=True,
-                    )
-                ],
+                candidates=candidates,
                 input_id=input_id,
                 user_id=author_id or user_id,
                 author_id=author_id,

--- a/tests/unit/eda/test_event_contracts.py
+++ b/tests/unit/eda/test_event_contracts.py
@@ -43,10 +43,10 @@ def test_event_envelope_roundtrip_validation():
             {"user_input": "hi", "attachments": [{"url": "https://a", "size": 2}]},
         ),
         (MemoryRetrievedPayload, {"retrieved_knowledge": {"k": "v"}}),
-        (ResponseCandidatesPayload, {"candidates": [{"text": "a", "confidence": 0.2}]}),
+        (ResponseCandidatesPayload, {"candidates": [{"text": "a", "confidence": 0.2, "source": "remote", "confidence_components": {"token_score": 0.4}, "safety_metadata": {"policy": "keyword_v1"}}]}),
         (
             ResponseRankedPayload,
-            {"final_response": "a", "candidates": [{"text": "a", "confidence": 0.2}]},
+            {"final_response": "a", "candidates": [{"text": "a", "confidence": 0.2, "source": "remote", "safety_metadata": {"policy": "keyword_v1"}}]},
         ),
         (
             PerceptionEmbeddingsPayload,

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -96,10 +96,10 @@ async def test_generate_posts(monkeypatch):
     session = DummySession(resp)
     llm = create_llm(monkeypatch, session)
 
-    result = await llm._generate("hello")
+    result = await llm._generate_candidates("hello")
 
-    assert result == "generated"
-    assert session.calls == [("http://api", {"text": "hello"})]
+    assert result[0].text == "generated"
+    assert session.calls == [("http://api", {"text": "hello", "n": 3})]
     assert resp.raise_called
 
 
@@ -121,10 +121,10 @@ class DummyMsg:
 async def test_handle_context_event_publishes(monkeypatch):
     llm = create_llm(monkeypatch)
 
-    async def fake_generate(self, prompt):
-        return "answer"
+    async def fake_generate_candidates(self, prompt):
+        return [llm_remote.ResponseCandidate(text="answer", confidence=0.8, source="stub", safety_passed=True)]
 
-    monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
 
     payload = ContextAssembledPayload(input_id="42", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
@@ -155,7 +155,7 @@ async def test_generate_timeout(monkeypatch):
     llm = create_llm(monkeypatch, TimeoutSession())
 
     with pytest.raises(asyncio.TimeoutError):
-        await llm._generate("hello")
+        await llm._generate_candidates("hello")
 
 
 @pytest.mark.asyncio
@@ -169,17 +169,17 @@ async def test_generate_malformed_json(monkeypatch):
     llm = create_llm(monkeypatch, session)
 
     with pytest.raises(ValueError):
-        await llm._generate("hello")
+        await llm._generate_candidates("hello")
 
 
 @pytest.mark.asyncio
 async def test_handle_context_event_timeout(monkeypatch):
     llm = create_llm(monkeypatch)
 
-    async def fake_generate(self, prompt):
+    async def fake_generate_candidates(self, prompt):
         raise asyncio.TimeoutError
 
-    monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
 
     payload = ContextAssembledPayload(input_id="99", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
@@ -194,10 +194,10 @@ async def test_handle_context_event_timeout(monkeypatch):
 async def test_handle_context_event_bad_json(monkeypatch):
     llm = create_llm(monkeypatch)
 
-    async def fake_generate(self, prompt):
+    async def fake_generate_candidates(self, prompt):
         raise ValueError("bad json")
 
-    monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
 
     payload = ContextAssembledPayload(input_id="88", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
@@ -229,14 +229,14 @@ async def test_generate_http_error(monkeypatch):
     llm = create_llm(monkeypatch, session)
 
     with pytest.raises(aiohttp.ClientResponseError):
-        await llm._generate("hello")
+        await llm._generate_candidates("hello")
 
 
 @pytest.mark.asyncio
 async def test_handle_context_event_http_error(monkeypatch):
     llm = create_llm(monkeypatch)
 
-    async def fake_generate(self, prompt):
+    async def fake_generate_candidates(self, prompt):
         raise aiohttp.ClientResponseError(
             request_info=MagicMock(real_url="http://api"),
             history=(),
@@ -244,7 +244,7 @@ async def test_handle_context_event_http_error(monkeypatch):
             message="bad",
         )
 
-    monkeypatch.setattr(llm, "_generate", fake_generate.__get__(llm, type(llm)))
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
 
     payload = ContextAssembledPayload(input_id="77", user_input="hello", retrieved_facts=["f1"])
     msg = DummyMsg(payload.to_json())
@@ -325,3 +325,26 @@ async def test_handle_context_event_missing_user_input_naks(monkeypatch):
     assert msg.nacked
     assert not msg.acked
     assert not llm._publisher.published
+
+
+@pytest.mark.asyncio
+async def test_generate_candidates_uses_scores_and_safety(monkeypatch):
+    resp = DummyResponse(
+        {
+            "candidates": [
+                {"text": "safe response", "avg_logprob": 0.2, "score": 0.7, "source": "sampler"},
+                {"text": "unsafe kill plan", "avg_logprob": 0.1, "score": 0.6},
+            ]
+        }
+    )
+    session = DummySession(resp)
+    llm = create_llm(monkeypatch, session)
+
+    result = await llm._generate_candidates("hello")
+
+    assert len(result) == 2
+    assert result[0].source == "sampler"
+    assert result[0].confidence_components["model_score"] == 0.7
+    assert result[0].safety_passed is True
+    assert result[1].safety_passed is False
+    assert "kill" in result[1].safety_metadata["matched_terms"]

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -180,3 +180,66 @@ async def test_source_calibration_changes_ranking(monkeypatch):
     assert svc._publisher.published[0][1].final_response == "weighted"
     diagnostics = svc._publisher.published[1][1]["diagnostics"]
     assert diagnostics[0]["source"] == "trusted"
+
+
+@pytest.mark.asyncio
+async def test_mixed_source_and_confidence_filters_and_weights(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(
+        DummyNATS(),
+        DummyJS(),
+        early_exit_confidence=0.0,
+        window_seconds=0.0,
+        source_confidence_weights={"default": 1.0, "tool": 1.3, "rule": 0.9},
+    )
+
+    msg = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="mix-1",
+            candidates=[
+                ResponseCandidate(text="safe tool", confidence=0.65, source="tool", safety_passed=True),
+                ResponseCandidate(text="unsafe rule", confidence=0.95, source="rule", safety_passed=False),
+                ResponseCandidate(text="safe default", confidence=0.7, source="default", safety_passed=True),
+            ],
+        ).to_json()
+    )
+
+    await svc._handle_candidates_event(msg)
+
+    ranked = svc._publisher.published[0][1]
+    telemetry = svc._publisher.published[1][1]
+    assert ranked.final_response == "safe tool"
+    rejected = [item for item in telemetry["diagnostics"] if item["rejection_reasons"]]
+    assert rejected and rejected[0]["text"] == "unsafe rule"
+
+
+@pytest.mark.asyncio
+async def test_early_exit_flushes_without_waiting(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(
+        DummyNATS(),
+        DummyJS(),
+        window_seconds=10.0,
+        early_exit_confidence=0.8,
+        source_confidence_weights={"trusted": 1.2},
+    )
+
+    msg = DummyMsg(
+        ResponseCandidatesPayload(
+            input_id="early-1",
+            candidates=[ResponseCandidate(text="fast", confidence=0.75, source="trusted")],
+        ).to_json()
+    )
+
+    await svc._handle_candidates_event(msg)
+
+    assert msg.acked
+    assert svc._publisher.published
+    assert svc._publisher.published[0][1].final_response == "fast"
+    assert "early-1" not in svc._pending_by_input


### PR DESCRIPTION
### Motivation

- Allow LLM responders to emit N candidates (sampling or hybrid tool/rule outputs) so the selector can choose between multiple alternatives. 
- Provide per-candidate calibrated confidence and safety signals so selector weighting, early-exit heuristics and telemetry have richer inputs. 
- Make candidate provenance and safety diagnostics explicit to improve troubleshooting and allow source-specific weighting in `SelectorService`.

### Description

- Extended the event model by adding `confidence_components` and `safety_metadata` to `ResponseCandidate` to carry calibration and safety diagnostics. 
- Reworked `RemoteLLM` to request `N` candidates (`LLM_NUM_CANDIDATES`, default `3`) and to publish a `ResponseCandidatesPayload` containing multiple `ResponseCandidate` entries. 
- Implemented `_generate_candidates`, `_calibrate_confidence`, and `_evaluate_safety` in `src/deepthought/modules/llm_remote.py` to materialize candidates, compute a heuristic calibrated confidence (token/model/length components), and attach basic safety metadata. 
- Kept DSPy fallback path but unified it into the candidate pipeline and added source labeling via `LLM_SOURCE_NAME`. 
- Extended `SelectorService` unit tests to validate mixed-source/mixed-confidence candidate sets and early-exit flush behavior, and updated LLM unit tests to assert multi-candidate payload shape, confidence components and safety metadata. 
- Documented candidate schema expectations in `docs/architecture.md` and updated event contract roundtrip tests to include the enriched candidate metadata.

### Testing

- Ran the modified unit test subset with `pytest -q -c /tmp/pytest.ini tests/unit/modules/test_llm_remote.py tests/unit/services/test_selector_service.py tests/unit/eda/test_event_contracts.py` and observed `46 passed` for that suite. 
- Verified linting with `ruff check --isolated` on the changed files which returned `All checks passed!`. 
- Note: an initial `pytest` invocation hit a local `pyproject.toml` parse conflict in this workspace; tests were executed successfully using a temporary `pytest.ini` as shown above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9aca5b6a88326bf92534db6fd8733)