### PR TITLE
Add FeedbackService for outcome/correction signals, user-summary jobs, and metrics/dashboard

### DIFF
--- a/grafana/feedback_adaptation_dashboard.json
+++ b/grafana/feedback_adaptation_dashboard.json
@@ -1,0 +1,34 @@
+{
+  "title": "DeepThought Feedback Adaptation",
+  "schemaVersion": 39,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Feedback signal volume",
+      "targets": [
+        {
+          "expr": "sum by(signal_type,signal) (rate(response_feedback_signals_total[5m]))"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Response quality trend",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum by(le, source) (rate(response_quality_score_bucket[5m])))"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Adaptation effect deltas",
+      "targets": [
+        {
+          "expr": "sum by(target) (rate(adaptation_effect_delta_sum[5m]))"
+        }
+      ]
+    }
+  ]
+}

--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -24,6 +24,9 @@ class CanonicalSubjects:
     PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings.v1"
     PERCEPTION_EXTRACT = "dtr.perception.extract.v1"
     SOCIAL_PERCEPTION = "dtr.social.perception.v1"
+    OUTCOME_SIGNAL = "dtr.feedback.outcome_signal.v1"
+    CORRECTION_SIGNAL = "dtr.feedback.correction_signal.v1"
+    USER_SUMMARY_REFRESH = "dtr.memory.user_summary.refresh.v1"
 
 
 LEGACY_SUBJECT_MAP: Dict[str, str] = {
@@ -41,6 +44,9 @@ LEGACY_SUBJECT_MAP: Dict[str, str] = {
     "dtr.perception.embeddings": CanonicalSubjects.PERCEPTION_EMBEDDINGS,
     "dtr.perception.extract": CanonicalSubjects.PERCEPTION_EXTRACT,
     "dtr.social.perception": CanonicalSubjects.SOCIAL_PERCEPTION,
+    "dtr.feedback.outcome_signal": CanonicalSubjects.OUTCOME_SIGNAL,
+    "dtr.feedback.correction_signal": CanonicalSubjects.CORRECTION_SIGNAL,
+    "dtr.memory.user_summary.refresh": CanonicalSubjects.USER_SUMMARY_REFRESH,
 }
 
 

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -40,6 +40,9 @@ class EventSubjects:
     RESPONSE_GENERATED = "dtr.llm.response_generated"
     RESPONSE_CANDIDATES = CanonicalSubjects.RESPONSE_CANDIDATES
     RESPONSE_RANKED = CanonicalSubjects.RESPONSE_RANKED
+    OUTCOME_SIGNAL = CanonicalSubjects.OUTCOME_SIGNAL
+    CORRECTION_SIGNAL = CanonicalSubjects.CORRECTION_SIGNAL
+    USER_SUMMARY_REFRESH = CanonicalSubjects.USER_SUMMARY_REFRESH
 
     # Perception events
     PERCEPTION_EMBEDDINGS = CanonicalSubjects.PERCEPTION_EMBEDDINGS
@@ -329,6 +332,36 @@ class ResponseRankedPayload(EventPayload):
             candidates=candidates,
         )
 
+
+
+
+@dataclass
+class OutcomeSignalPayload(EventPayload):
+    """Payload for post-response positive/negative outcome signals."""
+
+    signal: str
+    input_id: Optional[str] = None
+    user_id: Optional[str] = None
+    author_id: Optional[str] = None
+    response_source: Optional[str] = None
+    confidence_delta: float = 0.0
+    affinity_delta: float = 0.0
+    timestamp: Optional[str] = None
+
+
+@dataclass
+class CorrectionSignalPayload(EventPayload):
+    """Payload for explicit correction events following a response."""
+
+    correction: str
+    input_id: Optional[str] = None
+    user_id: Optional[str] = None
+    author_id: Optional[str] = None
+    prior_response: Optional[str] = None
+    response_source: Optional[str] = None
+    confidence_delta: float = -0.1
+    affinity_delta: float = 0.0
+    timestamp: Optional[str] = None
 
 @dataclass
 class ReminderTriggeredPayload(EventPayload):

--- a/src/deepthought/metrics/prometheus.py
+++ b/src/deepthought/metrics/prometheus.py
@@ -85,6 +85,33 @@ if "missing_modality_total" not in REGISTRY._names_to_collectors:
 else:  # pragma: no cover - already registered
     MISSING_MODALITY_TOTAL = REGISTRY._names_to_collectors["missing_modality_total"]  # type: ignore
 
+if "response_feedback_signals_total" not in REGISTRY._names_to_collectors:
+    RESPONSE_FEEDBACK_SIGNALS_TOTAL = Counter(
+        "response_feedback_signals_total",
+        "Total response feedback signals processed",
+        labelnames=["signal_type", "signal", "source"],
+    )
+else:  # pragma: no cover - already registered
+    RESPONSE_FEEDBACK_SIGNALS_TOTAL = REGISTRY._names_to_collectors["response_feedback_signals_total"]  # type: ignore
+
+if "response_quality_score" not in REGISTRY._names_to_collectors:
+    RESPONSE_QUALITY_SCORE = Histogram(
+        "response_quality_score",
+        "Distribution of response quality outcomes used for adaptation",
+        labelnames=["source"],
+    )
+else:  # pragma: no cover - already registered
+    RESPONSE_QUALITY_SCORE = REGISTRY._names_to_collectors["response_quality_score"]  # type: ignore
+
+if "adaptation_effect_delta" not in REGISTRY._names_to_collectors:
+    ADAPTATION_EFFECT_DELTA = Histogram(
+        "adaptation_effect_delta",
+        "Observed adaptation deltas applied to affinity and memory confidence",
+        labelnames=["target"],
+    )
+else:  # pragma: no cover - already registered
+    ADAPTATION_EFFECT_DELTA = REGISTRY._names_to_collectors["adaptation_effect_delta"]  # type: ignore
+
 __all__ = [
     "INPUTS_TOTAL",
     "INPUT_LATENCY_SECONDS",
@@ -92,4 +119,7 @@ __all__ = [
     "RULE_EVALUATIONS_TOTAL",
     "RULE_EVALUATION_ERRORS_TOTAL",
     "MISSING_MODALITY_TOTAL",
+    "RESPONSE_FEEDBACK_SIGNALS_TOTAL",
+    "RESPONSE_QUALITY_SCORE",
+    "ADAPTATION_EFFECT_DELTA",
 ]

--- a/src/deepthought/services/__init__.py
+++ b/src/deepthought/services/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "DiscordGatewayService",
     "PerceptionInterpretService",
     "ContextAssemblerService",
+    "FeedbackService",
     "manipulation_score",
 ]
 
@@ -46,6 +47,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "DiscordGatewayService": ("discord_gateway_service", "DiscordGatewayService"),
     "PerceptionInterpretService": ("perception_interpret_service", "PerceptionInterpretService"),
     "ContextAssemblerService": ("context_assembler_service", "ContextAssemblerService"),
+    "FeedbackService": ("feedback_service", "FeedbackService"),
     "manipulation_score": ("manipulative_detection", "manipulation_score"),
 }
 

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -177,6 +177,14 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS user_summaries (
+            user_id TEXT PRIMARY KEY,
+            summary TEXT,
+            source_count INTEGER DEFAULT 0,
+            updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS sentiment_trends (
             user_id TEXT,
             channel_id TEXT,
@@ -649,6 +657,68 @@ class DBManager:
             (str(subject_id), theory, confidence),
         )
         await self._db.commit()
+
+
+    async def adjust_theory_confidence(self, subject_id: int | str, delta: float) -> None:
+        """Adjust confidence for all theories associated with ``subject_id``."""
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            UPDATE theories
+            SET confidence = MIN(1.0, MAX(0.0, confidence + ?)),
+                updated=CURRENT_TIMESTAMP
+            WHERE subject_id=?
+            """,
+            (float(delta), str(subject_id)),
+        )
+        await self._db.commit()
+
+    async def upsert_user_summary(self, user_id: int | str, summary: str, source_count: int) -> None:
+        if not isinstance(summary, str) or not summary.strip():
+            raise ValueError("summary must be a non-empty string")
+        await self.connect()
+        assert self._db
+        await self._db.execute(
+            """
+            INSERT INTO user_summaries (user_id, summary, source_count, updated)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(user_id) DO UPDATE SET
+                summary=excluded.summary,
+                source_count=excluded.source_count,
+                updated=CURRENT_TIMESTAMP
+            """,
+            (str(user_id), summary.strip(), int(source_count)),
+        )
+        await self._db.commit()
+
+    async def get_user_summary(self, user_id: int | str) -> tuple[str, int, str] | None:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            "SELECT summary, source_count, updated FROM user_summaries WHERE user_id=?",
+            (str(user_id),),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return None
+        return str(row[0]), int(row[1] or 0), str(row[2])
+
+    async def list_users_with_long_history(self, min_memories: int = 25) -> list[tuple[str, int]]:
+        await self.connect()
+        assert self._db
+        async with self._db.execute(
+            """
+            SELECT user_id, COUNT(*) as memory_count
+            FROM memories
+            GROUP BY user_id
+            HAVING COUNT(*) >= ?
+            ORDER BY COUNT(*) DESC
+            """,
+            (int(min_memories),),
+        ) as cur:
+            rows = await cur.fetchall()
+        return [(str(user_id), int(count)) for user_id, count in rows]
 
     async def get_theories(self, subject_id: int):
         await self.connect()

--- a/src/deepthought/services/feedback_service.py
+++ b/src/deepthought/services/feedback_service.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from nats.aio.client import Client as NATS
+from nats.aio.msg import Msg
+from nats.js.client import JetStreamContext
+
+from ..eda.events import (
+    CorrectionSignalPayload,
+    EventSubjects,
+    OutcomeSignalPayload,
+    ResponseRankedPayload,
+)
+from ..metrics.prometheus import (
+    ADAPTATION_EFFECT_DELTA,
+    RESPONSE_FEEDBACK_SIGNALS_TOTAL,
+    RESPONSE_QUALITY_SCORE,
+)
+from .base import BaseService
+from .db_manager import DBManager
+
+logger = logging.getLogger(__name__)
+
+
+class FeedbackService(BaseService):
+    """Consume response feedback and adapt social/memory confidence state."""
+
+    def __init__(
+        self,
+        nats_client: Optional[NATS] = None,
+        js_context: Optional[JetStreamContext] = None,
+        db_manager: Optional[DBManager] = None,
+        *,
+        nats_url: str | None = None,
+        connect_retries: int = 1,
+        connect_timeout: float = 2.0,
+    ) -> None:
+        super().__init__(
+            nats_client,
+            js_context,
+            nats_url=nats_url,
+            connect_retries=connect_retries,
+            connect_timeout=connect_timeout,
+        )
+        self._db = db_manager or DBManager()
+        self._recent_responses: dict[str, dict[str, Any]] = {}
+
+    async def _handle_response_ranked(self, msg: Msg) -> None:
+        try:
+            payload = ResponseRankedPayload.from_dict(json.loads(msg.data.decode()))
+            if payload.input_id:
+                self._recent_responses[payload.input_id] = {
+                    "user_id": payload.user_id,
+                    "author_id": payload.author_id,
+                    "source": payload.source,
+                    "confidence": payload.confidence,
+                    "final_response": payload.final_response,
+                    "timestamp": payload.timestamp,
+                }
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("Failed to process response ranked feedback context", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_outcome_signal(self, msg: Msg) -> None:
+        try:
+            payload = OutcomeSignalPayload.from_dict(json.loads(msg.data.decode()))
+            await self._apply_feedback(
+                signal_type="outcome",
+                signal=payload.signal.lower(),
+                input_id=payload.input_id,
+                user_id=payload.user_id or payload.author_id,
+                source=payload.response_source,
+                affinity_delta=payload.affinity_delta,
+                confidence_delta=payload.confidence_delta,
+                details={"timestamp": payload.timestamp},
+            )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("Failed to process outcome signal", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _handle_correction_signal(self, msg: Msg) -> None:
+        try:
+            payload = CorrectionSignalPayload.from_dict(json.loads(msg.data.decode()))
+            await self._apply_feedback(
+                signal_type="correction",
+                signal="corrected",
+                input_id=payload.input_id,
+                user_id=payload.user_id or payload.author_id,
+                source=payload.response_source,
+                affinity_delta=payload.affinity_delta,
+                confidence_delta=payload.confidence_delta,
+                details={
+                    "correction": payload.correction,
+                    "prior_response": payload.prior_response,
+                    "timestamp": payload.timestamp,
+                },
+            )
+            if hasattr(msg, "ack") and callable(msg.ack):
+                await msg.ack()
+        except Exception:
+            logger.error("Failed to process correction signal", exc_info=True)
+            if hasattr(msg, "nak") and callable(msg.nak):
+                await msg.nak()
+
+    async def _apply_feedback(
+        self,
+        *,
+        signal_type: str,
+        signal: str,
+        input_id: str | None,
+        user_id: str | None,
+        source: str | None,
+        affinity_delta: float,
+        confidence_delta: float,
+        details: dict[str, Any],
+    ) -> None:
+        source_label = source or "unknown"
+        resolved_user = user_id
+        if input_id and input_id in self._recent_responses:
+            cached = self._recent_responses[input_id]
+            resolved_user = resolved_user or cached.get("author_id") or cached.get("user_id")
+            source_label = source_label if source else str(cached.get("source") or "unknown")
+
+        if signal_type == "outcome" and affinity_delta == 0:
+            affinity_delta = 1.0 if signal in {"positive", "success", "thumbs_up"} else -1.0
+        if signal_type == "outcome" and confidence_delta == 0:
+            confidence_delta = 0.1 if signal in {"positive", "success", "thumbs_up"} else -0.1
+
+        if resolved_user:
+            await self._db.adjust_affinity(resolved_user, affinity_delta)
+            await self._db.adjust_theory_confidence(resolved_user, confidence_delta)
+
+        RESPONSE_FEEDBACK_SIGNALS_TOTAL.labels(
+            signal_type=signal_type,
+            signal=signal,
+            source=source_label,
+        ).inc()
+        RESPONSE_QUALITY_SCORE.labels(source=source_label).observe(1.0 if confidence_delta > 0 else 0.0)
+        ADAPTATION_EFFECT_DELTA.labels(target="affinity").observe(abs(float(affinity_delta)))
+        ADAPTATION_EFFECT_DELTA.labels(target="memory_confidence").observe(abs(float(confidence_delta)))
+
+        telemetry_payload = {
+            "event": "response_feedback",
+            "signal_type": signal_type,
+            "signal": signal,
+            "input_id": input_id,
+            "user_id": resolved_user,
+            "source": source_label,
+            "affinity_delta": affinity_delta,
+            "confidence_delta": confidence_delta,
+            "details": details,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        await self._publisher.publish(
+            "dtr.telemetry.response_feedback.v1",
+            telemetry_payload,
+            use_jetstream=True,
+        )
+
+    async def start(self, durable_name: str = "feedback_service") -> bool:
+        self._subscriptions.clear()
+        self.add_subscription(
+            subject=EventSubjects.RESPONSE_RANKED,
+            handler=self._handle_response_ranked,
+            use_jetstream=True,
+            durable=f"{durable_name}_ranked",
+        )
+        self.add_subscription(
+            subject=EventSubjects.OUTCOME_SIGNAL,
+            handler=self._handle_outcome_signal,
+            use_jetstream=True,
+            durable=f"{durable_name}_outcome",
+        )
+        self.add_subscription(
+            subject=EventSubjects.CORRECTION_SIGNAL,
+            handler=self._handle_correction_signal,
+            use_jetstream=True,
+            durable=f"{durable_name}_correction",
+        )
+        return await super().start()

--- a/src/deepthought/services/scheduler.py
+++ b/src/deepthought/services/scheduler.py
@@ -37,6 +37,8 @@ class SchedulerService:
         summary_interval: float = 60.0,
         daily_summary_interval: float = 24 * 60 * 60.0,
         chat_summary_interval: float = 300.0,
+        user_summary_interval: float = 900.0,
+        min_user_history_for_summary: int = 25,
         summary_db=None,
         now_func: Callable[[], datetime] | None = None,
         sleep_func: Callable[[float], Awaitable[None]] = asyncio.sleep,
@@ -55,6 +57,8 @@ class SchedulerService:
         self._sleep = sleep_func
         self._summary_db = summary_db
         self._chat_summary_interval = chat_summary_interval
+        self._user_summary_interval = user_summary_interval
+        self._min_user_history_for_summary = min_user_history_for_summary
         self._micro_tick_range = micro_tick_range
         self._standup_interval = daily_standup_interval
         self._weekly_planning_interval = weekly_planning_interval
@@ -85,6 +89,7 @@ class SchedulerService:
         self._daily_summary_task: Optional[asyncio.Task] = None
         self._chat_summary_task: Optional[asyncio.Task] = None
         self._goal_task: Optional[asyncio.Task] = None
+        self._user_summary_task: Optional[asyncio.Task] = None
         self._micro_tick_task: Optional[asyncio.Task] = None
         self._standup_task: Optional[asyncio.Task] = None
         self._planning_task: Optional[asyncio.Task] = None
@@ -101,6 +106,7 @@ class SchedulerService:
         self._reminder_task = asyncio.create_task(self._reminder_loop())
         self._chat_summary_task = asyncio.create_task(self._chat_summary_loop())
         self._goal_task = asyncio.create_task(self._goal_loop())
+        self._user_summary_task = asyncio.create_task(self._user_summary_loop())
         if self._micro_tick_range is not None:
             self._micro_tick_task = asyncio.create_task(self._micro_tick_loop())
         if self._standup_interval is not None:
@@ -119,6 +125,7 @@ class SchedulerService:
                 self._reminder_task,
                 self._chat_summary_task,
                 self._goal_task,
+                self._user_summary_task,
                 self._micro_tick_task,
                 self._standup_task,
                 self._planning_task,
@@ -209,6 +216,36 @@ class SchedulerService:
             }
             await self._summary_db.add_summary_goal(0, goal, summary)
 
+
+    async def _generate_user_history_summaries(self) -> None:
+        if self._summary_db is None:
+            return
+        users = await self._summary_db.list_users_with_long_history(
+            self._min_user_history_for_summary
+        )
+        for user_id, memory_count in users:
+            memories = await self._summary_db.recall_user(user_id, limit=50)
+            snippets = [str(memory) for _topic, memory in memories if memory]
+            if not snippets:
+                continue
+            summary = summarise_message(" ".join(snippets), max_words=40)
+            await self._summary_db.upsert_user_summary(
+                user_id=user_id,
+                summary=summary,
+                source_count=memory_count,
+            )
+            await self._publisher.publish(
+                EventSubjects.USER_SUMMARY_REFRESH,
+                {
+                    "user_id": str(user_id),
+                    "summary": summary,
+                    "source_count": memory_count,
+                    "timestamp": self._now().isoformat(),
+                },
+                use_jetstream=True,
+                timeout=10.0,
+            )
+
     async def _reminder_loop(self) -> None:
         while self._running:
             await self._sleep(1.0)
@@ -232,6 +269,12 @@ class SchedulerService:
         while self._running:
             await self._sleep(self._chat_summary_interval)
             await self._generate_chat_summary()
+
+
+    async def _user_summary_loop(self) -> None:
+        while self._running:
+            await self._sleep(self._user_summary_interval)
+            await self._generate_user_history_summaries()
 
     async def _micro_tick_loop(self) -> None:
         while self._running:

--- a/tests/unit/services/test_feedback_service.py
+++ b/tests/unit/services/test_feedback_service.py
@@ -1,0 +1,88 @@
+import json
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.feedback_service import FeedbackService
+
+
+class DummyDB:
+    def __init__(self):
+        self.affinity_calls = []
+        self.confidence_calls = []
+
+    async def adjust_affinity(self, user_id, delta):
+        self.affinity_calls.append((user_id, delta))
+
+    async def adjust_theory_confidence(self, user_id, delta):
+        self.confidence_calls.append((user_id, delta))
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.calls = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.calls.append((subject, payload, use_jetstream))
+
+
+class DummyMsg:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_feedback_service_tracks_response_and_applies_positive_outcome():
+    service = FeedbackService(nats_client=None, js_context=None, db_manager=DummyDB())
+    service._publisher = DummyPublisher()
+
+    ranked = DummyMsg(
+        {
+            "final_response": "hello",
+            "input_id": "in-1",
+            "user_id": "u-1",
+            "author_id": "u-1",
+            "source": "responder_a",
+            "confidence": 0.7,
+        }
+    )
+    await service._handle_response_ranked(ranked)
+    assert ranked.acked
+
+    outcome = DummyMsg({"signal": "positive", "input_id": "in-1"})
+    await service._handle_outcome_signal(outcome)
+
+    assert service._db.affinity_calls == [("u-1", 1.0)]
+    assert service._db.confidence_calls == [("u-1", 0.1)]
+    assert outcome.acked
+    assert service._publisher.calls[0][0] == "dtr.telemetry.response_feedback.v1"
+
+
+@pytest.mark.asyncio
+async def test_feedback_service_correction_uses_explicit_deltas():
+    service = FeedbackService(nats_client=None, js_context=None, db_manager=DummyDB())
+    service._publisher = DummyPublisher()
+
+    correction = DummyMsg(
+        {
+            "correction": "The city is Rome.",
+            "user_id": "u-9",
+            "confidence_delta": -0.35,
+            "affinity_delta": -0.2,
+        }
+    )
+    await service._handle_correction_signal(correction)
+
+    assert service._db.affinity_calls == [("u-9", -0.2)]
+    assert service._db.confidence_calls == [("u-9", -0.35)]
+
+
+def test_feedback_subjects_are_canonicalized():
+    assert EventSubjects.OUTCOME_SIGNAL.endswith(".v1")
+    assert EventSubjects.CORRECTION_SIGNAL.endswith(".v1")
+    assert EventSubjects.USER_SUMMARY_REFRESH.endswith(".v1")

--- a/tests/unit/services/test_scheduler_user_summary.py
+++ b/tests/unit/services/test_scheduler_user_summary.py
@@ -1,0 +1,56 @@
+import pytest
+
+pytest.importorskip("aiosqlite")
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.scheduler import SchedulerService
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+class DummyMemoryDAL:
+    def get_recent_facts(self, count=3):
+        return []
+
+
+class DummyGraphDAL:
+    def add_entity(self, label, props):
+        return None
+
+
+class DummySummaryDB:
+    def __init__(self):
+        self.upserts = []
+
+    async def list_users_with_long_history(self, min_memories):
+        assert min_memories == 2
+        return [("42", 3)]
+
+    async def recall_user(self, user_id, limit=None):
+        return [("topic", "User likes chess"), ("topic", "User prefers concise answers")]
+
+    async def upsert_user_summary(self, user_id, summary, source_count):
+        self.upserts.append((user_id, summary, source_count))
+
+
+@pytest.mark.asyncio
+async def test_generate_user_history_summaries_publishes_refresh_event():
+    service = SchedulerService(
+        DummyPublisher(),
+        DummyMemoryDAL(),
+        DummyGraphDAL(),
+        user_summary_interval=100.0,
+        min_user_history_for_summary=2,
+        summary_db=DummySummaryDB(),
+    )
+
+    await service._generate_user_history_summaries()
+
+    assert service._summary_db.upserts
+    assert any(subject == EventSubjects.USER_SUMMARY_REFRESH for subject, _payload in service._publisher.published)


### PR DESCRIPTION
### Motivation
- Capture post-response feedback (positive/negative outcomes and explicit corrections) to adapt social affinity and memory confidence. 
- Compress long user memory histories into concise, retrievable summaries to improve retrieval and downstream responders. 
- Provide telemetry and dashboards to observe response quality trends and adaptation effects.

### Description
- Add `FeedbackService` (`src/deepthought/services/feedback_service.py`) that subscribes to `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL`, applies affinity and theory-confidence updates, and publishes telemetry. 
- Introduce canonical feedback event subjects and payloads (`OUTCOME_SIGNAL`, `CORRECTION_SIGNAL`, `USER_SUMMARY_REFRESH`) in `src/deepthought/eda/contracts/__init__.py` and `src/deepthought/eda/events.py`. 
- Extend `DBManager` (`src/deepthought/services/db_manager.py`) with `user_summaries` table and helper methods `adjust_theory_confidence`, `upsert_user_summary`, `get_user_summary`, and `list_users_with_long_history` for persistence and confidence updates. 
- Enhance `SchedulerService` (`src/deepthought/services/scheduler.py`) with periodic user-history summarization, a user-summary loop/publisher that emits `USER_SUMMARY_REFRESH`, and wiring to upsert summaries. 
- Add Prometheus metrics (`src/deepthought/metrics/prometheus.py`) and a Grafana dashboard (`grafana/feedback_adaptation_dashboard.json`) to track feedback signals, response quality, and adaptation deltas, and expose `FeedbackService` via the services lazy importer. 
- Add unit tests for feedback handling and user-summary refresh publishing (`tests/unit/services/test_feedback_service.py`, `tests/unit/services/test_scheduler_user_summary.py`).

### Testing
- Ran `pytest -c pytest.ini tests/unit/services/test_feedback_service.py tests/unit/services/test_scheduler_user_summary.py`, and both tests were skipped in this environment because `aiosqlite` is unavailable. 
- An initial `pytest` invocation failed with a `pyproject.toml` parse error (duplicate key) unrelated to the code changes before switching to `-c pytest.ini`. 
- Ran linter checks with `ruff check --isolated ...` against modified files which passed. 
- Committed the changes (10 files changed, new tests and dashboard added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b16360b08326b6fee40e66d58022)