### PR TITLE
Add bounded TTL/LRU cache with metrics to PerceptionInterpretService

### DIFF
--- a/src/deepthought/services/perception_interpret_service.py
+++ b/src/deepthought/services/perception_interpret_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from collections import OrderedDict
 from typing import Any
 
 import nats
@@ -20,10 +22,68 @@ logger = logging.getLogger(__name__)
 class PerceptionInterpretService:
     """Convert perception payloads into compact prompt-ready interpretations."""
 
-    def __init__(self, nats_client: NATS, js_context: JetStreamContext) -> None:
+    def __init__(
+        self,
+        nats_client: NATS,
+        js_context: JetStreamContext,
+        *,
+        cache_max_entries: int = 512,
+        cache_max_age_seconds: float = 300.0,
+    ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
-        self._embeddings_by_input_id: dict[str, dict[str, Any]] = {}
+        self._cache_max_entries = max(1, cache_max_entries)
+        self._cache_max_age_seconds = max(0.0, cache_max_age_seconds)
+        self._embeddings_by_input_id: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
+        self._cache_hits = 0
+        self._cache_misses = 0
+        self._cache_evictions = 0
+
+    def _evict(self, input_id: str) -> None:
+        if self._embeddings_by_input_id.pop(input_id, None) is not None:
+            self._cache_evictions += 1
+
+    def _prune_expired(self, now: float | None = None) -> None:
+        if not self._embeddings_by_input_id:
+            return
+        ts = time.monotonic() if now is None else now
+        expired: list[str] = []
+        for input_id, entry in self._embeddings_by_input_id.items():
+            if (ts - float(entry.get("cached_at", ts))) > self._cache_max_age_seconds:
+                expired.append(input_id)
+        for input_id in expired:
+            self._evict(input_id)
+
+    def _cache_get(self, input_id: str) -> dict[str, Any]:
+        self._prune_expired()
+        entry = self._embeddings_by_input_id.get(input_id)
+        if entry is None:
+            self._cache_misses += 1
+            return {}
+        self._cache_hits += 1
+        self._embeddings_by_input_id.move_to_end(input_id)
+        return entry.get("payload", {})
+
+    def _cache_put(self, input_id: str, payload: dict[str, Any]) -> None:
+        self._prune_expired()
+        self._embeddings_by_input_id[input_id] = {
+            "payload": payload,
+            "cached_at": time.monotonic(),
+        }
+        self._embeddings_by_input_id.move_to_end(input_id)
+        while len(self._embeddings_by_input_id) > self._cache_max_entries:
+            oldest_input_id = next(iter(self._embeddings_by_input_id))
+            self._evict(oldest_input_id)
+
+    @property
+    def cache_metrics(self) -> dict[str, float | int]:
+        total_lookups = self._cache_hits + self._cache_misses
+        hit_rate = (self._cache_hits / total_lookups) if total_lookups else 0.0
+        return {
+            "cache_size": len(self._embeddings_by_input_id),
+            "evictions": self._cache_evictions,
+            "hit_rate": hit_rate,
+        }
 
     async def _handle_embeddings(self, msg: Msg) -> None:
         try:
@@ -35,7 +95,9 @@ class PerceptionInterpretService:
             if payload is None or not payload.input_id:
                 await msg.ack()
                 return
-            self._embeddings_by_input_id[payload.input_id] = {
+            self._cache_put(
+                payload.input_id,
+                {
                 "confidence": payload.confidence,
                 "modality_confidence": payload.modality_confidence,
                 "by_modality": {
@@ -45,7 +107,8 @@ class PerceptionInterpretService:
                     }
                     for name, mod in payload.by_modality.items()
                 },
-            }
+                },
+            )
             await msg.ack()
         except Exception:
             logger.exception("Failed to process PERCEPTION_EMBEDDINGS")
@@ -61,7 +124,7 @@ class PerceptionInterpretService:
             if not isinstance(input_id, str):
                 raise ValueError("Interpret request missing input_id")
 
-            cached = self._embeddings_by_input_id.get(input_id, {})
+            cached = self._cache_get(input_id)
             multimodal_notes = build_semantic_notes(
                 attachments=payload.get("attachments"),
                 embeddings_payload=cached,
@@ -76,6 +139,7 @@ class PerceptionInterpretService:
                 out_payload,
                 use_jetstream=True,
             )
+            self._evict(input_id)
             await msg.ack()
         except Exception:
             logger.exception("Failed to process PERCEPTION_INTERPRET_REQUESTED")

--- a/tests/unit/services/test_perception_interpret_service.py
+++ b/tests/unit/services/test_perception_interpret_service.py
@@ -1,0 +1,147 @@
+import importlib.machinery
+import json
+import sys
+import types
+
+import pytest
+
+if "nats" not in sys.modules:
+    nats_stub = types.ModuleType("nats")
+    nats_stub.__spec__ = importlib.machinery.ModuleSpec("nats", loader=None)
+    nats_stub.aio = types.ModuleType("aio")
+    client_mod = types.ModuleType("client")
+    client_mod.Client = object
+    msg_mod = types.ModuleType("msg")
+    msg_mod.Msg = object
+    nats_stub.aio.client = client_mod
+    nats_stub.aio.msg = msg_mod
+    nats_stub.js = types.ModuleType("js")
+    js_client_mod = types.ModuleType("client")
+    js_client_mod.JetStreamContext = object
+    nats_stub.js.client = js_client_mod
+    err_mod = types.ModuleType("errors")
+    err_mod.Error = Exception
+    nats_stub.errors = err_mod
+    sys.modules.setdefault("nats", nats_stub)
+    sys.modules.setdefault("nats.aio", nats_stub.aio)
+    sys.modules.setdefault("nats.aio.client", client_mod)
+    sys.modules.setdefault("nats.aio.msg", msg_mod)
+    sys.modules.setdefault("nats.js", nats_stub.js)
+    sys.modules.setdefault("nats.js.client", js_client_mod)
+    sys.modules.setdefault("nats.errors", err_mod)
+
+from deepthought.eda.events import EventSubjects
+from deepthought.services.perception_interpret_service import PerceptionInterpretService
+
+
+class DummyNATS:
+    pass
+
+
+class DummyJS:
+    pass
+
+
+class DummySubscriber:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def subscribe(self, **kwargs):
+        return True
+
+    async def unsubscribe_all(self):
+        return None
+
+
+class RecordingPublisher:
+    def __init__(self, *_args, **_kwargs):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload, use_jetstream, timeout))
+
+
+class DummyMsg:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+        self.naked = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nak(self):
+        self.naked = True
+
+
+def test_perception_interpret_service_evicts_after_publish(monkeypatch):
+    import deepthought.services.perception_interpret_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+
+    service = PerceptionInterpretService(DummyNATS(), DummyJS(), cache_max_entries=4, cache_max_age_seconds=60)
+
+    embeddings_msg = DummyMsg(
+        {
+            "event": EventSubjects.PERCEPTION_EMBEDDINGS,
+            "version": 1,
+            "payload": {
+                "message_id": "m-1",
+                "user_id": "u-1",
+                "input_id": "input-1",
+                "confidence": 0.8,
+                "modality_confidence": {"image": 0.7},
+                "by_modality": {
+                    "image": {
+                        "spans": [[0, 1]],
+                        "embeddings": [[0.1, 0.2]],
+                        "encoders": [],
+                    }
+                },
+            },
+        }
+    )
+    import asyncio
+
+    asyncio.run(service._handle_embeddings(embeddings_msg))
+
+    request_msg = DummyMsg(
+        {
+            "input_id": "input-1",
+            "attachments": [{"url": "https://example.test/image.png", "content_type": "image/png"}],
+        }
+    )
+    asyncio.run(service._handle_interpret_request(request_msg))
+
+    assert embeddings_msg.acked is True
+    assert request_msg.acked is True
+    assert service.cache_metrics["cache_size"] == 0
+    assert service.cache_metrics["evictions"] == 1
+    assert service.cache_metrics["hit_rate"] == 1.0
+
+
+def test_perception_interpret_service_evicts_expired_and_lru(monkeypatch):
+    import deepthought.services.perception_interpret_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+
+    service = PerceptionInterpretService(DummyNATS(), DummyJS(), cache_max_entries=2, cache_max_age_seconds=0.1)
+
+    service._cache_put("a", {"value": "a"})
+    service._cache_put("b", {"value": "b"})
+    service._cache_put("c", {"value": "c"})
+
+    assert service._cache_get("a") == {}
+    assert service._cache_get("b") == {"value": "b"}
+    assert service._cache_get("c") == {"value": "c"}
+
+    service._embeddings_by_input_id["b"]["cached_at"] -= 1.0
+    assert service._cache_get("missing") == {}
+    assert service._cache_get("b") == {}
+
+    metrics = service.cache_metrics
+    assert metrics["cache_size"] == 1
+    assert metrics["evictions"] == 2
+    assert metrics["hit_rate"] == pytest.approx(0.4)


### PR DESCRIPTION
### Motivation
- Prevent unbounded growth of the in-memory embeddings cache by replacing the plain dict with a bounded TTL/LRU cache.
- Ensure embeddings are not retained indefinitely after interpretation is published and provide simple observability of cache behavior.

### Description
- Replaced `self._embeddings_by_input_id` plain `dict` with an `OrderedDict`-backed cache and added constructor options `cache_max_entries` and `cache_max_age_seconds` to configure bounds.
- Implemented TTL pruning and LRU behavior via `_prune_expired`, `_cache_get`, and `_cache_put`, and evict entries after a successful interpret publish using `_evict`.
- Added lightweight cache metrics exposed via the `cache_metrics` property (`cache_size`, `evictions`, `hit_rate`).
- Added unit tests `tests/unit/services/test_perception_interpret_service.py` that validate eviction-after-publish, LRU eviction when exceeding `cache_max_entries`, and TTL expiration behavior.

### Testing
- Ran linter checks with `python -m ruff check src/deepthought/services/perception_interpret_service.py tests/unit/services/test_perception_interpret_service.py`, which passed.
- Executed the new unit tests in isolation with `PYTHONPATH=src python -m pytest --noconftest tests/unit/services/test_perception_interpret_service.py -q`, which passed (2 tests).
- Attempting a full `pytest` run (without `--noconftest`) failed due to the repository `tests/conftest.py` environment stub expecting a `torch.from_numpy` fallback (environment limitation), and `flake8` was not available in the environment so `ruff` was used instead.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee78b77888326bdb212b85cc81fa0)