### PR TITLE
Ignore bot-authored inputs in DiscordGatewayService

### DIFF
--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -151,6 +151,10 @@ class DiscordGatewayService(BaseService):
             return None
 
         payload = self.build_input_payload(message)
+        if payload.author_is_bot:
+            logger.debug("Ignoring bot-authored Discord message", extra={"author_id": payload.author_id})
+            return None
+
         self._record_inbound_activity(channel_id=payload.channel_id, author_id=payload.author_id)
         if payload.input_id and payload.channel_id:
             self._pending_routes[payload.input_id] = _PendingRoute(

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -155,6 +155,23 @@ async def test_handle_discord_message_publishes_input_received(service):
 
 
 @pytest.mark.asyncio
+async def test_handle_discord_message_ignores_bot_authored_messages(service):
+    message = SimpleNamespace(
+        content="beep boop",
+        id=100,
+        author=SimpleNamespace(id=55, name="robot", display_name="Robot", bot=True),
+        channel=SimpleNamespace(id=123),
+        guild=SimpleNamespace(id=7),
+    )
+
+    input_id = await service.handle_discord_message(message)
+
+    assert input_id is None
+    assert service._publisher.published == []
+    assert service._pending_routes == {}
+
+
+@pytest.mark.asyncio
 async def test_ranked_response_respects_thread_reply_and_policy_override(service, fake_clock):
     payload = ResponseRankedPayload(
         final_response="done",


### PR DESCRIPTION
### Motivation
- Ensure the Discord gateway service never publishes or routes inputs created by bots, making the service safe regardless of caller behavior.
- Retain the existing runtime-layer filter as defense-in-depth while enforcing the invariant inside the service itself.

### Description
- Add an early-return in `DiscordGatewayService.handle_discord_message` immediately after `build_input_payload` when `payload.author_is_bot` is true, and log a debug message including the `author_id`.
- Preserve existing inbound-activity recording, pending-route creation, and publishing behavior for human-authored messages.
- Add a unit test `test_handle_discord_message_ignores_bot_authored_messages` that asserts bot-authored messages produce no publish and create no pending routes.

### Testing
- Ran `ruff check --isolated src/deepthought/services/discord_gateway_service.py tests/unit/services/test_discord_gateway_service.py` which passed.
- Ran `pytest -q -c pytest.ini tests/unit/services/test_discord_gateway_service.py` and all unit tests in that file passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bc272d64832699e3083344302955)