### PR TITLE
Implement per-input state machine for context assembly publishing

### DIFF
--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from enum import Enum
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -23,8 +24,22 @@ logger = logging.getLogger(__name__)
 class _PendingAssembly:
     request: dict[str, Any]
     provider_payloads: dict[str, dict[str, Any]] = field(default_factory=dict)
+    trace_id: str | None = None
+    required_providers: set[str] = field(default_factory=set)
+    provider_deadlines: dict[str, float] = field(default_factory=dict)
+    provider_received_at: dict[str, float] = field(default_factory=dict)
+    started_at: float = 0.0
+    published_reason: str | None = None
+    state: "_AssemblyState" = field(default_factory=lambda: _AssemblyState.OPEN)
     published: bool = False
     event: asyncio.Event = field(default_factory=asyncio.Event)
+
+
+class _AssemblyState(str, Enum):
+    OPEN = "OPEN"
+    PARTIAL_READY = "PARTIAL_READY"
+    COMPLETE = "COMPLETE"
+    TIMEOUT_PUBLISHED = "TIMEOUT_PUBLISHED"
 
 
 class ContextAssemblerService:
@@ -72,6 +87,7 @@ class ContextAssemblerService:
     async def _publish_fanout_requests(self, payload: dict[str, Any]) -> None:
         fanout_payload = {
             "input_id": payload.get("input_id"),
+            "trace_id": payload.get("trace_id"),
             "user_input": payload.get("user_input"),
             "user_id": payload.get("user_id"),
             "author_id": payload.get("author_id"),
@@ -94,7 +110,17 @@ class ContextAssemblerService:
             if not isinstance(input_id, str) or not isinstance(user_input, str):
                 raise ValueError("Input payload missing required fields")
 
-            pending = _PendingAssembly(request=payload)
+            loop_time = asyncio.get_running_loop().time()
+            provider_deadlines = {
+                provider: loop_time + self._wait_window_seconds for provider in self._PROVIDER_ORDER
+            }
+            pending = _PendingAssembly(
+                request=payload,
+                trace_id=payload.get("trace_id") if isinstance(payload.get("trace_id"), str) else None,
+                required_providers=set(self._PROVIDER_ORDER),
+                provider_deadlines=provider_deadlines,
+                started_at=loop_time,
+            )
             async with self._lock:
                 self._pending[input_id] = pending
 
@@ -114,11 +140,29 @@ class ContextAssemblerService:
             input_id = payload.get("input_id")
             if not isinstance(input_id, str):
                 raise ValueError("Provider payload missing input_id")
+            response_trace_id = payload.get("trace_id")
+            if response_trace_id is not None and not isinstance(response_trace_id, str):
+                raise ValueError("Provider payload trace_id must be a string when provided")
 
             async with self._lock:
                 pending = self._pending.get(input_id)
                 if pending is not None and not pending.published:
+                    if pending.trace_id and response_trace_id and pending.trace_id != response_trace_id:
+                        logger.debug(
+                            "Ignoring %s provider response due to trace mismatch input_id=%s expected=%s actual=%s",
+                            provider_name,
+                            input_id,
+                            pending.trace_id,
+                            response_trace_id,
+                        )
+                        await msg.ack()
+                        return
                     pending.provider_payloads[provider_name] = payload
+                    pending.provider_received_at[provider_name] = asyncio.get_running_loop().time()
+                    if len(pending.provider_payloads) == len(pending.required_providers):
+                        pending.state = _AssemblyState.COMPLETE
+                    else:
+                        pending.state = _AssemblyState.PARTIAL_READY
                     pending.event.set()
             await msg.ack()
         except Exception:
@@ -148,6 +192,17 @@ class ContextAssemblerService:
 
         completed = [name for name in self._PROVIDER_ORDER if name in pending.provider_payloads]
         missing = [name for name in self._PROVIDER_ORDER if name not in pending.provider_payloads]
+        provider_timings = {}
+        for provider in self._PROVIDER_ORDER:
+            deadline_offset_ms = int((pending.provider_deadlines[provider] - pending.started_at) * 1000)
+            received_at = pending.provider_received_at.get(provider)
+            received_offset_ms = int((received_at - pending.started_at) * 1000) if received_at is not None else None
+            provider_timings[provider] = {
+                "deadline_offset_ms": deadline_offset_ms,
+                "received_offset_ms": received_offset_ms,
+                "timed_out": provider in missing,
+            }
+
         confidence = {
             "provider_coverage": len(completed) / len(self._PROVIDER_ORDER),
             "completed_providers": completed,
@@ -155,6 +210,10 @@ class ContextAssemblerService:
             "window_ms": int(self._wait_window_seconds * 1000),
             "elapsed_ms": int(elapsed * 1000),
             "partial": bool(missing),
+            "publish_reason": pending.published_reason,
+            "assembly_state": pending.state.value,
+            "correlation": {"input_id": input_id, "trace_id": pending.trace_id},
+            "provider_timings": provider_timings,
         }
 
         return ContextAssembledPayload(
@@ -175,14 +234,17 @@ class ContextAssemblerService:
         )
 
     async def _await_and_publish(self, input_id: str) -> None:
-        started = asyncio.get_running_loop().time()
-        deadline = started + self._wait_window_seconds
-        while asyncio.get_running_loop().time() < deadline:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._wait_window_seconds
+        publish_reason = "timeout_partial"
+        while loop.time() < deadline:
             async with self._lock:
                 pending = self._pending.get(input_id)
                 if pending is None or pending.published:
                     return
                 if len(pending.provider_payloads) == len(self._PROVIDER_ORDER):
+                    pending.state = _AssemblyState.COMPLETE
+                    publish_reason = "all_providers_received"
                     break
             await asyncio.sleep(0.005)
 
@@ -190,8 +252,11 @@ class ContextAssemblerService:
             pending = self._pending.get(input_id)
             if pending is None or pending.published:
                 return
+            if publish_reason == "timeout_partial":
+                pending.state = _AssemblyState.TIMEOUT_PUBLISHED
+            pending.published_reason = publish_reason
             pending.published = True
-            elapsed = asyncio.get_running_loop().time() - started
+            elapsed = loop.time() - pending.started_at
             payload = self._build_context_payload(input_id, pending, elapsed)
             del self._pending[input_id]
 

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -101,6 +101,10 @@ async def test_race_safe_assembly_collects_all_providers(monkeypatch):
     assert payload.multimodal_interpretations["summary"] == "no multimodal signals"
     assert payload.confidence["partial"] is False
     assert payload.confidence["completed_providers"] == ["memory", "social", "perception"]
+    assert payload.confidence["publish_reason"] == "all_providers_received"
+    assert payload.confidence["assembly_state"] == "COMPLETE"
+    assert payload.confidence["correlation"] == {"input_id": "i-race", "trace_id": None}
+    assert payload.confidence["provider_timings"]["memory"]["timed_out"] is False
 
 
 @pytest.mark.asyncio
@@ -137,7 +141,42 @@ async def test_partial_result_when_provider_missing_is_deterministic(monkeypatch
     assert payload.confidence["partial"] is True
     assert payload.confidence["missing_providers"] == ["perception"]
     assert payload.confidence["completed_providers"] == ["memory", "social"]
+    assert payload.confidence["publish_reason"] == "timeout_partial"
+    assert payload.confidence["assembly_state"] == "TIMEOUT_PUBLISHED"
+    assert payload.confidence["provider_timings"]["perception"]["timed_out"] is True
 
+
+
+
+@pytest.mark.asyncio
+async def test_context_assembler_correlates_by_input_and_trace_id(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.04)
+
+    await svc._handle_input_received(DummyMsg({"input_id": "i-trace", "user_input": "hello", "trace_id": "trace-A"}))
+
+    await svc._handle_provider_response(
+        DummyMsg({"input_id": "i-trace", "trace_id": "trace-B", "retrieved_knowledge": {"facts": ["wrong"]}}),
+        "memory",
+    )
+    await svc._handle_provider_response(
+        DummyMsg({"input_id": "i-trace", "trace_id": "trace-A", "social_signals": {"sentiment": 0.9}}),
+        "social",
+    )
+
+    await asyncio.sleep(0.07)
+
+    assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    assert len(assembled) == 1
+    payload = assembled[0][1]
+    assert payload.retrieved_facts == []
+    assert payload.social_signals == {"sentiment": 0.9}
+    assert payload.confidence["correlation"] == {"input_id": "i-trace", "trace_id": "trace-A"}
+    assert payload.confidence["provider_timings"]["memory"]["timed_out"] is True
 
 @pytest.mark.asyncio
 async def test_context_assembler_merges_perception_interpretations_within_wait_window(monkeypatch):


### PR DESCRIPTION
### Motivation

- Replace the previous fixed-window publish behavior with a more deterministic, per-input lifecycle so context is published exactly once with a stable reason code. 
- Prevent cross-trace contamination by ensuring provider responses are correlated to the originating request using `input_id` + `trace_id`. 
- Surface degradation and timing metadata in assembled context so downstream ranking can reason about partial or delayed provider data.

### Description

- Introduced `_AssemblyState` (`OPEN`, `PARTIAL_READY`, `COMPLETE`, `TIMEOUT_PUBLISHED`) and extended `_PendingAssembly` with `trace_id`, `required_providers`, `provider_deadlines`, `provider_received_at`, `started_at`, `published_reason`, and `state` fields in `ContextAssemblerService` (`src/deepthought/services/context_assembler_service.py`).
- Fanout payloads now include `trace_id`, and provider responses with mismatched `trace_id` for the same `input_id` are acknowledged and ignored to avoid cross-trace mixing. 
- Replaced the fixed-window-only publish loop with per-input deadlines and a deterministic publish reason (`all_providers_received` or `timeout_partial`) that is recorded on the pending assembly and propagated into `ContextAssembledPayload.confidence` along with `assembly_state`, `correlation`, and `provider_timings`. 
- Expanded integration tests to assert deterministic publish reason/state and trace correlation behavior (`tests/integration/test_context_assembler_service.py`).

### Testing

- Ran `pytest -q -c /dev/null tests/integration/test_context_assembler_service.py` and all tests passed (`5 passed`).
- Ran `ruff check --isolated src/deepthought/services/context_assembler_service.py tests/integration/test_context_assembler_service.py` and linter checks passed.
- Note: repository `pyproject.toml` contains duplicate keys which causes default tooling parsing errors, so test/lint runs above used local overrides (`-c /dev/null`, `--isolated`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9be5cb52083268a3eea033c5f6eb7)