### PR TITLE
Add versioned policy engine and enforce pre-gen/egress guardrails across responder, selector, and Discord gateway

### DIFF
--- a/src/deepthought/__init__.py
+++ b/src/deepthought/__init__.py
@@ -23,6 +23,9 @@ def _ensure_torch_numpy_compat() -> None:
 
     torch._deepthought_numpy_checked = True  # type: ignore[attr-defined]
 
+    if not hasattr(torch, "from_numpy"):
+        return
+
     try:
         torch.from_numpy(_np.zeros(1, dtype=_np.float32))
     except RuntimeError as exc:

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -18,6 +18,7 @@ from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import DiscordFeedbackSignalPayload, EventSubjects, InputReceivedPayload, ResponseRankedPayload
 from .base import BaseService
 from .human_interaction_policy import HumanInteractionPolicy
+from .policy_engine import VersionedPolicyEngine
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ class DiscordGatewayService(BaseService):
         self._recent_channel_activity: dict[str, list[float]] = {}
         self._familiarity_counts: dict[tuple[str, str], int] = {}
         self._cooldown_until: dict[str, float] = {}
+        self._policy_engine = VersionedPolicyEngine()
         self.add_subscription(
             response_subject,
             self._handle_ranked_response,
@@ -373,6 +375,43 @@ class DiscordGatewayService(BaseService):
         self._set_cooldown(cooldown_keys, decision.cooldown_seconds)
         return True
 
+
+    def _collect_policy_artifacts(self, payload: ResponseRankedPayload) -> list[dict[str, Any]]:
+        artifacts: list[dict[str, Any]] = []
+        for candidate in payload.candidates or []:
+            metadata = candidate.safety_metadata if isinstance(candidate.safety_metadata, dict) else {}
+            cand_artifacts = metadata.get("policy_artifacts")
+            if isinstance(cand_artifacts, list):
+                artifacts.extend(item for item in cand_artifacts if isinstance(item, dict))
+        return artifacts
+
+    async def _publish_egress_escalation(
+        self,
+        *,
+        payload: ResponseRankedPayload,
+        decision_reason: str,
+        decision_action: str,
+    ) -> None:
+        if not self._publisher:
+            return
+        escalation_payload = {
+            "input_id": payload.input_id,
+            "channel_id": payload.channel_id,
+            "author_id": payload.author_id,
+            "response_source": payload.source,
+            "confidence": payload.confidence,
+            "decision_action": decision_action,
+            "decision_reason": decision_reason,
+            "policy_version": self._policy_engine.VERSION,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        await self._publisher.publish(
+            "dtr.telemetry.egress_policy.v1",
+            escalation_payload,
+            use_jetstream=True,
+            timeout=10.0,
+        )
+
     async def _handle_ranked_response(self, msg: Msg) -> None:
         action = "ack"
         try:
@@ -383,6 +422,21 @@ class DiscordGatewayService(BaseService):
             payload = ResponseRankedPayload.from_dict(decoded_payload)
             if not payload.final_response:
                 raise ValueError("final_response is required")
+
+            policy_artifacts = self._collect_policy_artifacts(payload)
+            egress_decision = self._policy_engine.evaluate_egress(
+                content=payload.final_response,
+                confidence=payload.confidence,
+                policy_artifacts=policy_artifacts,
+            )
+            if not egress_decision.allowed:
+                await self._publish_egress_escalation(
+                    payload=payload,
+                    decision_reason=egress_decision.reason,
+                    decision_action=egress_decision.action,
+                )
+                action = "ack"
+                return await msg.ack()
 
             route = self._pending_routes.get(payload.input_id or "") if payload.input_id else None
             channel_id = payload.channel_id or (route.channel_id if route else None)

--- a/src/deepthought/services/policy_engine.py
+++ b/src/deepthought/services/policy_engine.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    allowed: bool
+    action: str
+    risk_level: str
+    confidence_band: str
+    reason: str
+    artifacts: dict[str, Any]
+
+
+class VersionedPolicyEngine:
+    """Shared safety policy engine used by responder, selector, and gateway."""
+
+    VERSION = "v1"
+
+    _HIGH_RISK_TOKENS = {
+        "kill",
+        "bomb",
+        "attack",
+        "exploit",
+        "harm",
+        "suicide",
+        "weapon",
+        "malware",
+    }
+    _AMBIGUOUS_TOKENS = {
+        "bypass",
+        "hack",
+        "password",
+        "jailbreak",
+        "leak",
+        "phish",
+    }
+
+    def classify_input_risk(self, text: str) -> dict[str, Any]:
+        lowered = (text or "").lower()
+        tokens = {token for token in (self._HIGH_RISK_TOKENS | self._AMBIGUOUS_TOKENS) if token in lowered}
+        if tokens & self._HIGH_RISK_TOKENS:
+            level = "high"
+        elif tokens & self._AMBIGUOUS_TOKENS:
+            level = "ambiguous"
+        else:
+            level = "benign"
+        return {
+            "policy_version": self.VERSION,
+            "stage": "pre_generation",
+            "risk_level": level,
+            "matched_tokens": sorted(tokens),
+            "input_excerpt": (text or "")[:160],
+        }
+
+    def harden_prompt(self, user_input: str, *, risk_artifact: dict[str, Any]) -> dict[str, Any]:
+        risk_level = str(risk_artifact.get("risk_level", "benign"))
+        if risk_level == "high":
+            hardening = "Refuse unsafe instructions and pivot to de-escalation guidance."
+        elif risk_level == "ambiguous":
+            hardening = "Ask clarifying questions before providing potentially sensitive guidance."
+        else:
+            hardening = "Provide concise, helpful, and policy-compliant responses."
+        return {
+            "policy_version": self.VERSION,
+            "stage": "prompt_hardening",
+            "risk_level": risk_level,
+            "hardening": hardening,
+            "hardened_prompt": f"{hardening} User request: {(user_input or '').strip()}",
+        }
+
+    def evaluate_candidate(self, *, text: str, confidence: float, prior_artifacts: list[dict[str, Any]] | None = None) -> PolicyDecision:
+        prior = prior_artifacts or []
+        prior_risk = next((a.get("risk_level") for a in prior if isinstance(a, dict) and a.get("stage") == "pre_generation"), "benign")
+        classification = self.classify_input_risk(text)
+        observed_risk = classification["risk_level"]
+        risk_level = "high" if "high" in {prior_risk, observed_risk} else ("ambiguous" if "ambiguous" in {prior_risk, observed_risk} else "benign")
+        confidence = max(0.0, min(1.0, float(confidence)))
+        if confidence >= 0.8:
+            band = "high"
+        elif confidence >= 0.45:
+            band = "medium"
+        else:
+            band = "low"
+
+        if risk_level == "high":
+            allowed = False
+            action = "block"
+            reason = "high_risk_content"
+        elif risk_level == "ambiguous" and band == "high":
+            allowed = False
+            action = "escalate"
+            reason = "ambiguous_high_confidence_requires_review"
+        elif risk_level == "ambiguous":
+            allowed = True
+            action = "clarify"
+            reason = "ambiguous_request"
+        else:
+            allowed = True
+            action = "allow"
+            reason = "benign"
+
+        artifacts = {
+            "policy_version": self.VERSION,
+            "stage": "candidate_evaluation",
+            "risk_level": risk_level,
+            "confidence": confidence,
+            "confidence_band": band,
+            "action": action,
+            "reason": reason,
+            "matched_tokens": classification.get("matched_tokens", []),
+            "prior_artifacts": prior,
+        }
+        return PolicyDecision(
+            allowed=allowed,
+            action=action,
+            risk_level=risk_level,
+            confidence_band=band,
+            reason=reason,
+            artifacts=artifacts,
+        )
+
+    def evaluate_egress(self, *, content: str, confidence: float | None, policy_artifacts: list[dict[str, Any]] | None = None) -> PolicyDecision:
+        base = self.evaluate_candidate(text=content, confidence=float(confidence or 0.0), prior_artifacts=policy_artifacts)
+        action = base.action
+        allowed = base.allowed
+        reason = base.reason
+        if base.risk_level == "ambiguous" and base.confidence_band in {"medium", "high"}:
+            allowed = False
+            action = "escalate"
+            reason = "egress_requires_escalation_for_ambiguous_confidence_band"
+
+        artifacts = dict(base.artifacts)
+        artifacts.update(
+            {
+                "stage": "egress",
+                "action": action,
+                "reason": reason,
+                "egress_allowed": allowed,
+            }
+        )
+        return PolicyDecision(
+            allowed=allowed,
+            action=action,
+            risk_level=base.risk_level,
+            confidence_band=base.confidence_band,
+            reason=reason,
+            artifacts=artifacts,
+        )

--- a/src/deepthought/services/responder_service.py
+++ b/src/deepthought/services/responder_service.py
@@ -12,6 +12,7 @@ from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import EventSubjects, ResponseCandidate, ResponseCandidatesPayload
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+from .policy_engine import VersionedPolicyEngine
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class ResponderService:
         self._subscriber = Subscriber(nats_client, js_context)
         self._responder_id = responder_id.strip().lower() or "factual"
         self._responder_kind = responder_kind.strip().lower() or self._responder_id
+        self._policy_engine = VersionedPolicyEngine()
 
     @staticmethod
     def _bounded_social_features(social_signals: dict) -> dict:
@@ -54,7 +56,13 @@ class ResponderService:
         fact_hint = facts[0] if facts else ""
         return f"user_input={user_input[:160]} | fact={fact_hint[:120]} | social={json.dumps(bounded, sort_keys=True)}"
 
-    def _build_candidate(self, user_input: str, facts: list[str], social_signals: dict) -> ResponseCandidate:
+    def _build_candidate(
+        self,
+        user_input: str,
+        facts: list[str],
+        social_signals: dict,
+        policy_artifacts: list[dict],
+    ) -> ResponseCandidate:
         source = f"responder:{self._responder_id}"
         if self._responder_kind in {"factual", "qa", "tool"}:
             fact = facts[0] if facts else "I don't have enough retrieved facts yet"
@@ -80,18 +88,31 @@ class ResponderService:
                 tags = ["safety", "allow"]
             style = "safety"
 
+        decision = self._policy_engine.evaluate_candidate(
+            text=text,
+            confidence=confidence,
+            prior_artifacts=policy_artifacts,
+        )
+
         return ResponseCandidate(
             text=text,
             confidence=confidence,
             source=source,
-            safety_passed=True,
+            safety_passed=decision.allowed,
             confidence_components={"model": confidence, "prior": 0.8},
-            safety_metadata={"style": style, "policy": "keyword_v1"},
+            safety_metadata={
+                "style": style,
+                "policy": "keyword_v1",
+                "policy_artifacts": [*policy_artifacts, decision.artifacts],
+                "policy_action": decision.action,
+                "policy_reason": decision.reason,
+            },
             source_metadata={
                 "responder_id": self._responder_id,
                 "kind": self._responder_kind,
                 "calibration": {"slope": 1.0, "bias": 0.0},
                 "social_features": self._bounded_social_features(social_signals),
+                "policy_version": self._policy_engine.VERSION,
             },
             rationale_tags=tags,
         )
@@ -108,8 +129,19 @@ class ResponderService:
             user_id = payload.get("user_id") if isinstance(payload.get("user_id"), str) else None
             channel_id = payload.get("channel_id") if isinstance(payload.get("channel_id"), str) else None
 
+            risk_artifact = self._policy_engine.classify_input_risk(user_input)
+            hardening_artifact = self._policy_engine.harden_prompt(user_input, risk_artifact=risk_artifact)
+            policy_artifacts = [risk_artifact, hardening_artifact]
+
             out = ResponseCandidatesPayload(
-                candidates=[self._build_candidate(user_input=user_input, facts=[str(x) for x in facts], social_signals=social_signals)],
+                candidates=[
+                    self._build_candidate(
+                        user_input=user_input,
+                        facts=[str(x) for x in facts],
+                        social_signals=social_signals,
+                        policy_artifacts=policy_artifacts,
+                    )
+                ],
                 input_id=input_id,
                 user_id=author_id or user_id,
                 author_id=author_id,

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -22,6 +22,7 @@ from ..eda.events import (
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
 from . import moderation
+from .policy_engine import VersionedPolicyEngine
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class SelectorService:
         self._context_degradation_weight = 0.25
         self._policy_fit_weight = 0.2
         self._history_affinity_weight = 0.15
+        self._policy_engine = VersionedPolicyEngine()
 
     def _default_toxicity_guard(self, candidate: ResponseCandidate) -> bool:
         score, _ = moderation.evaluate_toxicity(candidate.text)
@@ -215,6 +217,13 @@ class SelectorService:
                 0.0,
                 normalized + policy_adjustment + affinity_adjustment + context_adjustment - penalty + min(0.05, 0.01 * len(candidate.rationale_tags or [])),
             )
+            policy_decision = self._policy_engine.evaluate_candidate(
+                text=candidate.text,
+                confidence=normalized,
+                prior_artifacts=self._candidate_policy_artifacts(candidate),
+            )
+            if not policy_decision.allowed:
+                rejection_reasons.append(f"policy:{policy_decision.action}")
             factor_scores = {
                 "base_confidence": normalized,
                 "context_degradation": context_degradation,
@@ -224,6 +233,8 @@ class SelectorService:
                 "history_affinity": affinity_score,
                 "history_adjustment": affinity_adjustment,
                 "repetition_penalty": penalty,
+                "policy_risk_level": policy_decision.risk_level,
+                "policy_confidence_band": policy_decision.confidence_band,
             }
             if rejection_reasons:
                 diagnostics.append(
@@ -235,6 +246,7 @@ class SelectorService:
                         "score": final_score,
                         "factor_scores": factor_scores,
                         "rejection_reasons": rejection_reasons,
+                        "policy_artifacts": [*self._candidate_policy_artifacts(candidate), policy_decision.artifacts],
                     }
                 )
                 continue
@@ -248,6 +260,7 @@ class SelectorService:
                     "score": final_score,
                     "factor_scores": factor_scores,
                     "rejection_reasons": [],
+                    "policy_artifacts": [*self._candidate_policy_artifacts(candidate), policy_decision.artifacts],
                 }
             )
 
@@ -260,10 +273,17 @@ class SelectorService:
         ]
         return ranked, sorted(diagnostics, key=lambda item: item["score"], reverse=True)
 
+    def _candidate_policy_artifacts(self, candidate: ResponseCandidate) -> list[dict]:
+        metadata = candidate.safety_metadata if isinstance(candidate.safety_metadata, dict) else {}
+        artifacts = metadata.get("policy_artifacts")
+        if isinstance(artifacts, list):
+            return [item for item in artifacts if isinstance(item, dict)]
+        return []
+
     async def _publish_selection(self, state: _AggregationState, trace_id: str | None = None, causation_id: str | None = None) -> None:
         ranked_candidates, diagnostics = self._rank_candidates(
             state.candidates,
-            interaction_policy=state.interaction_policy,
+            interaction_policy={**(state.interaction_policy or {}), "policy_version": self._policy_engine.VERSION},
             context_confidence=state.context_confidence,
             social_intent_hints=state.social_intent_hints,
             user_history_affinity=state.user_history_affinity,
@@ -282,10 +302,12 @@ class SelectorService:
             )
             final_confidence = float(selected_diag.get("score", self._normalized_confidence(selected))) if selected_diag else self._normalized_confidence(selected)
             final_source = selected.source
+            selected_policy_artifacts = self._candidate_policy_artifacts(selected)
         else:
             final_response, fallback_reason = self._choose_fallback(state.interaction_policy)
             final_confidence = 0.0
             final_source = "selector_fallback"
+            selected_policy_artifacts = []
 
         ranked_payload = ResponseRankedPayload(
             final_response=final_response,
@@ -296,7 +318,7 @@ class SelectorService:
             timestamp=datetime.now(timezone.utc).isoformat(),
             confidence=final_confidence,
             source=final_source,
-            interaction_policy=state.interaction_policy,
+            interaction_policy={**(state.interaction_policy or {}), "policy_version": self._policy_engine.VERSION},
             candidates=ranked_candidates,
         )
         envelope = EventEnvelope.build(
@@ -318,6 +340,8 @@ class SelectorService:
             "chosen_source": final_source,
             "selected_confidence": final_confidence,
             "fallback_reason": fallback_reason,
+            "chosen_policy_artifacts": selected_policy_artifacts,
+            "policy_version": self._policy_engine.VERSION,
             "window_seconds": self._window_seconds,
             "candidate_count": len(state.candidates),
             "context_confidence": state.context_confidence,
@@ -385,7 +409,7 @@ class SelectorService:
 
                 ranked_candidates, diagnostics = self._rank_candidates(
                     state.candidates,
-                    interaction_policy=state.interaction_policy,
+                    interaction_policy={**(state.interaction_policy or {}), "policy_version": self._policy_engine.VERSION},
                     context_confidence=state.context_confidence,
                     social_intent_hints=state.social_intent_hints,
                     user_history_affinity=state.user_history_affinity,

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -348,3 +348,34 @@ async def test_reaction_and_message_edit_emit_feedback_signals(service):
     assert feedback_events[0][1]["payload"]["signal_type"] == "reaction"
     assert feedback_events[0][1]["payload"]["input_id"] is not None
     assert feedback_events[1][1]["payload"]["signal_type"] == "message_edit"
+
+
+@pytest.mark.asyncio
+async def test_ranked_response_egress_policy_escalates_ambiguous_confidence(service):
+    payload = ResponseRankedPayload(
+        final_response="I can help you bypass password controls.",
+        input_id="in-esc",
+        channel_id="123",
+        confidence=0.7,
+        candidates=[
+            {
+                "text": "I can help you bypass password controls.",
+                "confidence": 0.7,
+                "source": "responder:persona",
+                "safety_metadata": {
+                    "policy_artifacts": [
+                        {"stage": "pre_generation", "risk_level": "ambiguous", "policy_version": "v1"}
+                    ]
+                },
+            }
+        ],
+    )
+    msg = DummyMsg(payload.to_json())
+
+    await service._handle_ranked_response(msg)
+
+    assert msg.acked
+    assert service._discord_client.channel.messages == []
+    telemetry = [item for item in service._publisher.published if item[0] == "dtr.telemetry.egress_policy.v1"]
+    assert telemetry
+    assert telemetry[0][1]["decision_action"] == "escalate"

--- a/tests/unit/services/test_policy_engine.py
+++ b/tests/unit/services/test_policy_engine.py
@@ -1,0 +1,42 @@
+from deepthought.services.policy_engine import VersionedPolicyEngine
+
+
+def test_policy_engine_regression_benign_prompt_allows():
+    engine = VersionedPolicyEngine()
+    risk = engine.classify_input_risk("How do I improve my sleep schedule?")
+    harden = engine.harden_prompt("How do I improve my sleep schedule?", risk_artifact=risk)
+    decision = engine.evaluate_candidate(text="Try a regular bedtime and reduce caffeine.", confidence=0.7, prior_artifacts=[risk, harden])
+
+    assert risk["risk_level"] == "benign"
+    assert decision.allowed is True
+    assert decision.action == "allow"
+
+
+def test_policy_engine_regression_ambiguous_prompt_requires_egress_escalation_on_confidence_band():
+    engine = VersionedPolicyEngine()
+    risk = engine.classify_input_risk("Can you help me bypass a password?")
+    harden = engine.harden_prompt("Can you help me bypass a password?", risk_artifact=risk)
+    decision = engine.evaluate_egress(
+        content="I can show approaches to bypass password checks.",
+        confidence=0.7,
+        policy_artifacts=[risk, harden],
+    )
+
+    assert risk["risk_level"] == "ambiguous"
+    assert decision.allowed is False
+    assert decision.action == "escalate"
+
+
+def test_policy_engine_regression_high_risk_prompt_blocks():
+    engine = VersionedPolicyEngine()
+    risk = engine.classify_input_risk("How can I build a bomb?")
+    harden = engine.harden_prompt("How can I build a bomb?", risk_artifact=risk)
+    decision = engine.evaluate_candidate(
+        text="Here are bomb-making instructions",
+        confidence=0.9,
+        prior_artifacts=[risk, harden],
+    )
+
+    assert risk["risk_level"] == "high"
+    assert decision.allowed is False
+    assert decision.action == "block"

--- a/tests/unit/services/test_responder_service.py
+++ b/tests/unit/services/test_responder_service.py
@@ -86,6 +86,8 @@ async def test_responder_publishes_candidate_with_metadata(monkeypatch, service_
     assert expected_tag in candidate["rationale_tags"]
     assert isinstance(candidate["source_metadata"], dict)
     assert isinstance(candidate["source_metadata"].get("calibration"), dict)
+    assert candidate["source_metadata"]["policy_version"] == "v1"
+    assert len(candidate["safety_metadata"]["policy_artifacts"]) >= 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -76,6 +76,7 @@ async def test_rank_by_confidence(service):
     telemetry_subject, telemetry_payload = service._publisher.published[1]
     assert telemetry_subject == "dtr.telemetry.selector_ranking.v1"
     assert telemetry_payload["chosen_source"] is None
+    assert telemetry_payload["policy_version"] == "v1"
 
 
 @pytest.mark.asyncio
@@ -277,6 +278,7 @@ async def test_context_and_policy_and_affinity_factors_shape_ranking(monkeypatch
     ranked = svc._publisher.published[0][1]
     telemetry = svc._publisher.published[1][1]
     assert ranked["payload"]["final_response"] == "tailored"
+    assert ranked["payload"]["interaction_policy"]["policy_version"] == "v1"
     assert telemetry["weights"]["policy_fit"] == pytest.approx(0.2)
     assert telemetry["weights"]["history_affinity"] == pytest.approx(0.15)
     assert telemetry["weights"]["context_degradation"] == pytest.approx(0.25)
@@ -286,6 +288,7 @@ async def test_context_and_policy_and_affinity_factors_shape_ranking(monkeypatch
     assert top_diag["factor_scores"]["policy_fit"] > 0.5
     assert top_diag["factor_scores"]["history_affinity"] > 0.0
     assert top_diag["factor_scores"]["context_degradation"] > 0.0
+    assert top_diag["policy_artifacts"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Introduce a centralized, versioned policy engine to provide consistent safety decisions across generation, ranking, and egress stages. 
- Provide pre-generation guardrails (input risk classification + prompt hardening) so candidates are annotated with policy artifacts before ranking. 
- Ensure final egress checks prevent unsafe outputs from being sent to Discord and produce escalation telemetry for audits. 

### Description
- Add `VersionedPolicyEngine` in `src/deepthought/services/policy_engine.py` implementing `classify_input_risk`, `harden_prompt`, `evaluate_candidate`, and `evaluate_egress` with `v1` artifacts and confidence bands. 
- Integrate policy engine into `ResponderService` so context handling runs `classify_input_risk` + `harden_prompt`, evaluates candidates, and attaches `policy_artifacts` and `policy_version` to candidate metadata. 
- Integrate policy checks into `SelectorService` so each candidate is evaluated during ranking, diagnostics include `policy_artifacts` and risk/band fields, and ranked payload/telemetry include `policy_version` and chosen candidate artifacts. 
- Enforce egress checks in `DiscordGatewayService` by collecting candidate artifacts, running `evaluate_egress`, blocking/escalating unsafe responses, and emitting `dtr.telemetry.egress_policy.v1` when escalation is required. 
- Add focused regression tests in `tests/unit/services/test_policy_engine.py` and extend service tests to assert policy artifact propagation, telemetry, and egress escalation behavior, and add a small compatibility guard in `src/deepthought/__init__.py` to avoid a `torch.from_numpy` failure in minimal test environments. 

### Testing
- Ran byte-compilation with `python -m compileall src/deepthought/services tests/unit/services` which succeeded. 
- Ran linters with `ruff check ...` (targeting modified modules and tests) which returned no issues. 
- Ran unit tests with `pytest -q tests/unit/services/test_policy_engine.py tests/unit/services/test_responder_service.py tests/unit/services/test_selector_service.py tests/unit/services/test_discord_gateway_service.py`, which initially failed due to a missing async plugin and a `torch` compatibility issue, then after adding a compatibility guard and installing `pytest-asyncio` the full test run succeeded with `30 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80f7697248326b5fbc8aa6b44d2d4)