### PR TITLE
Add explicit graph memory runtime profiles and fail-fast backend health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,13 +11,11 @@ services:
     image: memgraph/memgraph
     ports:
       - "7687:7687"
-
-  neo4j:
-    image: neo4j:5
-    ports:
-      - "7687:7687"
-    environment:
-      - NEO4J_AUTH=neo4j/test
+    healthcheck:
+      test: ["CMD", "bash", "-lc", "echo > /dev/tcp/127.0.0.1/7687"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
 
   chroma:
     image: chromadb/chroma

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,14 @@ relational database layers behind a single interface. Internally it relies on
 tracking interactions. An optional `OfflineSearch` index may be attached to
 augment memory with local documents.
 
+The Discord-bot runtime now uses an explicit graph-memory profile:
+
+- `development`: `DT_GRAPH_BACKEND=file`, a lightweight persistent local graph file.
+- `production`: `DT_GRAPH_BACKEND=memgraph` or `DT_GRAPH_BACKEND=neo4j`; a remote persistent graph backend is required.
+- `test`: `DT_GRAPH_BACKEND=stub`; an in-memory stub is used only for tests.
+
+`CognitiveCoreService` performs a startup health check against the configured graph backend and fails fast if that backend is unavailable. Production-oriented profiles no longer degrade silently to in-memory graph state. The default orchestrator and Compose deployment set `DT_RUNTIME_PROFILE=production` and provision exactly one persistent graph backend: Memgraph.
+
 When an `INPUT_RECEIVED` event arrives the service stores the text in each
 backend, queries for relevant context and publishes `MEMORY_RETRIEVED`. Downstream
 services subscribe to this subject and may then respond with

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -37,6 +37,12 @@ service_bindings:
     description: Unified memory + retrieval + social signal persistence.
     env:
       - NATS_URL
+      - DT_RUNTIME_PROFILE
+      - DT_GRAPH_BACKEND
+      - DT_MG_HOST
+      - DT_MG_PORT
+      - DT_MG_USER
+      - DT_MG_PASSWORD
       - DT_MEMORY_DB
       - DT_SOCIAL_GRAPH_DB
       - DT_SEARCH_DB
@@ -305,6 +311,12 @@ environment:
   NATS_URL: ${NATS_URL:-nats://localhost:4222}
   DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
   LLM_ENDPOINT: ${LLM_ENDPOINT:-http://localhost:8000/generate}
+  DT_RUNTIME_PROFILE: ${DT_RUNTIME_PROFILE:-production}
+  DT_GRAPH_BACKEND: ${DT_GRAPH_BACKEND:-memgraph}
+  DT_MG_HOST: ${DT_MG_HOST:-memgraph}
+  DT_MG_PORT: ${DT_MG_PORT:-7687}
+  DT_MG_USER: ${DT_MG_USER:-memgraph}
+  DT_MG_PASSWORD: ${DT_MG_PASSWORD:-memgraph}
   DT_MEMORY_DB: ${DT_MEMORY_DB:-./data/memory.db}
   DT_SOCIAL_GRAPH_DB: ${DT_SOCIAL_GRAPH_DB:-./data/social_graph.db}
   DT_SEARCH_DB: ${DT_SEARCH_DB:-./examples/data/sample_docs.json}

--- a/src/deepthought/config.py
+++ b/src/deepthought/config.py
@@ -9,7 +9,7 @@ import subprocess
 import warnings
 from importlib import metadata
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import AnyUrl, Field, ValidationError
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -128,7 +128,9 @@ def _build_env_overrides() -> dict[str, object]:
     vector_gpu = _coerce_bool(os.getenv("DT_VECTOR_USE_GPU"))
     if vector_gpu is not None:
         _set(("vector_use_gpu",), vector_gpu)
+    _set(("runtime_profile",), os.getenv("DT_RUNTIME_PROFILE"))
     _set(("graph_backend",), os.getenv("DT_GRAPH_BACKEND"))
+    _set(("graph_local_path",), os.getenv("DT_GRAPH_LOCAL_PATH"))
 
     response_filter_enabled = _coerce_bool(os.getenv("DT_RESPONSE_FILTER_ENABLED"))
     if response_filter_enabled is not None:
@@ -201,6 +203,56 @@ class RewardThresholds(BaseSettings):
 DEFAULT_SOCIAL_MODEL = Path(__file__).resolve().parent / "perception" / "default_social_perception_model.json"
 
 
+GraphRuntimeProfile = Literal["development", "production", "test"]
+
+
+def _normalize_runtime_profile(value: str | None) -> str:
+    normalized = (value or "development").strip().lower()
+    aliases = {
+        "dev": "development",
+        "local": "development",
+        "prod": "production",
+        "testing": "test",
+        "tests": "test",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def resolve_graph_backend_for_profile(
+    runtime_profile: str | None,
+    graph_backend: str | None,
+) -> str:
+    """Return the canonical graph backend for the selected runtime profile."""
+
+    profile = _normalize_runtime_profile(runtime_profile)
+    requested = (graph_backend or "").strip().lower()
+
+    if profile == "test":
+        if requested and requested not in {"stub", "noop", "none", "inmemory", "in-memory"}:
+            raise ValueError("Test profile requires the in-memory stub graph backend")
+        return "stub"
+
+    if profile == "development":
+        if not requested:
+            return "file"
+        if requested in {"file", "local", "dev", "development"}:
+            return "file"
+        if requested in {"memgraph", "neo4j"}:
+            return requested
+        if requested in {"stub", "noop", "none", "inmemory", "in-memory"}:
+            raise ValueError("Development profile requires a persistent local or remote graph backend")
+        raise ValueError(f"Unsupported graph backend for development profile: {graph_backend}")
+
+    if profile == "production":
+        if not requested:
+            return "memgraph"
+        if requested not in {"memgraph", "neo4j"}:
+            raise ValueError("Production profile requires Neo4j or Memgraph")
+        return requested
+
+    raise ValueError(f"Unknown runtime profile: {runtime_profile}")
+
+
 class Settings(BaseSettings):
     """Application wide settings."""
 
@@ -237,7 +289,9 @@ class Settings(BaseSettings):
     memory_capacity: int = 100
     memory_top_k: int = 3
 
-    graph_backend: str = Field("memgraph", env="DT_GRAPH_BACKEND")
+    runtime_profile: GraphRuntimeProfile = Field("development", env="DT_RUNTIME_PROFILE")
+    graph_backend: str = Field("", env="DT_GRAPH_BACKEND")
+    graph_local_path: str = Field("data/graph_memory.json", env="DT_GRAPH_LOCAL_PATH")
     mg_host: str = Field("localhost", env="DT_MG_HOST")
     mg_port: int = Field(7687, env="DT_MG_PORT")
     mg_user: str = Field("memgraph", env="DT_MG_USER")
@@ -264,7 +318,27 @@ class Settings(BaseSettings):
         env="DT_RESPONSE_FILTER_FALLBACK_MESSAGE",
     )
 
+
+    @model_validator(mode="after")
+    def _normalize_memory_runtime(self) -> "Settings":
+        self.runtime_profile = _normalize_runtime_profile(getattr(self, "runtime_profile", None))  # type: ignore[assignment]
+        self.graph_backend = resolve_graph_backend_for_profile(
+            getattr(self, "runtime_profile", None), getattr(self, "graph_backend", None)
+        )
+        return self
+
     model_config = SettingsConfigDict(env_prefix="DT_", env_nested_delimiter="__")
+
+
+
+def _finalize_settings(settings: Settings) -> Settings:
+    """Apply runtime-profile normalization for settings instances."""
+
+    settings.runtime_profile = _normalize_runtime_profile(getattr(settings, "runtime_profile", None))  # type: ignore[assignment]
+    settings.graph_backend = resolve_graph_backend_for_profile(
+        getattr(settings, "runtime_profile", None), getattr(settings, "graph_backend", None)
+    )
+    return settings
 
 
 def load_settings(config_file: Optional[str] = None) -> Settings:
@@ -298,19 +372,19 @@ def load_settings(config_file: Optional[str] = None) -> Settings:
             raise ValueError("Config data must be a mapping")
 
         if hasattr(Settings, "model_validate"):
-            return Settings.model_validate(data)
+            return _finalize_settings(Settings.model_validate(data))
 
         # Fallback for environments where pydantic is stubbed during tests.
         inst = Settings()  # pragma: no cover
         _assign_settings(inst, data)  # pragma: no cover
-        return inst  # pragma: no cover
+        return _finalize_settings(inst)  # pragma: no cover
     if hasattr(Settings, "model_validate"):
-        return Settings()
+        return _finalize_settings(Settings())
     inst = Settings()  # pragma: no cover - executed with stubbed settings
     env_overrides = _build_env_overrides()
     if env_overrides:
         _assign_settings(inst, env_overrides)
-    return inst
+    return _finalize_settings(inst)
 
 
 _settings_cache: Optional[Settings] = None

--- a/src/deepthought/graph/backend.py
+++ b/src/deepthought/graph/backend.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Graph backend strategy interfaces."""
+
+from __future__ import annotations
 
 import uuid
 from abc import ABC, abstractmethod
@@ -69,7 +69,7 @@ def create_graph_backend(
     backend: str = "memgraph", *, settings: Settings | None = None, **params: Any
 ) -> GraphBackend:
     """Return a :class:`GraphBackend` implementation for ``backend``."""
-    from ..config import get_settings, Settings
+    from ..config import get_settings
 
     settings = settings or get_settings()
 
@@ -81,6 +81,11 @@ def create_graph_backend(
     if lower == "neo4j":
         connector = Neo4jConnector(settings=settings, **params)
         return Neo4jBackend(connector)
-    if lower in {"none", "noop", "stub"}:
+    if lower == "file":
+        from ..services.file_graph_dal import FileGraphBackend
+
+        graph_file = params.pop("graph_file", settings.graph_local_path)
+        return FileGraphBackend(graph_file)
+    if lower in {"none", "noop", "stub", "inmemory", "in-memory"}:
         return NoOpGraphBackend()
     raise ValueError(f"Unknown graph backend: {backend}")

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -80,6 +80,7 @@ class CognitiveCoreService(BaseService):
         if memory is None:
             memory = create_memory_backend(settings=self._settings)
         self._memory = memory
+        self._ensure_graph_backend_ready()
         self._db = db or DBManager()
         if search is None:
             db_path = self._settings.search_db
@@ -111,22 +112,49 @@ class CognitiveCoreService(BaseService):
         self._consolidation_interval_s = 60.0
         self._retrieval_policy = RetrievalPolicy()
 
+    def _graph_connector(self):
+        graph_backend = getattr(self._memory, "graph_backend", None)
+        if hasattr(graph_backend, "_dal"):
+            return getattr(getattr(graph_backend, "_dal", None), "_connector", None)
+        if graph_backend is not None and hasattr(graph_backend, "_connector"):
+            return getattr(graph_backend, "_connector", None)
+        return None
+
+    def _ensure_graph_backend_ready(self) -> None:
+        backend = (self._settings.graph_backend or "").lower()
+        if backend in {"stub", "noop", "none", "inmemory", "in-memory"}:
+            if self._settings.runtime_profile != "test":
+                raise RuntimeError("In-memory stub graph backend is only allowed in test profile")
+            return
+        if backend == "file":
+            graph_file = getattr(self._settings, "graph_local_path", "graph_memory.json")
+            parent = os.path.dirname(graph_file)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            try:
+                with open(graph_file, "a", encoding="utf-8"):
+                    pass
+            except OSError as exc:
+                raise RuntimeError(f"Local graph backend is unavailable: {graph_file}") from exc
+            return
+        connector = self._graph_connector()
+        if connector is None:
+            raise RuntimeError(f"Configured graph backend '{backend}' did not expose a connector")
+        try:
+            connector.execute("RETURN 1 AS ok", {})
+        except Exception as exc:
+            raise RuntimeError(
+                f"Configured graph backend '{backend}' is unavailable for runtime profile "
+                f"'{self._settings.runtime_profile}'"
+            ) from exc
+
     def _build_graph_memory_store(self):
         backend = (self._settings.graph_backend or "").lower()
         if backend in {"memgraph", "neo4j"}:
-            try:
-                graph_backend = getattr(self._memory, "graph_backend", None)
-                connector = None
-                if hasattr(graph_backend, "_dal"):
-                    connector = getattr(
-                        getattr(graph_backend, "_dal", None), "_connector", None
-                    )
-                elif graph_backend is not None and hasattr(graph_backend, "_connector"):
-                    connector = getattr(graph_backend, "_connector", None)
-                if connector is not None:
-                    return CypherGraphMemoryStore(connector)
-            except Exception:
-                logger.warning("Falling back to in-memory graph store", exc_info=True)
+            connector = self._graph_connector()
+            if connector is None:
+                raise RuntimeError(f"Configured graph backend '{backend}' did not expose a connector")
+            return CypherGraphMemoryStore(connector)
         return InMemoryGraphMemoryStore()
 
     @classmethod
@@ -740,6 +768,7 @@ class CognitiveCoreService(BaseService):
             use_jetstream=True,
             durable=f"{durable_name}_bdi",
         )
+        self._ensure_graph_backend_ready()
         started = await super().start()
         if started:
             logger.info(

--- a/src/deepthought/services/file_graph_dal.py
+++ b/src/deepthought/services/file_graph_dal.py
@@ -8,7 +8,7 @@ from typing import Any, List
 
 import importlib
 
-from ..graph import GraphBackend
+from ..graph.backend import GraphBackend
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -221,3 +221,36 @@ def test_llm_backend_env_overrides(monkeypatch):
     assert settings.llm_model_path == "local/model"
     assert settings.llm_quantization_bits == 4
     assert settings.llm_local_max_new_tokens == 256
+
+
+def test_graph_backend_defaults_to_local_persistence_in_development():
+    settings = load_settings()
+
+    assert settings.runtime_profile == "development"
+    assert settings.graph_backend == "file"
+
+
+def test_production_profile_defaults_to_memgraph(monkeypatch):
+    monkeypatch.setenv("DT_RUNTIME_PROFILE", "production")
+
+    settings = load_settings()
+
+    assert settings.runtime_profile == "production"
+    assert settings.graph_backend == "memgraph"
+
+
+def test_test_profile_uses_in_memory_stub(monkeypatch):
+    monkeypatch.setenv("DT_RUNTIME_PROFILE", "test")
+
+    settings = load_settings()
+
+    assert settings.runtime_profile == "test"
+    assert settings.graph_backend == "stub"
+
+
+def test_production_profile_rejects_non_persistent_graph_backend(monkeypatch):
+    monkeypatch.setenv("DT_RUNTIME_PROFILE", "production")
+    monkeypatch.setenv("DT_GRAPH_BACKEND", "noop")
+
+    with pytest.raises(ValueError, match="Production profile requires Neo4j or Memgraph"):
+        load_settings()


### PR DESCRIPTION
### Motivation
- Make graph persistence explicit for different runtimes so production bots require a persistent graph backend instead of silently degrading to in-memory storage.
- Provide a canonical selection flow for graph adapters (local file for development, Memgraph/Neo4j for production, in-memory stub for tests) and surface startup failures early when backends are unavailable.

### Description
- Add runtime profile handling and canonical backend resolution to `Settings` via `runtime_profile`, `resolve_graph_backend_for_profile`, and a finalization pass so the chosen profile determines the effective `graph_backend` and `graph_local_path` defaults (`src/deepthought/config.py`).
- Register a lightweight on-disk `FileGraphBackend` and wire it into the graph factory so `file` is the default persistent backend for development; allow `memgraph` and `neo4j` for production and `stub`/`noop` for tests (`src/deepthought/graph/backend.py`, `src/deepthought/services/file_graph_dal.py`).
- Add health-check plumbing to `CognitiveCoreService` that validates the configured graph backend at construction/startup (helper `_graph_connector` and `_ensure_graph_backend_ready`) and fail-fast when production-oriented backends are unavailable; preserve safe behavior for the `file` backend and restrict in-memory stubs to the `test` profile (`src/deepthought/services/cognitive_core_service.py`).
- Update deployment/configuration and docs so the canonical orchestrator and Compose defaults provision exactly one persistent graph backend (Memgraph) and expose the runtime graph env vars; add a Memgraph healthcheck to `docker-compose.yml` and document the runtime profiles in `docs/architecture.md` and `examples/orchestrator.yml`.

### Testing
- Ran targeted unit tests with `pytest tests/unit/test_config.py tests/unit/test_graph_backend.py tests/unit/test_memory_factory.py` and observed all tests passing (`21 passed`).
- Iterated on and exercised `pytest tests/unit/services/test_cognitive_core_service.py` during development to validate health-check behavior and fixed related issues until the targeted checks succeeded.
- Ran linters and static checks with `ruff check ...` and bytecode checks with `python -m py_compile ...` and confirmed no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babc151b688326bfc30f00782736a9)