### PR TITLE
Extend social graph edges, ingestion, summarized social signals, and bounded responder features

### DIFF
--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -127,9 +127,15 @@ class DBManager:
             source_id TEXT,
             target_id TEXT,
             edge_type TEXT,
+            channel_id TEXT,
             weight REAL DEFAULT 0,
+            event_count INTEGER DEFAULT 0,
+            reciprocity REAL DEFAULT 0,
+            sentiment_sum REAL DEFAULT 0,
+            sentiment_avg REAL DEFAULT 0,
+            sentiment_trend TEXT DEFAULT 'stable',
             last_updated DATETIME DEFAULT CURRENT_TIMESTAMP,
-            PRIMARY KEY(source_id, target_id, edge_type)
+            PRIMARY KEY(source_id, target_id, edge_type, channel_id)
         )
         """,
         """
@@ -368,6 +374,7 @@ class DBManager:
                 for query in self.CREATE_TABLE_QUERIES:
                     await self._db.execute(query)
                 await self._ensure_relationship_columns()
+                await self._ensure_social_edges_columns()
                 await self._ensure_fact_records_migration()
                 await self._db.execute("INSERT OR IGNORE INTO trust_config (id) VALUES (1)")
                 await self._db.execute("INSERT OR IGNORE INTO interaction_decay (id) VALUES (1)")
@@ -442,6 +449,26 @@ class DBManager:
             await self._db.execute("ALTER TABLE relationships ADD COLUMN interaction_weight REAL DEFAULT 0")
         if "last_interaction" not in cols:
             await self._db.execute("ALTER TABLE relationships ADD COLUMN last_interaction DATETIME")
+
+    async def _ensure_social_edges_columns(self) -> None:
+        """Add new columns to the social_edges table if they don't exist."""
+        assert self._db is not None
+        async with self._db.execute("PRAGMA table_info(social_edges)") as cur:
+            cols = [row[1] async for row in cur]
+        if "channel_id" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN channel_id TEXT")
+            await self._db.execute("UPDATE social_edges SET channel_id='global' WHERE channel_id IS NULL")
+        if "event_count" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN event_count INTEGER DEFAULT 0")
+            await self._db.execute("UPDATE social_edges SET event_count=CASE WHEN event_count=0 THEN 1 ELSE event_count END")
+        if "reciprocity" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN reciprocity REAL DEFAULT 0")
+        if "sentiment_sum" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN sentiment_sum REAL DEFAULT 0")
+        if "sentiment_avg" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN sentiment_avg REAL DEFAULT 0")
+        if "sentiment_trend" not in cols:
+            await self._db.execute("ALTER TABLE social_edges ADD COLUMN sentiment_trend TEXT DEFAULT 'stable'")
 
     @staticmethod
     def _normalize_timestamp_input(value: Any) -> str | None:
@@ -1627,50 +1654,137 @@ class DBManager:
             row = await cur.fetchone()
         return row[0] if row else None
 
-    async def update_edge(self, source_id: int, target_id: int, edge_type: str, weight_delta: float) -> None:
+    async def update_edge(
+        self,
+        source_id: int,
+        target_id: int,
+        edge_type: str,
+        weight_delta: float,
+        *,
+        channel_id: str | None = None,
+        sentiment_score: float | None = None,
+        event_count_delta: int = 1,
+    ) -> None:
         """Insert or update a typed edge applying decay to the stored weight."""
         await self.connect()
         assert self._db
         w_decay, _ = await self.get_decay_params()
         now = datetime.utcnow()
+        channel_key = str(channel_id) if channel_id else "global"
         async with self._db.execute(
-            "SELECT weight, last_updated FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=?",
-            (str(source_id), str(target_id), edge_type),
+            "SELECT weight, event_count, sentiment_sum, last_updated FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+            (str(source_id), str(target_id), edge_type, channel_key),
         ) as cur:
             row = await cur.fetchone()
+
+        sentiment_value = float(sentiment_score) if sentiment_score is not None else 0.0
+        event_inc = max(0, int(event_count_delta))
         if row:
-            weight, last_ts = row
+            weight, event_count, sentiment_sum, last_ts = row
             if last_ts:
                 last_dt = datetime.fromisoformat(str(last_ts))
                 elapsed = (now - last_dt).total_seconds()
                 weight = float(weight) * (w_decay**elapsed)
-            weight += float(weight_delta)
+            updated_weight = float(weight) + float(weight_delta)
+            updated_events = int(event_count or 0) + event_inc
+            updated_sentiment_sum = float(sentiment_sum or 0.0) + sentiment_value
+            updated_sentiment_avg = (
+                updated_sentiment_sum / updated_events if updated_events else 0.0
+            )
+            trend = "up" if updated_sentiment_avg > 0.2 else "down" if updated_sentiment_avg < -0.2 else "stable"
             await self._db.execute(
                 """
                 UPDATE social_edges
-                SET weight=?, last_updated=CURRENT_TIMESTAMP
-                WHERE source_id=? AND target_id=? AND edge_type=?
+                SET weight=?,
+                    event_count=?,
+                    sentiment_sum=?,
+                    sentiment_avg=?,
+                    sentiment_trend=?,
+                    last_updated=CURRENT_TIMESTAMP
+                WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?
                 """,
-                (weight, str(source_id), str(target_id), edge_type),
+                (
+                    updated_weight,
+                    updated_events,
+                    updated_sentiment_sum,
+                    updated_sentiment_avg,
+                    trend,
+                    str(source_id),
+                    str(target_id),
+                    edge_type,
+                    channel_key,
+                ),
             )
         else:
+            initial_events = event_inc or 1
+            initial_avg = sentiment_value / initial_events
+            trend = "up" if initial_avg > 0.2 else "down" if initial_avg < -0.2 else "stable"
             await self._db.execute(
                 """
-                INSERT INTO social_edges (source_id, target_id, edge_type, weight, last_updated)
-                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+                INSERT INTO social_edges (
+                    source_id, target_id, edge_type, channel_id, weight,
+                    event_count, reciprocity, sentiment_sum, sentiment_avg,
+                    sentiment_trend, last_updated
+                )
+                VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?, CURRENT_TIMESTAMP)
                 """,
-                (str(source_id), str(target_id), edge_type, float(weight_delta)),
+                (
+                    str(source_id),
+                    str(target_id),
+                    edge_type,
+                    channel_key,
+                    float(weight_delta),
+                    initial_events,
+                    sentiment_value,
+                    initial_avg,
+                    trend,
+                ),
             )
+
+        await self._recompute_reciprocity(source_id, target_id, edge_type, channel_key)
         await self._db.commit()
 
-    async def get_edge_weight(self, source_id: int, target_id: int, edge_type: str) -> float:
+    async def _recompute_reciprocity(self, source_id: int, target_id: int, edge_type: str, channel_key: str) -> None:
+        assert self._db is not None
+        async with self._db.execute(
+            "SELECT weight FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+            (str(source_id), str(target_id), edge_type, channel_key),
+        ) as cur:
+            forward = await cur.fetchone()
+        async with self._db.execute(
+            "SELECT weight FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+            (str(target_id), str(source_id), edge_type, channel_key),
+        ) as cur:
+            backward = await cur.fetchone()
+        fw = abs(float(forward[0])) if forward else 0.0
+        bw = abs(float(backward[0])) if backward else 0.0
+        reciprocity = (2 * min(fw, bw) / (fw + bw)) if (fw + bw) > 0 else 0.0
+        await self._db.execute(
+            "UPDATE social_edges SET reciprocity=? WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+            (reciprocity, str(source_id), str(target_id), edge_type, channel_key),
+        )
+        if backward:
+            await self._db.execute(
+                "UPDATE social_edges SET reciprocity=? WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+                (reciprocity, str(target_id), str(source_id), edge_type, channel_key),
+            )
+
+    async def get_edge_weight(
+        self,
+        source_id: int,
+        target_id: int,
+        edge_type: str,
+        *,
+        channel_id: str | None = None,
+    ) -> float:
         """Return the decayed weight for the edge between ``source_id`` and ``target_id``."""
         await self.connect()
         assert self._db
         w_decay, _ = await self.get_decay_params()
+        channel_key = str(channel_id) if channel_id else "global"
         async with self._db.execute(
-            "SELECT weight, last_updated FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=?",
-            (str(source_id), str(target_id), edge_type),
+            "SELECT weight, last_updated FROM social_edges WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?",
+            (str(source_id), str(target_id), edge_type, channel_key),
         ) as cur:
             row = await cur.fetchone()
         if not row:
@@ -1682,16 +1796,28 @@ class DBManager:
             weight = float(weight) * (w_decay**elapsed)
         return float(weight)
 
-    async def get_edges(self, edge_type: str | None = None) -> list[tuple[str, str, float]]:
+    async def get_edges(
+        self,
+        edge_type: str | None = None,
+        *,
+        channel_id: str | None = None,
+    ) -> list[tuple[str, str, float]]:
         """Return all edges, optionally filtered by ``edge_type`` with decay applied."""
         await self.connect()
         assert self._db
         w_decay, _ = await self.get_decay_params()
         query = "SELECT source_id, target_id, edge_type, weight, last_updated FROM social_edges"
-        params: tuple = ()
+        clauses: list[str] = []
+        params_list: list[str] = []
         if edge_type:
-            query += " WHERE edge_type=?"
-            params = (edge_type,)
+            clauses.append("edge_type=?")
+            params_list.append(edge_type)
+        if channel_id:
+            clauses.append("channel_id=?")
+            params_list.append(str(channel_id))
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        params = tuple(params_list)
         results: list[tuple[str, str, float]] = []
         async with self._db.execute(query, params) as cur:
             async for src, tgt, etype, weight, last_ts in cur:
@@ -1701,6 +1827,44 @@ class DBManager:
                     weight = float(weight) * (w_decay**elapsed)
                 results.append((src, tgt, float(weight)))
         return results
+
+    async def get_edge_summary(
+        self,
+        source_id: int,
+        target_id: int,
+        edge_type: str,
+        *,
+        channel_id: str | None = None,
+    ) -> dict[str, Any]:
+        await self.connect()
+        assert self._db
+        channel_key = str(channel_id) if channel_id else "global"
+        async with self._db.execute(
+            """
+            SELECT weight, event_count, reciprocity, sentiment_avg, sentiment_trend, last_updated
+            FROM social_edges
+            WHERE source_id=? AND target_id=? AND edge_type=? AND channel_id=?
+            """,
+            (str(source_id), str(target_id), edge_type, channel_key),
+        ) as cur:
+            row = await cur.fetchone()
+        if not row:
+            return {
+                "weight": 0.0,
+                "event_count": 0,
+                "reciprocity": 0.0,
+                "sentiment_avg": 0.0,
+                "sentiment_trend": "stable",
+                "last_updated": None,
+            }
+        return {
+            "weight": float(row[0] or 0.0),
+            "event_count": int(row[1] or 0),
+            "reciprocity": float(row[2] or 0.0),
+            "sentiment_avg": float(row[3] or 0.0),
+            "sentiment_trend": str(row[4] or "stable"),
+            "last_updated": self._format_timestamp(row[5]),
+        }
 
     async def set_theme(self, user_id: int, channel_id: int, theme: str) -> None:
         if not isinstance(theme, str) or not theme.strip():

--- a/src/deepthought/services/prism_adapter.py
+++ b/src/deepthought/services/prism_adapter.py
@@ -18,6 +18,10 @@ class PrismEvent:
     sentiment: float
     reply_latency: Optional[float] = None
     emoji_counts: Dict[str, int] | None = None
+    channel_id: Optional[str] = None
+    referenced_user_id: Optional[str] = None
+    thread_participants: tuple[str, ...] = ()
+    co_occurring_users: tuple[str, ...] = ()
 
 
 class PrismAdapter:
@@ -36,6 +40,18 @@ class PrismAdapter:
             sentiment=float(payload.get("sentiment", 0.0)),
             reply_latency=float(latency) if latency is not None else None,
             emoji_counts=payload.get("emoji_counts") or {},
+            channel_id=str(payload.get("channel_id")) if payload.get("channel_id") is not None else None,
+            referenced_user_id=(
+                str(payload.get("referenced_user_id"))
+                if payload.get("referenced_user_id") is not None
+                else None
+            ),
+            thread_participants=tuple(
+                str(item) for item in (payload.get("thread_participants") or []) if item is not None
+            ),
+            co_occurring_users=tuple(
+                str(item) for item in (payload.get("co_occurring_users") or []) if item is not None
+            ),
         )
 
     async def ingest(self, payload: Dict) -> None:
@@ -43,4 +59,3 @@ class PrismAdapter:
 
         event = self.translate(payload)
         await self._memory.ingest_prism_event(event)
-

--- a/src/deepthought/services/responder_service.py
+++ b/src/deepthought/services/responder_service.py
@@ -32,7 +32,29 @@ class ResponderService:
         self._responder_id = responder_id.strip().lower() or "factual"
         self._responder_kind = responder_kind.strip().lower() or self._responder_id
 
-    def _build_candidate(self, user_input: str, facts: list[str]) -> ResponseCandidate:
+    @staticmethod
+    def _bounded_social_features(social_signals: dict) -> dict:
+        if not isinstance(social_signals, dict):
+            return {}
+        channel_norms = social_signals.get("channel_norms")
+        if not isinstance(channel_norms, dict):
+            channel_norms = {}
+        return {
+            "relationship_status": social_signals.get("relationship_status", "neutral"),
+            "familiarity_tier": social_signals.get("familiarity_tier", "low"),
+            "channel_norms": {
+                "interaction_frequency": channel_norms.get("interaction_frequency", 0),
+                "reciprocity": channel_norms.get("reciprocity", 0.0),
+                "sentiment_trend": channel_norms.get("sentiment_trend", "stable"),
+            },
+        }
+
+    def _compose_prompt_context(self, user_input: str, facts: list[str], social_signals: dict) -> str:
+        bounded = self._bounded_social_features(social_signals)
+        fact_hint = facts[0] if facts else ""
+        return f"user_input={user_input[:160]} | fact={fact_hint[:120]} | social={json.dumps(bounded, sort_keys=True)}"
+
+    def _build_candidate(self, user_input: str, facts: list[str], social_signals: dict) -> ResponseCandidate:
         source = f"responder:{self._responder_id}"
         if self._responder_kind in {"factual", "qa", "tool"}:
             fact = facts[0] if facts else "I don't have enough retrieved facts yet"
@@ -41,7 +63,8 @@ class ResponderService:
             tags = ["factual", "grounded", "tool_ready"]
             style = "concise"
         elif self._responder_kind in {"persona", "conversational"}:
-            text = f"I hear you: {user_input}. I'm here and happy to keep talking."
+            prompt_context = self._compose_prompt_context(user_input, facts, social_signals)
+            text = f"I hear you: {user_input}. Context: {prompt_context}."
             confidence = 0.73
             tags = ["persona", "empathetic", "rapport"]
             style = "friendly"
@@ -68,6 +91,7 @@ class ResponderService:
                 "responder_id": self._responder_id,
                 "kind": self._responder_kind,
                 "calibration": {"slope": 1.0, "bias": 0.0},
+                "social_features": self._bounded_social_features(social_signals),
             },
             rationale_tags=tags,
         )
@@ -78,13 +102,14 @@ class ResponderService:
             payload, envelope_meta = decode_payload_or_envelope(EventSubjects.CONTEXT_ASSEMBLED, data)
             user_input = payload.get("user_input") if isinstance(payload.get("user_input"), str) else ""
             facts = payload.get("retrieved_facts") if isinstance(payload.get("retrieved_facts"), list) else []
+            social_signals = payload.get("social_signals") if isinstance(payload.get("social_signals"), dict) else {}
             input_id = payload.get("input_id") if isinstance(payload.get("input_id"), str) else "global"
             author_id = payload.get("author_id") if isinstance(payload.get("author_id"), str) else None
             user_id = payload.get("user_id") if isinstance(payload.get("user_id"), str) else None
             channel_id = payload.get("channel_id") if isinstance(payload.get("channel_id"), str) else None
 
             out = ResponseCandidatesPayload(
-                candidates=[self._build_candidate(user_input=user_input, facts=[str(x) for x in facts])],
+                candidates=[self._build_candidate(user_input=user_input, facts=[str(x) for x in facts], social_signals=social_signals)],
                 input_id=input_id,
                 user_id=author_id or user_id,
                 author_id=author_id,

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -120,14 +120,70 @@ class SocialGraphMemory:
         return await self._db.get_relationship_type(user_a, user_b)
 
     async def update_edge(
-        self, source: str, target: str, edge_type: str, weight: float = 1.0
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        weight: float = 1.0,
+        *,
+        channel_id: str | None = None,
+        sentiment_score: float | None = None,
+        event_count_delta: int = 1,
     ) -> None:
         """Add or update a typed edge between ``source`` and ``target``."""
-        await self._db.update_edge(source, target, edge_type, weight)
+        await self._db.update_edge(
+            source,
+            target,
+            edge_type,
+            weight,
+            channel_id=channel_id,
+            sentiment_score=sentiment_score,
+            event_count_delta=event_count_delta,
+        )
 
-    async def get_edge_weight(self, source: str, target: str, edge_type: str) -> float:
+    async def get_edge_weight(
+        self,
+        source: str,
+        target: str,
+        edge_type: str,
+        *,
+        channel_id: str | None = None,
+    ) -> float:
         """Return the current weight of a typed edge."""
-        return await self._db.get_edge_weight(source, target, edge_type)
+        return await self._db.get_edge_weight(source, target, edge_type, channel_id=channel_id)
+
+    async def get_social_context_summary(
+        self,
+        source: str,
+        target: str,
+        *,
+        channel_id: str | None = None,
+    ) -> dict:
+        status = await self._db.get_relationship_type(source, target) or "neutral"
+        rel = await self.get_relationship_stats(source, target)
+        pair_events = int(rel["a_to_b"]["count"]) + int(rel["b_to_a"]["count"])
+        if pair_events >= 12:
+            familiarity = "high"
+        elif pair_events >= 4:
+            familiarity = "medium"
+        else:
+            familiarity = "low"
+        interaction = await self._db.get_edge_summary(
+            source,
+            target,
+            "interaction",
+            channel_id=channel_id,
+        )
+        return {
+            "relationship_status": status,
+            "familiarity_tier": familiarity,
+            "channel_norms": {
+                "interaction_frequency": interaction["event_count"],
+                "reciprocity": interaction["reciprocity"],
+                "sentiment_trend": interaction["sentiment_trend"],
+            },
+            "interaction_edge": interaction,
+        }
 
     async def discover_factions(self, edge_type: str = "ally") -> list[list[str]]:
         """Cluster users into factions based on their positive edges.
@@ -160,19 +216,56 @@ class SocialGraphMemory:
         await self._db.log_interaction(
             event.source, event.target, sentiment_score=event.sentiment
         )
+
+        inferred_targets: set[str] = set()
         if event.target is not None:
-            await self._update_relationship_type(event.source, event.target)
+            inferred_targets.add(str(event.target))
+        if event.referenced_user_id:
+            inferred_targets.add(str(event.referenced_user_id))
+        for participant in event.thread_participants:
+            if participant and participant != event.source:
+                inferred_targets.add(participant)
+        for user in event.co_occurring_users:
+            if user and user != event.source:
+                inferred_targets.add(user)
+
+        for target in inferred_targets:
+            await self.update_edge(
+                event.source,
+                target,
+                "interaction",
+                1.0,
+                channel_id=event.channel_id,
+                sentiment_score=event.sentiment,
+            )
+            await self._update_relationship_type(event.source, target)
 
         if event.reply_latency is not None:
             delta = 1 if event.reply_latency <= LATENCY_THRESHOLD else -1
             await self._db.adjust_affinity(event.source, delta)
 
-        if event.target is not None and event.emoji_counts:
-            for emoji, count in event.emoji_counts.items():
-                if emoji in POSITIVE_EMOJIS:
-                    await self.update_edge(event.source, event.target, "ally", float(count))
-                elif emoji in NEGATIVE_EMOJIS:
-                    await self.update_edge(event.source, event.target, "rival", float(count))
+        if event.emoji_counts:
+            emoji_target = event.target or event.referenced_user_id
+            if emoji_target is not None:
+                for emoji, count in event.emoji_counts.items():
+                    if emoji in POSITIVE_EMOJIS:
+                        await self.update_edge(
+                            event.source,
+                            emoji_target,
+                            "ally",
+                            float(count),
+                            channel_id=event.channel_id,
+                            sentiment_score=event.sentiment,
+                        )
+                    elif emoji in NEGATIVE_EMOJIS:
+                        await self.update_edge(
+                            event.source,
+                            emoji_target,
+                            "rival",
+                            float(count),
+                            channel_id=event.channel_id,
+                            sentiment_score=event.sentiment,
+                        )
 
     async def close(self) -> None:
         await self._db.close()

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -53,7 +53,8 @@ class SocialGraphService(BaseService):
     async def _handle_social_signals_requested(self, msg: Msg) -> None:
         """Respond to SOCIAL_SIGNALS_REQUESTED with context and telemetry events."""
         try:
-            enriched = self._input_enrichment.parse_input_received(msg)
+            data = json.loads(msg.data.decode())
+            enriched = self._input_enrichment.parse_input_received_data(data, headers=getattr(msg, "headers", None))
             logger.info("SocialGraphService received input %s", enriched.input_id)
             try:
                 perception = analyze_social(enriched.user_input)
@@ -77,6 +78,26 @@ class SocialGraphService(BaseService):
                 None,
                 channel_id=enriched.channel_id,
             )
+
+            prism_payload = {
+                "source": resolved_user_id,
+                "target": data.get("target_id") or data.get("reply_to_author_id"),
+                "sentiment": float(delta),
+                "reply_latency": data.get("reply_latency"),
+                "emoji_counts": data.get("emoji_counts") or {},
+                "channel_id": enriched.channel_id,
+                "referenced_user_id": data.get("referenced_user_id"),
+                "thread_participants": data.get("thread_participants") or [],
+                "co_occurring_users": data.get("co_occurring_users") or [],
+            }
+            await self._prism.ingest(prism_payload)
+
+            social_context = await self._memory.get_social_context_summary(
+                resolved_user_id,
+                str(prism_payload["target"] or prism_payload["referenced_user_id"] or resolved_user_id),
+                channel_id=enriched.channel_id,
+            )
+
             social_snapshot = {
                 "input_id": enriched.input_id,
                 "user_id": enriched.user_id,
@@ -87,6 +108,9 @@ class SocialGraphService(BaseService):
                     "delta": delta,
                     "affinity": affinity,
                     "persona": persona,
+                    "relationship_status": social_context.get("relationship_status", "neutral"),
+                    "familiarity_tier": social_context.get("familiarity_tier", "low"),
+                    "channel_norms": social_context.get("channel_norms", {}),
                 },
             }
             social_update = {

--- a/tests/test_social_edges.py
+++ b/tests/test_social_edges.py
@@ -55,3 +55,27 @@ async def test_faction_discovery(tmp_path):
     assert set(["d", "e"]) in factions
 
     await mem.close()
+
+
+@pytest.mark.asyncio
+async def test_channel_contextual_edge_summary_and_reciprocity(tmp_path):
+    db = DBManager(str(tmp_path / "sg.db"))
+    mem = SocialGraphMemory(db)
+
+    await mem.update_edge("a", "b", "interaction", 3.0, channel_id="chan-1", sentiment_score=0.8)
+    await mem.update_edge("b", "a", "interaction", 1.0, channel_id="chan-1", sentiment_score=0.2)
+
+    summary = await db.get_edge_summary("a", "b", "interaction", channel_id="chan-1")
+    reverse = await db.get_edge_summary("b", "a", "interaction", channel_id="chan-1")
+
+    assert summary["event_count"] >= 1
+    assert summary["sentiment_trend"] in {"up", "stable", "down"}
+    assert 0.0 <= summary["reciprocity"] <= 1.0
+    assert summary["reciprocity"] == pytest.approx(reverse["reciprocity"])
+
+    ctx = await mem.get_social_context_summary("a", "b", channel_id="chan-1")
+    assert ctx["relationship_status"] in {"neutral", "friend", "rival"}
+    assert ctx["familiarity_tier"] in {"low", "medium", "high"}
+    assert "channel_norms" in ctx
+
+    await mem.close()

--- a/tests/unit/services/test_responder_service.py
+++ b/tests/unit/services/test_responder_service.py
@@ -86,3 +86,44 @@ async def test_responder_publishes_candidate_with_metadata(monkeypatch, service_
     assert expected_tag in candidate["rationale_tags"]
     assert isinstance(candidate["source_metadata"], dict)
     assert isinstance(candidate["source_metadata"].get("calibration"), dict)
+
+
+@pytest.mark.asyncio
+async def test_responder_bounded_social_features_in_candidate_metadata(monkeypatch):
+    import deepthought.services.responder_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = PersonaResponderService(DummyNATS(), DummyJS())
+    await svc.start()
+
+    context_payload = {
+        "input_id": "in-social",
+        "user_input": "hello",
+        "retrieved_facts": ["fact1"],
+        "author_id": "a-1",
+        "social_signals": {
+            "relationship_status": "friend",
+            "familiarity_tier": "high",
+            "channel_norms": {
+                "interaction_frequency": 42,
+                "reciprocity": 0.7,
+                "sentiment_trend": "up",
+                "extra_large_payload": "x" * 500,
+            },
+            "raw_blob": {"nested": "ignore me"},
+        },
+    }
+    msg = DummyMsg(json.dumps(context_payload))
+    await svc._handle_context_event(msg)
+
+    payload = svc._publisher.calls[0][1]["payload"]
+    candidate = payload["candidates"][0]
+    features = candidate["source_metadata"]["social_features"]
+    assert set(features.keys()) == {"relationship_status", "familiarity_tier", "channel_norms"}
+    assert set(features["channel_norms"].keys()) == {
+        "interaction_frequency",
+        "reciprocity",
+        "sentiment_trend",
+    }

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -163,3 +163,45 @@ async def test_social_contract_update_and_retrieval_semantics(tmp_path, monkeypa
     assert retrieved["payload"]["social_signals"]["affinity"] == updated["payload"]["affinity"]
 
     await db.close()
+
+
+@pytest.mark.asyncio
+async def test_social_signals_include_summarized_context_and_channel_norms(tmp_path, monkeypatch):
+    db = DBManager(str(tmp_path / "sg.db"))
+    await db.init_db()
+    service = SocialGraphService(db_manager=db, persona_manager=PersonaManager(db))
+    service._publisher = RecordingPublisher()
+
+    monkeypatch.setattr(
+        social_graph_service,
+        "analyze_social",
+        lambda _text: {"flirtation": 0.4, "avoidance": 0.0, "manipulation": 0.0},
+    )
+
+    payload = InputReceivedPayload(user_input="hey", input_id="in-social", author_id="u-1").to_json()
+    msg = DummyMsg(payload)
+    msg.data = json.dumps(
+        {
+            "user_input": "hey",
+            "input_id": "in-social",
+            "author_id": "u-1",
+            "target_id": "u-2",
+            "channel_id": "c-1",
+            "thread_participants": ["u-2", "u-3"],
+            "co_occurring_users": ["u-4"],
+        }
+    ).encode()
+
+    await service._handle_social_signals_requested(msg)
+
+    retrieved = service._publisher.calls[1][1]["payload"]["social_signals"]
+    assert retrieved["relationship_status"] in {"neutral", "friend", "rival"}
+    assert retrieved["familiarity_tier"] in {"low", "medium", "high"}
+    assert isinstance(retrieved["channel_norms"]["interaction_frequency"], int)
+    assert "reciprocity" in retrieved["channel_norms"]
+    assert "sentiment_trend" in retrieved["channel_norms"]
+
+    assert await db.get_edge_weight("u-1", "u-2", "interaction", channel_id="c-1") > 0
+    assert await db.get_edge_weight("u-1", "u-3", "interaction", channel_id="c-1") > 0
+    assert await db.get_edge_weight("u-1", "u-4", "interaction", channel_id="c-1") > 0
+    await db.close()


### PR DESCRIPTION
### Motivation

- Improve the social graph to represent user-user edges scoped by channel with richer telemetry (counts, reciprocity, sentiment trends) for better context-aware behavior.
- Infer interaction edges from richer Prism inputs (message references, thread participants, co-occurrence) so the graph reflects realistic conversational structure.
- Surface a compact, summarized social context (relationship status, familiarity tier, channel norms) in `SOCIAL_SIGNALS_RETRIEVED` so downstream systems can use bounded cues without large payloads.
- Prevent responder prompt bloat by exposing only bounded, relevant social features in candidate metadata and prompt context.

### Description

- Schema and DB: extended `social_edges` table to include `channel_id`, `event_count`, `reciprocity`, `sentiment_sum`, `sentiment_avg`, and `sentiment_trend`, and added `_ensure_social_edges_columns` migration logic. (`src/deepthought/services/db_manager.py`)
- Edge operations: updated `update_edge` to be channel-aware, accept `sentiment_score` / `event_count_delta`, compute sentiment averages and trend, and recompute reciprocity; added `get_edge_summary` and channel-scoped `get_edges`/`get_edge_weight` variants. (`src/deepthought/services/db_manager.py`)
- Prism ingestion: extended `PrismEvent` to carry `channel_id`, `referenced_user_id`, `thread_participants`, and `co_occurring_users`, and updated ingestion to infer interaction targets from direct target, references, thread participants and co-occurrence and to update channel-scoped interaction edges and emoji-based ally/rival edges. (`src/deepthought/services/prism_adapter.py`, `src/deepthought/services/social_graph_memory.py`)
- Social context summarization: added `get_social_context_summary` that returns `relationship_status`, `familiarity_tier`, and `channel_norms` (frequency, reciprocity, sentiment trend), and surfaced these fields in `SOCIAL_SIGNALS_RETRIEVED` payloads. (`src/deepthought/services/social_graph_memory.py`, `src/deepthought/services/social_graph_service.py`)
- Responder bounding: added `_bounded_social_features` and `_compose_prompt_context` helpers and updated responder candidate assembly to include only bounded social features in `source_metadata` and to use a bounded social context in persona prompts. (`src/deepthought/services/responder_service.py`)
- Tests: added/updated tests to cover channel-scoped edge summaries and reciprocity, inclusion of summarized social context in `SOCIAL_SIGNALS_RETRIEVED`, and bounded social feature extraction in responder output metadata. (tests in `tests/test_social_edges.py`, `tests/unit/services/test_social_graph_service.py`, `tests/unit/services/test_responder_service.py`)

### Testing

- Ran linter/formatter checks with `ruff` which passed for the touched files (`ruff check ...` reported all checks passed).
- Verified Python syntax by compiling modules with `python -m compileall` which completed successfully for the modified modules. (`python -m compileall -q ...` succeeded)
- Ran targeted test suites with `pytest` in this environment but the full test run timed out (`timeout 90 pytest -q tests/unit/services/test_social_graph_service.py tests/unit/services/test_responder_service.py tests/test_social_edges.py` resulted in an environment timeout `EXIT:124`).
- All modified files were committed and the PR branch was prepared; added unit/integration tests described above for future CI runs where the full test suite should run to completion.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8084214d883268716eb8be2ca91d2)