### PR TITLE
Enforce enveloped dtr event publishing

### DIFF
--- a/src/deepthought/services/demo/service.py
+++ b/src/deepthought/services/demo/service.py
@@ -7,6 +7,7 @@ from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
 from deepthought.eda import Publisher, Subscriber
+from deepthought.eda.contracts import EventEnvelope
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,12 @@ class DemoService:
     async def _handle_input(self, msg: Msg) -> None:
         logger.info("Handling message %s", msg.subject)
         try:
-            await self._publisher.publish("dtr.template.output", msg.data, use_jetstream=True)
+            envelope = EventEnvelope.build(
+                subject="dtr.template.output",
+                payload={"data": msg.data.decode(errors="replace")},
+                producer=self.__class__.__name__,
+            )
+            await self._publisher.publish("dtr.template.output", envelope.__dict__, use_jetstream=True)
         finally:
             await msg.ack()
 

--- a/src/deepthought/services/discord_gateway_service.py
+++ b/src/deepthought/services/discord_gateway_service.py
@@ -17,6 +17,7 @@ from nats.js.client import JetStreamContext
 
 from ..eda.contracts import EventEnvelope, decode_payload_or_envelope
 from ..eda.events import DiscordFeedbackSignalPayload, EventSubjects, InputReceivedPayload, ResponseRankedPayload
+from ..eda.publisher import publish_enveloped
 from .base import BaseService
 from .human_interaction_policy import HumanInteractionPolicy
 from .policy_engine import VersionedPolicyEngine
@@ -25,11 +26,13 @@ logger = logging.getLogger(__name__)
 
 
 class _Channel(Protocol):
-    async def send(self, content: str, **kwargs: Any) -> None: ...
+    async def send(self, content: str, **kwargs: Any) -> None:
+        ...
 
 
 class _DiscordClient(Protocol):
-    def get_channel(self, channel_id: int) -> _Channel | None: ...
+    def get_channel(self, channel_id: int) -> _Channel | None:
+        ...
 
 
 @dataclass
@@ -100,7 +103,7 @@ class _ConversationStateStore:
                 seen.add(dedupe_key)
                 merged.append(turn)
         merged.sort(key=lambda turn: (turn.timestamp, turn.message_id or ""))
-        return [turn.as_payload() for turn in merged[-self._window_size :]]
+        return [turn.as_payload() for turn in merged[-self._window_size:]]
 
     @staticmethod
     def _scope_keys(
@@ -494,9 +497,11 @@ class DiscordGatewayService(BaseService):
             "policy_version": self._policy_engine.VERSION,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
-        await self._publisher.publish(
-            "dtr.telemetry.egress_policy.v1",
-            escalation_payload,
+        await publish_enveloped(
+            self._publisher,
+            subject="dtr.telemetry.egress_policy.v1",
+            payload=escalation_payload,
+            producer=self.__class__.__name__,
             use_jetstream=True,
             timeout=10.0,
         )

--- a/src/deepthought/services/feedback_service.py
+++ b/src/deepthought/services/feedback_service.py
@@ -20,6 +20,7 @@ from ..eda.events import (
     OutcomeSignalPayload,
     ResponseRankedPayload,
 )
+from ..eda.publisher import publish_enveloped
 from ..metrics.prometheus import (
     ADAPTATION_EFFECT_DELTA,
     RESPONSE_FEEDBACK_SIGNALS_TOTAL,
@@ -361,9 +362,11 @@ class FeedbackService(BaseService):
             "details": details,
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
-        await self._publisher.publish(
-            "dtr.telemetry.response_feedback.v1",
-            telemetry_payload,
+        await publish_enveloped(
+            self._publisher,
+            subject="dtr.telemetry.response_feedback.v1",
+            payload=telemetry_payload,
+            producer=self.__class__.__name__,
             use_jetstream=True,
         )
 
@@ -375,9 +378,11 @@ class FeedbackService(BaseService):
             tuples = await self._db.fetch_high_value_feedback(limit=100, min_score=self._export_min_score)
             if not tuples:
                 continue
-            await self._publisher.publish(
-                "dtr.training.feedback_tuples.v1",
-                {"count": len(tuples), "items": tuples, "exported_at": datetime.now(timezone.utc).isoformat()},
+            await publish_enveloped(
+                self._publisher,
+                subject="dtr.training.feedback_tuples.v1",
+                payload={"count": len(tuples), "items": tuples, "exported_at": datetime.now(timezone.utc).isoformat()},
+                producer=self.__class__.__name__,
                 use_jetstream=True,
             )
 

--- a/src/deepthought/services/perception/delete_user_data.py
+++ b/src/deepthought/services/perception/delete_user_data.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from nats.aio.client import Client as NATS
 
+from ...eda.contracts import EventEnvelope
 from .config import PerceptionConfig
 from .user_embeddings import UserEmbeddings
 
@@ -20,9 +21,14 @@ async def trigger_replay_jobs(user_id: str, nats_url: str) -> None:
     nc = NATS()
     await nc.connect(servers=[nats_url])
     js = nc.jetstream()
+    envelope = EventEnvelope.build(
+        subject="dtr.perception.replay.delete_user",
+        payload={"user_id": user_id},
+        producer="perception.delete_user_data",
+    )
     await js.publish(
         "dtr.perception.replay.delete_user",
-        json.dumps({"user_id": user_id}).encode(),
+        json.dumps(envelope.__dict__).encode(),
     )
     await nc.drain()
 

--- a/src/deepthought/services/selector_service.py
+++ b/src/deepthought/services/selector_service.py
@@ -19,7 +19,7 @@ from ..eda.events import (
     ResponseCandidatesPayload,
     ResponseRankedPayload,
 )
-from ..eda.publisher import Publisher
+from ..eda.publisher import Publisher, publish_enveloped
 from ..eda.subscriber import Subscriber
 from . import moderation
 from .policy_engine import VersionedPolicyEngine
@@ -385,9 +385,13 @@ class SelectorService:
             },
             "diagnostics": diagnostics,
         }
-        await self._publisher.publish(
-            "dtr.telemetry.selector_ranking.v1",
-            telemetry_payload,
+        await publish_enveloped(
+            self._publisher,
+            subject="dtr.telemetry.selector_ranking.v1",
+            payload=telemetry_payload,
+            producer=self.__class__.__name__,
+            trace_id=trace_id,
+            causation_id=causation_id,
             use_jetstream=True,
             timeout=10.0,
         )

--- a/tests/unit/eda/test_dtr_publish_envelope_contract.py
+++ b/tests/unit/eda/test_dtr_publish_envelope_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+TARGET_ROOTS = (
+    Path("src/deepthought/services"),
+    Path("src/deepthought/modules"),
+)
+
+
+def _iter_dtr_publish_violations() -> list[str]:
+    violations: list[str] = []
+    for root in TARGET_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not isinstance(func, ast.Attribute) or func.attr != "publish" or len(node.args) < 2:
+                    continue
+                subject = node.args[0]
+                if not isinstance(subject, ast.Constant) or not isinstance(subject.value, str):
+                    continue
+                if not subject.value.startswith("dtr."):
+                    continue
+                payload_expr = ast.unparse(node.args[1])
+                if "__dict__" not in payload_expr:
+                    violations.append(f"{path}:{node.lineno} -> {subject.value} uses non-enveloped payload `{payload_expr}`")
+    return violations
+
+
+def test_dtr_subject_publishes_use_envelopes() -> None:
+    violations = _iter_dtr_publish_violations()
+    assert not violations, "Found dtr.* publishes without an envelope:\n" + "\n".join(violations)

--- a/tests/unit/services/test_discord_gateway_service.py
+++ b/tests/unit/services/test_discord_gateway_service.py
@@ -100,13 +100,11 @@ class DummyDiscordClient:
 
 
 @pytest.fixture
-
 def fake_clock():
     return FakeClock()
 
 
 @pytest.fixture
-
 def service(monkeypatch, fake_clock):
     import deepthought.services.base as base_mod
 
@@ -400,4 +398,4 @@ async def test_ranked_response_egress_policy_escalates_ambiguous_confidence(serv
     assert service._discord_client.channel.messages == []
     telemetry = [item for item in service._publisher.published if item[0] == "dtr.telemetry.egress_policy.v1"]
     assert telemetry
-    assert telemetry[0][1]["decision_action"] == "escalate"
+    assert telemetry[0][1]["payload"]["decision_action"] == "escalate"

--- a/tests/unit/services/test_feedback_service.py
+++ b/tests/unit/services/test_feedback_service.py
@@ -4,6 +4,7 @@ import pytest
 pytest.importorskip("aiosqlite")
 
 from deepthought.eda.events import EventSubjects
+from deepthought.eda.publisher import publish_enveloped
 from deepthought.services.feedback_service import FeedbackService
 
 
@@ -87,6 +88,7 @@ async def test_feedback_service_tracks_response_and_applies_positive_outcome():
     assert service._db.confidence_calls == [("u-1", 0.1)]
     assert outcome.acked
     assert service._publisher.calls[0][0] == "dtr.telemetry.response_feedback.v1"
+    assert service._publisher.calls[0][1]["payload"]["event"] == "response_feedback"
 
 
 @pytest.mark.asyncio
@@ -181,11 +183,17 @@ async def test_feedback_queue_generation_filters_high_value_rows():
     )
 
     tuples = await service._db.fetch_high_value_feedback(min_score=0.7)
-    await service._publisher.publish("dtr.training.feedback_tuples.v1", {"items": tuples})
+    await publish_enveloped(
+        service._publisher,
+        subject="dtr.training.feedback_tuples.v1",
+        payload={"items": tuples},
+        producer="test_feedback_service",
+    )
 
     assert len(tuples) == 1
     assert tuples[0]["input_id"] == "in-h"
     assert service._publisher.calls[-1][0] == "dtr.training.feedback_tuples.v1"
+    assert service._publisher.calls[-1][1]["payload"]["items"] == tuples
 
 
 def test_feedback_subjects_are_canonicalized():

--- a/tests/unit/services/test_selector_service.py
+++ b/tests/unit/services/test_selector_service.py
@@ -75,8 +75,8 @@ async def test_rank_by_confidence(service):
     assert ranked["payload"]["final_response"] == "high"
     telemetry_subject, telemetry_payload = service._publisher.published[1]
     assert telemetry_subject == "dtr.telemetry.selector_ranking.v1"
-    assert telemetry_payload["chosen_source"] is None
-    assert telemetry_payload["policy_version"] == "v1"
+    assert telemetry_payload["payload"]["chosen_source"] is None
+    assert telemetry_payload["payload"]["policy_version"] == "v1"
 
 
 @pytest.mark.asyncio
@@ -179,7 +179,7 @@ async def test_source_calibration_changes_ranking(monkeypatch):
     await svc._handle_candidates_event(msg)
 
     assert svc._publisher.published[0][1]["payload"]["final_response"] == "weighted"
-    diagnostics = svc._publisher.published[1][1]["diagnostics"]
+    diagnostics = svc._publisher.published[1][1]["payload"]["diagnostics"]
     assert diagnostics[0]["source"] == "trusted"
 
 
@@ -211,7 +211,7 @@ async def test_mixed_source_and_confidence_filters_and_weights(monkeypatch):
     await svc._handle_candidates_event(msg)
 
     ranked = svc._publisher.published[0][1]
-    telemetry = svc._publisher.published[1][1]
+    telemetry = svc._publisher.published[1][1]["payload"]
     assert ranked["payload"]["final_response"] == "safe tool"
     rejected = [item for item in telemetry["diagnostics"] if item["rejection_reasons"]]
     assert rejected and rejected[0]["text"] == "unsafe rule"
@@ -276,7 +276,7 @@ async def test_context_and_policy_and_affinity_factors_shape_ranking(monkeypatch
     await svc._handle_candidates_event(msg)
 
     ranked = svc._publisher.published[0][1]
-    telemetry = svc._publisher.published[1][1]
+    telemetry = svc._publisher.published[1][1]["payload"]
     assert ranked["payload"]["final_response"] == "tailored"
     assert ranked["payload"]["interaction_policy"]["policy_version"] == "v1"
     assert telemetry["weights"]["policy_fit"] == pytest.approx(0.2)
@@ -392,7 +392,7 @@ async def test_adaptation_state_changes_selector_weight_and_fallback(monkeypatch
     await svc._handle_candidates_event(DummyMsg(payload.to_json()))
 
     ranked_payload = svc._publisher.published[0][1]
-    telemetry_payload = svc._publisher.published[1][1]
+    telemetry_payload = svc._publisher.published[1][1]["payload"]
     assert ranked_payload["payload"]["source"] == "responder:persona"
     assert telemetry_payload["adaptation_state"]["fallback"]["aggressiveness"] == pytest.approx(0.9)
 


### PR DESCRIPTION
### Motivation

- Prevent accidental contract drift by ensuring all cross-service `dtr.*` subjects leave services as canonical `EventEnvelope`s rather than raw dicts.
- Replace fragile ad-hoc telemetry/training publishes with the standard `publish_enveloped(...)` helper so envelopes are built, validated, and consistent across services.
- Add a centralized lint-style check so future code cannot introduce unenveloped `dtr.*` publishes unnoticed.

### Description

- Replaced raw `dtr.*` publishes with `publish_enveloped(...)` in `selector_service`, `discord_gateway_service`, and `feedback_service`, and added required imports. (uses `producer`, optional `trace_id` / `causation_id`).
- Enveloped remaining direct publishes found in the audit: `demo/service.py` (wrapped demo output via `EventEnvelope.build(...)`) and `perception/delete_user_data.py` (wrapped replay delete message before `js.publish`).
- Added an AST-based unit test `tests/unit/eda/test_dtr_publish_envelope_contract.py` that fails if any `publish(...)` under `src/deepthought/services/` or `src/deepthought/modules/` sends a `dtr.*` subject without an envelope (`__dict__` check of an envelope).
- Updated affected unit tests to assert the enveloped payload shape (selector telemetry, Discord egress telemetry, feedback exports) and made small style fixes to satisfy linters.

### Testing

- Ran static/compile checks with `python -m py_compile` on modified service files and tests, which succeeded after small style adjustments.
- Ran `flake8` on the modified files and fixed style issues reported by the linter.
- Ran unit tests with `pytest tests/unit/eda/test_dtr_publish_envelope_contract.py tests/unit/services/test_selector_service.py tests/unit/services/test_discord_gateway_service.py tests/unit/services/test_feedback_service.py tests/unit/eda/test_publisher.py`, with the result: all tests passed (29 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc181cdca883268e685f01be377785)