### PR TITLE
Unify memory facts across backends with canonical schema and deterministic dedup

### DIFF
--- a/src/deepthought/fact_schema.py
+++ b/src/deepthought/fact_schema.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CanonicalFact:
+    id: str
+    subject: str
+    predicate: str
+    object_value: str | None = None
+    object_id: str | None = None
+    provenance: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 1.0
+    created_at: str = ""
+    updated_at: str = ""
+    dedup_key: str = ""
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def normalized_atom(value: Any) -> str:
+    return " ".join(str(value or "").strip().lower().split())
+
+
+def canonical_fact_dedup_key(subject: str, predicate: str, object_value: str | None, object_id: str | None = None) -> str:
+    payload = "|".join(
+        [
+            normalized_atom(subject),
+            normalized_atom(predicate),
+            normalized_atom(object_id),
+            normalized_atom(object_value),
+        ]
+    )
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def canonical_fact_id(subject: str, predicate: str, object_value: str | None, object_id: str | None = None) -> str:
+    return canonical_fact_dedup_key(subject, predicate, object_value, object_id)
+
+
+def make_canonical_fact(
+    *,
+    subject: str,
+    predicate: str,
+    object_value: str | None = None,
+    object_id: str | None = None,
+    provenance: dict[str, Any] | None = None,
+    confidence: float = 1.0,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    attributes: dict[str, Any] | None = None,
+    id: str | None = None,
+) -> CanonicalFact:
+    now = utc_now_iso()
+    created = created_at or now
+    dedup_key = canonical_fact_dedup_key(subject, predicate, object_value, object_id)
+    return CanonicalFact(
+        id=id or canonical_fact_id(subject, predicate, object_value, object_id),
+        subject=str(subject),
+        predicate=str(predicate),
+        object_value=object_value,
+        object_id=object_id,
+        provenance=dict(provenance or {}),
+        confidence=float(confidence),
+        created_at=created,
+        updated_at=updated_at or created,
+        dedup_key=dedup_key,
+        attributes=dict(attributes or {}),
+    )
+
+
+def format_fact_snippet(fact: CanonicalFact) -> str:
+    obj = fact.object_value or fact.object_id or ""
+    if obj:
+        return f"{fact.predicate}: {obj}"
+    return fact.predicate

--- a/src/deepthought/memory/graph/__init__.py
+++ b/src/deepthought/memory/graph/__init__.py
@@ -2,6 +2,7 @@ from .adapters import CypherGraphMemoryStore, InMemoryGraphMemoryStore
 from .migration import migrate_sqlite_memories_to_graph
 from .pipeline import ingest_conversation_turns
 from .retrieval import retrieve_topic_context, retrieve_user_context
+from .facts import CanonicalFact, canonical_fact_dedup_key, canonical_fact_id, make_canonical_fact
 from .store import (
     GraphEntity,
     GraphEvidence,
@@ -13,6 +14,10 @@ from .store import (
 )
 
 __all__ = [
+    "CanonicalFact",
+    "canonical_fact_dedup_key",
+    "canonical_fact_id",
+    "make_canonical_fact",
     "GraphMemoryStore",
     "GraphEntity",
     "GraphRelation",

--- a/src/deepthought/memory/graph/adapters.py
+++ b/src/deepthought/memory/graph/adapters.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Any, Sequence
 
 from ...graph.connector import GraphConnector, Neo4jConnector
+from ...fact_schema import format_fact_snippet
 from .store import (
     GraphEntity,
     GraphEvidence,
@@ -59,31 +60,33 @@ class CypherGraphMemoryStore(GraphMemoryStore):
 
     def upsert_fact(self, fact: GraphFact) -> None:
         self._connector.execute(
-            "MERGE (s:Entity {id: $subject_id}) "
-            "MERGE (f:Fact {id: $fact_id}) "
-            "SET f.predicate = $predicate, f.fact_type = $fact_type, f.attributes = $attributes, "
-            "f.confidence = $confidence, f.valid_from = $valid_from, f.valid_to = $valid_to, "
-            "f.provenance = $provenance, f.object_value = $object_value "
+            "MERGE (s:Entity {id: $subject}) "
+            "MERGE (f:Fact {dedup_key: $dedup_key}) "
+            "ON CREATE SET f.id = $id, f.created_at = $created_at "
+            "SET f.subject = $subject, f.predicate = $predicate, f.attributes = $attributes, "
+            "f.confidence = $confidence, f.updated_at = $updated_at, f.provenance = $provenance, "
+            "f.object_value = $object_value, f.object_id = $object_id, f.dedup_key = $dedup_key "
             "MERGE (s)-[:HAS_FACT]->(f)",
             {
-                "subject_id": fact.subject_id,
-                "fact_id": fact.fact_id,
+                "id": fact.id,
+                "subject": fact.subject,
                 "predicate": fact.predicate,
-                "fact_type": fact.fact_type,
+                "object_id": fact.object_id,
+                "object_value": fact.object_value,
                 "attributes": fact.attributes,
                 "confidence": fact.confidence,
-                "valid_from": fact.temporal.valid_from,
-                "valid_to": fact.temporal.valid_to,
-                "provenance": asdict(fact.provenance),
-                "object_value": fact.object_value,
+                "created_at": fact.created_at,
+                "updated_at": fact.updated_at,
+                "provenance": fact.provenance,
+                "dedup_key": fact.dedup_key,
             },
         )
         if fact.object_id:
             self._connector.execute(
                 "MERGE (o:Entity {id: $object_id}) "
-                "MERGE (f:Fact {id: $fact_id}) "
+                "MERGE (f:Fact {dedup_key: $dedup_key}) "
                 "MERGE (f)-[:ABOUT]->(o)",
-                {"object_id": fact.object_id, "fact_id": fact.fact_id},
+                {"object_id": fact.object_id, "dedup_key": fact.dedup_key},
             )
 
     def retrieve_user_evidence(
@@ -92,10 +95,11 @@ class CypherGraphMemoryStore(GraphMemoryStore):
         rows = self._connector.execute(
             "MATCH (u:Entity {id: $user_id})-[:HAS_FACT]->(f:Fact) "
             "OPTIONAL MATCH (f)-[:ABOUT]->(o:Entity) "
-            "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
+            "RETURN coalesce(f.id, f.dedup_key) AS evidence_id, f.subject AS subject, "
+            "f.predicate AS predicate, f.object_value AS object_value, "
             "o.id AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
-            "f.attributes AS attributes, f.valid_from AS valid_from, f.fact_type AS fact_type, u.id AS subject_id "
-            "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
+            "f.attributes AS attributes, f.created_at AS created_at, f.updated_at AS updated_at "
+            "ORDER BY f.confidence DESC, f.updated_at DESC LIMIT $limit",
             {"user_id": user_id, "limit": limit},
         )
         return _rows_to_evidence(rows)
@@ -107,10 +111,11 @@ class CypherGraphMemoryStore(GraphMemoryStore):
             "MATCH (s:Entity)-[:HAS_FACT]->(f:Fact) "
             "WHERE toLower(f.predicate) CONTAINS toLower($topic) "
             "OR toLower(coalesce(f.object_value, '')) CONTAINS toLower($topic) "
-            "RETURN f.id AS evidence_id, f.predicate AS predicate, f.object_value AS object_value, "
-            "NULL AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
-            "f.attributes AS attributes, f.valid_from AS valid_from, f.fact_type AS fact_type, s.id AS subject_id "
-            "ORDER BY f.confidence DESC, f.valid_from DESC LIMIT $limit",
+            "RETURN coalesce(f.id, f.dedup_key) AS evidence_id, f.subject AS subject, "
+            "f.predicate AS predicate, f.object_value AS object_value, "
+            "f.object_id AS object_id, f.confidence AS confidence, f.provenance AS provenance, "
+            "f.attributes AS attributes, f.created_at AS created_at, f.updated_at AS updated_at "
+            "ORDER BY f.confidence DESC, f.updated_at DESC LIMIT $limit",
             {"topic": topic, "limit": limit},
         )
         return _rows_to_evidence(rows)
@@ -133,7 +138,9 @@ class InMemoryGraphMemoryStore(GraphMemoryStore):
         ] = relation
 
     def upsert_fact(self, fact: GraphFact) -> None:
-        self.facts[fact.fact_id] = fact
+        prev = self.facts.get(fact.dedup_key)
+        if prev is None or fact.updated_at >= prev.updated_at:
+            self.facts[fact.dedup_key] = fact
 
     def retrieve_user_evidence(
         self, user_id: str, *, limit: int = 10
@@ -141,7 +148,7 @@ class InMemoryGraphMemoryStore(GraphMemoryStore):
         out = [
             _fact_to_evidence(f)
             for f in self.facts.values()
-            if f.subject_id == user_id or f.object_id == user_id
+            if f.subject == user_id or f.object_id == user_id
         ]
         return _rank_and_dedup(out, limit)
 
@@ -167,15 +174,17 @@ def _rows_to_evidence(rows: Sequence[Any]) -> list[GraphEvidence]:
     evidences = []
     for row in rows:
         evidence_id = _row_get(row, "evidence_id", "")
+        subject = _row_get(row, "subject", "")
         predicate = _row_get(row, "predicate", "fact")
         object_value = _row_get(row, "object_value", "")
         confidence = float(_row_get(row, "confidence", 0.5) or 0.5)
         provenance = _row_get(row, "provenance", {}) or {}
         attrs = _row_get(row, "attributes", {}) or {}
         attrs = dict(attrs)
-        attrs.setdefault("fact_type", _row_get(row, "fact_type", "observation"))
-        attrs.setdefault("subject_id", _row_get(row, "subject_id"))
-        attrs.setdefault("user_scoped", bool(attrs.get("subject_id")))
+        attrs.setdefault("subject", subject)
+        attrs.setdefault("user_scoped", bool(subject))
+        attrs.setdefault("created_at", _row_get(row, "created_at"))
+        attrs.setdefault("updated_at", _row_get(row, "updated_at"))
         summary = f"{predicate}: {object_value}".strip()
         evidences.append(
             GraphEvidence(
@@ -211,26 +220,26 @@ def _row_get(row: Any, key: str, default: Any = None) -> Any:
 
 
 def _fact_to_evidence(fact: GraphFact) -> GraphEvidence:
-    summary = fact.object_value or fact.object_id or ""
     attrs = dict(fact.attributes)
-    attrs.setdefault("fact_type", fact.fact_type)
-    attrs.setdefault("subject_id", fact.subject_id)
+    attrs.setdefault("subject", fact.subject)
     attrs.setdefault("user_scoped", True)
+    attrs.setdefault("created_at", fact.created_at)
+    attrs.setdefault("updated_at", fact.updated_at)
     return GraphEvidence(
-        evidence_id=fact.fact_id,
-        summary=f"{fact.predicate}: {summary}",
+        evidence_id=fact.id,
+        summary=format_fact_snippet(fact),
         entity_id=fact.object_id,
         relation_type=fact.predicate,
         score=_score(fact.confidence, fact.attributes),
         confidence=fact.confidence,
-        provenance=fact.provenance,
+        provenance=_prov_from_any(fact.provenance),
         attributes=attrs,
     )
 
 
 def _score(confidence: float, attrs: dict[str, Any]) -> float:
     recency_boost = 0.0
-    observed = attrs.get("observed_at") or attrs.get("timestamp")
+    observed = attrs.get("observed_at") or attrs.get("updated_at") or attrs.get("timestamp")
     if observed:
         try:
             delta = datetime.now(timezone.utc) - datetime.fromisoformat(
@@ -240,10 +249,7 @@ def _score(confidence: float, attrs: dict[str, Any]) -> float:
         except Exception:
             recency_boost = 0.0
     salience = float(attrs.get("salience", 0.0) or 0.0) * 0.3
-    summary_boost = (
-        0.2 if attrs.get("is_summary") or attrs.get("fact_type") == "summary" else 0.0
-    )
-    return round(float(confidence) + recency_boost + salience + summary_boost, 6)
+    return round(float(confidence) + recency_boost + salience, 6)
 
 
 def _rank_and_dedup(

--- a/src/deepthought/memory/graph/facts.py
+++ b/src/deepthought/memory/graph/facts.py
@@ -1,0 +1,19 @@
+from ...fact_schema import (
+    CanonicalFact,
+    canonical_fact_dedup_key,
+    canonical_fact_id,
+    format_fact_snippet,
+    make_canonical_fact,
+    normalized_atom,
+    utc_now_iso,
+)
+
+__all__ = [
+    "CanonicalFact",
+    "utc_now_iso",
+    "normalized_atom",
+    "canonical_fact_dedup_key",
+    "canonical_fact_id",
+    "make_canonical_fact",
+    "format_fact_snippet",
+]

--- a/src/deepthought/memory/graph/pipeline.py
+++ b/src/deepthought/memory/graph/pipeline.py
@@ -4,6 +4,7 @@ import hashlib
 from typing import Any, Iterable, Sequence
 
 from ..fact_extractor import extract_typed_fact_triples_from_turn
+from ...fact_schema import make_canonical_fact
 from .store import GraphEntity, GraphFact, GraphMemoryStore, GraphRelation, Provenance, TemporalValidity, utc_now_iso
 
 
@@ -74,21 +75,27 @@ def ingest_fact_triples(
                     temporal=TemporalValidity(valid_from=timestamp),
                 )
             )
-        fact_id = _stable_id(triple["subject_id"], triple["predicate"], str(obj_id or triple.get("object_value")))
-        store.upsert_fact(
-            GraphFact(
-                fact_id=fact_id,
-                subject_id=triple["subject_id"],
-                predicate=triple["predicate"],
-                object_id=obj_id,
-                object_value=triple.get("object_value"),
-                fact_type=triple.get("fact_type", "profile"),
-                attributes={**triple.get("attributes", {}), "timestamp": timestamp},
-                provenance=subject.provenance,
-                confidence=float(triple.get("confidence", 0.7)),
-                temporal=TemporalValidity(valid_from=timestamp),
-            )
+
+        canonical = make_canonical_fact(
+            subject=triple["subject_id"],
+            predicate=triple["predicate"],
+            object_id=obj_id,
+            object_value=triple.get("object_value"),
+            provenance={
+                "source": "conversation_turn",
+                "source_id": source_id,
+                "observed_at": timestamp,
+            },
+            confidence=float(triple.get("confidence", 0.7)),
+            created_at=timestamp,
+            updated_at=timestamp,
+            attributes={
+                **triple.get("attributes", {}),
+                "timestamp": timestamp,
+                "fact_type": triple.get("fact_type", "profile"),
+            },
         )
+        store.upsert_fact(GraphFact(**canonical.__dict__))
         upserts += 1
     return upserts
 

--- a/src/deepthought/memory/graph/store.py
+++ b/src/deepthought/memory/graph/store.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Protocol, Sequence
 
+from ...fact_schema import CanonicalFact
+
 
 @dataclass(frozen=True)
 class Provenance:
@@ -41,17 +43,8 @@ class GraphRelation:
 
 
 @dataclass(frozen=True)
-class GraphFact:
-    fact_id: str
-    subject_id: str
-    predicate: str
-    object_id: str | None = None
-    object_value: str | None = None
-    fact_type: str = "observation"
-    attributes: dict[str, Any] = field(default_factory=dict)
-    provenance: Provenance = field(default_factory=lambda: Provenance(source="unknown"))
-    confidence: float = 1.0
-    temporal: TemporalValidity = field(default_factory=TemporalValidity)
+class GraphFact(CanonicalFact):
+    """Backward-compatible alias for canonical fact records."""
 
 
 @dataclass(frozen=True)

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -31,6 +31,7 @@ from ..memory.graph import (
     retrieve_user_context,
 )
 from ..memory.graph.pipeline import ingest_fact_triples
+from ..fact_schema import format_fact_snippet, make_canonical_fact
 from ..memory.graph.store import utc_now_iso
 from ..memory.tiered import TieredMemory
 from ..metrics.prometheus import INPUT_LATENCY_SECONDS, INPUTS_TOTAL
@@ -190,8 +191,15 @@ class CognitiveCoreService(BaseService):
             for topic, memory in rows:
                 if not memory or not str(memory).strip():
                     continue
-                entry = f"[{topic}] {memory}" if topic else str(memory)
-                db_snippets.append(entry.strip())
+                fact = make_canonical_fact(
+                    subject=str(user_id),
+                    predicate="memory_note",
+                    object_value=str(memory),
+                    provenance={"source": "db_context"},
+                    confidence=0.6,
+                    attributes={"topic": topic},
+                )
+                db_snippets.append(format_fact_snippet(fact))
 
         merged: List[str] = []
         seen = set()
@@ -212,7 +220,19 @@ class CognitiveCoreService(BaseService):
         if self._db is None or resolved_user_id is None:
             return []
         rows = await self._db.recall_user(resolved_user_id, limit=self._top_k)
-        snippets = [m[1] for m in rows if len(m) > 1 and m[1]]
+        snippets = []
+        for m in rows:
+            if len(m) <= 1 or not m[1]:
+                continue
+            fact = make_canonical_fact(
+                subject=str(resolved_user_id),
+                predicate="memory_note",
+                object_value=str(m[1]),
+                provenance={"source": "db_context"},
+                confidence=0.6,
+                attributes={"topic": m[0]},
+            )
+            snippets.append(format_fact_snippet(fact))
         if channel_id is None:
             return snippets
         return snippets
@@ -290,9 +310,20 @@ class CognitiveCoreService(BaseService):
         graph_topic_evidence = retrieve_topic_context(
             self._graph_memory, topic, limit=self._top_k
         )
-        graph_facts = [
-            ev.summary for ev in [*graph_user_evidence, *graph_topic_evidence]
-        ]
+        graph_facts = []
+        for ev in [*graph_user_evidence, *graph_topic_evidence]:
+            fact = make_canonical_fact(
+                subject=str(ev.attributes.get("subject") or user_id),
+                predicate=str(ev.relation_type or "fact"),
+                object_value=str(ev.summary.split(":", 1)[-1].strip() if ":" in ev.summary else ev.summary),
+                object_id=ev.entity_id,
+                provenance={"source": ev.provenance.source, "source_id": ev.provenance.source_id, "observed_at": ev.provenance.observed_at},
+                confidence=ev.confidence,
+                created_at=str(ev.attributes.get("created_at") or ev.attributes.get("timestamp") or utc_now_iso()),
+                updated_at=str(ev.attributes.get("updated_at") or ev.attributes.get("timestamp") or utc_now_iso()),
+                attributes=dict(ev.attributes),
+            )
+            graph_facts.append(format_fact_snippet(fact))
         return summary_facts + graph_facts
 
     async def _handle_input(self, msg: Msg) -> None:

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping
 import aiosqlite
 
 from ..config import get_settings
+from ..fact_schema import make_canonical_fact
 
 SENTIMENT_BACKEND = os.getenv("SENTIMENT_BACKEND", "textblob").lower()
 try:  # Optional dependency
@@ -145,6 +146,21 @@ class DBManager:
             memory TEXT,
             sentiment_score REAL,
             timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        )
+        """,
+        """
+        CREATE TABLE IF NOT EXISTS fact_records (
+            id TEXT PRIMARY KEY,
+            dedup_key TEXT UNIQUE,
+            subject TEXT NOT NULL,
+            predicate TEXT NOT NULL,
+            object_value TEXT,
+            object_id TEXT,
+            provenance TEXT,
+            confidence REAL DEFAULT 1.0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            attributes TEXT
         )
         """,
         """
@@ -352,6 +368,7 @@ class DBManager:
                 for query in self.CREATE_TABLE_QUERIES:
                     await self._db.execute(query)
                 await self._ensure_relationship_columns()
+                await self._ensure_fact_records_migration()
                 await self._db.execute("INSERT OR IGNORE INTO trust_config (id) VALUES (1)")
                 await self._db.execute("INSERT OR IGNORE INTO interaction_decay (id) VALUES (1)")
                 await self._db.commit()
@@ -361,6 +378,60 @@ class DBManager:
         if self._db is not None:
             await self._db.close()
             self._db = None
+
+    async def _ensure_fact_records_migration(self) -> None:
+        """Backfill canonical fact rows from legacy memories table."""
+        assert self._db is not None
+        async with self._db.execute("SELECT COUNT(*) FROM fact_records") as cur:
+            row = await cur.fetchone()
+        if row and int(row[0] or 0) > 0:
+            return
+
+        async with self._db.execute(
+            "SELECT user_id, topic, memory, sentiment_score, timestamp FROM memories ORDER BY timestamp ASC"
+        ) as cur:
+            rows = await cur.fetchall()
+
+        for row in rows:
+            topic = str(row["topic"] or "")
+            memory = str(row["memory"] or "")
+            timestamp = str(row["timestamp"] or datetime.utcnow().isoformat())
+            fact = make_canonical_fact(
+                subject=str(row["user_id"] or "anonymous"),
+                predicate="memory_note",
+                object_value=memory,
+                provenance={"source": "sqlite_memories", "observed_at": timestamp},
+                confidence=0.6,
+                created_at=timestamp,
+                updated_at=timestamp,
+                attributes={"topic": topic, "sentiment_score": row["sentiment_score"]},
+            )
+            await self._db.execute(
+                """
+                INSERT INTO fact_records (
+                    id, dedup_key, subject, predicate, object_value, object_id,
+                    provenance, confidence, created_at, updated_at, attributes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(dedup_key) DO UPDATE SET
+                    confidence=MAX(confidence, excluded.confidence),
+                    updated_at=excluded.updated_at,
+                    provenance=excluded.provenance,
+                    attributes=excluded.attributes
+                """,
+                (
+                    fact.id,
+                    fact.dedup_key,
+                    fact.subject,
+                    fact.predicate,
+                    fact.object_value,
+                    fact.object_id,
+                    json.dumps(fact.provenance),
+                    fact.confidence,
+                    fact.created_at,
+                    fact.updated_at,
+                    json.dumps(fact.attributes),
+                ),
+            )
 
     async def _ensure_relationship_columns(self) -> None:
         """Add new columns to the relationships table if they don't exist."""
@@ -572,14 +643,18 @@ class DBManager:
             return []
 
         assert self._db
-        query = "SELECT topic, memory FROM memories WHERE user_id=? ORDER BY timestamp DESC"
+        query = (
+            "SELECT json_extract(attributes, '$.topic') as topic, object_value as memory "
+            "FROM fact_records WHERE subject=? ORDER BY updated_at DESC"
+        )
         params: list[str | int] = [str(user_id)]
         if limit is not None:
             query += " LIMIT ?"
             params.append(int(limit))
 
         async with self._db.execute(query, params) as cur:
-            return await cur.fetchall()
+            rows = await cur.fetchall()
+        return [(str(r[0] or ""), str(r[1] or "")) for r in rows]
 
     async def store_memory(
         self,
@@ -605,6 +680,43 @@ class DBManager:
         await self._db.execute(
             "INSERT INTO memories (user_id, topic, memory, sentiment_score) VALUES (?, ?, ?, ?)",
             (str(user_id), topic, memory, sentiment_score),
+        )
+        timestamp = datetime.utcnow().replace(microsecond=0).isoformat()
+        fact = make_canonical_fact(
+            subject=str(user_id),
+            predicate="memory_note",
+            object_value=memory.strip(),
+            provenance={"source": "db_manager.store_memory", "observed_at": timestamp},
+            confidence=0.7,
+            created_at=timestamp,
+            updated_at=timestamp,
+            attributes={"topic": topic, "sentiment_score": sentiment_score},
+        )
+        await self._db.execute(
+            """
+            INSERT INTO fact_records (
+                id, dedup_key, subject, predicate, object_value, object_id,
+                provenance, confidence, created_at, updated_at, attributes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(dedup_key) DO UPDATE SET
+                confidence=MAX(fact_records.confidence, excluded.confidence),
+                updated_at=excluded.updated_at,
+                provenance=excluded.provenance,
+                attributes=excluded.attributes
+            """,
+            (
+                fact.id,
+                fact.dedup_key,
+                fact.subject,
+                fact.predicate,
+                fact.object_value,
+                fact.object_id,
+                json.dumps(fact.provenance),
+                fact.confidence,
+                fact.created_at,
+                fact.updated_at,
+                json.dumps(fact.attributes),
+            ),
         )
         if topic:
             await self._db.execute(

--- a/tests/test_db_manager_init.py
+++ b/tests/test_db_manager_init.py
@@ -16,6 +16,7 @@ TABLES = [
     "affinity",
     "trust",
     "memories",
+    "fact_records",
     "theories",
     "queued_tasks",
     "sentiment_trends",

--- a/tests/test_theories_queue.py
+++ b/tests/test_theories_queue.py
@@ -271,3 +271,27 @@ async def test_assign_themes(tmp_path, monkeypatch):
 
     theme = await sg.get_theme("u1", "c1")
     assert theme == "positive"
+
+
+@pytest.mark.asyncio
+async def test_store_memory_writes_canonical_fact_and_dedups(tmp_path):
+    db_file = tmp_path / "db.sqlite"
+    sg.db_manager = DBManager(str(db_file))
+    await sg.db_manager.connect()
+    await sg.db_manager.init_db()
+
+    await sg.store_memory("u1", "I like chess", topic="hobby")
+    await sg.store_memory("u1", "I like   chess", topic="hobby")
+
+    async with aiosqlite.connect(str(db_file)) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM fact_records WHERE subject=? AND predicate='memory_note'",
+            ("u1",),
+        ) as cur:
+            row = await cur.fetchone()
+    assert row[0] == 1
+
+    recalled = await sg.db_manager.recall_user("u1", limit=5)
+    assert recalled
+    assert recalled[0][1]
+    await sg.db_manager.close()

--- a/tests/unit/test_graph_memory_subsystem.py
+++ b/tests/unit/test_graph_memory_subsystem.py
@@ -8,6 +8,7 @@ from deepthought.memory.graph import (
     retrieve_topic_context,
     retrieve_user_context,
 )
+from deepthought.memory.graph.pipeline import ingest_fact_triples
 
 
 def test_extract_typed_fact_triples_from_turn():
@@ -104,3 +105,44 @@ def test_migrate_sqlite_memories_to_graph(tmp_path):
     assert stats["rows_read"] == 1
     assert stats["graph_upserts"] >= 1
     assert retrieve_user_context(store, "u1", limit=5)
+
+
+def test_canonical_dedup_merges_semantically_identical_facts():
+    store = InMemoryGraphMemoryStore()
+    triples = [
+        {
+            "subject_id": "u1",
+            "predicate": "likes_hobby",
+            "object_value": " Chess ",
+            "fact_type": "preference",
+            "confidence": 0.8,
+        },
+        {
+            "subject_id": "u1",
+            "predicate": "likes_hobby",
+            "object_value": "chess",
+            "fact_type": "preference",
+            "confidence": 0.7,
+        },
+    ]
+    ingest_fact_triples(triples, store, timestamp="2024-01-01T00:00:00+00:00", source_id="dup")
+
+    assert len(store.facts) == 1
+    only = next(iter(store.facts.values()))
+    assert only.dedup_key
+
+
+def test_retrieval_interoperability_uses_canonical_fact_shape():
+    store = InMemoryGraphMemoryStore()
+    ingest_conversation_turns(
+        [
+            {"user_id": "u9", "text": "My favorite snack is popcorn", "timestamp": "2024-01-01T00:00:00+00:00", "input_id": "turn1"},
+        ],
+        store,
+    )
+
+    context = retrieve_user_context(store, "u9", limit=5)
+    assert context
+    ev = context[0]
+    assert "subject" in ev.attributes
+    assert "updated_at" in ev.attributes


### PR DESCRIPTION
### Motivation

- Reduce schema drift between graph and relational memory backends by introducing a single canonical fact shape with timestamps, provenance and a deterministic dedup key. 
- Ensure semantically identical facts merge (not duplicate) across ingestion paths and backends to improve retrieval quality and context assembly. 
- Provide a migration path for legacy `memories` rows so existing data interoperates with the new schema.

### Description

- Added a canonical fact schema and helpers in `src/deepthought/fact_schema.py` (fields: `id`, `subject`, `predicate`, `object_value`, `object_id`, `provenance`, `confidence`, `created_at`, `updated_at`, `dedup_key`, `attributes`) and a graph-level re-export at `src/deepthought/memory/graph/facts.py`.
- Refactored graph ingestion to construct canonical facts via `make_canonical_fact` in `ingest_fact_triples` and updated the graph `GraphFact` type to be a backward-compatible alias over the canonical type (`src/deepthought/memory/graph/pipeline.py`, `src/deepthought/memory/graph/store.py`).
- Updated adapters to persist/retrieve canonical fact fields (use `dedup_key` for `MERGE`/upsert in Cypher adapter) and made in-memory adapter deduplicate by `dedup_key` and prefer newer/ higher-updated facts (`src/deepthought/memory/graph/adapters.py`).
- Unified DB path: added `fact_records` table and deterministic upsert logic in `DBManager` so `store_memory` writes canonical facts and `recall_user` reads canonical facts; included `_ensure_fact_records_migration` to backfill legacy `memories` into `fact_records` with conflict/merge logic (`src/deepthought/services/db_manager.py`).
- Normalized response context assembly in the cognitive core to format both graph evidence and DB snippets via canonical facts (`src/deepthought/services/cognitive_core_service.py`).
- Added regression/unit tests verifying canonical dedup, graph/DB interoperability and updated DB-init expectations (`tests/unit/test_graph_memory_subsystem.py`, `tests/test_theories_queue.py`, `tests/test_db_manager_init.py`).

### Testing

- Ran `python -m py_compile` on modified modules to validate syntax; compilation succeeded. 
- Ran the focused unit test set: `pytest -q tests/unit/test_graph_memory_subsystem.py tests/test_db_manager_init.py tests/test_theories_queue.py` and all tests passed (9 passed, 1 skipped). 
- Ran static checks with `ruff` over touched files and resolved reported issues; `ruff` checks passed for the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ce64992c8326aacd8bf1116de0f4)