### PR TITLE
Add deterministic layered conversation memory context

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -159,6 +159,8 @@ class InputReceivedPayload(EventPayload):
     reference_message_id: Optional[str] = None
     thread_id: Optional[str] = None
     attachments: Optional[list[AttachmentDescriptor]] = None
+    conversation_window: list[Dict[str, Any]] = field(default_factory=list)
+    recent_turn_summary: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "InputReceivedPayload":
@@ -176,7 +178,10 @@ class InputReceivedPayload(EventPayload):
             "author_is_bot": data.get("author_is_bot"),
             "reference_message_id": data.get("reference_message_id"),
             "thread_id": data.get("thread_id"),
+            "recent_turn_summary": data.get("recent_turn_summary"),
         }
+        conversation_window = data.get("conversation_window")
+        normalized["conversation_window"] = conversation_window if isinstance(conversation_window, list) else []
         raw_attachments = data.get("attachments")
         if isinstance(raw_attachments, list):
             attachments = [

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import List, Optional
 
@@ -41,6 +42,15 @@ from .db_manager import DBManager
 from .input_enrichment_service import InputEnrichmentService
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RetrievalPolicy:
+    recent_turns: int = 4
+    durable_user_facts: int = 4
+    topic_memory: int = 4
+    continuity_summaries: int = 2
+    final_fact_budget: int = 12
 
 
 class CognitiveCoreService(BaseService):
@@ -99,6 +109,7 @@ class CognitiveCoreService(BaseService):
         self._salience_summaries: list[dict[str, str | float]] = []
         self._consolidation_task: asyncio.Task | None = None
         self._consolidation_interval_s = 60.0
+        self._retrieval_policy = RetrievalPolicy()
 
     def _build_graph_memory_store(self):
         backend = (self._settings.graph_backend or "").lower()
@@ -326,6 +337,93 @@ class CognitiveCoreService(BaseService):
             graph_facts.append(format_fact_snippet(fact))
         return summary_facts + graph_facts
 
+    @staticmethod
+    def _normalize_fact_entries(entries: list[str], *, prefix: str | None = None) -> list[str]:
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in entries:
+            text = " ".join(str(item).split()).strip()
+            if not text:
+                continue
+            key = text.lower()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(f"{prefix}{text}" if prefix else text)
+        return normalized
+
+    def _recent_episodic_turns(
+        self,
+        *,
+        conversation_window: list[dict[str, object]],
+        user_input: str,
+    ) -> list[str]:
+        prior_turns: list[str] = []
+        for turn in conversation_window[:-1]:
+            if not isinstance(turn, dict):
+                continue
+            role = str(turn.get("role") or "user")
+            text = " ".join(str(turn.get("text") or "").split()).strip()
+            if text:
+                prior_turns.append(f"{role}: {text}")
+        if not prior_turns and user_input.strip():
+            prior_turns.append(f"user: {user_input.strip()}")
+        return self._normalize_fact_entries(prior_turns)[-self._retrieval_policy.recent_turns :]
+
+    def _channel_thread_continuity(
+        self,
+        *,
+        conversation_window: list[dict[str, object]],
+        recent_turn_summary: str | None,
+        channel_id: str | None,
+        thread_id: str | None,
+    ) -> list[str]:
+        continuity: list[str] = []
+        if recent_turn_summary and recent_turn_summary.strip():
+            continuity.append(f"recent summary: {recent_turn_summary.strip()}")
+        if thread_id:
+            continuity.append(f"thread focus: thread:{thread_id}")
+        elif channel_id:
+            continuity.append(f"channel focus: channel:{channel_id}")
+        if conversation_window:
+            participants = sorted(
+                {
+                    str(turn.get("author_id")).strip()
+                    for turn in conversation_window
+                    if isinstance(turn, dict) and str(turn.get("author_id") or "").strip()
+                }
+            )
+            if participants:
+                continuity.append(f"active participants: {', '.join(participants[:4])}")
+        return self._normalize_fact_entries(continuity)[: self._retrieval_policy.continuity_summaries]
+
+    def _assemble_retrieval_layers(
+        self,
+        *,
+        recent_turns: list[str],
+        durable_user_facts: list[str],
+        topic_memory: list[str],
+        continuity_summaries: list[str],
+    ) -> dict[str, list[str]]:
+        return {
+            "recent_episodic_turns": recent_turns[: self._retrieval_policy.recent_turns],
+            "durable_user_facts": durable_user_facts[: self._retrieval_policy.durable_user_facts],
+            "topic_entity_memory": topic_memory[: self._retrieval_policy.topic_memory],
+            "channel_thread_continuity": continuity_summaries[: self._retrieval_policy.continuity_summaries],
+        }
+
+    def _flatten_retrieval_layers(self, layers: dict[str, list[str]]) -> list[str]:
+        ordered: list[str] = []
+        for layer_name in (
+            "recent_episodic_turns",
+            "durable_user_facts",
+            "topic_entity_memory",
+            "channel_thread_continuity",
+        ):
+            for item in layers.get(layer_name, []):
+                ordered.append(f"[{layer_name}] {item}")
+        return ordered[: self._retrieval_policy.final_fact_budget]
+
     async def _handle_input(self, msg: Msg) -> None:
         input_id = "unknown"
         start = time.perf_counter()
@@ -344,6 +442,15 @@ class CognitiveCoreService(BaseService):
             user_id = enriched.user_id
             author_id = enriched.author_id
             channel_id = enriched.channel_id
+            conversation_window = decoded_payload.get("conversation_window")
+            if not isinstance(conversation_window, list):
+                conversation_window = []
+            recent_turn_summary = decoded_payload.get("recent_turn_summary")
+            if not isinstance(recent_turn_summary, str):
+                recent_turn_summary = None
+            thread_id = decoded_payload.get("thread_id")
+            if not isinstance(thread_id, str):
+                thread_id = None
             logger.info("CognitiveCoreService received input %s", input_id)
 
             resolved_user_id = enriched.resolved_user_id
@@ -394,9 +501,7 @@ class CognitiveCoreService(BaseService):
                     source_id=input_id,
                 )
 
-            memory_facts = (
-                self._memory.retrieve_context(user_input) if self._memory else []
-            )
+            memory_facts = self._memory.retrieve_context(user_input) if self._memory else []
             vector_facts: List[str] = []
             if self._search:
                 try:
@@ -412,32 +517,27 @@ class CognitiveCoreService(BaseService):
                 str(resolved_user_id), user_input
             )
 
-            facts: List[str] = []
-            merged_facts: dict[str, dict[str, List[str] | str]] = {}
-            for source, entries in (
-                ("memory", memory_facts),
-                ("vector", vector_facts),
-                ("graph", graph_facts),
-                ("db", db_facts),
-            ):
-                for item in entries:
-                    if not item or not str(item).strip():
-                        continue
-                    normalized = " ".join(str(item).split()).strip().lower()
-                    if not normalized:
-                        continue
-                    if normalized not in merged_facts:
-                        merged_facts[normalized] = {
-                            "text": str(item).strip(),
-                            "sources": [source],
-                        }
-                        continue
-                    if source not in merged_facts[normalized]["sources"]:
-                        merged_facts[normalized]["sources"].append(source)
-
-            for data in merged_facts.values():
-                source_tag = ",".join(data["sources"])
-                facts.append(f"[{source_tag}] {data['text']}")
+            recent_turns = self._recent_episodic_turns(
+                conversation_window=conversation_window,
+                user_input=user_input,
+            )
+            durable_user_facts = self._normalize_fact_entries(
+                [*db_facts, *memory_facts, *vector_facts]
+            )
+            topic_memory = self._normalize_fact_entries(graph_facts)
+            continuity_summaries = self._channel_thread_continuity(
+                conversation_window=conversation_window,
+                recent_turn_summary=recent_turn_summary,
+                channel_id=channel_id,
+                thread_id=thread_id,
+            )
+            retrieval_layers = self._assemble_retrieval_layers(
+                recent_turns=recent_turns,
+                durable_user_facts=durable_user_facts,
+                topic_memory=topic_memory,
+                continuity_summaries=continuity_summaries,
+            )
+            facts = self._flatten_retrieval_layers(retrieval_layers)
             trace_id = (
                 envelope_meta.get("trace_id")
                 if isinstance(envelope_meta.get("trace_id"), str)
@@ -449,12 +549,20 @@ class CognitiveCoreService(BaseService):
                 else input_id
             )
             payload = MemoryRetrievedPayload(
-                retrieved_knowledge={"facts": facts, "source": "cognitive_core"},
+                retrieved_knowledge={
+                    "facts": facts,
+                    "source": "cognitive_core",
+                    "layers": retrieval_layers,
+                    "retrieval_policy": self._retrieval_policy.__dict__,
+                    "conversation_window": conversation_window[-self._retrieval_policy.recent_turns :],
+                    "recent_turn_summary": recent_turn_summary,
+                },
                 user_input=user_input,
                 input_id=input_id,
                 user_id=author_id or user_id,
                 author_id=author_id,
                 channel_id=channel_id,
+                recent_turn_summary=recent_turn_summary,
                 timestamp=datetime.now(timezone.utc).isoformat(),
             )
 

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -359,6 +359,9 @@ class ContextAssemblerService:
         facts = retrieved.get("facts") if isinstance(retrieved, dict) else []
         if not isinstance(facts, list):
             facts = []
+        retrieval_layers = retrieved.get("layers") if isinstance(retrieved, dict) else {}
+        if not isinstance(retrieval_layers, dict):
+            retrieval_layers = {}
 
         social_payload = pending.provider_payloads.get("social", {})
         social_signals = social_payload.get("social_signals", social_payload)
@@ -368,9 +371,34 @@ class ContextAssemblerService:
         perception_payload = pending.provider_payloads.get("perception", {})
         multimodal = self._normalize_multimodal(perception_payload.get("multimodal_interpretations", perception_payload))
 
-        conversation_window = request.get("conversation_window")
-        if not isinstance(conversation_window, list):
-            conversation_window = []
+        request_window = request.get("conversation_window")
+        memory_window = retrieved.get("conversation_window") if isinstance(retrieved, dict) else None
+        conversation_window = []
+        for candidate in (request_window, memory_window):
+            if not isinstance(candidate, list):
+                continue
+            for turn in candidate:
+                if isinstance(turn, dict):
+                    conversation_window.append(turn)
+        if conversation_window:
+            deduped_window = []
+            seen_turns: set[tuple[str, str]] = set()
+            for turn in conversation_window:
+                key = (str(turn.get("message_id") or ""), str(turn.get("timestamp") or ""))
+                if key in seen_turns:
+                    continue
+                seen_turns.add(key)
+                deduped_window.append(turn)
+            conversation_window = deduped_window[-8:]
+
+        recent_turn_summary = request.get("recent_turn_summary")
+        if not isinstance(recent_turn_summary, str) or not recent_turn_summary.strip():
+            memory_summary = retrieved.get("recent_turn_summary") if isinstance(retrieved, dict) else None
+            recent_turn_summary = memory_summary if isinstance(memory_summary, str) and memory_summary.strip() else None
+
+        retrieval_policy = retrieved.get("retrieval_policy") if isinstance(retrieved, dict) else None
+        if not isinstance(retrieval_policy, dict):
+            retrieval_policy = {}
 
         completed = [name for name in self._PROVIDER_ORDER if name in pending.provider_payloads]
         now = pending.started_at + elapsed
@@ -417,6 +445,8 @@ class ContextAssemblerService:
             "provider_timings": provider_timings,
             "provider_latency_p95_ms": provider_latency_p95_ms,
             "provider_timeout_budget_ms": provider_timeout_budget_ms,
+            "retrieval_layers": retrieval_layers,
+            "retrieval_policy": retrieval_policy,
         }
 
         return ContextAssembledPayload(
@@ -432,7 +462,7 @@ class ContextAssemblerService:
             author_name=request.get("author_name"),
             channel_id=request.get("channel_id"),
             channel_context=request.get("channel_context"),
-            recent_turn_summary=request.get("recent_turn_summary"),
+            recent_turn_summary=recent_turn_summary,
             timestamp=request.get("timestamp") or datetime.now(timezone.utc).isoformat(),
         )
 

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 from contextlib import asynccontextmanager
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from time import monotonic
@@ -37,6 +38,84 @@ class _PendingRoute:
     source_message_id: str | None
     thread_id: str | None
     author_id: str | None
+
+
+
+
+@dataclass(frozen=True)
+class _ConversationTurn:
+    role: str
+    text: str
+    author_id: str | None
+    channel_id: str | None
+    thread_id: str | None
+    message_id: str | None
+    timestamp: str
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "role": self.role,
+            "text": self.text,
+            "author_id": self.author_id,
+            "channel_id": self.channel_id,
+            "thread_id": self.thread_id,
+            "message_id": self.message_id,
+            "timestamp": self.timestamp,
+        }
+
+
+class _ConversationStateStore:
+    def __init__(self, *, window_size: int = 6) -> None:
+        self._window_size = max(1, window_size)
+        self._windows: dict[tuple[str, str], deque[_ConversationTurn]] = {}
+
+    def record_input(self, payload: InputReceivedPayload) -> list[dict[str, Any]]:
+        turn = _ConversationTurn(
+            role="user",
+            text=payload.user_input,
+            author_id=payload.author_id,
+            channel_id=payload.channel_id,
+            thread_id=payload.thread_id,
+            message_id=payload.message_id,
+            timestamp=payload.timestamp or datetime.now(timezone.utc).isoformat(),
+        )
+        for key in self._scope_keys(payload.channel_id, payload.thread_id, payload.author_id):
+            window = self._windows.setdefault(key, deque(maxlen=self._window_size))
+            window.append(turn)
+        return self.window_for(payload.channel_id, payload.thread_id, payload.author_id)
+
+    def window_for(
+        self,
+        channel_id: str | None,
+        thread_id: str | None,
+        author_id: str | None,
+    ) -> list[dict[str, Any]]:
+        merged: list[_ConversationTurn] = []
+        seen: set[tuple[str | None, str]] = set()
+        for key in self._scope_keys(channel_id, thread_id, author_id):
+            for turn in self._windows.get(key, ()):  # deterministic scope priority
+                dedupe_key = (turn.message_id, turn.timestamp)
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                merged.append(turn)
+        merged.sort(key=lambda turn: (turn.timestamp, turn.message_id or ""))
+        return [turn.as_payload() for turn in merged[-self._window_size :]]
+
+    @staticmethod
+    def _scope_keys(
+        channel_id: str | None,
+        thread_id: str | None,
+        author_id: str | None,
+    ) -> list[tuple[str, str]]:
+        keys: list[tuple[str, str]] = []
+        if thread_id:
+            keys.append(("thread", thread_id))
+        if channel_id:
+            keys.append(("channel", channel_id))
+        if author_id:
+            keys.append(("user", author_id))
+        return keys
 
 
 class DiscordGatewayService(BaseService):
@@ -74,6 +153,7 @@ class DiscordGatewayService(BaseService):
         self._familiarity_counts: dict[tuple[str, str], int] = {}
         self._cooldown_until: dict[str, float] = {}
         self._policy_engine = VersionedPolicyEngine()
+        self._conversation_state = _ConversationStateStore()
         self.add_subscription(
             response_subject,
             self._handle_ranked_response,
@@ -159,7 +239,16 @@ class DiscordGatewayService(BaseService):
             logger.debug("Ignoring bot-authored Discord message", extra={"author_id": payload.author_id})
             return None
 
+        payload.conversation_window = self._conversation_state.record_input(payload)
         self._record_inbound_activity(channel_id=payload.channel_id, author_id=payload.author_id)
+        if payload.conversation_window:
+            recent_user_turns = [
+                turn.get("text", "")
+                for turn in payload.conversation_window[:-1]
+                if turn.get("role") == "user" and isinstance(turn.get("text"), str)
+            ]
+            if recent_user_turns:
+                payload.recent_turn_summary = " | ".join(recent_user_turns[-3:])
         if payload.input_id and payload.message_id:
             self._message_input_index[payload.message_id] = payload.input_id
 

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -101,6 +101,54 @@ async def test_race_safe_assembly_collects_all_providers(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_context_assembler_composes_request_and_memory_context(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.05)
+
+    await svc._handle_input_received(
+        DummyMsg(
+            {
+                "input_id": "i-compose",
+                "user_input": "hello",
+                "conversation_window": [{"role": "user", "text": "from-request", "timestamp": "2026-03-18T00:00:00+00:00"}],
+            }
+        )
+    )
+    await svc._handle_provider_response(
+        DummyMsg(
+            {
+                "input_id": "i-compose",
+                "retrieved_knowledge": {
+                    "facts": ["fact-a"],
+                    "conversation_window": [{"role": "assistant", "text": "from-memory", "timestamp": "2026-03-18T00:00:01+00:00"}],
+                    "recent_turn_summary": "summary-from-memory",
+                    "layers": {"recent_episodic_turns": ["user: from-request"]},
+                    "retrieval_policy": {"recent_turns": 4},
+                },
+            }
+        ),
+        "memory",
+    )
+    await svc._handle_provider_response(DummyMsg({"input_id": "i-compose", "social_signals": {"tone": "neutral"}}), "social")
+    await svc._handle_provider_response(
+        DummyMsg({"input_id": "i-compose", "multimodal_interpretations": {"summary": "none", "notes": []}}),
+        "perception",
+    )
+    await asyncio.sleep(0.06)
+
+    assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    payload = assembled[0][1]["payload"]
+    assert [turn["text"] for turn in payload["conversation_window"]] == ["from-request", "from-memory"]
+    assert payload["recent_turn_summary"] == "summary-from-memory"
+    assert payload["confidence"]["retrieval_layers"] == {"recent_episodic_turns": ["user: from-request"]}
+    assert payload["confidence"]["retrieval_policy"] == {"recent_turns": 4}
+
+
+@pytest.mark.asyncio
 async def test_partial_result_uses_missing_reason_timeout(monkeypatch):
     import deepthought.services.context_assembler_service as mod
 

--- a/tests/unit/services/test_cognitive_core_service.py
+++ b/tests/unit/services/test_cognitive_core_service.py
@@ -1,3 +1,6 @@
+#! /usr/bin/env python
+# ruff: noqa: E402
+
 import importlib.machinery
 import sys
 import types
@@ -264,7 +267,8 @@ async def test_handle_input_stores_and_publishes(monkeypatch):
     subject, sent_payload = service._publisher.published[0]
     assert subject == EventSubjects.MEMORY_RETRIEVED
     assert sent_payload["payload"]["input_id"] == "x"
-    assert "[memory,db] hello" in sent_payload["payload"]["retrieved_knowledge"]["facts"]
+    assert "[durable_user_facts] hello" in sent_payload["payload"]["retrieved_knowledge"]["facts"]
+    assert sent_payload["payload"]["retrieved_knowledge"]["layers"]["recent_episodic_turns"] == ["user: hello"]
     assert service._graph_memory.retrieve_user_evidence("anonymous", limit=5)
 
 
@@ -350,6 +354,47 @@ async def test_handle_input_does_not_cross_contaminate_users():
     _, user_b_payload = service._publisher.published[-1]
     facts = user_b_payload["payload"]["retrieved_knowledge"]["facts"]
     assert not any("favorite: tea" in fact for fact in facts)
+
+
+@pytest.mark.asyncio
+async def test_handle_input_returns_stable_retrieval_layers():
+    memory = DummyMemory()
+    db = DummyDB()
+    service = CognitiveCoreService(DummyNATS(), DummyJS(), Settings(), memory=memory, db=db)
+    service._publisher = DummyPublisher()
+    service._subscriber = DummySubscriber()
+
+    msg = DummyMsg(
+        json.dumps(
+            {
+                "user_input": "Can you continue?",
+                "input_id": "x-layered",
+                "user_id": "u1",
+                "channel_id": "c1",
+                "thread_id": "t1",
+                "conversation_window": [
+                    {"role": "user", "text": "Earlier question", "author_id": "u1", "timestamp": "2026-03-18T00:00:00+00:00"},
+                    {"role": "assistant", "text": "Earlier answer", "author_id": "bot", "timestamp": "2026-03-18T00:00:01+00:00"},
+                    {"role": "user", "text": "Can you continue?", "author_id": "u1", "timestamp": "2026-03-18T00:00:02+00:00"},
+                ],
+                "recent_turn_summary": "Earlier question | Earlier answer",
+            }
+        )
+    )
+
+    await service._handle_input(msg)
+
+    _, payload = service._publisher.published[-1]
+    layers = payload["payload"]["retrieved_knowledge"]["layers"]
+    assert list(layers) == [
+        "recent_episodic_turns",
+        "durable_user_facts",
+        "topic_entity_memory",
+        "channel_thread_continuity",
+    ]
+    assert layers["recent_episodic_turns"] == ["user: Earlier question", "assistant: Earlier answer"]
+    assert payload["payload"]["retrieved_knowledge"]["retrieval_policy"]["recent_turns"] == 4
+    assert "recent summary: Earlier question | Earlier answer" in layers["channel_thread_continuity"][0]
 
 
 class DummyStore:

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -152,11 +152,33 @@ async def test_handle_discord_message_publishes_input_received(service):
     assert payload["payload"]["reference_message_id"] == "66"
     assert payload["payload"]["thread_id"] == "999"
     assert payload["payload"]["attachments"] is not None
+    assert payload["payload"]["conversation_window"][-1]["text"] == "hello"
     assert payload["payload"]["attachments"][0]["url"] == "https://cdn.discordapp.com/file.png"
     extract_subject, extract_payload, _, _ = service._publisher.published[1]
     assert extract_subject == EventSubjects.PERCEPTION_EXTRACT_REQUESTED
     assert extract_payload["payload"]["input_id"] == input_id
     assert extract_payload["payload"]["attachments"][0]["content_type"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_handle_discord_message_includes_bounded_recent_window(service):
+    for idx in range(8):
+        message = SimpleNamespace(
+            content=f"turn-{idx}",
+            id=200 + idx,
+            author=SimpleNamespace(id=5, name="alice", display_name="Alice", bot=False),
+            channel=SimpleNamespace(id=123),
+            guild=SimpleNamespace(id=7),
+            thread=SimpleNamespace(id=999),
+        )
+        await service.handle_discord_message(message)
+
+    subject, payload, _, _ = service._publisher.published[-1]
+    assert subject == EventSubjects.INPUT_RECEIVED
+    window = payload["payload"]["conversation_window"]
+    assert len(window) == 6
+    assert [turn["text"] for turn in window] == [f"turn-{idx}" for idx in range(2, 8)]
+    assert payload["payload"]["recent_turn_summary"] == "turn-4 | turn-5 | turn-6"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Ensure each `INPUT_RECEIVED` event carries a bounded recent conversation window and short recent-turn summary scoped by channel/thread/user so downstream services have stable short-term context. 
- Make recent-turn context, retrieved long-term memory, and continuity summaries always composed together when building assembled context so responder prompts have consistent shape. 
- Promote user/thread-scoped recall into explicit retrieval layers so memory retrieval is deterministic and the bot develops a stable memory-aware voice.

### Description

- Added a conversation-state store and bounded conversation window tracking in `src/deepthought/services/discord_gateway_service.py` with a `_ConversationStateStore` and `_ConversationTurn`, and populate `InputReceivedPayload.conversation_window` and `recent_turn_summary` on input. 
- Extended the canonical payloads in `src/deepthought/eda/events.py` to include `conversation_window` and `recent_turn_summary` on `InputReceivedPayload`. 
- Introduced a `RetrievalPolicy` and layered retrieval in `src/deepthought/services/cognitive_core_service.py`, including deterministic layers: `recent_episodic_turns`, `durable_user_facts`, `topic_entity_memory`, and `channel_thread_continuity`, and stable flattening into published facts. 
- Refactored `src/deepthought/services/context_assembler_service.py` to always merge the request-provided conversation window with memory-returned conversation state, include `retrieval_layers` and `retrieval_policy` in the assembled `ContextAssembledPayload.confidence`, and prefer memory-provided `recent_turn_summary` when present. 
- Added/adjusted unit and integration tests to cover bounded Discord window behavior, stable layered retrieval output, and composition of request+memory context in the assembler (`tests/unit/services/test_discord_gateway_service.py`, `tests/unit/services/test_cognitive_core_service.py`, `tests/integration/test_context_assembler_service.py`).

### Testing

- Ran unit and integration test subset: `pytest tests/unit/services/test_discord_gateway_service.py tests/unit/services/test_cognitive_core_service.py tests/integration/test_context_assembler_service.py`, result: `20 passed, 1 skipped` (the skipped test depends on optional `aiosqlite`).
- Ran linter: `ruff check` on the changed service and test files, result: all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab99088b88326baf8841afb8d20f5)