### PR TITLE
Durable adaptation profiles: persist feedback and apply adaptation state to selection/generation

### DIFF
--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -227,6 +227,7 @@ class ContextAssembledPayload(EventPayload):
     social_signals: Dict[str, Any] = field(default_factory=dict)
     multimodal_interpretations: Dict[str, Any] = field(default_factory=dict)
     confidence: Dict[str, Any] = field(default_factory=dict)
+    adaptation_state: Dict[str, Any] = field(default_factory=dict)
     user_id: Optional[str] = None
     author_id: Optional[str] = None
     author_name: Optional[str] = None
@@ -280,6 +281,7 @@ class ResponseCandidatesPayload(EventPayload):
     context_confidence: Optional[Dict[str, Any]] = None
     social_intent_hints: Optional[Dict[str, Any]] = None
     user_history_affinity: Optional[Dict[str, float]] = None
+    adaptation_state: Optional[Dict[str, Any]] = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ResponseCandidatesPayload":
@@ -309,6 +311,7 @@ class ResponseCandidatesPayload(EventPayload):
             }
             if isinstance(data.get("user_history_affinity"), dict)
             else None,
+            adaptation_state=data.get("adaptation_state") if isinstance(data.get("adaptation_state"), dict) else None,
         )
 
 

--- a/src/deepthought/services/context_assembler_service.py
+++ b/src/deepthought/services/context_assembler_service.py
@@ -7,7 +7,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import nats
 from nats.aio.client import Client as NATS
@@ -18,8 +18,15 @@ from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import ContextAssembledPayload, EventSubjects
 from ..eda.publisher import Publisher
 from ..eda.subscriber import Subscriber
+if TYPE_CHECKING:  # pragma: no cover
+    from .db_manager import DBManager
 
 logger = logging.getLogger(__name__)
+
+
+class _NullAdaptationStore:
+    async def get_adaptation_state(self, *, user_id: str | None = None) -> dict[str, Any]:
+        return {}
 
 
 @dataclass
@@ -86,6 +93,7 @@ class ContextAssemblerService:
         self,
         nats_client: NATS,
         js_context: JetStreamContext,
+        db_manager: "DBManager | None" = None,
         *,
         wait_window_seconds: float = 0.2,
         provider_jitter_budget_seconds: float = 0.01,
@@ -96,6 +104,15 @@ class ContextAssemblerService:
     ) -> None:
         self._publisher = Publisher(nats_client, js_context)
         self._subscriber = Subscriber(nats_client, js_context)
+        if db_manager is None:
+            try:
+                from .db_manager import DBManager
+
+                self._db = DBManager()
+            except ModuleNotFoundError:
+                self._db = _NullAdaptationStore()
+        else:
+            self._db = db_manager
         self._wait_window_seconds = max(0.01, wait_window_seconds)
         self._provider_jitter_budget_seconds = max(0.0, provider_jitter_budget_seconds)
         self._min_provider_timeout_seconds = max(0.005, min_provider_timeout_seconds)
@@ -109,6 +126,54 @@ class ContextAssemblerService:
         self._pending: dict[str, _PendingAssembly] = {}
         self._recently_published: dict[str, _PublishedAssembly] = {}
         self._lock = asyncio.Lock()
+
+    async def _load_adaptation_state(self, request: dict[str, Any]) -> dict[str, Any]:
+        principal = request.get("author_id") or request.get("user_id")
+        if not isinstance(principal, str) or not principal.strip():
+            return {}
+        try:
+            return await self._db.get_adaptation_state(user_id=principal)
+        except Exception:
+            logger.exception("Failed to load adaptation state for principal=%s", principal)
+            return {}
+
+    @staticmethod
+    def _merge_adaptation_into_social_signals(
+        social_signals: dict[str, Any],
+        adaptation_state: dict[str, Any],
+    ) -> dict[str, Any]:
+        merged = dict(social_signals)
+        selector_inputs = dict(merged.get("selector_inputs") or {})
+        user_profile = adaptation_state.get("user") if isinstance(adaptation_state.get("user"), dict) else {}
+        response_style = None
+        if isinstance(user_profile.get("response_style"), dict):
+            response_style = user_profile["response_style"].get("preferred")
+        fallback_profile = adaptation_state.get("fallback") if isinstance(adaptation_state.get("fallback"), dict) else {}
+        source_profiles = adaptation_state.get("sources") if isinstance(adaptation_state.get("sources"), dict) else {}
+
+        interaction_policy = dict(selector_inputs.get("interaction_policy") or {})
+        if isinstance(response_style, str) and response_style.strip():
+            interaction_policy["response_style"] = response_style.strip().lower()
+        if "aggressiveness" in fallback_profile:
+            interaction_policy["fallback_aggressiveness"] = fallback_profile.get("aggressiveness")
+
+        user_history_affinity = dict(selector_inputs.get("user_history_affinity") or {})
+        for source_name, source_profile in source_profiles.items():
+            if not isinstance(source_profile, dict):
+                continue
+            selector_profile = source_profile.get("selector")
+            if not isinstance(selector_profile, dict):
+                continue
+            weight_multiplier = selector_profile.get("weight_multiplier")
+            if isinstance(weight_multiplier, (int, float)):
+                user_history_affinity.setdefault(str(source_name), max(-1.0, min(1.0, float(weight_multiplier) - 1.0)))
+
+        selector_inputs["interaction_policy"] = interaction_policy
+        selector_inputs["user_history_affinity"] = user_history_affinity
+        selector_inputs["adaptation_state"] = adaptation_state
+        merged["selector_inputs"] = selector_inputs
+        merged["adaptation_state"] = adaptation_state
+        return merged
 
     @staticmethod
     def _estimate_p95(latencies: deque[float]) -> float | None:
@@ -207,6 +272,8 @@ class ContextAssemblerService:
             provider_deadlines = {
                 provider: loop_time + self._provider_timeout_seconds(provider) for provider in self._PROVIDER_ORDER
             }
+            adaptation_state = await self._load_adaptation_state(payload)
+            payload["adaptation_state"] = adaptation_state
             pending = _PendingAssembly(
                 request=payload,
                 trace_id=envelope_meta.get("trace_id") if isinstance(envelope_meta.get("trace_id"), str) else None,
@@ -367,6 +434,8 @@ class ContextAssemblerService:
         social_signals = social_payload.get("social_signals", social_payload)
         if not isinstance(social_signals, dict):
             social_signals = {}
+        adaptation_state = request.get("adaptation_state") if isinstance(request.get("adaptation_state"), dict) else {}
+        social_signals = self._merge_adaptation_into_social_signals(social_signals, adaptation_state)
 
         perception_payload = pending.provider_payloads.get("perception", {})
         multimodal = self._normalize_multimodal(perception_payload.get("multimodal_interpretations", perception_payload))
@@ -399,6 +468,9 @@ class ContextAssemblerService:
         retrieval_policy = retrieved.get("retrieval_policy") if isinstance(retrieved, dict) else None
         if not isinstance(retrieval_policy, dict):
             retrieval_policy = {}
+        retrieval_adaptation = adaptation_state.get("retrieval") if isinstance(adaptation_state.get("retrieval"), dict) else {}
+        if retrieval_adaptation:
+            retrieval_policy = {**retrieval_policy, **retrieval_adaptation}
 
         completed = [name for name in self._PROVIDER_ORDER if name in pending.provider_payloads]
         now = pending.started_at + elapsed
@@ -457,6 +529,7 @@ class ContextAssemblerService:
             social_signals=social_signals,
             multimodal_interpretations=multimodal,
             confidence=confidence,
+            adaptation_state=adaptation_state,
             user_id=request.get("user_id"),
             author_id=request.get("author_id"),
             author_name=request.get("author_name"),

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -319,6 +319,15 @@ class DBManager:
         )
         """,
         """
+        CREATE TABLE IF NOT EXISTS adaptation_profiles (
+            scope_type TEXT NOT NULL,
+            scope_key TEXT NOT NULL,
+            profile_json TEXT NOT NULL DEFAULT '{}',
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY(scope_type, scope_key)
+        )
+        """,
+        """
         CREATE TABLE IF NOT EXISTS recent_topics (
             topic TEXT PRIMARY KEY,
             last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -2289,3 +2298,106 @@ class DBManager:
         await self._db.commit()
         return items
 
+    @staticmethod
+    def _deep_merge_profile(base: Mapping[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+        merged = dict(base)
+        for key, value in override.items():
+            if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+                merged[key] = DBManager._deep_merge_profile(
+                    dict(merged[key]),  # type: ignore[arg-type]
+                    value,
+                )
+            else:
+                merged[key] = value
+        return merged
+
+    async def upsert_adaptation_profile(
+        self,
+        *,
+        scope_type: str,
+        scope_key: str,
+        profile: Mapping[str, Any],
+        merge: bool = True,
+    ) -> dict[str, Any]:
+        await self.connect()
+        assert self._db
+        scope_type = str(scope_type).strip().lower()
+        scope_key = str(scope_key).strip().lower()
+        if not scope_type or not scope_key:
+            raise ValueError("scope_type and scope_key must be non-empty strings")
+
+        current: dict[str, Any] = {}
+        async with self._db.execute(
+            "SELECT profile_json FROM adaptation_profiles WHERE scope_type=? AND scope_key=?",
+            (scope_type, scope_key),
+        ) as cur:
+            row = await cur.fetchone()
+        if row and row[0]:
+            try:
+                parsed = json.loads(row[0])
+                if isinstance(parsed, dict):
+                    current = parsed
+            except json.JSONDecodeError:
+                current = {}
+
+        next_profile = self._deep_merge_profile(current, profile) if merge else dict(profile)
+        await self._db.execute(
+            """
+            INSERT INTO adaptation_profiles (scope_type, scope_key, profile_json, updated_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(scope_type, scope_key) DO UPDATE SET
+                profile_json=excluded.profile_json,
+                updated_at=CURRENT_TIMESTAMP
+            """,
+            (scope_type, scope_key, json.dumps(next_profile)),
+        )
+        await self._db.commit()
+        return next_profile
+
+    async def get_adaptation_state(self, *, user_id: str | None = None) -> dict[str, Any]:
+        await self.connect()
+        assert self._db
+
+        state: dict[str, Any] = {
+            "user": {},
+            "sources": {},
+            "retrieval": {},
+            "fallback": {},
+            "confidence": {},
+        }
+
+        normalized_user_id = str(user_id).strip().lower() if isinstance(user_id, str) and user_id.strip() else None
+        if normalized_user_id:
+            async with self._db.execute(
+                "SELECT profile_json FROM adaptation_profiles WHERE scope_type='user' AND scope_key=?",
+                (normalized_user_id,),
+            ) as cur:
+                row = await cur.fetchone()
+            if row and row[0]:
+                try:
+                    parsed = json.loads(row[0])
+                    if isinstance(parsed, dict):
+                        state["user"] = parsed
+                except json.JSONDecodeError:
+                    state["user"] = {}
+
+        async with self._db.execute(
+            "SELECT scope_key, profile_json FROM adaptation_profiles WHERE scope_type='source'"
+        ) as cur:
+            rows = await cur.fetchall()
+        for scope_key, profile_json in rows:
+            parsed: dict[str, Any] = {}
+            if profile_json:
+                try:
+                    decoded = json.loads(profile_json)
+                    if isinstance(decoded, dict):
+                        parsed = decoded
+                except json.JSONDecodeError:
+                    parsed = {}
+            state["sources"][str(scope_key)] = parsed
+
+        user_profile = state["user"] if isinstance(state["user"], dict) else {}
+        state["retrieval"] = dict(user_profile.get("memory", {})) if isinstance(user_profile.get("memory"), dict) else {}
+        state["fallback"] = dict(user_profile.get("fallback", {})) if isinstance(user_profile.get("fallback"), dict) else {}
+        state["confidence"] = dict(user_profile.get("confidence", {})) if isinstance(user_profile.get("confidence"), dict) else {}
+        return state

--- a/src/deepthought/services/feedback_service.py
+++ b/src/deepthought/services/feedback_service.py
@@ -31,6 +31,10 @@ from .db_manager import DBManager
 logger = logging.getLogger(__name__)
 
 
+def _clamp(value: float, *, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, float(value)))
+
+
 class FeedbackService(BaseService):
     """Consume response feedback and adapt social/memory confidence state."""
 
@@ -190,6 +194,88 @@ class FeedbackService(BaseService):
         history.append(now)
         return len(history) > self._abuse_max_events
 
+    @staticmethod
+    def _inferred_style_for_source(source: str | None) -> str | None:
+        source_key = (source or "").strip().lower()
+        if "persona" in source_key:
+            return "friendly"
+        if "safety" in source_key:
+            return "cautious"
+        if "factual" in source_key or "tool" in source_key:
+            return "concise"
+        return None
+
+    async def _update_adaptation_profile(
+        self,
+        *,
+        user_id: str | None,
+        source: str,
+        signal: str,
+        affinity_delta: float,
+        confidence_delta: float,
+        signal_confidence: float,
+        score: float,
+    ) -> None:
+        normalized_source = (source or "unknown").strip().lower()
+        feedback_direction = 1.0 if affinity_delta >= 0 else -1.0
+        confidence_direction = 1.0 if confidence_delta >= 0 else -1.0
+        intensity = _clamp(abs(affinity_delta) * 0.18 + abs(confidence_delta) * 1.2 + signal_confidence * 0.12, lower=0.02, upper=0.35)
+
+        source_patch = {
+            "selector": {
+                "weight_multiplier": round(_clamp(1.0 + feedback_direction * intensity, lower=0.5, upper=1.75), 4),
+            },
+            "confidence": {
+                "calibration": {
+                    "bias": round(confidence_direction * min(0.12, abs(confidence_delta) * 0.8 + intensity * 0.1), 4),
+                    "slope": round(_clamp(1.0 + confidence_direction * min(0.25, abs(confidence_delta) * 0.35), lower=0.7, upper=1.3), 4),
+                }
+            },
+            "feedback_summary": {
+                "last_signal": signal,
+                "last_score": round(float(score), 4),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+        await self._db.upsert_adaptation_profile(scope_type="source", scope_key=normalized_source, profile=source_patch)
+
+        normalized_user = user_id.strip().lower() if isinstance(user_id, str) and user_id.strip() else None
+        if not normalized_user:
+            return
+
+        style = self._inferred_style_for_source(normalized_source)
+        user_patch: dict[str, Any] = {
+            "fallback": {
+                "aggressiveness": round(_clamp(0.35 - feedback_direction * intensity, lower=0.05, upper=0.95), 4),
+            },
+            "memory": {
+                "salience_boost": round(_clamp(abs(affinity_delta) * 0.25 + max(0.0, -confidence_delta) * 1.5, lower=0.0, upper=1.0), 4),
+                "retrieval_priority": round(_clamp(0.45 + max(0.0, abs(confidence_delta)) * 1.2 + (0.15 if signal == "corrected" else 0.0), lower=0.0, upper=1.0), 4),
+            },
+            "confidence": {
+                "default_calibration": {
+                    "bias": round(confidence_direction * min(0.15, abs(confidence_delta) * 0.9), 4),
+                    "slope": round(_clamp(1.0 + confidence_direction * min(0.2, abs(confidence_delta) * 0.5), lower=0.75, upper=1.25), 4),
+                }
+            },
+            "selector": {
+                "source_affinity": {
+                    normalized_source: round(_clamp(0.5 + feedback_direction * intensity, lower=0.0, upper=1.0), 4),
+                }
+            },
+            "feedback_summary": {
+                "last_signal": signal,
+                "last_score": round(float(score), 4),
+                "updated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+        if style:
+            user_patch["response_style"] = {
+                "preferred": style,
+                "preferences": {style: round(_clamp(0.5 + feedback_direction * intensity, lower=0.0, upper=1.0), 4)},
+            }
+        await self._db.upsert_adaptation_profile(scope_type="user", scope_key=normalized_user, profile=user_patch)
+
     async def _apply_feedback(
         self,
         *,
@@ -240,6 +326,15 @@ class FeedbackService(BaseService):
             confidence=signal_confidence,
             score=score,
             details=details,
+        )
+        await self._update_adaptation_profile(
+            user_id=resolved_user,
+            source=source_label,
+            signal=signal,
+            affinity_delta=affinity_delta,
+            confidence_delta=confidence_delta,
+            signal_confidence=signal_confidence,
+            score=score,
         )
 
         RESPONSE_FEEDBACK_SIGNALS_TOTAL.labels(

--- a/src/deepthought/services/responder_service.py
+++ b/src/deepthought/services/responder_service.py
@@ -61,40 +61,45 @@ class ResponderService:
         user_input: str,
         facts: list[str],
         social_signals: dict,
+        response_style: str | None,
     ) -> tuple[str, float, list[str], str, str]:
+        preferred_style = (response_style or "").strip().lower()
         if self._responder_kind in {"factual", "qa", "tool"}:
             fact = facts[0] if facts else "I don't have enough retrieved facts yet"
+            style = preferred_style or "concise"
             return (
                 f"Useful grounding fact: {fact}.",
                 0.78,
-                ["specialist", "factual", "grounded", "tool_ready"],
-                "concise",
+                ["specialist", "factual", "grounded", "tool_ready", style],
+                style,
                 "Fact-grounded specialist hint",
             )
         if self._responder_kind in {"persona", "conversational"}:
             prompt_context = self._compose_prompt_context(user_input, facts, social_signals)
+            style = preferred_style or "friendly"
             return (
                 f"Tone/rapport hint: acknowledge the user warmly while staying aligned with {prompt_context}.",
                 0.73,
-                ["specialist", "persona", "empathetic", "rapport"],
-                "friendly",
+                ["specialist", "persona", "empathetic", "rapport", style],
+                style,
                 "Persona specialist hint",
             )
 
         blocked = any(token in user_input.lower() for token in ("harm", "attack", "exploit"))
+        style = preferred_style or "safety"
         if blocked:
             return (
                 "Safety hint: refuse harmful assistance and redirect to safer alternatives.",
                 0.93,
-                ["specialist", "safety", "refusal", "policy"],
-                "safety",
+                ["specialist", "safety", "refusal", "policy", style],
+                style,
                 "Safety specialist refusal",
             )
         return (
             "Safety hint: content appears answerable, but avoid escalating risk and keep the reply bounded.",
             0.62,
-            ["specialist", "safety", "allow"],
-            "safety",
+            ["specialist", "safety", "allow", style],
+            style,
             "Safety specialist allow hint",
         )
 
@@ -104,12 +109,15 @@ class ResponderService:
         facts: list[str],
         social_signals: dict,
         policy_artifacts: list[dict],
+        response_style: str | None,
+        source_adaptation: dict[str, object],
     ) -> ResponseCandidate:
         source = f"responder:{self._responder_id}"
         text, confidence, tags, style, role_description = self._build_specialist_payload(
             user_input=user_input,
             facts=facts,
             social_signals=social_signals,
+            response_style=response_style,
         )
 
         decision = self._policy_engine.evaluate_candidate(
@@ -119,7 +127,13 @@ class ResponderService:
         )
         safety_passed = decision.allowed
         confidence_components = {"model": confidence, "prior": 0.8}
-        calibration = {"slope": 1.0, "bias": 0.0, "version": "heuristic_v1"}
+        source_confidence = source_adaptation.get("confidence") if isinstance(source_adaptation.get("confidence"), dict) else {}
+        source_calibration = source_confidence.get("calibration") if isinstance(source_confidence, dict) else {}
+        calibration = {
+            "slope": float(source_calibration.get("slope", 1.0)) if isinstance(source_calibration, dict) else 1.0,
+            "bias": float(source_calibration.get("bias", 0.0)) if isinstance(source_calibration, dict) else 0.0,
+            "version": "heuristic_v1",
+        }
 
         return ResponseCandidate(
             text=text,
@@ -145,13 +159,15 @@ class ResponderService:
                 "calibration": calibration,
                 "calibration_metadata": {
                     "calibration": calibration,
-                    "confidence_components": confidence_components,
-                    "policy_version": self._policy_engine.VERSION,
-                },
-                "social_features": self._bounded_social_features(social_signals),
+                "confidence_components": confidence_components,
                 "policy_version": self._policy_engine.VERSION,
+                "adaptation": source_adaptation,
             },
-            rationale_tags=tags,
+            "social_features": self._bounded_social_features(social_signals),
+            "adaptation": source_adaptation,
+            "policy_version": self._policy_engine.VERSION,
+        },
+        rationale_tags=tags,
         )
 
     async def _handle_context_event(self, msg: Msg) -> None:
@@ -171,6 +187,15 @@ class ResponderService:
             policy_artifacts = [risk_artifact, hardening_artifact]
 
             selector_inputs = social_signals.get("selector_inputs") if isinstance(social_signals.get("selector_inputs"), dict) else {}
+            adaptation_state = payload.get("adaptation_state") if isinstance(payload.get("adaptation_state"), dict) else {}
+            response_style = None
+            interaction_policy = selector_inputs.get("interaction_policy")
+            if isinstance(interaction_policy, dict) and isinstance(interaction_policy.get("response_style"), str):
+                response_style = interaction_policy.get("response_style")
+            source_adaptation = {}
+            sources = adaptation_state.get("sources") if isinstance(adaptation_state.get("sources"), dict) else {}
+            if isinstance(sources.get(f"responder:{self._responder_id}"), dict):
+                source_adaptation = dict(sources[f"responder:{self._responder_id}"])
             out = ResponseCandidatesPayload(
                 candidates=[
                     self._build_candidate(
@@ -178,6 +203,8 @@ class ResponderService:
                         facts=[str(x) for x in facts],
                         social_signals=social_signals,
                         policy_artifacts=policy_artifacts,
+                        response_style=response_style,
+                        source_adaptation=source_adaptation,
                     )
                 ],
                 input_id=input_id,
@@ -188,6 +215,7 @@ class ResponderService:
                 interaction_policy=selector_inputs.get("interaction_policy"),
                 social_intent_hints=selector_inputs.get("social_intent_hints"),
                 user_history_affinity=selector_inputs.get("user_history_affinity"),
+                adaptation_state=adaptation_state,
             )
             envelope = EventEnvelope.build(
                 subject=EventSubjects.RESPONSE_CANDIDATES,

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -38,6 +38,7 @@ class _AggregationState:
     context_confidence: dict = field(default_factory=dict)
     social_intent_hints: dict = field(default_factory=dict)
     user_history_affinity: dict[str, float] = field(default_factory=dict)
+    adaptation_state: dict = field(default_factory=dict)
     opened_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     flush_task: asyncio.Task[None] | None = None
 
@@ -91,11 +92,28 @@ class SelectorService:
         duplicates = sum(1 for item in all_candidates if item.text.strip().lower() == candidate.text.strip().lower())
         return min(0.3, max(0, duplicates - 1) * 0.1)
 
-    def _normalized_confidence(self, candidate: ResponseCandidate) -> float:
+    def _source_adaptation(self, adaptation_state: Optional[dict], source: str) -> dict:
+        if not isinstance(adaptation_state, dict):
+            return {}
+        sources = adaptation_state.get("sources")
+        if not isinstance(sources, dict):
+            return {}
+        profile = sources.get(source)
+        return dict(profile) if isinstance(profile, dict) else {}
+
+    def _normalized_confidence(self, candidate: ResponseCandidate, adaptation_state: Optional[dict] = None) -> float:
         source = (candidate.source or "default").lower()
         weight = self._source_confidence_weights.get(source, self._source_confidence_weights.get("default", 1.0))
+        source_adaptation = self._source_adaptation(adaptation_state, source)
+        selector_profile = source_adaptation.get("selector") if isinstance(source_adaptation.get("selector"), dict) else {}
+        if isinstance(selector_profile.get("weight_multiplier"), (int, float)):
+            weight *= float(selector_profile["weight_multiplier"])
         calibrated = max(0.0, candidate.confidence * weight)
         profile = self._source_calibration_profiles.get(source) or self._source_calibration_profiles.get("default") or {}
+        adaptation_confidence = source_adaptation.get("confidence") if isinstance(source_adaptation.get("confidence"), dict) else {}
+        adaptation_calibration = adaptation_confidence.get("calibration") if isinstance(adaptation_confidence, dict) else {}
+        if isinstance(adaptation_calibration, dict):
+            profile = {**profile, **adaptation_calibration}
         slope = float(profile.get("slope", 1.0))
         bias = float(profile.get("bias", 0.0))
         floor = float(profile.get("floor", 0.0))
@@ -116,9 +134,16 @@ class SelectorService:
         rationale = ",".join(sorted(candidate.rationale_tags)) if isinstance(candidate.rationale_tags, list) else ""
         return (source, text, rationale)
 
-    def _choose_fallback(self, interaction_policy: Optional[dict]) -> tuple[str, str]:
+    def _choose_fallback(self, interaction_policy: Optional[dict], adaptation_state: Optional[dict] = None) -> tuple[str, str]:
         policy = interaction_policy or {}
-        if policy.get("ask_clarifying_on_no_safe", True):
+        fallback_profile = adaptation_state.get("fallback") if isinstance(adaptation_state, dict) and isinstance(adaptation_state.get("fallback"), dict) else {}
+        aggressiveness = fallback_profile.get("aggressiveness", policy.get("fallback_aggressiveness", 0.5))
+        try:
+            fallback_aggressiveness = max(0.0, min(1.0, float(aggressiveness)))
+        except (TypeError, ValueError):
+            fallback_aggressiveness = 0.5
+        should_clarify = policy.get("ask_clarifying_on_no_safe", True) and fallback_aggressiveness <= 0.6
+        if should_clarify:
             return (
                 "I don't yet have a safe, reliable answer. Could you clarify what outcome you want?",
                 "clarifying_question",
@@ -192,6 +217,7 @@ class SelectorService:
         context_confidence: Optional[dict] = None,
         social_intent_hints: Optional[dict] = None,
         user_history_affinity: Optional[dict[str, float]] = None,
+        adaptation_state: Optional[dict] = None,
     ) -> tuple[list[ResponseCandidate], list[dict]]:
         diagnostics: list[dict] = []
         scored: list[tuple[float, ResponseCandidate]] = []
@@ -200,7 +226,7 @@ class SelectorService:
 
         for candidate in candidates:
             rejection_reasons: list[str] = []
-            normalized = self._normalized_confidence(candidate)
+            normalized = self._normalized_confidence(candidate, adaptation_state)
             policy_fit = self._policy_fit_score(candidate, interaction_policy, social_intent_hints)
             policy_adjustment = self._policy_fit_weight * policy_fit
             affinity_score = self._user_history_affinity_score(candidate, user_history_affinity, social_intent_hints)
@@ -236,6 +262,9 @@ class SelectorService:
                 "policy_risk_level": policy_decision.risk_level,
                 "policy_confidence_band": policy_decision.confidence_band,
             }
+            source_adaptation = self._source_adaptation(adaptation_state, (candidate.source or "default").lower())
+            if source_adaptation:
+                factor_scores["adaptation"] = source_adaptation
             if rejection_reasons:
                 diagnostics.append(
                     {
@@ -287,6 +316,7 @@ class SelectorService:
             context_confidence=state.context_confidence,
             social_intent_hints=state.social_intent_hints,
             user_history_affinity=state.user_history_affinity,
+            adaptation_state=state.adaptation_state,
         )
         fallback_reason = None
         if ranked_candidates:
@@ -304,7 +334,7 @@ class SelectorService:
             final_source = selected.source
             selected_policy_artifacts = self._candidate_policy_artifacts(selected)
         else:
-            final_response, fallback_reason = self._choose_fallback(state.interaction_policy)
+            final_response, fallback_reason = self._choose_fallback(state.interaction_policy, state.adaptation_state)
             final_confidence = 0.0
             final_source = "selector_fallback"
             selected_policy_artifacts = []
@@ -347,6 +377,7 @@ class SelectorService:
             "context_confidence": state.context_confidence,
             "social_intent_hints": state.social_intent_hints,
             "user_history_affinity": state.user_history_affinity,
+            "adaptation_state": state.adaptation_state,
             "weights": {
                 "context_degradation": self._context_degradation_weight,
                 "policy_fit": self._policy_fit_weight,
@@ -395,6 +426,7 @@ class SelectorService:
                         context_confidence=payload.context_confidence or {},
                         social_intent_hints=payload.social_intent_hints or {},
                         user_history_affinity=payload.user_history_affinity or {},
+                        adaptation_state=payload.adaptation_state or {},
                     )
                     self._pending_by_input[input_id] = state
 
@@ -406,6 +438,7 @@ class SelectorService:
                 state.context_confidence = state.context_confidence or (payload.context_confidence or {})
                 state.social_intent_hints = state.social_intent_hints or (payload.social_intent_hints or {})
                 state.user_history_affinity = state.user_history_affinity or (payload.user_history_affinity or {})
+                state.adaptation_state = state.adaptation_state or (payload.adaptation_state or {})
 
                 ranked_candidates, diagnostics = self._rank_candidates(
                     state.candidates,
@@ -413,6 +446,7 @@ class SelectorService:
                     context_confidence=state.context_confidence,
                     social_intent_hints=state.social_intent_hints,
                     user_history_affinity=state.user_history_affinity,
+                    adaptation_state=state.adaptation_state,
                 )
                 top_score = diagnostics[0]["score"] if diagnostics else 0.0
                 early_exit = bool(ranked_candidates) and top_score >= self._early_exit_confidence

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -48,6 +48,14 @@ class DummyMsg:
         self.nacked = True
 
 
+class DummyDB:
+    def __init__(self, adaptation_state=None):
+        self.adaptation_state = adaptation_state or {}
+
+    async def get_adaptation_state(self, *, user_id=None):
+        return self.adaptation_state
+
+
 @pytest.mark.asyncio
 async def test_race_safe_assembly_collects_all_providers(monkeypatch):
     import deepthought.services.context_assembler_service as mod
@@ -295,3 +303,45 @@ async def test_context_assembler_uses_social_signals_retrieved_as_social_provide
     subjects = [call["subject"] for call in svc._subscriber.calls]
     assert EventSubjects.SOCIAL_SIGNALS_RETRIEVED in subjects
     assert EventSubjects.SOCIAL_UPDATED not in subjects
+
+
+@pytest.mark.asyncio
+async def test_context_assembler_merges_adaptation_state_into_selector_inputs(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(
+        DummyNATS(),
+        DummyJS(),
+        db_manager=DummyDB(
+            {
+                "user": {
+                    "response_style": {"preferred": "concise"},
+                    "fallback": {"aggressiveness": 0.2},
+                    "memory": {"salience_boost": 0.7, "retrieval_priority": 0.9},
+                },
+                "sources": {
+                    "responder:factual": {"selector": {"weight_multiplier": 1.25}},
+                },
+                "retrieval": {"salience_boost": 0.7, "retrieval_priority": 0.9},
+                "fallback": {"aggressiveness": 0.2},
+            }
+        ),
+        wait_window_seconds=0.05,
+    )
+
+    await svc._handle_input_received(DummyMsg({"input_id": "i-adapt", "user_input": "hello", "author_id": "u-adapt"}))
+    await svc._handle_provider_response(DummyMsg({"input_id": "i-adapt", "retrieved_knowledge": {"facts": ["fact-a"]}}), "memory")
+    await svc._handle_provider_response(DummyMsg({"input_id": "i-adapt", "social_signals": {"selector_inputs": {"interaction_policy": {"ask_clarifying_on_no_safe": True}}}}), "social")
+    await svc._handle_provider_response(DummyMsg({"input_id": "i-adapt", "multimodal_interpretations": {"summary": "none", "notes": []}}), "perception")
+    await asyncio.sleep(0.06)
+
+    assembled = [c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED]
+    payload = assembled[0][1]["payload"]
+    assert payload["adaptation_state"]["user"]["response_style"]["preferred"] == "concise"
+    assert payload["social_signals"]["selector_inputs"]["interaction_policy"]["response_style"] == "concise"
+    assert payload["social_signals"]["selector_inputs"]["interaction_policy"]["fallback_aggressiveness"] == pytest.approx(0.2)
+    assert payload["confidence"]["retrieval_policy"]["salience_boost"] == pytest.approx(0.7)
+    assert payload["social_signals"]["selector_inputs"]["user_history_affinity"]["responder:factual"] == pytest.approx(0.25)

--- a/tests/unit/services/test_feedback_service.py
+++ b/tests/unit/services/test_feedback_service.py
@@ -12,6 +12,7 @@ class DummyDB:
         self.affinity_calls = []
         self.confidence_calls = []
         self.feedback_rows = []
+        self.adaptation_profiles = {}
 
     async def adjust_affinity(self, user_id, delta):
         self.affinity_calls.append((user_id, delta))
@@ -25,6 +26,23 @@ class DummyDB:
     async def fetch_high_value_feedback(self, *, limit=100, min_score=0.7):
         high = [r for r in self.feedback_rows if float(r.get("score", 0.0)) >= min_score]
         return high[:limit]
+
+    async def upsert_adaptation_profile(self, *, scope_type, scope_key, profile, merge=True):
+        key = (scope_type, scope_key)
+        current = self.adaptation_profiles.get(key, {})
+
+        def merge_dict(base, override):
+            merged = dict(base)
+            for name, value in override.items():
+                if isinstance(value, dict) and isinstance(merged.get(name), dict):
+                    merged[name] = merge_dict(merged[name], value)
+                else:
+                    merged[name] = value
+            return merged
+
+        next_profile = merge_dict(current, profile) if merge else dict(profile)
+        self.adaptation_profiles[key] = next_profile
+        return next_profile
 
 
 class DummyPublisher:
@@ -106,6 +124,32 @@ async def test_feedback_service_discord_reaction_mapping_and_guardrails():
         details={"emoji": "👎"},
     )
     assert len(service._db.feedback_rows) == prior
+
+
+@pytest.mark.asyncio
+async def test_feedback_service_persists_user_and_source_adaptation_profiles():
+    service = FeedbackService(nats_client=None, js_context=None, db_manager=DummyDB())
+    service._publisher = DummyPublisher()
+
+    await service._apply_feedback(
+        signal_type="outcome",
+        signal="positive",
+        input_id="in-3",
+        user_id="u-3",
+        source="responder:persona",
+        model_id="m-3",
+        affinity_delta=1.0,
+        confidence_delta=0.1,
+        signal_confidence=0.95,
+        details={},
+    )
+
+    user_profile = service._db.adaptation_profiles[("user", "u-3")]
+    source_profile = service._db.adaptation_profiles[("source", "responder:persona")]
+    assert user_profile["response_style"]["preferred"] == "friendly"
+    assert user_profile["fallback"]["aggressiveness"] < 0.35
+    assert source_profile["selector"]["weight_multiplier"] > 1.0
+    assert source_profile["confidence"]["calibration"]["bias"] > 0.0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_responder_service.py
+++ b/tests/unit/services/test_responder_service.py
@@ -165,3 +165,41 @@ async def test_responder_passes_selector_inputs_from_durable_social_model(monkey
     assert payload["interaction_policy"]["response_style"] == "friendly"
     assert payload["social_intent_hints"]["high_rapport_expected"] is True
     assert payload["user_history_affinity"]["default"] == pytest.approx(0.5)
+
+
+@pytest.mark.asyncio
+async def test_responder_applies_adaptation_state_to_candidate_metadata(monkeypatch):
+    import deepthought.services.responder_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = FactualResponderService(DummyNATS(), DummyJS())
+    await svc.start()
+
+    context_payload = {
+        "input_id": "in-adaptation",
+        "user_input": "hello",
+        "retrieved_facts": ["fact1"],
+        "author_id": "a-1",
+        "adaptation_state": {
+            "sources": {
+                "responder:factual": {
+                    "confidence": {"calibration": {"slope": 0.85, "bias": 0.04}}
+                }
+            }
+        },
+        "social_signals": {
+            "selector_inputs": {
+                "interaction_policy": {"response_style": "concise", "ask_clarifying_on_no_safe": True},
+            }
+        },
+    }
+    msg = DummyMsg(json.dumps(context_payload))
+    await svc._handle_context_event(msg)
+
+    payload = svc._publisher.calls[0][1]["payload"]
+    candidate = payload["candidates"][0]
+    assert "concise" in candidate["rationale_tags"]
+    assert candidate["source_metadata"]["adaptation"]["confidence"]["calibration"]["slope"] == pytest.approx(0.85)
+    assert payload["adaptation_state"]["sources"]["responder:factual"]["confidence"]["calibration"]["bias"] == pytest.approx(0.04)

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -356,3 +356,52 @@ async def test_deterministic_tie_breaking_prefers_lexicographic_source(monkeypat
 
     ranked_payload = svc._publisher.published[0][1]
     assert ranked_payload["payload"]["source"] == "responder:factual"
+
+
+@pytest.mark.asyncio
+async def test_adaptation_state_changes_selector_weight_and_fallback(monkeypatch):
+    import deepthought.services.selector_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", DummyPublisher)
+    monkeypatch.setattr(mod, "Subscriber", DummySubscriber)
+    svc = SelectorService(
+        DummyNATS(),
+        DummyJS(),
+        early_exit_confidence=0.0,
+        window_seconds=0.0,
+    )
+
+    payload = ResponseCandidatesPayload(
+        input_id="adapt-selector-1",
+        interaction_policy={"ask_clarifying_on_no_safe": True},
+        adaptation_state={
+            "fallback": {"aggressiveness": 0.9},
+            "sources": {
+                "responder:persona": {
+                    "selector": {"weight_multiplier": 1.4},
+                    "confidence": {"calibration": {"bias": 0.05}},
+                }
+            },
+        },
+        candidates=[
+            ResponseCandidate(text="persona", confidence=0.6, source="responder:persona"),
+            ResponseCandidate(text="factual", confidence=0.7, source="responder:factual", safety_passed=False),
+        ],
+    )
+
+    await svc._handle_candidates_event(DummyMsg(payload.to_json()))
+
+    ranked_payload = svc._publisher.published[0][1]
+    telemetry_payload = svc._publisher.published[1][1]
+    assert ranked_payload["payload"]["source"] == "responder:persona"
+    assert telemetry_payload["adaptation_state"]["fallback"]["aggressiveness"] == pytest.approx(0.9)
+
+    fallback_payload = ResponseCandidatesPayload(
+        input_id="adapt-selector-fallback",
+        interaction_policy={"ask_clarifying_on_no_safe": True},
+        adaptation_state={"fallback": {"aggressiveness": 0.95}},
+        candidates=[ResponseCandidate(text="unsafe", confidence=0.6, source="x", safety_passed=False)],
+    )
+    await svc._handle_candidates_event(DummyMsg(fallback_payload.to_json()))
+    await asyncio.sleep(0.02)
+    assert "safer way" in svc._publisher.published[2][1]["payload"]["final_response"].lower()


### PR DESCRIPTION
### Motivation

- Make recorded feedback actually influence future behavior by persisting a durable adaptation profile and reading it at ranking/generation time. 
- Enable adaptation to affect selector source weights, per-user response-style preferences, confidence calibration, fallback aggressiveness, and memory retrieval hints. 
- Provide a single read path so adaptation state is consumed once per request and threaded through responders and the selector.

### Description

- Add a new `adaptation_profiles` table and read/merge APIs in `DBManager` (`upsert_adaptation_profile`, `get_adaptation_state`) for user- and source-scoped durable adaptation data. (edited `src/deepthought/services/db_manager.py`)
- Persist adaptation signals from feedback in `FeedbackService` by computing compact patches (selector weight multipliers, calibration deltas, fallback/memory hints, inferred response-style) and calling `upsert_adaptation_profile`. (edited `src/deepthought/services/feedback_service.py`)
- Load adaptation state once per request in `ContextAssemblerService`, merge it into `social_signals.selector_inputs`, inject retrieval/fallback hints, and include `adaptation_state` in the assembled payload. (edited `src/deepthought/services/context_assembler_service.py`)
- Thread `adaptation_state` through the responder and selector flows so responders can apply style and source calibration and the selector can use source-specific weight multipliers, calibration profiles, and fallback aggressiveness when ranking. (edited `src/deepthought/services/responder_service.py`, `src/deepthought/services/selector_service.py`, `src/deepthought/eda/events.py`)
- Add/extend unit and integration tests to cover adaptation persistence, context assembly propagation, responder candidate metadata, and selector weighting/fallback changes. (edited tests in `tests/unit/services/*` and `tests/integration/*`)

### Testing

- Ran the unit and integration test set: `pytest tests/unit/services/test_feedback_service.py tests/unit/services/test_responder_service.py tests/unit/services/test_selector_service.py tests/integration/test_context_assembler_service.py`; result: all tests passed (26 passed, 1 skipped).
- Ran linter checks with `ruff` on modified modules; result: all checks passed.
- Verified bytecode compilation with `python -m compileall` for changed modules; result: successful compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc0fd6dee8832685b2d0dff09fc669)