### PR TITLE
Normalize Discord token env var to DISCORD_BOT_TOKEN with legacy alias fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,8 @@ export DT_SCHEDULER_INTERVAL=120
 
 ### Required environment variables
 
-* `DISCORD_TOKEN` - Discord bot token
+* `DISCORD_BOT_TOKEN` - Discord bot token
+* `DISCORD_TOKEN` - deprecated legacy alias for `DISCORD_BOT_TOKEN`
 * `MONITOR_CHANNEL` - Channel ID the bot should monitor
 * `NATS_URL` - Address of the NATS server
 
@@ -480,7 +481,7 @@ python -m textblob.download_corpora
 Set the environment variables used by the bot:
 
 ```bash
-export DISCORD_TOKEN=your_token
+export DISCORD_BOT_TOKEN=your_token
 export MONITOR_CHANNEL=1234567890
 export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
@@ -490,7 +491,7 @@ export PLAYFUL_REPLY_TIMEOUT_MINUTES=5          # bot-to-bot reply cooldown
 export MAX_BOT_SPEAKERS=2                       # ignore chatter when too many bots talk
 ```
 
-`DISCORD_TOKEN` and `MONITOR_CHANNEL` are required. `NATS_URL` must also be set
+`DISCORD_BOT_TOKEN` and `MONITOR_CHANNEL` are required. `NATS_URL` must also be set
 to a valid NATS server address if the default `nats://localhost:4222` is not
 appropriate. All other variables are optional. `USER_REPLY_RATE_SECONDS`
 controls how quickly the bot may respond to the same user, while

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ def main() -> None:
     env = load_bot_env()
     asyncio.run(
         run(
-            env.DISCORD_TOKEN,
+            env.DISCORD_BOT_TOKEN,
             env.MONITOR_CHANNEL,
             holiday_locale=env.PROJECT_HOLIDAY_LOCALE,
         )

--- a/docs/discord_bot_phase_report.md
+++ b/docs/discord_bot_phase_report.md
@@ -48,7 +48,8 @@ After installing TextBlob, download its corpora:
 ```bash
 python -m textblob.download_corpora
 
-export DISCORD_TOKEN=your_token
+export DISCORD_BOT_TOKEN=your_token
+# DISCORD_TOKEN remains a deprecated legacy alias.
 export MONITOR_CHANNEL=1234567890
 export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
 export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -21,7 +21,7 @@ service_bindings:
     description: Bridge Discord I/O to NATS.
     env:
       - NATS_URL
-      - DISCORD_TOKEN
+      - DISCORD_BOT_TOKEN
     subscribe:
       - subject: dtr.response.ranked.v1  # legacy alias: dtr.response.ranked
         event_subject: EventSubjects.RESPONSE_RANKED
@@ -252,7 +252,7 @@ service_bindings:
 
 environment:
   NATS_URL: ${NATS_URL:-nats://localhost:4222}
-  DISCORD_TOKEN: ${DISCORD_TOKEN:-}
+  DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
   LLM_ENDPOINT: ${LLM_ENDPOINT:-http://localhost:8000/generate}
   DT_MEMORY_DB: ${DT_MEMORY_DB:-./data/memory.db}
   DT_SOCIAL_GRAPH_DB: ${DT_SOCIAL_GRAPH_DB:-./data/social_graph.db}

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1945,7 +1945,7 @@ if __name__ == "__main__":
         env = load_bot_env()
         asyncio.run(
             run(
-                env.DISCORD_TOKEN,
+                env.DISCORD_BOT_TOKEN,
                 env.MONITOR_CHANNEL,
                 forum_channel_id=env.PROJECT_FORUM_CHANNEL_ID,
                 index_channel_id=env.PROJECT_INDEX_CHANNEL_ID,

--- a/src/deepthought/cli/__init__.py
+++ b/src/deepthought/cli/__init__.py
@@ -245,7 +245,7 @@ def _cmd_perception_delete_user(args: argparse.Namespace) -> int:
 
 def _cmd_run_discord_gateway(args: argparse.Namespace) -> int:
     if not args.token:
-        raise SystemExit("DISCORD_TOKEN is required (use --token or set DISCORD_TOKEN)")
+        raise SystemExit("DISCORD_BOT_TOKEN is required (use --token or set DISCORD_BOT_TOKEN)")
 
     from ..runtime.discord_gateway_app import run_discord_gateway
 
@@ -254,6 +254,7 @@ def _cmd_run_discord_gateway(args: argparse.Namespace) -> int:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    from ..config import load_discord_bot_token
     from ..services.perception.config import PerceptionConfig
 
     parser = argparse.ArgumentParser(prog="dtrt")
@@ -387,7 +388,7 @@ def _build_parser() -> argparse.ArgumentParser:
     run_sub = run_p.add_subparsers(dest="run_cmd")
 
     run_discord_gateway = run_sub.add_parser("discord-gateway", description="Run the Discord gateway runtime")
-    run_discord_gateway.add_argument("--token", default=os.getenv("DISCORD_TOKEN", ""))
+    run_discord_gateway.add_argument("--token", default=load_discord_bot_token())
     run_discord_gateway.add_argument("--nats-url", default=os.getenv("NATS_URL", "nats://localhost:4222"))
     run_discord_gateway.set_defaults(func=_cmd_run_discord_gateway)
 

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -6,6 +6,7 @@ import functools
 import json
 import os
 import subprocess
+import warnings
 from importlib import metadata
 from pathlib import Path
 from typing import Optional
@@ -404,7 +405,9 @@ def _alias_choices(*names: str) -> object:
 class BotEnv(BaseSettings):
     """Environment variables required for running the Discord bot."""
 
-    DISCORD_TOKEN: str
+    DISCORD_BOT_TOKEN: str = Field(
+        validation_alias=_alias_choices("DISCORD_BOT_TOKEN", "DISCORD_TOKEN"),
+    )
     MONITOR_CHANNEL: int
     PROJECT_FORUM_CHANNEL_ID: int | None = Field(
         default=None,
@@ -466,10 +469,35 @@ class BotEnv(BaseSettings):
     def PROJECTS_REQUIRE_EVENTS(self) -> bool:  # pragma: no cover - compatibility shim
         return self.PROJECT_REQUIRE_EVENTS
 
+    @property
+    def DISCORD_TOKEN(self) -> str:  # pragma: no cover - compatibility shim
+        return self.DISCORD_BOT_TOKEN
+
+
+def load_discord_bot_token(*, warn_on_legacy: bool = True) -> str:
+    """Load the Discord bot token from canonical env var with legacy fallback."""
+
+    token = (os.getenv("DISCORD_BOT_TOKEN") or "").strip()
+    if token:
+        return token
+
+    legacy_token = (os.getenv("DISCORD_TOKEN") or "").strip()
+    if legacy_token and warn_on_legacy:
+        warnings.warn(
+            "DISCORD_TOKEN is deprecated; please use DISCORD_BOT_TOKEN.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    return legacy_token
+
 
 
 def load_bot_env() -> BotEnv:
     """Return bot environment settings or exit with a clear error."""
+
+    token = load_discord_bot_token()
+    if token and "DISCORD_BOT_TOKEN" not in os.environ:
+        os.environ["DISCORD_BOT_TOKEN"] = token
 
     for legacy, canonical in (
         ("PROJECTS_FORUM_CHANNEL", "PROJECT_FORUM_CHANNEL_ID"),
@@ -490,9 +518,9 @@ def load_bot_env() -> BotEnv:
         missing: list[str] = []
         invalid: list[str] = []
 
-        token = os.getenv("DISCORD_TOKEN")
+        token = load_discord_bot_token(warn_on_legacy=False)
         if not token:
-            missing.append("DISCORD_TOKEN")
+            missing.append("DISCORD_BOT_TOKEN")
 
         monitor_raw = os.getenv("MONITOR_CHANNEL")
         monitor: int | None = None
@@ -538,7 +566,7 @@ def load_bot_env() -> BotEnv:
                 f"Missing or invalid environment variables: {', '.join(problems)}"
             )
 
-        setattr(env, "DISCORD_TOKEN", token)
+        setattr(env, "DISCORD_BOT_TOKEN", token)
         setattr(env, "MONITOR_CHANNEL", monitor)
         setattr(env, "PROJECT_FORUM_CHANNEL_ID", forum_id)
         setattr(env, "PROJECT_INDEX_CHANNEL_ID", index_id)

--- a/src/deepthought/quest/writer.py
+++ b/src/deepthought/quest/writer.py
@@ -9,6 +9,8 @@ from typing import Any, Optional
 
 import requests
 
+from ..config import load_discord_bot_token
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,7 @@ class QuestWriter:
     - ``AUTOPSY_CHANNEL``: channel for quest autopsies.
     - ``PARAMETERS_CHANNEL``: channel for parameter dumps.
     - ``LIVING_REPORT_CHANNEL``: channel for weekly living reports.
-    - ``DISCORD_TOKEN``: bot token for authentication.
+    - ``DISCORD_BOT_TOKEN``: bot token for authentication (``DISCORD_TOKEN`` is a deprecated alias).
     """
 
     def __init__(
@@ -52,7 +54,7 @@ class QuestWriter:
         self._autopsy_channel = autopsy_channel or os.getenv("AUTOPSY_CHANNEL")
         self._parameters_channel = parameters_channel or os.getenv("PARAMETERS_CHANNEL")
         self._living_channel = living_channel or os.getenv("LIVING_REPORT_CHANNEL")
-        self._token = token or os.getenv("DISCORD_TOKEN")
+        self._token = token or load_discord_bot_token()
 
     # ------------------------------------------------------------------
     def _post(self, channel_id: Optional[str], content: str) -> None:

--- a/src/deepthought/services/reward_manager_service.py
+++ b/src/deepthought/services/reward_manager_service.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import os
-
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
+from ..config import load_discord_bot_token
 from ..motivate import Ledger, RewardManager
 from .base import BaseService
 
@@ -21,7 +20,7 @@ class RewardManagerService(BaseService):
     ) -> None:
         super().__init__(nats_client, js_context, connect_retries=connect_retries)
         ledger = Ledger(nats_client, js_context)
-        token = os.getenv("DISCORD_TOKEN", "")
+        token = load_discord_bot_token()
         self._manager = RewardManager(self._subscriber, ledger, self._publisher, token)
 
     async def start(self, durable_name: str = "reward_manager_service") -> bool:

--- a/src/deepthought/templates/reward_service/service.py
+++ b/src/deepthought/templates/reward_service/service.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import os
-
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
+from deepthought.config import load_discord_bot_token
 from deepthought.eda import Publisher, Subscriber
 from deepthought.motivate import Ledger, RewardManager
 
@@ -16,7 +15,7 @@ class TemplateService:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
         self._ledger = Ledger(nats_client, js_context)
-        token = os.getenv("DISCORD_TOKEN", "")
+        token = load_discord_bot_token()
         self._manager = RewardManager(
             self._subscriber, self._ledger, self._publisher, token
         )

--- a/tests/test_quest_reports.py
+++ b/tests/test_quest_reports.py
@@ -88,7 +88,7 @@ def test_send_quest_story_posts_to_autopsy(monkeypatch):
         return Resp()
 
     monkeypatch.setenv("AUTOPSY_CHANNEL", "42")
-    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
     monkeypatch.setattr("requests.post", fake_post)
 
     writer = QuestWriter()
@@ -107,7 +107,7 @@ def test_send_quest_story_ignores_incomplete(monkeypatch):
         called["called"] = True
 
     monkeypatch.setenv("AUTOPSY_CHANNEL", "42")
-    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
     monkeypatch.setattr("requests.post", fake_post)
 
     writer = QuestWriter()
@@ -138,7 +138,7 @@ def test_send_living_report_posts(monkeypatch):
         return Resp()
 
     monkeypatch.setenv("LIVING_REPORT_CHANNEL", "99")
-    monkeypatch.setenv("DISCORD_TOKEN", "token")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "token")
     monkeypatch.setattr("requests.post", fake_post)
 
     writer = QuestWriter()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -328,5 +328,5 @@ def test_parse_run_discord_gateway():
 def test_run_discord_gateway_requires_token():
     parser = _build_parser()
     args = parser.parse_args(["run", "discord-gateway", "--token", ""])
-    with pytest.raises(SystemExit, match="DISCORD_TOKEN is required"):
+    with pytest.raises(SystemExit, match="DISCORD_BOT_TOKEN is required"):
         args.func(args)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -159,7 +159,7 @@ def test_get_settings_env(monkeypatch):
 
 
 def test_load_bot_env_success(monkeypatch):
-    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "abc")
     monkeypatch.setenv("MONITOR_CHANNEL", "42")
 
     env = load_bot_env()
@@ -170,7 +170,7 @@ def test_load_bot_env_success(monkeypatch):
 
 
 def test_load_bot_env_custom_locale(monkeypatch):
-    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "abc")
     monkeypatch.setenv("MONITOR_CHANNEL", "42")
     monkeypatch.setenv("PROJECT_HOLIDAY_LOCALE", "gb")
 
@@ -179,8 +179,22 @@ def test_load_bot_env_custom_locale(monkeypatch):
     assert env.PROJECT_HOLIDAY_LOCALE == "GB"
 
 
+
+
+def test_load_bot_env_legacy_token_warns(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("MONITOR_CHANNEL", "42")
+
+    with pytest.deprecated_call(match="DISCORD_TOKEN is deprecated"):
+        env = load_bot_env()
+
+    assert env.DISCORD_BOT_TOKEN == "abc"
+
+
 def test_load_bot_env_missing(monkeypatch):
     monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
     monkeypatch.delenv("MONITOR_CHANNEL", raising=False)
 
     with pytest.raises(SystemExit):
@@ -188,7 +202,7 @@ def test_load_bot_env_missing(monkeypatch):
 
 
 def test_load_bot_env_invalid_channel(monkeypatch):
-    monkeypatch.setenv("DISCORD_TOKEN", "abc")
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "abc")
     monkeypatch.setenv("MONITOR_CHANNEL", "x")
 
     with pytest.raises(SystemExit):


### PR DESCRIPTION
### Motivation

- Standardize Discord bot token usage across runtimes and docs by choosing a single canonical env var name and provide a clear upgrade path from the old name. 

### Description

- Add `DISCORD_BOT_TOKEN` as the canonical BotEnv field and introduce `load_discord_bot_token()` which prefers `DISCORD_BOT_TOKEN` and falls back to `DISCORD_TOKEN` while emitting a `DeprecationWarning`.
- Update `load_bot_env()` to populate the canonical env and use the shared loader so all runtime code gets token resolution and deprecation handling in one place.
- Replace direct `DISCORD_TOKEN` reads with the shared loader across runtime entrypoints and consumers (`bot.py`, `examples/social_graph_bot.py`, `dtrt` CLI defaults/error text, reward manager, reward template, quest writer).
- Update examples/docs (`examples/orchestrator.yml`, README, `docs/discord_bot_phase_report.md`) and unit tests to use `DISCORD_BOT_TOKEN` and document `DISCORD_TOKEN` as a deprecated alias.

### Testing

- Ran targeted unit tests for the bot env and CLI token flows: `pytest -q tests/unit/test_config.py::test_load_bot_env_success tests/unit/test_config.py::test_load_bot_env_custom_locale tests/unit/test_config.py::test_load_bot_env_legacy_token_warns tests/unit/test_config.py::test_load_bot_env_missing tests/unit/test_config.py::test_load_bot_env_invalid_channel tests/unit/test_cli.py::test_parse_run_discord_gateway tests/unit/test_cli.py::test_run_discord_gateway_requires_token` and they passed (7 passed).
- Performed `python -m py_compile` on modified modules to verify syntax (succeeded).
- Broader test/lint runs (`pytest` across larger subsets and `ruff check`) surfaced unrelated repo/container baseline issues (missing optional deps like `pydantic`, `aiosqlite`, transformer-related imports, and pre-existing lint violations in `examples/social_graph_bot.py`) which prevented a clean full-suite green run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef2762570832699d9216a42e0b8e7)