### PR TITLE
Add feedback service wiring to orchestrator defaults

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,8 @@ For the default orchestrator profile, the following event chain is **required**.
 3. Social context must come from either `SOCIAL_UPDATED` (from `social_graph`) **or** `SOCIAL_SIGNALS_RETRIEVED` (from alternative social providers) and be consumed by `context_assembler`.
 4. `PERCEPTION_INTERPRET_RETRIEVED` is published by `perception_interpret` and consumed by `context_assembler`.
 5. `CONTEXT_ASSEMBLED` is published by `context_assembler` and consumed by `llm_remote` (or another LLM responder).
+6. `RESPONSE_RANKED` is published by `selector`, consumed by `discord_gateway` for delivery, and consumed by `feedback` for adaptation context capture.
+7. `OUTCOME_SIGNAL` and `CORRECTION_SIGNAL` are consumed by `feedback` via durable JetStream consumers to adapt affinity and confidence state.
 
 Operators should treat this as a deployment invariant and verify that each required subject has at least one publisher and one subscriber before startup.
 
@@ -36,11 +38,14 @@ sequenceDiagram
     LLM->>NATS: RESPONSE_CANDIDATES
     NATS->>Selector: RESPONSE_CANDIDATES
     Selector->>NATS: RESPONSE_RANKED
+    NATS->>Feedback: RESPONSE_RANKED
     NATS->>Bot: RESPONSE_RANKED
     Bot-->>User: Reply
 ```
 
 The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the responder publishes `RESPONSE_CANDIDATES` and the selector picks the winner.
+
+Feedback adaptation is part of the default production DAG and should be deployed with durable subscriptions for `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL` as documented in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
 
 ### Candidate schema expectations (`RESPONSE_CANDIDATES`)

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -66,6 +66,10 @@ The orchestrator starts multiple services with a single NATS connection. Each se
    and environment variable references), copy from
    [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
+   The default production DAG includes feedback adaptation: keep the `feedback` service enabled with durable subscriptions on `dtr.response.ranked.v1`, `dtr.feedback.outcome_signal.v1`, and `dtr.feedback.correction_signal.v1`.
+
+   Set `DT_MEMORY_DB` and `DT_SOCIAL_GRAPH_DB` so adaptation writes are persisted, and optionally set `DT_FEEDBACK_DURABLE_PREFIX` to control durable naming (defaults to `feedback_service`).
+
    `llm_remote` requires the `LLM_ENDPOINT` variable pointing to a running
    `/generate` endpoint.
 

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -13,6 +13,7 @@ services:
   - context_assembler
   - llm_remote
   - selector
+  - feedback
   - reasoning
 
 service_bindings:
@@ -104,6 +105,34 @@ service_bindings:
     publish:
       - subject: dtr.response.ranked.v1  # legacy alias: dtr.response.ranked
         event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+
+  feedback:
+    description: Adapt memory/social confidence from ranked responses and explicit user feedback signals.
+    env:
+      - NATS_URL
+      - DT_MEMORY_DB
+      - DT_SOCIAL_GRAPH_DB
+      - DT_FEEDBACK_DURABLE_PREFIX
+    subscribe:
+      - subject: dtr.response.ranked.v1  # legacy aliases: dtr.response.ranked, dtr.llm.response_generated
+        event_subject: EventSubjects.RESPONSE_RANKED
+        jetstream: true
+        durable: feedback_service_ranked
+        required_reliability: true
+      - subject: dtr.feedback.outcome_signal.v1  # legacy alias: dtr.feedback.outcome_signal
+        event_subject: EventSubjects.OUTCOME_SIGNAL
+        jetstream: true
+        durable: feedback_service_outcome
+        required_reliability: true
+      - subject: dtr.feedback.correction_signal.v1  # legacy alias: dtr.feedback.correction_signal
+        event_subject: EventSubjects.CORRECTION_SIGNAL
+        jetstream: true
+        durable: feedback_service_correction
+        required_reliability: true
+    publish:
+      - subject: dtr.telemetry.response_feedback.v1
+        event_subject: response_feedback_telemetry
         jetstream: true
 
   reasoning:
@@ -229,3 +258,5 @@ environment:
   DT_SOCIAL_GRAPH_DB: ${DT_SOCIAL_GRAPH_DB:-./data/social_graph.db}
   DT_SEARCH_DB: ${DT_SEARCH_DB:-./examples/data/sample_docs.json}
   PERCEPTION_MODEL_PATH: ${PERCEPTION_MODEL_PATH:-}
+
+  DT_FEEDBACK_DURABLE_PREFIX: ${DT_FEEDBACK_DURABLE_PREFIX:-feedback_service}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ cognitive_core = "deepthought.services.cognitive_core_service:CognitiveCoreServi
 context_assembler = "deepthought.services.context_assembler_service:ContextAssemblerService"
 llm_remote = "deepthought.services.llm_remote_service:LLMRemoteService"
 selector = "deepthought.services.selector_service:SelectorService"
+feedback = "deepthought.services.feedback_service:FeedbackService"
 social_graph = "deepthought.services.social_graph_service:SocialGraphService"
 perception = "deepthought.services.perception.service:PerceptionService"
 perception_interpret = "deepthought.services.perception_interpret_service:PerceptionInterpretService"
@@ -30,8 +31,6 @@ reward_manager = "deepthought.motivate.reward_manager:RewardManager"
 planning = "deepthought.services.planning_service:PlanningService"
 reasoning = "deepthought.services.reasoning_service:ReasoningService"
 discord_gateway = "deepthought.services.discord_gateway_service:DiscordGatewayService"
-perception_interpret = "deepthought.services.perception_interpret_service:PerceptionInterpretService"
-context_assembler = "deepthought.services.context_assembler_service:ContextAssemblerService"
 
 
 


### PR DESCRIPTION
### Motivation

- Ensure the `feedback` service is discoverable by the orchestrator and documented as part of the default production DAG so response adaptation is deployed with durable consumers and persisted state.

### Description

- Add a `feedback` entry-point under `deepthought.services` in `pyproject.toml` and remove duplicate entry-point keys so the TOML parses cleanly.
- Add `feedback` to the default `services` list in `examples/orchestrator.yml` and add a `feedback` binding that documents durable JetStream subscriptions for `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL`, plus telemetry publishing and the `DT_FEEDBACK_DURABLE_PREFIX` env var.
- Update `docs/architecture.md` and `docs/orchestrator_quickstart.md` to mark feedback adaptation as part of the default production DAG and to document required persistence/env settings for feedback.

### Testing

- Verified `pyproject.toml` parses with `tomllib` and `examples/orchestrator.yml` parses with `yaml.safe_load` without syntax errors (success).
- Ran the feedback unit tests with `pytest -q tests/unit/services/test_feedback_service.py` which returned `3 passed` (success).
- Ran `ruff check src/deepthought/services/feedback_service.py` with no issues (success).
- Ran `pytest -q tests/unit/services/test_selector_service.py` for broader validation and observed an existing unrelated failure (`1 failed`) in a selector unit test; this failure did not stem from the feedback wiring changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0872fcd083268bdb25236c823811)