### PR TITLE
Add salience-driven memory lifecycle, consolidation, and retrieval prioritization

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -13,6 +13,7 @@ from .vector_store import (
     VectorStore,
     create_vector_store,
 )
+from .memory_lifecycle_policy import MemoryLifecyclePolicy, MemoryTier, ScoredMemoryEvent
 from .fact_extractor import (
     extract_typed_fact_triples_from_turn,
     build_user_fact_context,
@@ -32,6 +33,9 @@ __all__ = [
     "SimpleEmbeddingFunction",
     "TieredMemory",
     "create_memory_backend",
+    "MemoryLifecyclePolicy",
+    "MemoryTier",
+    "ScoredMemoryEvent",
     "build_user_fact_context",
     "extract_typed_fact_triples_from_turn",
     "extract_and_store_user_facts",

--- a/src/deepthought/memory/graph/adapters.py
+++ b/src/deepthought/memory/graph/adapters.py
@@ -5,7 +5,13 @@ from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from ...graph.connector import GraphConnector, Neo4jConnector
-from .store import GraphEntity, GraphEvidence, GraphFact, GraphMemoryStore, GraphRelation
+from .store import (
+    GraphEntity,
+    GraphEvidence,
+    GraphFact,
+    GraphMemoryStore,
+    GraphRelation,
+)
 
 
 class CypherGraphMemoryStore(GraphMemoryStore):
@@ -80,7 +86,9 @@ class CypherGraphMemoryStore(GraphMemoryStore):
                 {"object_id": fact.object_id, "fact_id": fact.fact_id},
             )
 
-    def retrieve_user_evidence(self, user_id: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+    def retrieve_user_evidence(
+        self, user_id: str, *, limit: int = 10
+    ) -> Sequence[GraphEvidence]:
         rows = self._connector.execute(
             "MATCH (u:Entity {id: $user_id})-[:HAS_FACT]->(f:Fact) "
             "OPTIONAL MATCH (f)-[:ABOUT]->(o:Entity) "
@@ -92,7 +100,9 @@ class CypherGraphMemoryStore(GraphMemoryStore):
         )
         return _rows_to_evidence(rows)
 
-    def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+    def retrieve_topic_evidence(
+        self, topic: str, *, limit: int = 10
+    ) -> Sequence[GraphEvidence]:
         rows = self._connector.execute(
             "MATCH (s:Entity)-[:HAS_FACT]->(f:Fact) "
             "WHERE toLower(f.predicate) CONTAINS toLower($topic) "
@@ -118,12 +128,16 @@ class InMemoryGraphMemoryStore(GraphMemoryStore):
         self.entities[entity.entity_id] = entity
 
     def upsert_relation(self, relation: GraphRelation) -> None:
-        self.relations[(relation.source_id, relation.relation_type, relation.target_id)] = relation
+        self.relations[
+            (relation.source_id, relation.relation_type, relation.target_id)
+        ] = relation
 
     def upsert_fact(self, fact: GraphFact) -> None:
         self.facts[fact.fact_id] = fact
 
-    def retrieve_user_evidence(self, user_id: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+    def retrieve_user_evidence(
+        self, user_id: str, *, limit: int = 10
+    ) -> Sequence[GraphEvidence]:
         out = [
             _fact_to_evidence(f)
             for f in self.facts.values()
@@ -131,7 +145,9 @@ class InMemoryGraphMemoryStore(GraphMemoryStore):
         ]
         return _rank_and_dedup(out, limit)
 
-    def retrieve_topic_evidence(self, topic: str, *, limit: int = 10) -> Sequence[GraphEvidence]:
+    def retrieve_topic_evidence(
+        self, topic: str, *, limit: int = 10
+    ) -> Sequence[GraphEvidence]:
         topic_l = topic.lower()
         out = []
         for fact in self.facts.values():
@@ -217,14 +233,22 @@ def _score(confidence: float, attrs: dict[str, Any]) -> float:
     observed = attrs.get("observed_at") or attrs.get("timestamp")
     if observed:
         try:
-            delta = datetime.now(timezone.utc) - datetime.fromisoformat(str(observed).replace("Z", "+00:00"))
+            delta = datetime.now(timezone.utc) - datetime.fromisoformat(
+                str(observed).replace("Z", "+00:00")
+            )
             recency_boost = max(0.0, 1.0 - min(delta.days / 365.0, 1.0)) * 0.1
         except Exception:
             recency_boost = 0.0
-    return round(float(confidence) + recency_boost, 6)
+    salience = float(attrs.get("salience", 0.0) or 0.0) * 0.3
+    summary_boost = (
+        0.2 if attrs.get("is_summary") or attrs.get("fact_type") == "summary" else 0.0
+    )
+    return round(float(confidence) + recency_boost + salience + summary_boost, 6)
 
 
-def _rank_and_dedup(evidences: Sequence[GraphEvidence], limit: int) -> list[GraphEvidence]:
+def _rank_and_dedup(
+    evidences: Sequence[GraphEvidence], limit: int
+) -> list[GraphEvidence]:
     dedup: dict[str, GraphEvidence] = {}
     for item in evidences:
         key = item.summary.strip().lower()

--- a/src/deepthought/memory/graph/retrieval.py
+++ b/src/deepthought/memory/graph/retrieval.py
@@ -5,11 +5,15 @@ from typing import Sequence
 from .store import GraphEvidence, GraphMemoryStore
 
 
-def retrieve_user_context(store: GraphMemoryStore, user_id: str, *, limit: int = 8) -> list[GraphEvidence]:
+def retrieve_user_context(
+    store: GraphMemoryStore, user_id: str, *, limit: int = 8
+) -> list[GraphEvidence]:
     return _rank_dedup(store.retrieve_user_evidence(user_id, limit=limit), limit)
 
 
-def retrieve_topic_context(store: GraphMemoryStore, topic: str, *, limit: int = 8) -> list[GraphEvidence]:
+def retrieve_topic_context(
+    store: GraphMemoryStore, topic: str, *, limit: int = 8
+) -> list[GraphEvidence]:
     return _rank_dedup(store.retrieve_topic_evidence(topic, limit=limit), limit)
 
 
@@ -20,14 +24,23 @@ def _rank_dedup(items: Sequence[GraphEvidence], limit: int) -> list[GraphEvidenc
         prev = dedup.get(key)
         if prev is None or item.score > prev.score:
             dedup[key] = item
-    ranked = sorted(
-        dedup.values(),
-        key=lambda i: (
-            bool(i.attributes.get("user_scoped")),
-            i.confidence >= 0.8,
+
+    def _sort_key(i: GraphEvidence) -> tuple[bool, float, bool, bool, float, float]:
+        attrs = i.attributes or {}
+        salience = float(attrs.get("salience", 0.0) or 0.0)
+        is_summary = (
+            bool(attrs.get("is_summary"))
+            or str(attrs.get("fact_type", "")) == "summary"
+        )
+        is_long_term = str(attrs.get("memory_tier", "")) == "long_term"
+        return (
+            is_summary,
+            salience,
+            is_long_term,
+            bool(attrs.get("user_scoped")),
             i.score,
             i.confidence,
-        ),
-        reverse=True,
-    )
+        )
+
+    ranked = sorted(dedup.values(), key=_sort_key, reverse=True)
     return ranked[:limit]

--- a/src/deepthought/memory/memory_lifecycle_policy.py
+++ b/src/deepthought/memory/memory_lifecycle_policy.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class MemoryTier(StrEnum):
+    EPHEMERAL = "ephemeral"
+    WORKING = "working"
+    LONG_TERM = "long_term"
+
+
+@dataclass(frozen=True)
+class ScoredMemoryEvent:
+    text: str
+    salience: float
+    tier: MemoryTier
+    reason_tags: tuple[str, ...]
+
+
+class MemoryLifecyclePolicy:
+    """Score memory events by conversational salience and assign a tier."""
+
+    _PREFERENCE_MARKERS = ("prefer", "favorite", "like", "love", "dislike", "hate")
+    _IDENTITY_MARKERS = ("i am", "i'm", "my name is", "call me", "i work", "i live")
+    _COMMITMENT_MARKERS = ("i will", "i'll", "i promise", "i commit", "remind me")
+    _UNRESOLVED_TASK_MARKERS = (
+        "todo",
+        "to-do",
+        "need to",
+        "pending",
+        "follow up",
+        "later",
+    )
+
+    def score_event(self, text: str) -> ScoredMemoryEvent:
+        raw = (text or "").strip()
+        lowered = raw.lower()
+        score = 0.05
+        reasons: list[str] = []
+
+        if any(marker in lowered for marker in self._PREFERENCE_MARKERS):
+            score += 0.35
+            reasons.append("user_preference")
+        if any(marker in lowered for marker in self._IDENTITY_MARKERS):
+            score += 0.35
+            reasons.append("identity_fact")
+        if any(marker in lowered for marker in self._COMMITMENT_MARKERS):
+            score += 0.30
+            reasons.append("commitment")
+        if any(marker in lowered for marker in self._UNRESOLVED_TASK_MARKERS):
+            score += 0.30
+            reasons.append("unresolved_task")
+
+        tier = self._tier_from_score(score)
+        return ScoredMemoryEvent(
+            text=raw, salience=min(score, 1.0), tier=tier, reason_tags=tuple(reasons)
+        )
+
+    @staticmethod
+    def _tier_from_score(score: float) -> MemoryTier:
+        if score >= 0.65:
+            return MemoryTier.LONG_TERM
+        if score >= 0.30:
+            return MemoryTier.WORKING
+        return MemoryTier.EPHEMERAL

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -19,7 +21,7 @@ from ..eda.events import (
     MemoryRetrievedPayload,
     PerceptionEmbeddingsPayload,
 )
-from ..memory import create_memory_backend
+from ..memory import MemoryLifecyclePolicy, MemoryTier, create_memory_backend
 from ..memory.fact_extractor import extract_typed_fact_triples_from_turn
 from ..memory.graph import (
     CypherGraphMemoryStore,
@@ -29,6 +31,7 @@ from ..memory.graph import (
     retrieve_user_context,
 )
 from ..memory.graph.pipeline import ingest_fact_triples
+from ..memory.graph.store import utc_now_iso
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
 from ..search import OfflineSearch
@@ -74,7 +77,9 @@ class CognitiveCoreService(BaseService):
                     try:
                         search = OfflineSearch.create_index(db_path, [])
                     except ValueError:
-                        logger.warning("No documents available for search index; disabling offline search")
+                        logger.warning(
+                            "No documents available for search index; disabling offline search"
+                        )
                         search = None
                 else:
                     search = OfflineSearch(db_path)
@@ -82,6 +87,17 @@ class CognitiveCoreService(BaseService):
         self._top_k = self._settings.memory_top_k
         self._input_enrichment = InputEnrichmentService()
         self._graph_memory = self._build_graph_memory_store()
+        self._lifecycle_policy = MemoryLifecyclePolicy()
+        self._tiered_turns: dict[
+            str, list[dict[str, str | float | tuple[str, ...]]]
+        ] = {
+            MemoryTier.EPHEMERAL: [],
+            MemoryTier.WORKING: [],
+            MemoryTier.LONG_TERM: [],
+        }
+        self._salience_summaries: list[dict[str, str | float]] = []
+        self._consolidation_task: asyncio.Task | None = None
+        self._consolidation_interval_s = 60.0
 
     def _build_graph_memory_store(self):
         backend = (self._settings.graph_backend or "").lower()
@@ -90,7 +106,9 @@ class CognitiveCoreService(BaseService):
                 graph_backend = getattr(self._memory, "graph_backend", None)
                 connector = None
                 if hasattr(graph_backend, "_dal"):
-                    connector = getattr(getattr(graph_backend, "_dal", None), "_connector", None)
+                    connector = getattr(
+                        getattr(graph_backend, "_dal", None), "_connector", None
+                    )
                 elif graph_backend is not None and hasattr(graph_backend, "_connector"):
                     connector = getattr(graph_backend, "_connector", None)
                 if connector is not None:
@@ -199,6 +217,84 @@ class CognitiveCoreService(BaseService):
             return snippets
         return snippets
 
+    def _ingest_with_lifecycle(
+        self, *, user_id: str, text: str, input_id: str, timestamp: str
+    ) -> None:
+        scored = self._lifecycle_policy.score_event(text)
+        bucket = self._tiered_turns[scored.tier]
+        bucket.append(
+            {
+                "user_id": str(user_id),
+                "text": text,
+                "input_id": input_id,
+                "timestamp": timestamp,
+                "salience": scored.salience,
+                "reasons": scored.reason_tags,
+            }
+        )
+        if scored.tier is MemoryTier.WORKING and len(bucket) > max(self._top_k * 3, 16):
+            del bucket[: -max(self._top_k * 3, 16)]
+
+    def run_consolidation_cycle(self) -> int:
+        archived = 0
+        stale_ephemeral = self._tiered_turns[MemoryTier.EPHEMERAL]
+        while stale_ephemeral and len(stale_ephemeral) > max(self._top_k, 8):
+            entry = stale_ephemeral.pop(0)
+            note = str(entry.get("text", ""))
+            self._salience_summaries.append(
+                {
+                    "summary": note[:220],
+                    "salience": float(entry.get("salience", 0.1)),
+                    "timestamp": str(entry.get("timestamp") or utc_now_iso()),
+                    "source_tier": MemoryTier.EPHEMERAL,
+                    "user_id": str(entry.get("user_id") or "anonymous"),
+                }
+            )
+            archived += 1
+        if len(self._salience_summaries) > 200:
+            self._salience_summaries = self._salience_summaries[-200:]
+        return archived
+
+    async def _consolidation_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._consolidation_interval_s)
+                archived = self.run_consolidation_cycle()
+                if archived:
+                    logger.debug("Consolidated %s low-salience turns", archived)
+        except asyncio.CancelledError:
+            return
+
+    def _prioritized_graph_facts(self, user_id: str, topic: str) -> list[str]:
+        summary_evidence = [
+            item
+            for item in self._salience_summaries
+            if (
+                item.get("user_id") == str(user_id)
+                and topic.lower() in str(item.get("summary", "")).lower()
+            )
+            or item.get("user_id") == str(user_id)
+        ]
+        summary_evidence = sorted(
+            summary_evidence,
+            key=lambda e: (float(e.get("salience", 0.0)), str(e.get("timestamp", ""))),
+            reverse=True,
+        )
+        summary_facts = [
+            f"summary: {item['summary']}" for item in summary_evidence[: self._top_k]
+        ]
+
+        graph_user_evidence = retrieve_user_context(
+            self._graph_memory, str(user_id), limit=self._top_k
+        )
+        graph_topic_evidence = retrieve_topic_context(
+            self._graph_memory, topic, limit=self._top_k
+        )
+        graph_facts = [
+            ev.summary for ev in [*graph_user_evidence, *graph_topic_evidence]
+        ]
+        return summary_facts + graph_facts
+
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
         start = time.perf_counter()
@@ -206,8 +302,12 @@ class CognitiveCoreService(BaseService):
             raw_data = json.loads(msg.data.decode())
             if not isinstance(raw_data, dict):
                 raise ValueError("InputReceived payload must be a dict")
-            decoded_payload, envelope_meta = decode_payload_or_envelope(EventSubjects.MEMORY_RETRIEVAL_REQUESTED, raw_data)
-            enriched = self._input_enrichment.parse_input_received_data(decoded_payload, headers=getattr(msg, "headers", None))
+            decoded_payload, envelope_meta = decode_payload_or_envelope(
+                EventSubjects.MEMORY_RETRIEVAL_REQUESTED, raw_data
+            )
+            enriched = self._input_enrichment.parse_input_received_data(
+                decoded_payload, headers=getattr(msg, "headers", None)
+            )
             input_id = enriched.input_id
             user_input = enriched.user_input
             user_id = enriched.user_id
@@ -216,10 +316,18 @@ class CognitiveCoreService(BaseService):
             logger.info("CognitiveCoreService received input %s", input_id)
 
             resolved_user_id = enriched.resolved_user_id
-            self._memory.store_interaction(user_input)
-            await self._db.store_memory(resolved_user_id, user_input)
-
             turn_timestamp = datetime.now(timezone.utc).isoformat()
+            self._memory.store_interaction(user_input)
+            self._ingest_with_lifecycle(
+                user_id=str(resolved_user_id),
+                text=user_input,
+                input_id=input_id,
+                timestamp=turn_timestamp,
+            )
+            scored = self._lifecycle_policy.score_event(user_input)
+            db_topic = f"tier:{scored.tier}"
+            await self._db.store_memory(resolved_user_id, user_input, topic=db_topic)
+
             ingest_conversation_turns(
                 [
                     {
@@ -240,14 +348,24 @@ class CognitiveCoreService(BaseService):
                 source_id=input_id,
             )
             if extracted_triples:
+                enriched_triples = []
+                for triple in extracted_triples:
+                    attrs = dict(triple.get("attributes", {}))
+                    attrs.setdefault("memory_tier", str(scored.tier))
+                    attrs.setdefault("salience", scored.salience)
+                    if scored.reason_tags:
+                        attrs.setdefault("salience_reasons", list(scored.reason_tags))
+                    enriched_triples.append({**triple, "attributes": attrs})
                 ingest_fact_triples(
-                    extracted_triples,
+                    enriched_triples,
                     self._graph_memory,
                     timestamp=turn_timestamp,
                     source_id=input_id,
                 )
 
-            memory_facts = self._memory.retrieve_context(user_input) if self._memory else []
+            memory_facts = (
+                self._memory.retrieve_context(user_input) if self._memory else []
+            )
             vector_facts: List[str] = []
             if self._search:
                 try:
@@ -255,10 +373,13 @@ class CognitiveCoreService(BaseService):
                 except Exception:  # pragma: no cover - defensive
                     logger.error("Offline search failed", exc_info=True)
 
-            db_facts = await self._db_context(resolved_user_id=resolved_user_id, channel_id=channel_id)
-            graph_user_evidence = retrieve_user_context(self._graph_memory, str(resolved_user_id), limit=self._top_k)
-            graph_topic_evidence = retrieve_topic_context(self._graph_memory, user_input, limit=self._top_k)
-            graph_facts = [ev.summary for ev in [*graph_user_evidence, *graph_topic_evidence]]
+            self.run_consolidation_cycle()
+            db_facts = await self._db_context(
+                resolved_user_id=resolved_user_id, channel_id=channel_id
+            )
+            graph_facts = self._prioritized_graph_facts(
+                str(resolved_user_id), user_input
+            )
 
             facts: List[str] = []
             merged_facts: dict[str, dict[str, List[str] | str]] = {}
@@ -275,7 +396,10 @@ class CognitiveCoreService(BaseService):
                     if not normalized:
                         continue
                     if normalized not in merged_facts:
-                        merged_facts[normalized] = {"text": str(item).strip(), "sources": [source]}
+                        merged_facts[normalized] = {
+                            "text": str(item).strip(),
+                            "sources": [source],
+                        }
                         continue
                     if source not in merged_facts[normalized]["sources"]:
                         merged_facts[normalized]["sources"].append(source)
@@ -283,8 +407,16 @@ class CognitiveCoreService(BaseService):
             for data in merged_facts.values():
                 source_tag = ",".join(data["sources"])
                 facts.append(f"[{source_tag}] {data['text']}")
-            trace_id = envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None
-            causation_id = envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else input_id
+            trace_id = (
+                envelope_meta.get("trace_id")
+                if isinstance(envelope_meta.get("trace_id"), str)
+                else None
+            )
+            causation_id = (
+                envelope_meta.get("event_id")
+                if isinstance(envelope_meta.get("event_id"), str)
+                else input_id
+            )
             payload = MemoryRetrievedPayload(
                 retrieved_knowledge={"facts": facts, "source": "cognitive_core"},
                 user_input=user_input,
@@ -341,7 +473,9 @@ class CognitiveCoreService(BaseService):
         finally:
             duration = time.perf_counter() - start
             INPUTS_TOTAL.labels(service="cognitive_core_service").inc()
-            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(duration)
+            INPUT_LATENCY_SECONDS.labels(service="cognitive_core_service").observe(
+                duration
+            )
 
     async def _handle_embeddings(self, msg: Msg) -> None:
         """Store perception embeddings in the vector store and knowledge graph."""
@@ -362,7 +496,9 @@ class CognitiveCoreService(BaseService):
                     ids = [f"{message_id}:{idx}" for idx in range(len(vectors))]
                     missing = getattr(store, "missing_ids", lambda x: list(x))(ids)
                     if missing:
-                        new_vectors = [v for v, _id in zip(vectors, ids) if _id in missing]
+                        new_vectors = [
+                            v for v, _id in zip(vectors, ids) if _id in missing
+                        ]
                         store.upsert_vectors(new_vectors, missing)
 
             # Insert nodes/edges in the KG with modality and timestamp metadata
@@ -421,7 +557,9 @@ class CognitiveCoreService(BaseService):
         """React to BDI_INTENTION events by logging the goal."""
         try:
             payload = BDIIntentionPayload.from_json(msg.data.decode())
-            logger.info("CognitiveCoreService received intention goal: %s", payload.goal)
+            logger.info(
+                "CognitiveCoreService received intention goal: %s", payload.goal
+            )
             if hasattr(msg, "ack") and callable(msg.ack):
                 await msg.ack()
         except Exception:
@@ -465,10 +603,21 @@ class CognitiveCoreService(BaseService):
         )
         started = await super().start()
         if started:
-            logger.info("CognitiveCoreService subscribed to %s", EventSubjects.MEMORY_RETRIEVAL_REQUESTED)
+            logger.info(
+                "CognitiveCoreService subscribed to %s",
+                EventSubjects.MEMORY_RETRIEVAL_REQUESTED,
+            )
+            if self._consolidation_task is None or self._consolidation_task.done():
+                self._consolidation_task = asyncio.create_task(
+                    self._consolidation_loop()
+                )
         return started
 
     async def stop(self) -> None:
+        if self._consolidation_task and not self._consolidation_task.done():
+            self._consolidation_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._consolidation_task
         try:
             backend = getattr(self._memory, "graph_backend", None)
             connector = None

--- a/tests/integration/test_memory_lifecycle_flow.py
+++ b/tests/integration/test_memory_lifecycle_flow.py
@@ -1,0 +1,94 @@
+import json
+
+import pytest
+
+from deepthought.config import Settings
+from deepthought.services.cognitive_core_service import CognitiveCoreService
+
+
+class DummyNATS:
+    is_connected = True
+
+
+class DummyJS:
+    pass
+
+
+class DummyPublisher:
+    def __init__(self):
+        self.published = []
+
+    async def publish(self, subject, payload, use_jetstream=True, timeout=10.0):
+        self.published.append((subject, payload))
+
+
+class DummyMemory:
+    def __init__(self):
+        self.interactions = []
+
+    def store_interaction(self, text):
+        self.interactions.append(text)
+
+    def retrieve_context(self, prompt):
+        return self.interactions[-3:]
+
+
+class DummyDB:
+    def __init__(self):
+        self.memories_by_user = {}
+
+    async def store_memory(self, user_id, memory, topic="", sentiment_score=None):
+        self.memories_by_user.setdefault(str(user_id), []).append((topic, memory))
+
+    async def recall_user(self, user_id, limit=None):
+        rows = list(reversed(self.memories_by_user.get(str(user_id), [])))
+        if limit is not None:
+            rows = rows[: int(limit)]
+        return rows
+
+    async def close(self):
+        return None
+
+
+class DummyMsg:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode()
+        self.acked = False
+
+    async def ack(self):
+        self.acked = True
+
+
+@pytest.mark.asyncio
+async def test_memory_lifecycle_consolidation_and_summary_prioritization():
+    svc = CognitiveCoreService(
+        DummyNATS(), DummyJS(), Settings(), memory=DummyMemory(), db=DummyDB()
+    )
+    svc._publisher = DummyPublisher()
+    svc._consolidation_interval_s = 0.01
+
+    for idx in range(14):
+        payload = {
+            "user_input": f"small talk {idx}",
+            "input_id": f"ep-{idx}",
+            "user_id": "u-flow",
+        }
+        await svc._handle_input(DummyMsg(payload))
+
+    await svc._handle_input(
+        DummyMsg(
+            {
+                "user_input": "My favorite editor is vim and I will follow up later",
+                "input_id": "salient-1",
+                "user_id": "u-flow",
+            }
+        )
+    )
+
+    assert svc._salience_summaries
+    assert svc._tiered_turns["ephemeral"]
+    facts = svc._publisher.published[-1][1]["payload"]["retrieved_knowledge"]["facts"]
+    assert any("summary:" in fact for fact in facts)
+    assert any(
+        "tier:long_term" in topic for topic, _ in svc._db.memories_by_user["u-flow"]
+    )

--- a/tests/test_memgraph_service.py
+++ b/tests/test_memgraph_service.py
@@ -2,19 +2,67 @@ import os
 
 import pytest
 
+from deepthought.memory import MemoryLifecyclePolicy, MemoryTier
+from deepthought.memory.graph import InMemoryGraphMemoryStore, retrieve_user_context
+from deepthought.memory.graph.store import GraphEvidence, Provenance
 from tests.helpers import memgraph_available
 
-# Skip this test when ``pymemgraph`` is not installed
-pymemgraph = pytest.importorskip("pymemgraph")
-Memgraph = pymemgraph.Memgraph
 
-pytestmark = pytest.mark.memgraph
+def test_memory_lifecycle_policy_scores_salient_events_higher():
+    policy = MemoryLifecyclePolicy()
+
+    low = policy.score_event("weather is okay")
+    high = policy.score_event(
+        "My favorite editor is vim and I will finish this TODO later"
+    )
+
+    assert high.salience > low.salience
+    assert high.tier == MemoryTier.LONG_TERM
+    assert low.tier == MemoryTier.EPHEMERAL
+    assert "user_preference" in high.reason_tags
+    assert "unresolved_task" in high.reason_tags
 
 
+def test_retrieval_prioritizes_summary_evidence_over_raw_logs():
+    store = InMemoryGraphMemoryStore()
+    summary = GraphEvidence(
+        evidence_id="s1",
+        summary="summary: prefers tea over coffee",
+        entity_id="u1",
+        relation_type="summary",
+        score=0.7,
+        confidence=0.8,
+        provenance=Provenance(source="consolidation"),
+        attributes={
+            "is_summary": True,
+            "salience": 0.9,
+            "memory_tier": "long_term",
+            "user_scoped": True,
+        },
+    )
+    raw = GraphEvidence(
+        evidence_id="r1",
+        summary="chat turn: tea is nice",
+        entity_id="u1",
+        relation_type="observation",
+        score=0.85,
+        confidence=0.9,
+        provenance=Provenance(source="raw"),
+        attributes={"salience": 0.1, "memory_tier": "ephemeral", "user_scoped": True},
+    )
+
+    store.retrieve_user_evidence = lambda user_id, limit=10: [raw, summary]  # type: ignore[method-assign]
+    ordered = retrieve_user_context(store, "u1", limit=2)
+
+    assert ordered[0].summary.startswith("summary:")
+
+
+@pytest.mark.memgraph
 def test_memgraph_running():
+    pymemgraph = pytest.importorskip("pymemgraph")
     if not memgraph_available():
         pytest.skip("Memgraph not available")
-    mg = Memgraph(
+    mg = pymemgraph.Memgraph(
         host=os.getenv("MG_HOST", "localhost"),
         port=int(os.getenv("MG_PORT", 7687)),
         username=os.getenv("MG_USER", "memgraph"),


### PR DESCRIPTION
### Motivation
- Improve memory retention by scoring conversational events for salience and routing them into tiers (ephemeral / working / long_term) instead of storing everything equally.
- Reduce storage/noise by periodically consolidating low-salience turns into compact summaries and removing/archiving raw entries.
- Surface high-salience summaries and long-term facts earlier during retrieval so downstream components see the most relevant user context first.

### Description
- Added `MemoryLifecyclePolicy` at `src/deepthought/memory/memory_lifecycle_policy.py` providing `MemoryTier`, `ScoredMemoryEvent`, and `score_event()` to detect preferences, identity, commitments and unresolved tasks and map events to tiers.
- Updated `CognitiveCoreService` to classify and route ingested turns through the lifecycle policy, store tier metadata (DB topic `tier:<tier>`), enrich extracted fact triples with `memory_tier`/`salience` attributes, maintain in-memory tier buckets, and run a periodic consolidation loop that summarizes low-salience ephemeral turns into compact notes.
- Extended graph retrieval and scoring logic in `memory/graph` to prioritize `is_summary`, higher `salience`, and `long_term` entries ahead of raw logs, and updated score calculations to incorporate salience and summary boosts.
- Exported lifecycle primitives from the memory package and added tests: unit checks for scoring and retrieval ordering in `tests/test_memgraph_service.py` and an integration flow exercising tiering, consolidation and retrieval prioritization in `tests/integration/test_memory_lifecycle_flow.py`.

### Testing
- Ran linter checks with `python -m ruff check ...` against modified modules and the new tests and verified no issues (`All checks passed`).
- Ran targeted test suite with `python -m pytest tests/test_memgraph_service.py tests/integration/test_memory_lifecycle_flow.py tests/unit/services/test_cognitive_core_service.py -q` and observed `9 passed, 1 skipped`.
- Added formatting via `ruff format` on the changed files before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2cbae5d048326bff8f03c229f75f4)