### PR TITLE
Enforce EventEnvelope for cross-service messaging and add publish_enveloped helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,16 @@ For the default orchestrator profile, the following event chain is **required**.
 
 Operators should treat this as a deployment invariant and verify that each required subject has at least one publisher and one subscriber before startup.
 
+### Envelope-only cross-service contract invariant
+
+All cross-service messages on DeepThought EDA subjects **must** be emitted as an `EventEnvelope` (see `src/deepthought/eda/contracts`). Raw top-level payload dicts are not valid cross-service traffic. Each envelope is required to include: 
+
+- `trace_id`
+- `event_id`
+- `causation_id`
+
+Services should publish by calling `publish_enveloped(...)` from `src/deepthought/eda/publisher.py` to enforce this contract uniformly.
+
 ```mermaid
 sequenceDiagram
     participant User

--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -55,7 +55,7 @@ class EventEnvelope:
     schema_version: str
     event_id: str
     trace_id: str
-    causation_id: str | None
+    causation_id: str
     created_at: str
     producer: str
     subject: str
@@ -72,11 +72,12 @@ class EventEnvelope:
         causation_id: str | None = None,
         schema_version: str = "1.0.0",
     ) -> "EventEnvelope":
+        event_id = str(uuid4())
         return cls(
             schema_version=schema_version,
-            event_id=str(uuid4()),
+            event_id=event_id,
             trace_id=trace_id or str(uuid4()),
-            causation_id=causation_id,
+            causation_id=causation_id or event_id,
             created_at=datetime.now(timezone.utc).isoformat(),
             producer=producer,
             subject=to_canonical_subject(subject),
@@ -106,7 +107,7 @@ def validate_envelope(data: Dict[str, Any]) -> EventEnvelope:
     schema_version = _expect_type(data, "schema_version", str)
     event_id = _expect_type(data, "event_id", str)
     trace_id = _expect_type(data, "trace_id", str)
-    causation_id = _expect_type(data, "causation_id", str, optional=True)
+    causation_id = _expect_type(data, "causation_id", str)
     created_at = _expect_type(data, "created_at", str)
     producer = _expect_type(data, "producer", str)
     subject = _expect_type(data, "subject", str)
@@ -114,8 +115,7 @@ def validate_envelope(data: Dict[str, Any]) -> EventEnvelope:
 
     _expect_uuid(event_id, "event_id")
     _expect_uuid(trace_id, "trace_id")
-    if causation_id is not None:
-        _expect_uuid(causation_id, "causation_id")
+    _expect_uuid(causation_id, "causation_id")
     try:
         datetime.fromisoformat(created_at.replace("Z", "+00:00"))
     except ValueError as exc:
@@ -135,6 +135,18 @@ def validate_envelope(data: Dict[str, Any]) -> EventEnvelope:
 
 def to_canonical_subject(subject: str) -> str:
     return LEGACY_SUBJECT_MAP.get(subject, subject)
+
+
+def validate_cross_service_envelope(subject: str, data: Dict[str, Any]) -> EventEnvelope:
+    """Validate mandatory envelope contract for cross-service events."""
+
+    envelope = validate_envelope(data)
+    canonical_subject = to_canonical_subject(subject)
+    if envelope.subject != canonical_subject:
+        raise ValueError(
+            f"Envelope subject mismatch: expected '{canonical_subject}', got '{envelope.subject}'"
+        )
+    return envelope
 
 
 def normalize_legacy_payload(subject: str, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -10,7 +10,10 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
+from .contracts import EventEnvelope, validate_cross_service_envelope
+
 logger = logging.getLogger(__name__)
+NATS_TIMEOUT_ERROR = getattr(nats.errors, "TimeoutError", TimeoutError)
 
 
 class Publisher:
@@ -67,7 +70,7 @@ class Publisher:
                 await self._nc.publish(subject, data)
                 logger.debug("Published basic NATS message to '%s'", subject)
                 return None
-            except nats.errors.TimeoutError as err:
+            except NATS_TIMEOUT_ERROR as err:
                 last_error = err
                 logger.warning("Publish timeout for '%s' with payload %s: %s", subject, payload_summary, err)
             except Exception as err:
@@ -125,3 +128,44 @@ async def connect(
     )
     js = nc.jetstream()
     return Publisher(nc, js)
+
+
+async def publish_enveloped(
+    publisher: "Publisher",
+    *,
+    subject: str,
+    payload: Dict[str, Any],
+    producer: str,
+    trace_id: str | None = None,
+    causation_id: str | None = None,
+    use_jetstream: bool = True,
+    timeout: float = 10.0,
+    retries: int = 3,
+) -> Optional[Dict]:
+    """Build, validate, and publish a canonical EventEnvelope."""
+
+    envelope = EventEnvelope.build(
+        subject=subject,
+        payload=payload,
+        producer=producer,
+        trace_id=trace_id,
+        causation_id=causation_id,
+    )
+    validate_cross_service_envelope(subject, envelope.__dict__)
+    try:
+        return await publisher.publish(
+            subject,
+            envelope.__dict__,
+            use_jetstream=use_jetstream,
+            timeout=timeout,
+            retries=retries,
+        )
+    except TypeError as exc:
+        if "unexpected keyword argument 'retries'" not in str(exc):
+            raise
+        return await publisher.publish(
+            subject,
+            envelope.__dict__,
+            use_jetstream=use_jetstream,
+            timeout=timeout,
+        )

--- a/src/deepthought/services/perception_interpret_service.py
+++ b/src/deepthought/services/perception_interpret_service.py
@@ -12,7 +12,7 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from ..eda.events import EventSubjects, PerceptionEmbeddingsEvent
-from ..eda.publisher import Publisher
+from ..eda.publisher import Publisher, publish_enveloped
 from ..eda.subscriber import Subscriber
 from .perception.summarization import build_semantic_notes
 
@@ -134,10 +134,11 @@ class PerceptionInterpretService:
                 "input_id": input_id,
                 "multimodal_interpretations": multimodal_notes,
             }
-            await self._publisher.publish(
-                EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,
-                out_payload,
-                use_jetstream=True,
+            await publish_enveloped(
+                self._publisher,
+                subject=EventSubjects.PERCEPTION_INTERPRET_RETRIEVED,
+                payload=out_payload,
+                producer="perception_interpret_service",
             )
             self._evict(input_id)
             await msg.ack()

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -10,6 +10,7 @@ from nats.js.client import JetStreamContext
 
 from ..perception.social_perception import analyze as analyze_social
 from ..eda.events import EventSubjects
+from ..eda.publisher import publish_enveloped
 from .base import BaseService
 from .db_manager import DBManager
 from .persona_manager import PersonaManager
@@ -98,8 +99,18 @@ class SocialGraphService(BaseService):
                 "persona": persona,
                 "perception": perception,
             }
-            await self._publisher.publish(EventSubjects.SOCIAL_UPDATED, social_update, use_jetstream=True)
-            await self._publisher.publish(EventSubjects.SOCIAL_SIGNALS_RETRIEVED, social_snapshot, use_jetstream=True)
+            await publish_enveloped(
+                self._publisher,
+                subject=EventSubjects.SOCIAL_UPDATED,
+                payload=social_update,
+                producer="social_graph_service",
+            )
+            await publish_enveloped(
+                self._publisher,
+                subject=EventSubjects.SOCIAL_SIGNALS_RETRIEVED,
+                payload=social_snapshot,
+                producer="social_graph_service",
+            )
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except (json.JSONDecodeError, ValueError):

--- a/tests/integration/test_social_graph_affinity.py
+++ b/tests/integration/test_social_graph_affinity.py
@@ -94,3 +94,43 @@ async def test_cognitive_core_does_not_mutate_social_state(tmp_path):
     assert topics.count("social_perception") == 0
 
     await db.close()
+
+
+class RecordingPublisher:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.calls.append((subject, payload, use_jetstream, timeout))
+
+
+@pytest.mark.asyncio
+async def test_social_graph_cross_service_emits_enveloped_payloads(tmp_path, monkeypatch):
+    db = DBManager(str(tmp_path / "sg-envelope.db"))
+    await db.init_db()
+    pm = PersonaManager(db, friendly=1, playful=1)
+
+    svc = SocialGraphService(db_manager=db, persona_manager=pm)
+    svc._publisher = RecordingPublisher()
+    svc._subscriber = SimpleNamespace()
+
+    import deepthought.services.social_graph_service as sgsvc
+
+    monkeypatch.setattr(
+        sgsvc,
+        "analyze_social",
+        lambda _t: {"flirtation": 0.4, "avoidance": 0.1, "manipulation": 0.0},
+    )
+
+    msg = DummyMsg(InputReceivedPayload(user_input="hello", input_id="enveloped-1"))
+    await svc._handle_input(msg)
+
+    assert msg.acked
+    assert len(svc._publisher.calls) == 2
+    for _, payload, _, _ in svc._publisher.calls:
+        assert payload["trace_id"]
+        assert payload["event_id"]
+        assert payload["causation_id"]
+        assert payload["payload"]["input_id"] == "enveloped-1"
+
+    await db.close()

--- a/tests/unit/eda/test_event_contracts.py
+++ b/tests/unit/eda/test_event_contracts.py
@@ -6,6 +6,7 @@ from deepthought.eda.contracts import (
     decode_payload,
     decode_payload_or_envelope,
     to_canonical_subject,
+    validate_cross_service_envelope,
     validate_envelope,
 )
 from deepthought.eda.events import (
@@ -153,3 +154,20 @@ def test_decode_payload_or_envelope_accepts_enveloped_payload():
     assert payload["user_input"] == "hello"
     assert meta["trace_id"] == envelope.trace_id
     assert meta["producer"] == "discord_gateway"
+
+
+def test_cross_service_envelope_requires_trace_event_and_causation_ids():
+    envelope = EventEnvelope.build(
+        subject=CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED,
+        payload={"input_id": "i-1"},
+        producer="social_graph_service",
+    )
+    validated = validate_cross_service_envelope(CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED, envelope.__dict__)
+    assert validated.trace_id
+    assert validated.event_id
+    assert validated.causation_id
+
+
+def test_cross_service_envelope_rejects_raw_non_enveloped_payloads():
+    with pytest.raises(ValueError, match="Missing required key 'schema_version'"):
+        validate_cross_service_envelope(CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED, {"input_id": "i-1"})

--- a/tests/unit/eda/test_publisher.py
+++ b/tests/unit/eda/test_publisher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import types
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -22,7 +23,7 @@ sys.modules.setdefault("nats.aio", aio_mod)
 sys.modules.setdefault("nats.aio.client", client_mod)
 sys.modules.setdefault("nats.js.client", js_client_mod)
 
-from deepthought.eda.publisher import Publisher
+from deepthought.eda.publisher import Publisher, publish_enveloped  # noqa: E402
 
 
 class StubNATS:
@@ -37,9 +38,14 @@ class StubJS:
 
     def __init__(self) -> None:
         self.attempts = 0
+        self.last_subject = None
+        self.last_payload = None
 
     async def publish(self, subject, data, timeout=10.0):  # pragma: no cover - signature
         self.attempts += 1
+        self.last_subject = subject
+        if isinstance(data, bytes):
+            self.last_payload = json.loads(data.decode())
         if self.attempts < 2:
             raise RuntimeError("fail")
 
@@ -72,3 +78,24 @@ async def test_publish_raises_after_exhausting_retries():
 
     with pytest.raises(RuntimeError):
         await pub.publish("sub", b"data", retries=2)
+
+
+@pytest.mark.asyncio
+async def test_publish_enveloped_builds_required_envelope_metadata():
+    nc = StubNATS()
+    js = StubJS()
+    pub = Publisher(nc, js)
+
+    await publish_enveloped(
+        pub,
+        subject="dtr.social.signals.retrieved",
+        payload={"input_id": "in-1"},
+        producer="social_graph_service",
+    )
+
+    assert js.attempts == 2
+    assert js.last_subject == "dtr.social.signals.retrieved"
+    assert js.last_payload["trace_id"]
+    assert js.last_payload["event_id"]
+    assert js.last_payload["causation_id"]
+    assert js.last_payload["payload"]["input_id"] == "in-1"

--- a/tests/unit/services/test_perception_interpret_service.py
+++ b/tests/unit/services/test_perception_interpret_service.py
@@ -116,6 +116,13 @@ def test_perception_interpret_service_evicts_after_publish(monkeypatch):
 
     assert embeddings_msg.acked is True
     assert request_msg.acked is True
+    published = service._publisher.published[0]
+    assert published[0] == EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
+    envelope = published[1]
+    assert envelope["trace_id"]
+    assert envelope["event_id"]
+    assert envelope["causation_id"]
+    assert envelope["payload"]["input_id"] == "input-1"
     assert service.cache_metrics["cache_size"] == 0
     assert service.cache_metrics["evictions"] == 1
     assert service.cache_metrics["hit_rate"] == 1.0

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -63,14 +63,18 @@ async def test_handle_input_resolves_identity_from_payload_and_headers(tmp_path,
 
     update_subject, update_payload, _, _ = service._publisher.calls[0]
     assert update_subject == EventSubjects.SOCIAL_UPDATED
-    assert update_payload["input_id"] == "1"
-    assert update_payload["affinity"] == 1
+    assert update_payload["payload"]["input_id"] == "1"
+    assert update_payload["payload"]["affinity"] == 1
+    assert update_payload["trace_id"]
+    assert update_payload["event_id"]
+    assert update_payload["causation_id"]
 
     event_subject, payload, _, _ = service._publisher.calls[1]
     assert event_subject == EventSubjects.SOCIAL_SIGNALS_RETRIEVED
-    assert payload["input_id"] == "1"
-    assert payload["social_signals"]["affinity"] == 1
-    assert payload["social_signals"]["persona"] == "friendly"
+    assert payload["payload"]["input_id"] == "1"
+    assert payload["payload"]["social_signals"]["affinity"] == 1
+    assert payload["payload"]["social_signals"]["persona"] == "friendly"
+    assert payload["trace_id"]
 
     await db.close()
 
@@ -123,8 +127,8 @@ async def test_each_input_updates_social_state_exactly_once(tmp_path, monkeypatc
     assert len(service._publisher.calls) == 2
     assert service._publisher.calls[0][0] == EventSubjects.SOCIAL_UPDATED
     assert service._publisher.calls[1][0] == EventSubjects.SOCIAL_SIGNALS_RETRIEVED
-    assert service._publisher.calls[0][1]["input_id"] == "in-1"
-    assert service._publisher.calls[1][1]["input_id"] == "in-1"
+    assert service._publisher.calls[0][1]["payload"]["input_id"] == "in-1"
+    assert service._publisher.calls[1][1]["payload"]["input_id"] == "in-1"
 
     await db.close()
 
@@ -150,12 +154,12 @@ async def test_social_contract_update_and_retrieval_semantics(tmp_path, monkeypa
 
     updated = service._publisher.calls[0][1]
     retrieved = service._publisher.calls[1][1]
-    assert updated["input_id"] == "in-contract"
-    assert updated["perception"]["flirtation"] == pytest.approx(0.5)
-    assert "social_signals" not in updated
+    assert updated["payload"]["input_id"] == "in-contract"
+    assert updated["payload"]["perception"]["flirtation"] == pytest.approx(0.5)
+    assert "social_signals" not in updated["payload"]
 
-    assert retrieved["input_id"] == "in-contract"
-    assert retrieved["social_signals"]["perception"]["flirtation"] == pytest.approx(0.5)
-    assert retrieved["social_signals"]["affinity"] == updated["affinity"]
+    assert retrieved["payload"]["input_id"] == "in-contract"
+    assert retrieved["payload"]["social_signals"]["perception"]["flirtation"] == pytest.approx(0.5)
+    assert retrieved["payload"]["social_signals"]["affinity"] == updated["payload"]["affinity"]
 
     await db.close()


### PR DESCRIPTION
### Motivation
- Ensure all cross-service EDA traffic uses a canonical envelope that carries tracing and causation metadata so downstream services can rely on stable diagnostics and audit fields.
- Reduce duplicated envelope construction/validation across services by centralizing the build+validate+publish flow.
- Make the envelope-only invariant testable by failing CI when raw (non-enveloped) payloads are emitted across service boundaries.

### Description
- Require and default `causation_id` in `EventEnvelope.build(...)`, and add `validate_cross_service_envelope(subject, data)` to assert full envelope shape and subject alignment (`src/deepthought/eda/contracts/__init__.py`).
- Add `publish_enveloped(...)` helper to `src/deepthought/eda/publisher.py` which builds an `EventEnvelope`, validates it, and publishes it (with a compatibility fallback for publishers that don't accept a `retries` kwarg).
- Refactor publishers in `src/deepthought/services/social_graph_service.py` and `src/deepthought/services/perception_interpret_service.py` to emit envelopes via `publish_enveloped(...)` instead of publishing raw dict payloads.
- Extend/adjust unit and integration tests to assert envelope-only cross-service behavior and required fields, and update `docs/architecture.md` to document the envelope-only deployment invariant.

### Testing
- Ran linter checks with `ruff` on changed files and the checks passed.
- Executed the targeted pytest suite for updated tests (`tests/unit/eda/test_event_contracts.py`, `tests/unit/eda/test_publisher.py`, `tests/unit/services/test_social_graph_service.py`, `tests/unit/services/test_perception_interpret_service.py`, `tests/integration/test_social_graph_affinity.py`) and observed all tests in the suite passed (`40 passed`).
- Added and updated unit/integration assertions to ensure non-enveloped payloads are rejected and that emitted messages include `trace_id`, `event_id`, and `causation_id`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c6a722ac8326b52011d1edb7a2a5)