### PR TITLE
Introduce multimodal semantic notes and clarifying fallback for low-confidence perception

### DIFF
--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -49,6 +49,7 @@ def _build_generation_prompt(
     author_name: str | None = None,
     channel_context: str | None = None,
     recent_turn_summary: str | None = None,
+    multimodal_interpretations: dict[str, object] | None = None,
 ) -> str:
     facts_block = "\n".join(f"- {fact}" for fact in facts) if facts else "- None"
 
@@ -61,6 +62,34 @@ def _build_generation_prompt(
         hints.append(f"- Recent turn summary: {recent_turn_summary}")
     hints_block = "\n".join(hints) if hints else "- None"
 
+    multimodal = multimodal_interpretations if isinstance(multimodal_interpretations, dict) else {}
+    modality_notes = multimodal.get("notes")
+    notes = modality_notes if isinstance(modality_notes, list) else []
+    note_lines: list[str] = []
+    for raw_note in notes:
+        if not isinstance(raw_note, dict):
+            continue
+        modality = str(raw_note.get("modality", "unknown"))
+        what = str(raw_note.get("what", "unknown signal"))
+        where = str(raw_note.get("where", "unknown location"))
+        who = str(raw_note.get("who", "unknown actor"))
+        confidence = raw_note.get("confidence")
+        conf_txt = f"{float(confidence):.2f}" if isinstance(confidence, (int, float)) else "n/a"
+        note_lines.append(f"- [{modality}] what={what}; where={where}; who={who}; confidence={conf_txt}")
+    multimodal_block = "\n".join(note_lines) if note_lines else "- None"
+
+    multimodal_confidence = multimodal.get("confidence") if isinstance(multimodal.get("confidence"), dict) else {}
+    aggregate = multimodal_confidence.get("aggregate")
+    low_confidence = bool(multimodal_confidence.get("low_confidence"))
+    uncertainty_line = (
+        f"Multimodal confidence={float(aggregate):.2f}; low_confidence={low_confidence}."
+        if isinstance(aggregate, (int, float))
+        else f"Multimodal confidence unknown; low_confidence={low_confidence}."
+    )
+
+    fallback = multimodal.get("fallback") if isinstance(multimodal.get("fallback"), dict) else {}
+    clarify = bool(fallback.get("ask_clarifying_question"))
+
     return (
         "[SYSTEM PERSONA]\n"
         "You are DeepThought, a conversational assistant.\n"
@@ -71,9 +100,28 @@ def _build_generation_prompt(
         f"{user_input}\n\n"
         "[SOCIAL/PERCEPTION HINTS]\n"
         f"{hints_block}\n\n"
+        "[MULTIMODAL INTERPRETATIONS]\n"
+        f"{multimodal_block}\n\n"
+        "[UNCERTAINTY CUES]\n"
+        f"- {uncertainty_line}\n\n"
         "[TASK]\n"
-        "Generate a helpful response to the user message."
+        + (
+            "Ask a focused clarifying question before making claims about image/audio details."
+            if clarify or low_confidence
+            else "Generate a helpful response to the user message."
+        )
     )
+
+
+def _build_clarifying_question(multimodal_interpretations: dict[str, object] | None) -> str:
+    multimodal = multimodal_interpretations if isinstance(multimodal_interpretations, dict) else {}
+    notes = multimodal.get("notes")
+    if isinstance(notes, list):
+        modalities = [str(item.get("modality")) for item in notes if isinstance(item, dict) and item.get("modality")]
+        if modalities:
+            joined = ", ".join(sorted(set(modalities)))
+            return f"I might be missing details from the {joined} signal. Could you clarify what you want me to focus on?"
+    return "I may be missing key details from the attachment. Could you clarify what is most important for me to analyze?"
 
 
 class RemoteLLM:
@@ -197,6 +245,11 @@ class RemoteLLM:
                 channel_context = _normalized_optional_text(payload.channel_context)
                 recent_turn_summary = _normalized_optional_text(payload.recent_turn_summary)
                 facts = [str(item) for item in payload.retrieved_facts]
+                multimodal_interpretations = (
+                    payload.multimodal_interpretations
+                    if isinstance(payload.multimodal_interpretations, dict)
+                    else {}
+                )
             else:
                 input_id = data.get("input_id")
                 author_id = data.get("author_id") if isinstance(data.get("author_id"), str) else None
@@ -207,6 +260,11 @@ class RemoteLLM:
                 channel_context = _normalized_optional_text(data.get("channel_context"))
                 recent_turn_summary = _normalized_optional_text(data.get("recent_turn_summary"))
                 facts = _extract_memory_facts(data)
+                multimodal_interpretations = (
+                    data.get("multimodal_interpretations")
+                    if isinstance(data.get("multimodal_interpretations"), dict)
+                    else {}
+                )
 
             if author_id is None:
                 author_id = user_id
@@ -218,9 +276,29 @@ class RemoteLLM:
                 author_name=author_name,
                 channel_context=channel_context,
                 recent_turn_summary=recent_turn_summary,
+                multimodal_interpretations=multimodal_interpretations,
             )
+
+            fallback = multimodal_interpretations.get("fallback") if isinstance(multimodal_interpretations.get("fallback"), dict) else {}
+            should_clarify = bool(fallback.get("ask_clarifying_question"))
+            confidence_obj = multimodal_interpretations.get("confidence")
+            if isinstance(confidence_obj, dict):
+                should_clarify = should_clarify or bool(confidence_obj.get("low_confidence"))
+
             logger.info("RemoteLLM generating for %s", input_id)
-            candidates = await self._generate_candidates(prompt)
+            if should_clarify:
+                candidates = [
+                    ResponseCandidate(
+                        text=_build_clarifying_question(multimodal_interpretations),
+                        confidence=0.95,
+                        source=f"{self._source_name}:clarifying_fallback",
+                        safety_passed=True,
+                        confidence_components={"fallback": 1.0},
+                        safety_metadata={"rule": "low_multimodal_confidence"},
+                    )
+                ]
+            else:
+                candidates = await self._generate_candidates(prompt)
             payload = ResponseCandidatesPayload(
                 candidates=candidates,
                 input_id=input_id,

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -31,6 +31,30 @@ class ContextAssemblerService:
     """Assemble contextual data from memory/social/perception providers."""
 
     _PROVIDER_ORDER = ("memory", "social", "perception")
+    _MULTIMODAL_SCHEMA_VERSION = "multimodal.semantic-notes.v1"
+
+    @classmethod
+    def _normalize_multimodal(cls, raw: Any) -> dict[str, Any]:
+        if not isinstance(raw, dict):
+            return {
+                "schema_version": cls._MULTIMODAL_SCHEMA_VERSION,
+                "summary": "no multimodal signals",
+                "notes": [],
+                "by_modality": {},
+                "attachments": None,
+                "confidence": {"aggregate": 0.0, "low_confidence": True, "threshold": 0.45},
+                "fallback": {"ask_clarifying_question": True, "reason": "missing multimodal interpretations"},
+            }
+
+        normalized = dict(raw)
+        normalized.setdefault("schema_version", cls._MULTIMODAL_SCHEMA_VERSION)
+        normalized.setdefault("summary", "no multimodal signals")
+        normalized.setdefault("notes", [])
+        normalized.setdefault("by_modality", {})
+        normalized.setdefault("attachments", None)
+        normalized.setdefault("confidence", {"aggregate": 0.0, "low_confidence": True, "threshold": 0.45})
+        normalized.setdefault("fallback", {"ask_clarifying_question": False, "reason": ""})
+        return normalized
 
     def __init__(
         self,
@@ -116,9 +140,7 @@ class ContextAssemblerService:
             social_signals = {}
 
         perception_payload = pending.provider_payloads.get("perception", {})
-        multimodal = perception_payload.get("multimodal_interpretations", perception_payload)
-        if not isinstance(multimodal, dict):
-            multimodal = {}
+        multimodal = self._normalize_multimodal(perception_payload.get("multimodal_interpretations", perception_payload))
 
         conversation_window = request.get("conversation_window")
         if not isinstance(conversation_window, list):

--- a/src/deepthought/services/perception/summarization.py
+++ b/src/deepthought/services/perception/summarization.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+LOW_CONFIDENCE_THRESHOLD = 0.45
+
+
+def build_semantic_notes(*, attachments: Any, embeddings_payload: dict[str, Any]) -> dict[str, Any]:
+    """Build stable multimodal interpretation notes for prompt injection."""
+
+    raw_modalities = embeddings_payload.get("by_modality")
+    modalities = raw_modalities if isinstance(raw_modalities, dict) else {}
+    raw_modality_conf = embeddings_payload.get("modality_confidence")
+    modality_conf = raw_modality_conf if isinstance(raw_modality_conf, dict) else {}
+
+    notes: list[dict[str, Any]] = []
+    by_modality: dict[str, dict[str, Any]] = {}
+    confidences: list[float] = []
+
+    for modality_name, modality_payload in modalities.items():
+        if not isinstance(modality_payload, dict):
+            continue
+        vectors = modality_payload.get("embeddings")
+        vector_count = len(vectors) if isinstance(vectors, list) else 0
+        spans = modality_payload.get("spans")
+        span_count = len(spans) if isinstance(spans, list) else 0
+        confidence = modality_conf.get(modality_name)
+        conf = float(confidence) if isinstance(confidence, (int, float)) else 0.0
+        confidences.append(conf)
+
+        where_hint = "temporal spans" if str(modality_name).lower() == "audio" else "attachment regions"
+        what = f"{vector_count} embedding vectors across {span_count} spans"
+        who = "unknown"
+
+        note = {
+            "modality": str(modality_name),
+            "what": what,
+            "where": where_hint,
+            "who": who,
+            "confidence": round(conf, 3),
+        }
+        notes.append(note)
+        by_modality[str(modality_name)] = note
+
+    attachment_counts: dict[str, int] = {}
+    if isinstance(attachments, list):
+        for raw_attachment in attachments:
+            if not isinstance(raw_attachment, dict):
+                continue
+            content_type = raw_attachment.get("content_type")
+            if isinstance(content_type, str) and "/" in content_type:
+                media_type = content_type.split("/", maxsplit=1)[0].strip().lower()
+            else:
+                media_type = "file"
+            attachment_counts[media_type] = attachment_counts.get(media_type, 0) + 1
+
+    attachment_summary = None
+    if attachment_counts:
+        rendered = ", ".join(f"{kind}:{count}" for kind, count in sorted(attachment_counts.items()))
+        attachment_summary = f"attachments[{rendered}]"
+
+    aggregate_confidence = round(sum(confidences) / len(confidences), 3) if confidences else 0.0
+    low_confidence = aggregate_confidence < LOW_CONFIDENCE_THRESHOLD
+    summary_parts = [
+        f"{note['modality']}: {note['what']} (conf={note['confidence']:.2f})"
+        for note in notes
+    ]
+    if attachment_summary:
+        summary_parts.append(attachment_summary)
+    summary = " | ".join(summary_parts) if summary_parts else "no multimodal signals"
+
+    return {
+        "schema_version": "multimodal.semantic-notes.v1",
+        "summary": summary,
+        "notes": notes,
+        "by_modality": by_modality,
+        "attachments": attachment_summary,
+        "confidence": {
+            "aggregate": aggregate_confidence,
+            "low_confidence": low_confidence,
+            "threshold": LOW_CONFIDENCE_THRESHOLD,
+        },
+        "fallback": {
+            "ask_clarifying_question": low_confidence,
+            "reason": "low multimodal confidence" if low_confidence else "",
+        },
+    }
+

--- a/src/deepthought/services/perception_interpret_service.py
+++ b/src/deepthought/services/perception_interpret_service.py
@@ -12,6 +12,7 @@ from nats.js.client import JetStreamContext
 from ..eda.events import EventSubjects, PerceptionEmbeddingsEvent
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from .perception.summarization import build_semantic_notes
 
 logger = logging.getLogger(__name__)
 
@@ -23,54 +24,6 @@ class PerceptionInterpretService:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._embeddings_by_input_id: dict[str, dict[str, Any]] = {}
-
-    @staticmethod
-    def _attachment_summary(attachments: Any) -> str | None:
-        if not isinstance(attachments, list) or not attachments:
-            return None
-        counts: dict[str, int] = {}
-        for raw_attachment in attachments:
-            if not isinstance(raw_attachment, dict):
-                continue
-            content_type = raw_attachment.get("content_type")
-            if isinstance(content_type, str) and "/" in content_type:
-                media_type = content_type.split("/", maxsplit=1)[0].strip().lower()
-            else:
-                media_type = "file"
-            counts[media_type] = counts.get(media_type, 0) + 1
-        if not counts:
-            return None
-        parts = [f"{media}:{count}" for media, count in sorted(counts.items())]
-        return f"attachments[{', '.join(parts)}]"
-
-    @staticmethod
-    def _embedding_summary(embeddings_payload: dict[str, Any]) -> dict[str, str]:
-        raw_modalities = embeddings_payload.get("by_modality")
-        modalities = raw_modalities if isinstance(raw_modalities, dict) else {}
-        raw_modality_conf = embeddings_payload.get("modality_confidence")
-        modality_conf = raw_modality_conf if isinstance(raw_modality_conf, dict) else {}
-
-        summaries: dict[str, str] = {}
-        for modality_name, modality_payload in modalities.items():
-            if not isinstance(modality_payload, dict):
-                continue
-            vectors = modality_payload.get("embeddings")
-            span_count = len(modality_payload.get("spans") or [])
-            vector_count = len(vectors) if isinstance(vectors, list) else 0
-            dim = 0
-            if vector_count and isinstance(vectors[0], list):
-                dim = len(vectors[0])
-            confidence = modality_conf.get(modality_name)
-            conf_text = (
-                f", conf={float(confidence):.2f}"
-                if isinstance(confidence, (int, float))
-                else ""
-            )
-            summaries[str(modality_name)] = (
-                f"{modality_name}: {vector_count} vectors"
-                f" @dim{dim}, spans={span_count}{conf_text}"
-            )
-        return summaries
 
     async def _handle_embeddings(self, msg: Msg) -> None:
         try:
@@ -109,24 +62,14 @@ class PerceptionInterpretService:
                 raise ValueError("Interpret request missing input_id")
 
             cached = self._embeddings_by_input_id.get(input_id, {})
-            modality_summaries = self._embedding_summary(cached)
-            attachments_summary = self._attachment_summary(payload.get("attachments"))
-
-            compact_lines: list[str] = []
-            if modality_summaries:
-                compact_lines.extend(modality_summaries.values())
-            if attachments_summary:
-                compact_lines.append(attachments_summary)
-            if not compact_lines:
-                compact_lines.append("no multimodal signals")
+            multimodal_notes = build_semantic_notes(
+                attachments=payload.get("attachments"),
+                embeddings_payload=cached,
+            )
 
             out_payload = {
                 "input_id": input_id,
-                "multimodal_interpretations": {
-                    "summary": " | ".join(compact_lines),
-                    "by_modality": modality_summaries,
-                    "attachments": attachments_summary,
-                },
+                "multimodal_interpretations": multimodal_notes,
             }
             await self._publisher.publish(
                 EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -97,7 +97,8 @@ async def test_race_safe_assembly_collects_all_providers(monkeypatch):
     assert payload.input_id == "i-race"
     assert payload.retrieved_facts == ["f2", "f1"]
     assert payload.social_signals == {"tone": "neutral"}
-    assert payload.multimodal_interpretations == {"image": "none"}
+    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload.multimodal_interpretations["summary"] == "no multimodal signals"
     assert payload.confidence["partial"] is False
     assert payload.confidence["completed_providers"] == ["memory", "social", "perception"]
 
@@ -131,7 +132,8 @@ async def test_partial_result_when_provider_missing_is_deterministic(monkeypatch
     assert payload.input_id == "i-partial"
     assert payload.retrieved_facts == ["f1"]
     assert payload.social_signals == {"sentiment": 0.7}
-    assert payload.multimodal_interpretations == {}
+    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload.multimodal_interpretations["notes"] == []
     assert payload.confidence["partial"] is True
     assert payload.confidence["missing_providers"] == ["perception"]
     assert payload.confidence["completed_providers"] == ["memory", "social"]
@@ -222,7 +224,8 @@ async def test_context_assembler_merges_perception_interpretations_within_wait_w
     assert len(assembled) == 1
     payload = assembled[0][1]
     assert payload.input_id == "i-embed"
-    assert payload.multimodal_interpretations["by_modality"]["image"].startswith("image: 1 vectors")
+    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload.multimodal_interpretations["by_modality"]["image"]["what"].startswith("1 embedding vectors")
     assert "attachments[image:1]" in payload.multimodal_interpretations["summary"]
     assert payload.confidence["partial"] is False
 

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -297,6 +297,18 @@ def test_build_generation_prompt_includes_sections():
         author_name="Ada",
         channel_context="discord/#general",
         recent_turn_summary="The user asked about status.",
+        multimodal_interpretations={
+            "notes": [
+                {
+                    "modality": "image",
+                    "what": "2 embedding vectors across 1 spans",
+                    "where": "attachment regions",
+                    "who": "unknown",
+                    "confidence": 0.81,
+                }
+            ],
+            "confidence": {"aggregate": 0.81, "low_confidence": False},
+        },
     )
 
     assert "[SYSTEM PERSONA]" in prompt
@@ -306,6 +318,9 @@ def test_build_generation_prompt_includes_sections():
     assert "How are you?" in prompt
     assert "[SOCIAL/PERCEPTION HINTS]" in prompt
     assert "- Author name: Ada" in prompt
+    assert "[MULTIMODAL INTERPRETATIONS]" in prompt
+    assert "[image]" in prompt
+    assert "[UNCERTAINTY CUES]" in prompt
 
 
 def test_build_generation_prompt_without_optional_hints():
@@ -348,3 +363,63 @@ async def test_generate_candidates_uses_scores_and_safety(monkeypatch):
     assert result[0].safety_passed is True
     assert result[1].safety_passed is False
     assert "kill" in result[1].safety_metadata["matched_terms"]
+
+
+@pytest.mark.asyncio
+async def test_handle_context_event_falls_back_to_clarifying_question_on_low_confidence(monkeypatch):
+    llm = create_llm(monkeypatch)
+    called = {"generate": False}
+
+    async def fake_generate_candidates(self, prompt):
+        called["generate"] = True
+        return [llm_remote.ResponseCandidate(text="answer", confidence=0.8, source="stub", safety_passed=True)]
+
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
+
+    payload = ContextAssembledPayload(
+        input_id="low-conf",
+        user_input="what's in this clip?",
+        retrieved_facts=["f1"],
+        multimodal_interpretations={
+            "notes": [{"modality": "audio"}],
+            "confidence": {"aggregate": 0.2, "low_confidence": True},
+            "fallback": {"ask_clarifying_question": True, "reason": "low multimodal confidence"},
+        },
+    )
+    msg = DummyMsg(payload.to_json())
+
+    await llm._handle_context_event(msg)
+
+    assert msg.acked
+    assert called["generate"] is False
+    _, sent_payload = llm._publisher.published[0]
+    assert "Could you clarify" in sent_payload.candidates[0].text
+
+
+def test_build_generation_prompt_includes_image_and_audio_interpretations():
+    prompt = llm_remote._build_generation_prompt(
+        user_input="Please summarize these attachments",
+        facts=[],
+        multimodal_interpretations={
+            "notes": [
+                {
+                    "modality": "image",
+                    "what": "1 embedding vectors across 1 spans",
+                    "where": "attachment regions",
+                    "who": "unknown",
+                    "confidence": 0.73,
+                },
+                {
+                    "modality": "audio",
+                    "what": "3 embedding vectors across 2 spans",
+                    "where": "temporal spans",
+                    "who": "speaker unknown",
+                    "confidence": 0.52,
+                },
+            ],
+            "confidence": {"aggregate": 0.62, "low_confidence": False},
+        },
+    )
+
+    assert "[image] what=1 embedding vectors across 1 spans" in prompt
+    assert "[audio] what=3 embedding vectors across 2 spans" in prompt

--- a/tests/unit/services/test_perception_summarization.py
+++ b/tests/unit/services/test_perception_summarization.py
@@ -1,0 +1,34 @@
+from deepthought.services.perception.summarization import build_semantic_notes
+
+
+def test_build_semantic_notes_generates_stable_schema_with_modalities():
+    payload = {
+        "modality_confidence": {"image": 0.8, "audio": 0.5},
+        "by_modality": {
+            "image": {"spans": [[0, 1]], "embeddings": [[0.1, 0.2]]},
+            "audio": {"spans": [[0, 10], [11, 20]], "embeddings": [[0.1], [0.2]]},
+        },
+    }
+
+    result = build_semantic_notes(
+        attachments=[{"content_type": "image/png"}, {"content_type": "audio/wav"}],
+        embeddings_payload=payload,
+    )
+
+    assert result["schema_version"] == "multimodal.semantic-notes.v1"
+    assert len(result["notes"]) == 2
+    assert result["by_modality"]["image"]["what"].startswith("1 embedding vectors")
+    assert "attachments[audio:1, image:1]" == result["attachments"]
+
+
+def test_build_semantic_notes_marks_low_confidence_for_fallback():
+    result = build_semantic_notes(
+        attachments=[{"content_type": "image/png"}],
+        embeddings_payload={
+            "modality_confidence": {"image": 0.2},
+            "by_modality": {"image": {"spans": [], "embeddings": []}},
+        },
+    )
+
+    assert result["confidence"]["low_confidence"] is True
+    assert result["fallback"]["ask_clarifying_question"] is True


### PR DESCRIPTION
### Motivation
- Provide a compact, stable representation of perception outputs so downstream components can consume modality-specific cues without parsing ad-hoc text. 
- Reduce hallucination from image/audio attachments by surfacing uncertainty and enabling deterministic fallback behavior when multimodal confidence is low. 
- Inject modality-aware context into LLM prompts so prompts explicitly show what/where/who with uncertainty cues.

### Description
- Add `build_semantic_notes` in `src/deepthought/services/perception/summarization.py` which produces a stable schema `multimodal.semantic-notes.v1` with `notes` entries (`modality/what/where/who/confidence`), attachment summary, aggregate confidence and `fallback` flags. 
- Update `PerceptionInterpretService` to publish the new semantic notes instead of free-form strings by calling `build_semantic_notes`. 
- Normalize and inject multimodal interpretations in `ContextAssembledPayload.multimodal_interpretations` with defaults when perception data is missing via `ContextAssemblerService._normalize_multimodal`. 
- Extend `llm_remote` prompt builder (`_build_generation_prompt`) to include `[MULTIMODAL INTERPRETATIONS]` and `[UNCERTAINTY CUES]`, add `_build_clarifying_question`, and implement deterministic fallback to emit a clarifying-question `ResponseCandidate` when multimodal confidence is low instead of generating potentially hallucinated claims. 
- Add and update tests: new `tests/unit/services/test_perception_summarization.py`, updated `tests/unit/modules/test_llm_remote.py` (prompt content and low-confidence fallback), and updated `tests/integration/test_context_assembler_service.py` to assert the new schema and normalized values.

### Testing
- Ran the new/modified tests together: `python -m pytest -c /dev/null tests/unit/services/test_perception_summarization.py tests/unit/modules/test_llm_remote.py tests/integration/test_context_assembler_service.py` and the test selection passed (22 tests collected and passed). 
- Performed static checks and byte-compile: `python -m py_compile` on changed modules succeeded and `ruff check --isolated` on the changed files passed. 
- Note: an initial attempt to run the repo-wide `pytest`/`ruff` picked up a `pyproject.toml` parse/duplicate-key error in this environment; the targeted test and isolated lint runs above were used to validate the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b2e795d083269b6275b3c157bbd7)