### PR TITLE
Propagate EventEnvelope metadata across core services

### DIFF
--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -236,3 +236,35 @@ def decode_payload(subject: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     if validator is None:
         return normalized
     return validator(normalized)
+
+
+def decode_payload_or_envelope(subject: str, data: Dict[str, Any]) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    """Decode legacy raw payloads and canonical envelopes during migration.
+
+    Returns ``(payload, metadata)`` where metadata may contain envelope fields:
+    ``event_id``, ``trace_id``, ``causation_id``, ``producer``, and ``created_at``.
+    """
+
+    if "payload" in data and "schema_version" in data:
+        envelope = validate_envelope(data)
+        payload = decode_payload(subject, envelope.payload)
+        return payload, {
+            "event_id": envelope.event_id,
+            "trace_id": envelope.trace_id,
+            "causation_id": envelope.causation_id,
+            "producer": envelope.producer,
+            "created_at": envelope.created_at,
+            "subject": envelope.subject,
+        }
+
+    payload = decode_payload(subject, data)
+    trace_id = payload.get("trace_id") if isinstance(payload.get("trace_id"), str) else None
+    causation_id = payload.get("causation_id") if isinstance(payload.get("causation_id"), str) else None
+    return payload, {
+        "event_id": None,
+        "trace_id": trace_id,
+        "causation_id": causation_id,
+        "producer": None,
+        "created_at": None,
+        "subject": to_canonical_subject(subject),
+    }

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -14,6 +14,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import ContextAssembledPayload, EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -234,6 +235,10 @@ class RemoteLLM:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
                 raise ValueError("ContextAssembled payload must be a dict")
+            decoded_payload, envelope_meta = decode_payload_or_envelope(EventSubjects.CONTEXT_ASSEMBLED, data)
+            data = decoded_payload
+            trace_id = envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None
+            causation_id = envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else None
             if "retrieved_facts" in data:
                 payload = ContextAssembledPayload.from_dict(data)
                 input_id = payload.input_id
@@ -307,9 +312,16 @@ class RemoteLLM:
                 channel_id=channel_id,
                 timestamp=None,
             )
+            envelope = EventEnvelope.build(
+                subject=EventSubjects.RESPONSE_CANDIDATES,
+                payload=json.loads(payload.to_json()),
+                producer=self.__class__.__name__,
+                trace_id=trace_id,
+                causation_id=causation_id or input_id,
+            )
             await self._publisher.publish(
                 EventSubjects.RESPONSE_CANDIDATES,
-                payload,
+                envelope.__dict__,
                 use_jetstream=True,
                 timeout=10.0,
             )

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -12,6 +12,7 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from ..config import Settings, get_settings
+from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import (
     BDIIntentionPayload,
     EventSubjects,
@@ -202,7 +203,11 @@ class CognitiveCoreService(BaseService):
         input_id = "unknown"
         start = time.perf_counter()
         try:
-            enriched = self._input_enrichment.parse_input_received(msg)
+            raw_data = json.loads(msg.data.decode())
+            if not isinstance(raw_data, dict):
+                raise ValueError("InputReceived payload must be a dict")
+            decoded_payload, envelope_meta = decode_payload_or_envelope(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, raw_data)
+            enriched = self._input_enrichment.parse_input_received_data(decoded_payload, headers=getattr(msg, "headers", None))
             input_id = enriched.input_id
             user_input = enriched.user_input
             user_id = enriched.user_id
@@ -278,6 +283,8 @@ class CognitiveCoreService(BaseService):
             for data in merged_facts.values():
                 source_tag = ",".join(data["sources"])
                 facts.append(f"[{source_tag}] {data['text']}")
+            trace_id = envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None
+            causation_id = envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else input_id
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "cognitive_core"},
                 user_input=user_input,
@@ -288,9 +295,16 @@ class CognitiveCoreService(BaseService):
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 
+            envelope = EventEnvelope.build(
+                subject=EventSubjects.MEMORY_RETRIEVED,
+                payload=json.loads(payload.to_json()),
+                producer=self.__class__.__name__,
+                trace_id=trace_id,
+                causation_id=causation_id,
+            )
             await self._publisher.publish(
                 EventSubjects.MEMORY_RETRIEVED,
-                payload,
+                envelope.__dict__,
                 use_jetstream=True,
                 timeout=10.0,
             )

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -13,6 +13,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import ContextAssembledPayload, EventSubjects
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
@@ -84,10 +85,10 @@ class ContextAssemblerService:
         self._pending: dict[str, _PendingAssembly] = {}
         self._lock = asyncio.Lock()
 
-    async def _publish_fanout_requests(self, payload: dict[str, Any]) -> None:
+    async def _publish_fanout_requests(self, payload: dict[str, Any], *, trace_id: str | None, causation_id: str | None) -> None:
         fanout_payload = {
             "input_id": payload.get("input_id"),
-            "trace_id": payload.get("trace_id"),
+            "trace_id": trace_id,
             "user_input": payload.get("user_input"),
             "user_id": payload.get("user_id"),
             "author_id": payload.get("author_id"),
@@ -96,15 +97,26 @@ class ContextAssemblerService:
             "timestamp": payload.get("timestamp"),
             "attachments": payload.get("attachments"),
         }
-        await self._publisher.publish(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, fanout_payload, use_jetstream=True)
-        await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_REQUESTED, fanout_payload, use_jetstream=True)
-        await self._publisher.publish(EventSubjects.PERCEPTION_INTERPRET_REQUESTED, fanout_payload, use_jetstream=True)
+        for subject in (
+            EventSubjects.MEMORY_RETRIEVAL_REQUESTED,
+            EventSubjects.SOCIAL_SIGNALS_REQUESTED,
+            EventSubjects.PERCEPTION_INTERPRET_REQUESTED,
+        ):
+            envelope = EventEnvelope.build(
+                subject=subject,
+                payload=fanout_payload,
+                producer=self.__class__.__name__,
+                trace_id=trace_id,
+                causation_id=causation_id,
+            )
+            await self._publisher.publish(subject, envelope.__dict__, use_jetstream=True)
 
     async def _handle_input_received(self, msg: Msg) -> None:
         try:
-            payload = json.loads(msg.data.decode())
-            if not isinstance(payload, dict):
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
                 raise ValueError("Input payload must be an object")
+            payload, envelope_meta = decode_payload_or_envelope(EventSubjects.INPUT_RECEIVED, data)
             input_id = payload.get("input_id")
             user_input = payload.get("user_input")
             if not isinstance(input_id, str) or not isinstance(user_input, str):
@@ -116,7 +128,7 @@ class ContextAssemblerService:
             }
             pending = _PendingAssembly(
                 request=payload,
-                trace_id=payload.get("trace_id") if isinstance(payload.get("trace_id"), str) else None,
+                trace_id=envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None,
                 required_providers=set(self._PROVIDER_ORDER),
                 provider_deadlines=provider_deadlines,
                 started_at=loop_time,
@@ -124,7 +136,8 @@ class ContextAssemblerService:
             async with self._lock:
                 self._pending[input_id] = pending
 
-            await self._publish_fanout_requests(payload)
+            causation_id = envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else input_id
+            await self._publish_fanout_requests(payload, trace_id=pending.trace_id, causation_id=causation_id)
             asyncio.create_task(self._await_and_publish(input_id))
             await msg.ack()
         except Exception:
@@ -134,13 +147,19 @@ class ContextAssemblerService:
 
     async def _handle_provider_response(self, msg: Msg, provider_name: str) -> None:
         try:
-            payload = json.loads(msg.data.decode())
-            if not isinstance(payload, dict):
+            data = json.loads(msg.data.decode())
+            if not isinstance(data, dict):
                 raise ValueError("Provider payload must be an object")
+            provider_subject = {
+                "memory": EventSubjects.MEMORY_RETRIEVED,
+                "social": EventSubjects.SOCIAL_SIGNALS_RETRIEVED,
+                "perception": EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,
+            }.get(provider_name, EventSubjects.CONTEXT_ASSEMBLED)
+            payload, envelope_meta = decode_payload_or_envelope(provider_subject, data)
             input_id = payload.get("input_id")
             if not isinstance(input_id, str):
                 raise ValueError("Provider payload missing input_id")
-            response_trace_id = payload.get("trace_id")
+            response_trace_id = envelope_meta.get("trace_id") or payload.get("trace_id")
             if response_trace_id is not None and not isinstance(response_trace_id, str):
                 raise ValueError("Provider payload trace_id must be a string when provided")
 
@@ -260,7 +279,14 @@ class ContextAssemblerService:
             payload = self._build_context_payload(input_id, pending, elapsed)
             del self._pending[input_id]
 
-        await self._publisher.publish(EventSubjects.CONTEXT_ASSEMBLED, payload, use_jetstream=True)
+        envelope = EventEnvelope.build(
+            subject=EventSubjects.CONTEXT_ASSEMBLED,
+            payload=json.loads(payload.to_json()),
+            producer=self.__class__.__name__,
+            trace_id=pending.trace_id,
+            causation_id=input_id,
+        )
+        await self._publisher.publish(EventSubjects.CONTEXT_ASSEMBLED, envelope.__dict__, use_jetstream=True)
 
     async def start(self, durable_name: str = "context_assembler") -> bool:
         try:

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -14,6 +14,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import EventSubjects, InputReceivedPayload, ResponseRankedPayload
 from .base import BaseService
 from .human_interaction_policy import HumanInteractionPolicy
@@ -164,9 +165,16 @@ class DiscordGatewayService(BaseService):
                 author_id=payload.author_id,
             )
 
+        envelope = EventEnvelope.build(
+            subject=EventSubjects.INPUT_RECEIVED,
+            payload=json.loads(payload.to_json()),
+            producer=self.__class__.__name__,
+            trace_id=str(uuid.uuid4()),
+            causation_id=payload.input_id,
+        )
         await self._publisher.publish(
             EventSubjects.INPUT_RECEIVED,
-            payload,
+            envelope.__dict__,
             use_jetstream=True,
             timeout=10.0,
         )
@@ -252,7 +260,8 @@ class DiscordGatewayService(BaseService):
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
                 raise ValueError("ResponseRanked payload must be a dict")
-            payload = ResponseRankedPayload.from_dict(data)
+            decoded_payload, _meta = decode_payload_or_envelope(EventSubjects.RESPONSE_RANKED, data)
+            payload = ResponseRankedPayload.from_dict(decoded_payload)
             if not payload.final_response:
                 raise ValueError("final_response is required")
 

--- a/src/deepthought/services/input_enrichment_service.py
+++ b/src/deepthought/services/input_enrichment_service.py
@@ -23,17 +23,7 @@ class EnrichedInputPayload:
 
 
 class InputEnrichmentService:
-    """Parse and normalize INPUT_RECEIVED payloads from NATS messages."""
-
-    @staticmethod
-    def _normalized_identifier(value: object) -> str | None:
-        if not isinstance(value, str):
-            return None
-        normalized = value.strip()
-        return normalized or None
-
-    def parse_input_received(self, msg: Msg) -> EnrichedInputPayload:
-        data = json.loads(msg.data.decode())
+    def parse_input_received_data(self, data: object, *, headers: Mapping | None = None) -> EnrichedInputPayload:
         if not isinstance(data, dict):
             raise ValueError("InputReceived payload must be a dict")
 
@@ -42,7 +32,6 @@ class InputEnrichmentService:
         if not isinstance(input_id, str) or not isinstance(user_input, str):
             raise ValueError("Invalid input payload fields")
 
-        headers = getattr(msg, "headers", None)
         if headers is not None and not isinstance(headers, Mapping):
             headers = None
 
@@ -71,4 +60,17 @@ class InputEnrichmentService:
             author_id=author_id,
             channel_id=channel_id,
         )
+
+    """Parse and normalize INPUT_RECEIVED payloads from NATS messages."""
+
+    @staticmethod
+    def _normalized_identifier(value: object) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    def parse_input_received(self, msg: Msg) -> EnrichedInputPayload:
+        data = json.loads(msg.data.decode())
+        return self.parse_input_received_data(data, headers=getattr(msg, "headers", None))
 

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -12,6 +12,7 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import (
     EventSubjects,
     ResponseCandidate,
@@ -131,7 +132,7 @@ class SelectorService:
         ranked = [candidate for _, candidate in sorted(scored, key=lambda item: item[0], reverse=True)]
         return ranked, sorted(diagnostics, key=lambda item: item["score"], reverse=True)
 
-    async def _publish_selection(self, state: _AggregationState) -> None:
+    async def _publish_selection(self, state: _AggregationState, trace_id: str | None = None, causation_id: str | None = None) -> None:
         ranked_candidates, diagnostics = self._rank_candidates(state.candidates)
         fallback_reason = None
         if ranked_candidates:
@@ -156,9 +157,16 @@ class SelectorService:
             interaction_policy=state.interaction_policy,
             candidates=ranked_candidates,
         )
+        envelope = EventEnvelope.build(
+            subject=EventSubjects.RESPONSE_RANKED,
+            payload=json.loads(ranked_payload.to_json()),
+            producer=self.__class__.__name__,
+            trace_id=trace_id,
+            causation_id=causation_id or state.input_id,
+        )
         await self._publisher.publish(
             EventSubjects.RESPONSE_RANKED,
-            ranked_payload,
+            envelope.__dict__,
             use_jetstream=True,
             timeout=10.0,
         )
@@ -179,23 +187,26 @@ class SelectorService:
             timeout=10.0,
         )
 
-    async def _flush_input_id(self, input_id: str) -> None:
+    async def _flush_input_id(self, input_id: str, trace_id: str | None = None, causation_id: str | None = None) -> None:
         async with self._aggregation_lock:
             state = self._pending_by_input.pop(input_id, None)
         if state is None:
             return
-        await self._publish_selection(state)
+        await self._publish_selection(state, trace_id=trace_id, causation_id=causation_id)
 
-    async def _schedule_flush(self, input_id: str) -> None:
+    async def _schedule_flush(self, input_id: str, trace_id: str | None = None, causation_id: str | None = None) -> None:
         await asyncio.sleep(self._window_seconds)
-        await self._flush_input_id(input_id)
+        await self._flush_input_id(input_id, trace_id=trace_id, causation_id=causation_id)
 
     async def _handle_candidates_event(self, msg: Msg) -> None:
         try:
             data = json.loads(msg.data.decode())
             if not isinstance(data, dict):
                 raise ValueError("ResponseCandidates payload must be a dict")
-            payload = ResponseCandidatesPayload.from_dict(data)
+            decoded_payload, envelope_meta = decode_payload_or_envelope(EventSubjects.RESPONSE_CANDIDATES, data)
+            payload = ResponseCandidatesPayload.from_dict(decoded_payload)
+            trace_id = envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None
+            causation_id = envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else None
             input_id = payload.input_id or "global"
 
             async with self._aggregation_lock:
@@ -225,11 +236,11 @@ class SelectorService:
                 else:
                     flush_now = False
                     if state.flush_task is None or state.flush_task.done():
-                        state.flush_task = asyncio.create_task(self._schedule_flush(input_id))
+                        state.flush_task = asyncio.create_task(self._schedule_flush(input_id, trace_id=trace_id, causation_id=causation_id))
 
             await msg.ack()
             if flush_now:
-                await self._flush_input_id(input_id)
+                await self._flush_input_id(input_id, trace_id=trace_id, causation_id=causation_id)
         except (json.JSONDecodeError, ValueError):
             logger.error("Invalid response candidates payload", exc_info=True)
             if hasattr(msg, "nak") and callable(msg.nak):

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -93,18 +93,18 @@ async def test_race_safe_assembly_collects_all_providers(monkeypatch):
 
     assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
     assert len(assembled) == 1
-    payload = assembled[0][1]
-    assert payload.input_id == "i-race"
-    assert payload.retrieved_facts == ["f2", "f1"]
-    assert payload.social_signals == {"tone": "neutral"}
-    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
-    assert payload.multimodal_interpretations["summary"] == "no multimodal signals"
-    assert payload.confidence["partial"] is False
-    assert payload.confidence["completed_providers"] == ["memory", "social", "perception"]
-    assert payload.confidence["publish_reason"] == "all_providers_received"
-    assert payload.confidence["assembly_state"] == "COMPLETE"
-    assert payload.confidence["correlation"] == {"input_id": "i-race", "trace_id": None}
-    assert payload.confidence["provider_timings"]["memory"]["timed_out"] is False
+    payload = assembled[0][1]["payload"]
+    assert payload["input_id"] == "i-race"
+    assert payload["retrieved_facts"] == ["f2", "f1"]
+    assert payload["social_signals"] == {"tone": "neutral"}
+    assert payload["multimodal_interpretations"]["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload["multimodal_interpretations"]["summary"] == "no multimodal signals"
+    assert payload["confidence"]["partial"] is False
+    assert payload["confidence"]["completed_providers"] == ["memory", "social", "perception"]
+    assert payload["confidence"]["publish_reason"] == "all_providers_received"
+    assert payload["confidence"]["assembly_state"] == "COMPLETE"
+    assert payload["confidence"]["correlation"] == {"input_id": "i-race", "trace_id": None}
+    assert payload["confidence"]["provider_timings"]["memory"]["timed_out"] is False
 
 
 @pytest.mark.asyncio
@@ -132,18 +132,18 @@ async def test_partial_result_when_provider_missing_is_deterministic(monkeypatch
 
     assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
     assert len(assembled) == 1
-    payload = assembled[0][1]
-    assert payload.input_id == "i-partial"
-    assert payload.retrieved_facts == ["f1"]
-    assert payload.social_signals == {"sentiment": 0.7}
-    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
-    assert payload.multimodal_interpretations["notes"] == []
-    assert payload.confidence["partial"] is True
-    assert payload.confidence["missing_providers"] == ["perception"]
-    assert payload.confidence["completed_providers"] == ["memory", "social"]
-    assert payload.confidence["publish_reason"] == "timeout_partial"
-    assert payload.confidence["assembly_state"] == "TIMEOUT_PUBLISHED"
-    assert payload.confidence["provider_timings"]["perception"]["timed_out"] is True
+    payload = assembled[0][1]["payload"]
+    assert payload["input_id"] == "i-partial"
+    assert payload["retrieved_facts"] == ["f1"]
+    assert payload["social_signals"] == {"sentiment": 0.7}
+    assert payload["multimodal_interpretations"]["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload["multimodal_interpretations"]["notes"] == []
+    assert payload["confidence"]["partial"] is True
+    assert payload["confidence"]["missing_providers"] == ["perception"]
+    assert payload["confidence"]["completed_providers"] == ["memory", "social"]
+    assert payload["confidence"]["publish_reason"] == "timeout_partial"
+    assert payload["confidence"]["assembly_state"] == "TIMEOUT_PUBLISHED"
+    assert payload["confidence"]["provider_timings"]["perception"]["timed_out"] is True
 
 
 
@@ -172,11 +172,11 @@ async def test_context_assembler_correlates_by_input_and_trace_id(monkeypatch):
 
     assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
     assert len(assembled) == 1
-    payload = assembled[0][1]
-    assert payload.retrieved_facts == []
-    assert payload.social_signals == {"sentiment": 0.9}
-    assert payload.confidence["correlation"] == {"input_id": "i-trace", "trace_id": "trace-A"}
-    assert payload.confidence["provider_timings"]["memory"]["timed_out"] is True
+    payload = assembled[0][1]["payload"]
+    assert payload["retrieved_facts"] == []
+    assert payload["social_signals"] == {"sentiment": 0.9}
+    assert payload["confidence"]["correlation"] == {"input_id": "i-trace", "trace_id": "trace-A"}
+    assert payload["confidence"]["provider_timings"]["memory"]["timed_out"] is True
 
 @pytest.mark.asyncio
 async def test_context_assembler_merges_perception_interpretations_within_wait_window(monkeypatch):
@@ -261,12 +261,12 @@ async def test_context_assembler_merges_perception_interpretations_within_wait_w
 
     assembled = [item for item in bus.published if item[0] == EventSubjects.CONTEXT_ASSEMBLED]
     assert len(assembled) == 1
-    payload = assembled[0][1]
-    assert payload.input_id == "i-embed"
-    assert payload.multimodal_interpretations["schema_version"] == "multimodal.semantic-notes.v1"
-    assert payload.multimodal_interpretations["by_modality"]["image"]["what"].startswith("1 embedding vectors")
-    assert "attachments[image:1]" in payload.multimodal_interpretations["summary"]
-    assert payload.confidence["partial"] is False
+    payload = assembled[0][1]["payload"]
+    assert payload["input_id"] == "i-embed"
+    assert payload["multimodal_interpretations"]["schema_version"] == "multimodal.semantic-notes.v1"
+    assert payload["multimodal_interpretations"]["by_modality"]["image"]["what"].startswith("1 embedding vectors")
+    assert "attachments[image:1]" in payload["multimodal_interpretations"]["summary"]
+    assert payload["confidence"]["partial"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/eda/test_event_contracts.py
+++ b/tests/unit/eda/test_event_contracts.py
@@ -4,6 +4,7 @@ from deepthought.eda.contracts import (
     CanonicalSubjects,
     EventEnvelope,
     decode_payload,
+    decode_payload_or_envelope,
     to_canonical_subject,
     validate_envelope,
 )
@@ -126,3 +127,21 @@ def test_invalid_envelope_fails_safe():
                 "payload": {},
             }
         )
+
+
+def test_decode_payload_or_envelope_accepts_legacy_payload():
+    payload, meta = decode_payload_or_envelope(CanonicalSubjects.INPUT_RECEIVED, {"text": "hello"})
+    assert payload["user_input"] == "hello"
+    assert meta["trace_id"] is None
+
+
+def test_decode_payload_or_envelope_accepts_enveloped_payload():
+    envelope = EventEnvelope.build(
+        subject=CanonicalSubjects.INPUT_RECEIVED,
+        payload={"user_input": "hello"},
+        producer="discord_gateway",
+    )
+    payload, meta = decode_payload_or_envelope(CanonicalSubjects.INPUT_RECEIVED, envelope.__dict__)
+    assert payload["user_input"] == "hello"
+    assert meta["trace_id"] == envelope.trace_id
+    assert meta["producer"] == "discord_gateway"

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import importlib.util
 import sys
 from unittest.mock import AsyncMock, MagicMock
@@ -15,6 +16,7 @@ sys.modules[spec.name] = llm_remote
 assert spec.loader is not None
 spec.loader.exec_module(llm_remote)
 
+from deepthought.eda.contracts import EventEnvelope  # noqa: E402
 from deepthought.eda.events import ContextAssembledPayload, EventSubjects  # noqa: E402
 
 
@@ -136,8 +138,8 @@ async def test_handle_context_event_publishes(monkeypatch):
     assert pub.published
     subject, sent_payload = pub.published[0]
     assert subject == EventSubjects.RESPONSE_CANDIDATES
-    assert sent_payload.candidates[0].text == "answer"
-    assert sent_payload.input_id == "42"
+    assert sent_payload["payload"]["candidates"][0]["text"] == "answer"
+    assert sent_payload["payload"]["input_id"] == "42"
 
 
 @pytest.mark.asyncio
@@ -423,3 +425,28 @@ def test_build_generation_prompt_includes_image_and_audio_interpretations():
 
     assert "[image] what=1 embedding vectors across 1 spans" in prompt
     assert "[audio] what=3 embedding vectors across 2 spans" in prompt
+
+
+@pytest.mark.asyncio
+async def test_handle_context_event_accepts_enveloped_payload(monkeypatch):
+    llm = create_llm(monkeypatch)
+
+    async def fake_generate_candidates(self, prompt):
+        return [llm_remote.ResponseCandidate(text="answer", confidence=0.8, source="stub", safety_passed=True)]
+
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
+
+    payload = ContextAssembledPayload(input_id="42-env", user_input="hello", retrieved_facts=["f1"])
+    envelope = EventEnvelope.build(
+        subject=EventSubjects.CONTEXT_ASSEMBLED,
+        payload=json.loads(payload.to_json()),
+        producer="context_assembler",
+    )
+    msg = DummyMsg(json.dumps(envelope.__dict__))
+
+    await llm._handle_context_event(msg)
+
+    assert msg.acked
+    subject, sent_payload = llm._publisher.published[0]
+    assert subject == EventSubjects.RESPONSE_CANDIDATES
+    assert sent_payload["payload"]["input_id"] == "42-env"

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -263,8 +263,8 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     assert db.affinity == pytest.approx(0.0)
     subject, sent_payload = service._publisher.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
-    assert sent_payload.input_id == "x"
-    assert "[memory,db] hello" in sent_payload.retrieved_knowledge["facts"]
+    assert sent_payload["payload"]["input_id"] == "x"
+    assert "[memory,db] hello" in sent_payload["payload"]["retrieved_knowledge"]["facts"]
     assert service._graph_memory.retrieve_user_evidence("anonymous", limit=5)
 
 
@@ -327,7 +327,7 @@ async def test_handle_input_reuses_earlier_user_preferences_in_later_context():
 
     assert first.acked and second.acked
     _, payload = service._publisher.published[-1]
-    facts = payload.retrieved_knowledge["facts"]
+    facts = payload["payload"]["retrieved_knowledge"]["facts"]
     assert any("favorite: tea" in fact for fact in facts)
 
 
@@ -348,7 +348,7 @@ async def test_handle_input_does_not_cross_contaminate_users():
 
     assert user_a.acked and user_b.acked
     _, user_b_payload = service._publisher.published[-1]
-    facts = user_b_payload.retrieved_knowledge["facts"]
+    facts = user_b_payload["payload"]["retrieved_knowledge"]["facts"]
     assert not any("favorite: tea" in fact for fact in facts)
 
 

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from deepthought.eda.contracts import EventEnvelope
 from deepthought.eda.events import EventSubjects, ResponseRankedPayload
 from deepthought.services.discord_gateway_service import DiscordGatewayService
 
@@ -146,12 +147,12 @@ async def test_handle_discord_message_publishes_input_received(service):
     subject, payload, use_js, _timeout = service._publisher.published[0]
     assert subject == EventSubjects.INPUT_RECEIVED
     assert use_js is True
-    assert payload.user_input == "hello"
-    assert payload.channel_id == "123"
-    assert payload.reference_message_id == "66"
-    assert payload.thread_id == "999"
-    assert payload.attachments is not None
-    assert payload.attachments[0].url == "https://cdn.discordapp.com/file.png"
+    assert payload["payload"]["user_input"] == "hello"
+    assert payload["payload"]["channel_id"] == "123"
+    assert payload["payload"]["reference_message_id"] == "66"
+    assert payload["payload"]["thread_id"] == "999"
+    assert payload["payload"]["attachments"] is not None
+    assert payload["payload"]["attachments"][0]["url"] == "https://cdn.discordapp.com/file.png"
 
 
 @pytest.mark.asyncio
@@ -296,3 +297,19 @@ async def test_ranked_response_missing_channel_mapping_acks_once(service):
     assert msg.nacked is False
     assert msg.ack_calls == 1
     assert msg.nak_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_ranked_response_accepts_enveloped_payload(service):
+    payload = ResponseRankedPayload(final_response="wrapped", channel_id="123", input_id="in-wrap")
+    envelope = EventEnvelope.build(
+        subject=EventSubjects.RESPONSE_RANKED,
+        payload=json.loads(payload.to_json()),
+        producer="selector",
+    )
+    msg = DummyMsg(json.dumps(envelope.__dict__))
+
+    await service._handle_ranked_response(msg)
+
+    assert msg.acked
+    assert service._discord_client.channel.messages[-1][0] == "wrapped"

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -72,7 +72,7 @@ async def test_rank_by_confidence(service):
     assert not msg.nacked
     subject, ranked = service._publisher.published[0]
     assert subject == EventSubjects.RESPONSE_RANKED
-    assert ranked.final_response == "high"
+    assert ranked["payload"]["final_response"] == "high"
     telemetry_subject, telemetry_payload = service._publisher.published[1]
     assert telemetry_subject == "dtr.telemetry.selector_ranking.v1"
     assert telemetry_payload["chosen_source"] is None
@@ -87,7 +87,7 @@ async def test_empty_candidates_ack_without_publish(service):
 
     assert msg.acked
     assert len(service._publisher.published) == 2
-    assert service._publisher.published[0][1].source == "selector_fallback"
+    assert service._publisher.published[0][1]["payload"]["source"] == "selector_fallback"
 
 
 @pytest.mark.asyncio
@@ -122,7 +122,7 @@ async def test_window_aggregates_candidates_before_flush(monkeypatch):
     assert svc._publisher.published == []
 
     await asyncio.sleep(0.05)
-    assert svc._publisher.published[0][1].final_response == "two"
+    assert svc._publisher.published[0][1]["payload"]["final_response"] == "two"
 
 
 @pytest.mark.asyncio
@@ -149,8 +149,8 @@ async def test_unsafe_only_candidates_use_clarifying_fallback(monkeypatch):
     await asyncio.sleep(0.02)
 
     ranked_payload = svc._publisher.published[0][1]
-    assert ranked_payload.source == "selector_fallback"
-    assert "clarify" in ranked_payload.final_response.lower()
+    assert ranked_payload["payload"]["source"] == "selector_fallback"
+    assert "clarify" in ranked_payload["payload"]["final_response"].lower()
 
 
 @pytest.mark.asyncio
@@ -177,7 +177,7 @@ async def test_source_calibration_changes_ranking(monkeypatch):
     )
     await svc._handle_candidates_event(msg)
 
-    assert svc._publisher.published[0][1].final_response == "weighted"
+    assert svc._publisher.published[0][1]["payload"]["final_response"] == "weighted"
     diagnostics = svc._publisher.published[1][1]["diagnostics"]
     assert diagnostics[0]["source"] == "trusted"
 
@@ -211,7 +211,7 @@ async def test_mixed_source_and_confidence_filters_and_weights(monkeypatch):
 
     ranked = svc._publisher.published[0][1]
     telemetry = svc._publisher.published[1][1]
-    assert ranked.final_response == "safe tool"
+    assert ranked["payload"]["final_response"] == "safe tool"
     rejected = [item for item in telemetry["diagnostics"] if item["rejection_reasons"]]
     assert rejected and rejected[0]["text"] == "unsafe rule"
 


### PR DESCRIPTION
### Motivation

- Ensure core pipeline subjects (`INPUT_RECEIVED` → `RESPONSE_RANKED`) carry envelope metadata (`trace_id`, `causation_id`, `producer`, `created_at`) to enable traceability and an incremental migration to canonical envelopes. 
- Accept both legacy raw payloads and new enveloped messages during migration to avoid breaking running services. 
- Provide a minimal parsing API so services can consume already-decoded payload dicts without mutating `Msg` objects.

### Description

- Added `decode_payload_or_envelope(subject, data)` in `src/deepthought/eda/contracts/__init__.py` which returns a normalized payload and envelope metadata when present. 
- Emit canonical envelopes via `EventEnvelope.build(...)` and publish envelope dicts for `INPUT_RECEIVED`, `MEMORY_RETRIEVED`, `CONTEXT_ASSEMBLED`, `RESPONSE_CANDIDATES`, and `RESPONSE_RANKED` in the gateway, assembler, core, selector, and LLM modules. 
- Updated consumers to accept either legacy payloads or envelopes using `decode_payload_or_envelope(...)` (applied to `DiscordGatewayService`, `ContextAssemblerService`, `CognitiveCoreService`, `SelectorService`, and `RemoteLLM`). 
- Added `InputEnrichmentService.parse_input_received_data(...)` so services can parse decoded payload dicts directly; kept `parse_input_received(msg)` as a message-based wrapper. 
- Updated unit and integration tests to include compatibility checks for legacy and enveloped messages and to expect published envelopes in mocked publishers.

### Testing

- Ran linter checks with `ruff` on changed sources and tests, which passed. 
- Performed syntax checks with `python -m py_compile` across modified source and test files, which passed. 
- Attempted to run the targeted `pytest` suites for the changed modules, but full `pytest` execution is blocked in this environment by unrelated repository/test-time issues (an import-time `torch` compatibility error in test bootstrap and a `pyproject.toml` parse warning when not overriding pytest config); added/updated unit/integration tests for envelope compatibility but live `pytest` runs could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab00732940832684f5e272bf43d24c)