### PR TITLE
Refocus orchestration on canonical LLM responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,17 +900,33 @@ For the comprehensive plan outlining each phase, see [docs/discord_bot_phase_rep
 Two lightweight reference modules show how components can interact through NATS:
 
 * **BasicMemory** -- subscribes to `INPUT_RECEIVED` events, stores each user input in a local `memory.json` file and then publishes a `MEMORY_RETRIEVED` event containing the most recent entries.
-* **BasicLLM** -- listens for `MEMORY_RETRIEVED`, runs a small language model to generate one or more reply candidates, and publishes `RESPONSE_CANDIDATES`. A selector then publishes `RESPONSE_RANKED` for delivery. This module requires the optional heavy dependencies `transformers` and `torch`.
+* **BasicLLM** -- lightweight reference module for candidate generation. In the primary production path, `context_assembler` feeds `llm_remote`, which publishes grounded `RESPONSE_CANDIDATES` for the selector before the Discord gateway delivers `RESPONSE_RANKED`. This module requires the optional heavy dependencies `transformers` and `torch`.
 
 ### Example Workflow
 
 1. The `InputHandler` emits an `INPUT_RECEIVED` event when it receives a message.
 2. `BasicMemory` logs the text to `memory.json` and publishes a `MEMORY_RETRIEVED` event with the last few inputs.
-3. `BasicLLM` generates response candidates from those facts and publishes a `RESPONSE_CANDIDATES` event.
-4. A selector consumes candidates and publishes `RESPONSE_RANKED`.
-5. The `OutputHandler` (or another consumer) can then deliver the ranked response to the user.
+3. `ContextAssemblerService` publishes `CONTEXT_ASSEMBLED` for the canonical `llm_remote` conversational responder.
+4. `llm_remote` generates grounded response candidates and publishes `RESPONSE_CANDIDATES`; optional heuristic responders can add auxiliary specialist candidates on the same subject.
+5. `SelectorService` consumes candidates and publishes `RESPONSE_RANKED` for the Discord gateway or another output consumer.
 
 
+
+
+### Canonical Conversational Responder Contract
+
+The default bot architecture is:
+
+`context assembler -> llm responder -> selector -> Discord gateway`
+
+The canonical conversational responder consumes `EventSubjects.CONTEXT_ASSEMBLED` and publishes `EventSubjects.RESPONSE_CANDIDATES`. Every emitted `ResponseCandidate` should include grounded metadata so downstream ranking remains stable across responder types:
+
+- `source`
+- `confidence`
+- `safety_passed`
+- calibration metadata under `source_metadata`
+
+Heuristic responders in `src/deepthought/services/responder_service.py` are optional specialist candidate producers. They can publish extra factual, persona, or safety-oriented candidates to improve ranking, but they are not the default end-user voice anymore.
 
 ## DSPy Pipelines
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,10 @@ For the default orchestrator profile, the following event chain is **required**.
 2. `MEMORY_RETRIEVED` is published by `cognitive_core` and consumed by `context_assembler`.
 3. Social context must come from either `SOCIAL_UPDATED` (from `social_graph`) **or** `SOCIAL_SIGNALS_RETRIEVED` (from alternative social providers) and be consumed by `context_assembler`.
 4. `PERCEPTION_INTERPRET_RETRIEVED` is published by `perception_interpret` and consumed by `context_assembler`.
-5. `CONTEXT_ASSEMBLED` is published by `context_assembler` and consumed by `llm_remote` (or another LLM responder).
-6. `RESPONSE_RANKED` is published by `selector`, consumed by `discord_gateway` for delivery, and consumed by `feedback` for adaptation context capture.
-7. `OUTCOME_SIGNAL` and `CORRECTION_SIGNAL` are consumed by `feedback` via durable JetStream consumers to adapt affinity and confidence state.
+5. `CONTEXT_ASSEMBLED` is published by `context_assembler` and consumed by the canonical `llm_remote` conversational responder. Optional heuristic responders may also subscribe to contribute auxiliary candidates.
+6. `RESPONSE_CANDIDATES` is published primarily by `llm_remote`, then consumed by `selector`; optional heuristic responders may publish additional specialist candidates on the same subject for ranking.
+7. `RESPONSE_RANKED` is published by `selector`, consumed by `discord_gateway` for delivery, and consumed by `feedback` for adaptation context capture.
+8. `OUTCOME_SIGNAL` and `CORRECTION_SIGNAL` are consumed by `feedback` via durable JetStream consumers to adapt affinity and confidence state.
 
 Operators should treat this as a deployment invariant and verify that each required subject has at least one publisher and one subscriber before startup.
 
@@ -37,15 +38,15 @@ sequenceDiagram
     participant User
     participant Bot
     participant ContextAssembler
-    participant LLM
+    participant LLMResponder
     participant Selector
 
     User->>Bot: Message
     Bot->>NATS: INPUT_RECEIVED
     NATS->>ContextAssembler: INPUT_RECEIVED (+ provider outputs)
     ContextAssembler->>NATS: CONTEXT_ASSEMBLED
-    NATS->>LLM: CONTEXT_ASSEMBLED
-    LLM->>NATS: RESPONSE_CANDIDATES
+    NATS->>LLMResponder: CONTEXT_ASSEMBLED
+    LLMResponder->>NATS: RESPONSE_CANDIDATES
     NATS->>Selector: RESPONSE_CANDIDATES
     Selector->>NATS: RESPONSE_RANKED
     NATS->>Feedback: RESPONSE_RANKED
@@ -53,14 +54,14 @@ sequenceDiagram
     Bot-->>User: Reply
 ```
 
-The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the responder publishes `RESPONSE_CANDIDATES` and the selector picks the winner.
+The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the canonical path `context_assembler -> llm_remote -> selector -> discord_gateway` completes. Heuristic responders can be enabled as auxiliary candidate producers, but they are no longer the default user-facing voice.
 
 Feedback adaptation is part of the default production DAG and should be deployed with durable subscriptions for `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL` as documented in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
 
 ### Candidate schema expectations (`RESPONSE_CANDIDATES`)
 
-`ResponseCandidatesPayload` should carry one or more `ResponseCandidate` entries. Responders are expected to emit multiple candidates when the backend supports sampling or hybrid tool/rule generation.
+`ResponseCandidatesPayload` should carry one or more `ResponseCandidate` entries. The canonical conversational responder consumes `CONTEXT_ASSEMBLED` and emits `RESPONSE_CANDIDATES`. It should emit multiple candidates when the backend supports sampling or hybrid tool/rule generation. Optional heuristic specialists may publish additional candidates on the same subject.
 
 Each candidate should include:
 
@@ -68,8 +69,9 @@ Each candidate should include:
 - `confidence`: Calibrated `0..1` confidence used by selector ranking.
 - `source`: Candidate origin label (for example `remote_llm:sampling`, `tool`, or `rule`) used by source-specific selector weighting.
 - `safety_passed`: Boolean safety gate result for selector filtering.
-- `confidence_components`: Optional token/model/heuristic component breakdown for diagnostics and calibration audits.
-- `safety_metadata`: Optional policy details (matched terms, policy version, severity) for telemetry and incident triage.
+- `confidence_components`: Component breakdown for diagnostics and calibration audits.
+- `safety_metadata`: Policy details (matched terms, policy version, severity) for telemetry and incident triage.
+- `source_metadata`: Grounded responder metadata including canonical `source`, `confidence`, `safety_passed`, and calibration metadata so selector/ranker services can reason over heterogeneous candidates consistently.
 
 Selectors may down-weight or reject candidates using `source`, `confidence`, and safety fields; producers should keep this metadata stable across versions.
 

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -11,9 +11,7 @@ services:
   - perception
   - perception_interpret
   - context_assembler
-  - factual_responder
-  - persona_responder
-  - safety_responder
+  - llm_remote
   - selector
   - feedback
   - reasoning
@@ -78,8 +76,28 @@ service_bindings:
         event_subject: EventSubjects.MEMORY_RETRIEVED
         jetstream: true
 
+  llm_remote:
+    description: Canonical conversational responder path built on llm_remote_service.py and modules/llm_remote.py.
+    env:
+      - NATS_URL
+      - LLM_ENDPOINT
+      - LLM_BACKEND
+      - LLM_NUM_CANDIDATES
+      - LLM_SOURCE_NAME
+    subscribe:
+      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+        event_subject: EventSubjects.CONTEXT_ASSEMBLED
+        jetstream: true
+        durable: llm_remote_service
+        required_reliability: true
+    publish:
+      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+        event_subject: EventSubjects.RESPONSE_CANDIDATES
+        jetstream: true
+
   factual_responder:
-    description: Fact-grounded QA/tool responder that emits concise candidates.
+    optional: true
+    description: Optional fact specialist that contributes heuristic candidates for selector/ranker context.
     env:
       - NATS_URL
     subscribe:
@@ -87,14 +105,15 @@ service_bindings:
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_factual_service
-        required_reliability: true
+        required_reliability: false
     publish:
       - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
   persona_responder:
-    description: Persona-aligned conversational responder for rapport and continuity.
+    optional: true
+    description: Optional persona specialist that adds rapport-oriented candidate hints for the selector.
     env:
       - NATS_URL
     subscribe:
@@ -102,14 +121,15 @@ service_bindings:
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_persona_service
-        required_reliability: true
+        required_reliability: false
     publish:
       - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
   safety_responder:
-    description: Safety responder that can emit refusal/safe-default candidates.
+    optional: true
+    description: Optional safety specialist that contributes refusal or safe-default candidates.
     env:
       - NATS_URL
     subscribe:
@@ -117,7 +137,7 @@ service_bindings:
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_safety_service
-        required_reliability: true
+        required_reliability: false
     publish:
       - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
         event_subject: EventSubjects.RESPONSE_CANDIDATES

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -280,7 +280,50 @@ class RemoteLLM:
         lowered = text.lower()
         blocked_terms = ["kill", "bomb", "dox", "self-harm"]
         matched = [term for term in blocked_terms if term in lowered]
-        return (not matched), {"rule": "keyword_v1", "matched_terms": matched, "severity": "high" if matched else "none"}
+        safe = not matched
+        return safe, {
+            "rule": "keyword_v1",
+            "matched_terms": matched,
+            "severity": "high" if matched else "none",
+            "safety_passed": safe,
+        }
+
+    def _build_grounded_metadata(
+        self,
+        *,
+        source: str,
+        confidence: float,
+        confidence_components: dict[str, float],
+        safety_passed: bool,
+        safety_metadata: dict[str, object],
+        prompt: str | None = None,
+        response_mode: str = "generative",
+    ) -> dict[str, object]:
+        calibration = {
+            "slope": 1.0,
+            "bias": 0.0,
+            "version": "remote_llm_v1",
+        }
+        return {
+            "source": source,
+            "backend": self._backend_name,
+            "response_mode": response_mode,
+            "is_primary_voice": True,
+            "confidence": confidence,
+            "safety_passed": safety_passed,
+            "calibration": calibration,
+            "calibration_metadata": {
+                "calibration": calibration,
+                "confidence_components": confidence_components,
+                "prompt_chars": len(prompt or ""),
+                "candidate_count": self._num_candidates,
+            },
+            "grounding": {
+                "contract": "canonical_conversational_responder_v1",
+                "prompt_grounded": bool(prompt),
+                "safety_rule": safety_metadata.get("rule"),
+            },
+        }
 
     async def _generate_candidates(self, prompt: str) -> list[ResponseCandidate]:
         if self._use_dspy and self._qa_pipeline is not None:
@@ -297,6 +340,15 @@ class RemoteLLM:
                     safety_passed=safe,
                     confidence_components=components,
                     safety_metadata=safety_metadata,
+                    source_metadata=self._build_grounded_metadata(
+                        source=f"{self._source_name}:dspy",
+                        confidence=confidence,
+                        confidence_components=components,
+                        safety_passed=safe,
+                        safety_metadata=safety_metadata,
+                        prompt=prompt,
+                        response_mode="dspy",
+                    ),
                 )
             ]
 
@@ -318,6 +370,14 @@ class RemoteLLM:
                     safety_passed=safe,
                     confidence_components=components,
                     safety_metadata=safety_metadata,
+                    source_metadata=self._build_grounded_metadata(
+                        source=source,
+                        confidence=confidence,
+                        confidence_components=components,
+                        safety_passed=safe,
+                        safety_metadata=safety_metadata,
+                        prompt=prompt,
+                    ),
                 )
             )
 
@@ -399,7 +459,16 @@ class RemoteLLM:
                         source=f"{self._source_name}:clarifying_fallback",
                         safety_passed=True,
                         confidence_components={"fallback": 1.0},
-                        safety_metadata={"rule": "low_multimodal_confidence"},
+                        safety_metadata={"rule": "low_multimodal_confidence", "safety_passed": True},
+                        source_metadata=self._build_grounded_metadata(
+                            source=f"{self._source_name}:clarifying_fallback",
+                            confidence=0.95,
+                            confidence_components={"fallback": 1.0},
+                            safety_passed=True,
+                            safety_metadata={"rule": "low_multimodal_confidence", "safety_passed": True},
+                            prompt=prompt,
+                            response_mode="clarifying_fallback",
+                        ),
                     )
                 ]
             else:

--- a/src/deepthought/services/responder_service.py
+++ b/src/deepthought/services/responder_service.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class ResponderService:
-    """Configurable responder that emits candidate responses for selector ranking."""
+    """Optional heuristic specialist that emits selector inputs, not the primary bot voice."""
 
     def __init__(
         self,
@@ -56,6 +56,48 @@ class ResponderService:
         fact_hint = facts[0] if facts else ""
         return f"user_input={user_input[:160]} | fact={fact_hint[:120]} | social={json.dumps(bounded, sort_keys=True)}"
 
+    def _build_specialist_payload(
+        self,
+        user_input: str,
+        facts: list[str],
+        social_signals: dict,
+    ) -> tuple[str, float, list[str], str, str]:
+        if self._responder_kind in {"factual", "qa", "tool"}:
+            fact = facts[0] if facts else "I don't have enough retrieved facts yet"
+            return (
+                f"Useful grounding fact: {fact}.",
+                0.78,
+                ["specialist", "factual", "grounded", "tool_ready"],
+                "concise",
+                "Fact-grounded specialist hint",
+            )
+        if self._responder_kind in {"persona", "conversational"}:
+            prompt_context = self._compose_prompt_context(user_input, facts, social_signals)
+            return (
+                f"Tone/rapport hint: acknowledge the user warmly while staying aligned with {prompt_context}.",
+                0.73,
+                ["specialist", "persona", "empathetic", "rapport"],
+                "friendly",
+                "Persona specialist hint",
+            )
+
+        blocked = any(token in user_input.lower() for token in ("harm", "attack", "exploit"))
+        if blocked:
+            return (
+                "Safety hint: refuse harmful assistance and redirect to safer alternatives.",
+                0.93,
+                ["specialist", "safety", "refusal", "policy"],
+                "safety",
+                "Safety specialist refusal",
+            )
+        return (
+            "Safety hint: content appears answerable, but avoid escalating risk and keep the reply bounded.",
+            0.62,
+            ["specialist", "safety", "allow"],
+            "safety",
+            "Safety specialist allow hint",
+        )
+
     def _build_candidate(
         self,
         user_input: str,
@@ -64,53 +106,48 @@ class ResponderService:
         policy_artifacts: list[dict],
     ) -> ResponseCandidate:
         source = f"responder:{self._responder_id}"
-        if self._responder_kind in {"factual", "qa", "tool"}:
-            fact = facts[0] if facts else "I don't have enough retrieved facts yet"
-            text = f"Factual answer: {fact}."
-            confidence = 0.78
-            tags = ["factual", "grounded", "tool_ready"]
-            style = "concise"
-        elif self._responder_kind in {"persona", "conversational"}:
-            prompt_context = self._compose_prompt_context(user_input, facts, social_signals)
-            text = f"I hear you: {user_input}. Context: {prompt_context}."
-            confidence = 0.73
-            tags = ["persona", "empathetic", "rapport"]
-            style = "friendly"
-        else:
-            blocked = any(token in user_input.lower() for token in ("harm", "attack", "exploit"))
-            if blocked:
-                text = "I can’t help with harmful actions. I can help with safer alternatives instead."
-                confidence = 0.93
-                tags = ["safety", "refusal", "policy"]
-            else:
-                text = "This looks safe to answer. Please continue with what you need."
-                confidence = 0.62
-                tags = ["safety", "allow"]
-            style = "safety"
+        text, confidence, tags, style, role_description = self._build_specialist_payload(
+            user_input=user_input,
+            facts=facts,
+            social_signals=social_signals,
+        )
 
         decision = self._policy_engine.evaluate_candidate(
             text=text,
             confidence=confidence,
             prior_artifacts=policy_artifacts,
         )
+        safety_passed = decision.allowed
+        confidence_components = {"model": confidence, "prior": 0.8}
+        calibration = {"slope": 1.0, "bias": 0.0, "version": "heuristic_v1"}
 
         return ResponseCandidate(
             text=text,
             confidence=confidence,
             source=source,
-            safety_passed=decision.allowed,
-            confidence_components={"model": confidence, "prior": 0.8},
+            safety_passed=safety_passed,
+            confidence_components=confidence_components,
             safety_metadata={
                 "style": style,
                 "policy": "keyword_v1",
                 "policy_artifacts": [*policy_artifacts, decision.artifacts],
                 "policy_action": decision.action,
                 "policy_reason": decision.reason,
+                "safety_passed": safety_passed,
             },
             source_metadata={
+                "source": source,
                 "responder_id": self._responder_id,
                 "kind": self._responder_kind,
-                "calibration": {"slope": 1.0, "bias": 0.0},
+                "role": "specialist_candidate_producer",
+                "role_description": role_description,
+                "is_primary_voice": False,
+                "calibration": calibration,
+                "calibration_metadata": {
+                    "calibration": calibration,
+                    "confidence_components": confidence_components,
+                    "policy_version": self._policy_engine.VERSION,
+                },
                 "social_features": self._bounded_social_features(social_signals),
                 "policy_version": self._policy_engine.VERSION,
             },
@@ -155,7 +192,12 @@ class ResponderService:
                 trace_id=envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None,
                 causation_id=envelope_meta.get("event_id") if isinstance(envelope_meta.get("event_id"), str) else input_id,
             )
-            await self._publisher.publish(EventSubjects.RESPONSE_CANDIDATES, envelope.__dict__, use_jetstream=True, timeout=10.0)
+            await self._publisher.publish(
+                EventSubjects.RESPONSE_CANDIDATES,
+                envelope.__dict__,
+                use_jetstream=True,
+                timeout=10.0,
+            )
             await msg.ack()
         except Exception:
             logger.error("ResponderService[%s] failed", self._responder_id, exc_info=True)

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -486,3 +486,19 @@ async def test_generate_candidates_local_quantized_backend(monkeypatch):
     assert isinstance(result[0].confidence, float)
     assert result[0].safety_metadata["rule"] == "keyword_v1"
     await llm.stop_listening()
+
+
+@pytest.mark.asyncio
+async def test_generate_candidates_include_grounded_metadata(monkeypatch):
+    resp = DummyResponse({"candidates": [{"text": "generated", "source": "remote_http", "score": 0.7}]})
+    session = DummySession(resp)
+    llm = create_llm(monkeypatch, session)
+
+    result = await llm._generate_candidates("hello")
+
+    metadata = result[0].source_metadata
+    assert metadata["source"] == result[0].source
+    assert metadata["confidence"] == result[0].confidence
+    assert metadata["safety_passed"] == result[0].safety_passed
+    assert metadata["calibration_metadata"]["candidate_count"] == 3
+    assert metadata["grounding"]["contract"] == "canonical_conversational_responder_v1"

--- a/tests/unit/services/test_responder_service.py
+++ b/tests/unit/services/test_responder_service.py
@@ -87,7 +87,11 @@ async def test_responder_publishes_candidate_with_metadata(monkeypatch, service_
     assert isinstance(candidate["source_metadata"], dict)
     assert isinstance(candidate["source_metadata"].get("calibration"), dict)
     assert candidate["source_metadata"]["policy_version"] == "v1"
+    assert candidate["source_metadata"]["role"] == "specialist_candidate_producer"
+    assert candidate["source_metadata"]["is_primary_voice"] is False
+    assert candidate["source_metadata"]["source"] == expected_source
     assert len(candidate["safety_metadata"]["policy_artifacts"]) >= 3
+    assert candidate["safety_metadata"]["safety_passed"] == candidate["safety_passed"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Consolidate the primary conversational path around `llm_remote` so the runtime bot pipeline is: `context assembler -> llm responder -> selector -> Discord gateway`.
- Make lightweight heuristic responders (factual/persona/safety) optional specialist candidate producers instead of the default user-facing voice, and ensure candidates include stable grounded metadata for selector reasoning.

### Description

- Replace the default responder trio in `examples/orchestrator.yml` with a single canonical `llm_remote` service entry and mark the heuristic `factual_responder`, `persona_responder`, and `safety_responder` bindings as optional helper producers.
- Refactor `src/deepthought/services/responder_service.py` so heuristic responders emit specialist candidate hints and include explicit `source`/`is_primary_voice`/`role`/calibration fields in `source_metadata` and mirror `safety_passed` into `safety_metadata`.
- Extend `src/deepthought/modules/llm_remote.py` to produce grounded `source_metadata` for each `ResponseCandidate` (including `source`, `confidence`, `safety_passed`, and calibration metadata) and add a `_build_grounded_metadata` helper so the canonical LLM responder meets the conversational responder contract.
- Update `README.md` and `docs/architecture.md` to describe the primary bot architecture and the canonical responder contract, and document heuristic responders as optional auxiliary ranker inputs.
- Adjusted and added unit tests to assert the new metadata and contract expectations for both heuristic responders and the `llm_remote` module.

### Testing

- Ran unit tests `pytest tests/unit/services/test_responder_service.py tests/unit/modules/test_llm_remote.py` and all tests passed (`23 passed`).
- Ran linter/format checks with `ruff` which reported no issues, and verified Python compilation with `python -m compileall` for modified modules with no errors.
- Updated unit tests to validate the new metadata contract and specialist responder behavior and confirmed they succeed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab18d066883269b6c7b4f6724279f)