### PR TITLE
Validate required service bindings against architecture DAG

### DIFF
--- a/src/deepthought/orchestrator.py
+++ b/src/deepthought/orchestrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import ssl
 from contextlib import AsyncExitStack, suppress
 from importlib import metadata
@@ -15,6 +16,131 @@ from .eda.events import EventSubjects, PlanGeneratedPayload, PlanRequestedPayloa
 from .planning import planner, translator
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_event_subject(value: str) -> str:
+    return value.rsplit(".", 1)[-1].strip()
+
+
+def _parse_service_bindings(
+    service_bindings: dict[str, Any],
+) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    publishers: dict[str, set[str]] = {}
+    subscribers: dict[str, set[str]] = {}
+    for service, spec in service_bindings.items():
+        if not isinstance(spec, dict):
+            continue
+        for binding in spec.get("publish", []) or []:
+            if not isinstance(binding, dict):
+                continue
+            event_subject = binding.get("event_subject")
+            if not isinstance(event_subject, str):
+                continue
+            subject_key = _normalize_event_subject(event_subject)
+            publishers.setdefault(subject_key, set()).add(service)
+        for binding in spec.get("subscribe", []) or []:
+            if not isinstance(binding, dict):
+                continue
+            event_subject = binding.get("event_subject")
+            if not isinstance(event_subject, str):
+                continue
+            subject_key = _normalize_event_subject(event_subject)
+            subscribers.setdefault(subject_key, set()).add(service)
+    return publishers, subscribers
+
+
+def _required_subjects_from_architecture() -> list[dict[str, Any]]:
+    arch = Path(__file__).resolve().parents[2] / "docs" / "architecture.md"
+    text = arch.read_text(encoding="utf-8")
+    required: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not re.match(r"^\d+\.\s+", line):
+            continue
+        names = re.findall(r"`([^`]+)`", line)
+        if not names:
+            continue
+        consumed = re.findall(r"consumed by `([^`]+)`", line)
+        published = re.findall(r"published by `([^`]+)`", line)
+        if "either" in line and len(names) >= 3 and consumed:
+            required.append(
+                {
+                    "subjects": [_normalize_event_subject(names[0]), _normalize_event_subject(names[2])],
+                    "publishers": {_normalize_event_subject(names[1])},
+                    "subscribers": {_normalize_event_subject(consumed[0])},
+                    "kind": "any",
+                }
+            )
+            continue
+        if " are consumed by " in line and consumed:
+            for subject in names[:-1]:
+                required.append(
+                    {
+                        "subjects": [_normalize_event_subject(subject)],
+                        "publishers": set(),
+                        "subscribers": {_normalize_event_subject(consumed[0])},
+                        "kind": "all",
+                    }
+                )
+            continue
+        if len(names) >= 3 and published and consumed:
+            required.append(
+                {
+                    "subjects": [_normalize_event_subject(names[0])],
+                    "publishers": {_normalize_event_subject(names[1])},
+                    "subscribers": {_normalize_event_subject(c) for c in consumed},
+                    "kind": "all",
+                }
+            )
+    return required
+
+
+def _validate_required_bindings(service_bindings: dict[str, Any]) -> None:
+    publishers, subscribers = _parse_service_bindings(service_bindings)
+    problems: list[str] = []
+    for requirement in _required_subjects_from_architecture():
+        subjects = requirement["subjects"]
+        if requirement["kind"] == "any":
+            satisfied = False
+            for subject in subjects:
+                pub_services = publishers.get(subject, set())
+                sub_services = subscribers.get(subject, set())
+                if pub_services and requirement["subscribers"].issubset(sub_services):
+                    satisfied = True
+                    break
+            if not satisfied:
+                problems.append(
+                    "missing alternative edge: expected one of "
+                    f"{subjects} to have publisher(s) and subscriber(s) "
+                    f"{sorted(requirement['subscribers'])}"
+                )
+            continue
+
+        for subject in subjects:
+            pub_services = publishers.get(subject, set())
+            sub_services = subscribers.get(subject, set())
+            if not pub_services:
+                problems.append(
+                    f"missing publisher for {subject}: add a service_bindings.*.publish entry"
+                )
+            missing_pub = requirement["publishers"] - pub_services
+            if missing_pub:
+                problems.append(
+                    f"{subject} must be published by {sorted(missing_pub)}; found {sorted(pub_services) or 'none'}"
+                )
+            if not sub_services:
+                problems.append(
+                    f"missing subscriber for {subject}: add a service_bindings.*.subscribe entry"
+                )
+            missing_sub = requirement["subscribers"] - sub_services
+            if missing_sub:
+                problems.append(
+                    f"{subject} must be consumed by {sorted(missing_sub)}; found {sorted(sub_services) or 'none'}"
+                )
+
+    if problems:
+        msg = "Required orchestration edges failed validation:\n - " + "\n - ".join(problems)
+        raise ValueError(msg)
 
 
 def discover_services(names: Iterable[str] | None = None) -> list[type]:
@@ -85,6 +211,15 @@ async def _connect_nats():
 async def run(config_path: str) -> None:
     """Start services defined in ``config_path``."""
     cfg = _load_config(config_path)
+    service_bindings = cfg.get("service_bindings")
+    if service_bindings is None:
+        logger.warning(
+            "No service_bindings found in config; skipping required orchestration DAG validation"
+        )
+    elif not isinstance(service_bindings, dict):
+        raise ValueError("service_bindings must be a mapping of service name to binding metadata")
+    else:
+        _validate_required_bindings(service_bindings)
     names = cfg.get("services", [])
     service_classes = discover_services(names)
     crew_specs = cfg.get("crews", [])

--- a/tests/unit/orchestrator/test_orchestrator_extra.py
+++ b/tests/unit/orchestrator/test_orchestrator_extra.py
@@ -29,7 +29,6 @@ sys.modules.setdefault("l2p.utils", fake_l2p_utils)
 
 
 import asyncio
-import json
 from types import SimpleNamespace
 
 import pytest
@@ -89,7 +88,51 @@ async def test_run_starts_and_stops_service(monkeypatch, tmp_path):
     monkeypatch.setattr(asyncio.Event, "wait", lambda self: asyncio.sleep(0))
 
     cfg = tmp_path / "cfg.yaml"
-    cfg.write_text("services:\n  - dummy\n", encoding="utf-8")
+    cfg.write_text(
+        """
+services:
+  - dummy
+service_bindings:
+  discord_gateway:
+    publish:
+      - event_subject: EventSubjects.INPUT_RECEIVED
+    subscribe:
+      - event_subject: EventSubjects.RESPONSE_RANKED
+  cognitive_core:
+    publish:
+      - event_subject: EventSubjects.MEMORY_RETRIEVED
+  social_graph:
+    publish:
+      - event_subject: EventSubjects.SOCIAL_UPDATED
+  perception_interpret:
+    publish:
+      - event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
+  context_assembler:
+    subscribe:
+      - event_subject: EventSubjects.INPUT_RECEIVED
+      - event_subject: EventSubjects.MEMORY_RETRIEVED
+      - event_subject: EventSubjects.SOCIAL_UPDATED
+      - event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
+    publish:
+      - event_subject: EventSubjects.CONTEXT_ASSEMBLED
+  llm_remote:
+    subscribe:
+      - event_subject: EventSubjects.CONTEXT_ASSEMBLED
+  selector:
+    publish:
+      - event_subject: EventSubjects.RESPONSE_RANKED
+  feedback:
+    subscribe:
+      - event_subject: EventSubjects.RESPONSE_RANKED
+      - event_subject: EventSubjects.OUTCOME_SIGNAL
+      - event_subject: EventSubjects.CORRECTION_SIGNAL
+  adaptation:
+    publish:
+      - event_subject: EventSubjects.OUTCOME_SIGNAL
+      - event_subject: EventSubjects.CORRECTION_SIGNAL
+""",
+        encoding="utf-8",
+    )
 
     await orch.run(str(cfg))
 
@@ -97,3 +140,33 @@ async def test_run_starts_and_stops_service(monkeypatch, tmp_path):
     assert service is not None
     assert service.started is True
     assert service.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_run_warns_when_bindings_absent(monkeypatch, caplog, tmp_path):
+    orch = _load_orchestrator_module()
+    monkeypatch.setattr(orch, "discover_services", lambda names: [])
+
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("services: []\n", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        await orch.run(str(cfg))
+
+    assert "No service_bindings found" in caplog.text
+
+
+def test_validate_required_bindings_actionable_error():
+    orch = _load_orchestrator_module()
+
+    with pytest.raises(ValueError) as excinfo:
+        orch._validate_required_bindings(
+            {
+                "discord_gateway": {
+                    "publish": [{"event_subject": "EventSubjects.INPUT_RECEIVED"}]
+                }
+            }
+        )
+
+    assert "Required orchestration edges failed validation" in str(excinfo.value)
+    assert "missing subscriber for INPUT_RECEIVED" in str(excinfo.value)


### PR DESCRIPTION
### Motivation
- Ensure the runtime NATS event graph matches the deployment invariants documented in `docs/architecture.md` so the system fails early with clear diagnostics instead of silently stalling at runtime. 
- Provide backward compatibility by not breaking existing configs that omit `service_bindings`, while enforcing invariants when bindings are present.

### Description
- Added parsing helpers to `src/deepthought/orchestrator.py`: `_normalize_event_subject`, `_parse_service_bindings`, `_required_subjects_from_architecture`, and `_validate_required_bindings` to build publisher/subscriber maps and extract required edges from `docs/architecture.md`.
- Integrated preflight validation into `run()` so the orchestrator warns when `service_bindings` are absent but otherwise validates shape and required publish/subscribe edges and fails fast with actionable error messages when invariants are violated. 
- Detection/validation handles alternative edges (the documented either/or social signal case) and reports missing publisher/subscriber pairs with suggested config corrections.
- Extended unit tests in `tests/unit/orchestrator/test_orchestrator_extra.py` to cover successful startup with valid bindings, warning behavior when bindings are absent, and an actionable validation failure case.

### Testing
- Ran `pytest tests/unit/test_orchestrator.py tests/unit/orchestrator/test_orchestrator_extra.py` and all tests passed (`7 passed, 1 warning`).
- Ran `ruff` on the modified orchestrator file and it passed (`ruff check src/deepthought/orchestrator.py` reported no issues).
- Ran `ruff` on the updated test file with `--ignore E402` to accommodate the existing test import pattern (`ruff check tests/unit/orchestrator/test_orchestrator_extra.py --ignore E402`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef049ecf48326a0d7bbc2e2c30892)