### PR TITLE
Align development compose topology and orchestrator docs; add Neo4j profile to avoid port conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,76 @@
 version: '3.8'
+
+x-app-base: &app-base
+  image: python:3.11-slim
+  working_dir: /app
+  volumes:
+    - .:/app
+  environment: &app-env
+    PYTHONUNBUFFERED: '1'
+    PYTHONPATH: /app/src
+    NATS_URL: nats://nats:4222
+    LLM_ENDPOINT: ${LLM_ENDPOINT:-http://host.docker.internal:8000/generate}
+    DT_RUNTIME_PROFILE: production
+    DT_GRAPH_BACKEND: ${DT_GRAPH_BACKEND:-memgraph}
+    DT_MG_HOST: ${DT_MG_HOST:-memgraph}
+    DT_MG_PORT: ${DT_MG_PORT:-7687}
+    DT_MG_USER: ${DT_MG_USER:-memgraph}
+    DT_MG_PASSWORD: ${DT_MG_PASSWORD:-memgraph}
+    DT_MEMORY_DB: /app/data/memory.db
+    DT_SOCIAL_GRAPH_DB: /app/data/social_graph.db
+    DT_SEARCH_DB: /app/examples/data/sample_docs.json
+    DT_FEEDBACK_DURABLE_PREFIX: feedback_service
+    DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+    PERCEPTION_MODEL_PATH: ${PERCEPTION_MODEL_PATH:-}
+  command: >-
+    bash -lc "pip install --no-cache-dir -r requirements.txt && pip install --no-cache-dir -e . && python -m setup_jetstream && dtrt orchestrate examples/orchestrator.yml"
+  depends_on:
+    nats:
+      condition: service_started
+    chroma:
+      condition: service_started
+    memgraph:
+      condition: service_healthy
+  extra_hosts:
+    - host.docker.internal:host-gateway
+  restart: unless-stopped
+
 services:
   nats:
     image: nats:latest
-    command: ["-js"]
+    command: ['-js']
     ports:
-      - "4222:4222"
-      - "8222:8222"
+      - '4222:4222'
+      - '8222:8222'
 
   memgraph:
     image: memgraph/memgraph
     ports:
-      - "7687:7687"
+      - '7687:7687'
     healthcheck:
-      test: ["CMD", "bash", "-lc", "echo > /dev/tcp/127.0.0.1/7687"]
+      test: ['CMD', 'bash', '-lc', 'echo > /dev/tcp/127.0.0.1/7687']
       interval: 5s
       timeout: 3s
       retries: 20
 
+  neo4j:
+    image: neo4j:5
+    profiles: ['neo4j']
+    environment:
+      NEO4J_AUTH: ${NEO4J_AUTH:-neo4j/test}
+    ports:
+      - '7474:7474'
+      - '8687:7687'
+    volumes:
+      - neo4j-data:/data
+
   chroma:
     image: chromadb/chroma
     ports:
-      - "8000:8000"
+      - '8001:8000'
 
-  ume:
-    image: redpandadata/redpanda:latest
-    command:
-      - redpanda
-      - start
-      - --smp
-      - "1"
-      - --overprovisioned
-      - --node-id
-      - "0"
-      - --kafka-addr
-      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://localhost:9092
-      - --advertise-kafka-addr
-      - PLAINTEXT://ume:29092,OUTSIDE://localhost:9092
-    ports:
-      - "9092:9092"
+  app:
+    <<: *app-base
+
+volumes:
+  neo4j-data:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,11 +6,11 @@ This document provides a high level overview of how the main services in **DeepT
 
 The project follows an event driven architecture built on NATS/JetStream. Components publish and subscribe to event subjects defined in `src/deepthought/eda/events.py`.
 
-A canonical service-to-subject wiring reference (including durable consumers and required environment variables) is maintained in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
+A canonical service-to-subject wiring reference (including durable consumers and required environment variables) is maintained in [`examples/orchestrator.yml`](../examples/orchestrator.yml). The default `docker-compose.yml` launches that same topology inside the `app` container via `dtrt orchestrate examples/orchestrator.yml`.
 
 ### Required orchestration DAG
 
-For the default orchestrator profile, the following event chain is **required**. If any publish/subscribe edge is removed, the runtime graph becomes disconnected and response generation will stall.
+For the default development/runtime profile, Docker Compose starts NATS, Chroma, one graph backend (Memgraph by default), and an orchestrator container that runs exactly these application services: `discord_gateway`, `cognitive_core`, `social_graph`, `perception`, `perception_interpret`, `context_assembler`, `llm_remote` (the primary LLM responder), `selector`, and `feedback`. The following event chain is **required**. If any publish/subscribe edge is removed, the runtime graph becomes disconnected and response generation will stall.
 
 1. `INPUT_RECEIVED` is published by `discord_gateway` and consumed by `context_assembler`.
 2. `MEMORY_RETRIEVED` is published by `cognitive_core` and consumed by `context_assembler`.
@@ -54,7 +54,7 @@ sequenceDiagram
     Bot-->>User: Reply
 ```
 
-The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the canonical path `context_assembler -> llm_remote -> selector -> discord_gateway` completes. Heuristic responders can be enabled as auxiliary candidate producers, but they are no longer the default user-facing voice.
+The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the canonical path `discord_gateway -> cognitive_core/social_graph/perception/perception_interpret -> context_assembler -> llm_remote -> selector -> discord_gateway` completes. Heuristic responders can be enabled as auxiliary candidate producers, but they are no longer part of the default user-facing topology.
 
 Feedback adaptation is part of the default production DAG and should be deployed with durable subscriptions for `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL` as documented in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
@@ -89,7 +89,7 @@ The Discord-bot runtime now uses an explicit graph-memory profile:
 - `production`: `DT_GRAPH_BACKEND=memgraph` or `DT_GRAPH_BACKEND=neo4j`; a remote persistent graph backend is required.
 - `test`: `DT_GRAPH_BACKEND=stub`; an in-memory stub is used only for tests.
 
-`CognitiveCoreService` performs a startup health check against the configured graph backend and fails fast if that backend is unavailable. Production-oriented profiles no longer degrade silently to in-memory graph state. The default orchestrator and Compose deployment set `DT_RUNTIME_PROFILE=production` and provision exactly one persistent graph backend: Memgraph.
+`CognitiveCoreService` performs a startup health check against the configured graph backend and fails fast if that backend is unavailable. Production-oriented profiles no longer degrade silently to in-memory graph state. The default orchestrator and Compose deployment set `DT_RUNTIME_PROFILE=production` and provision exactly one persistent graph backend: Memgraph on host port `7687`. A Neo4j alternative is available behind the Compose `neo4j` profile on host port `8687`, so operators can test Neo4j without colliding with the default Memgraph listener.
 
 When an `INPUT_RECEIVED` event arrives the service stores the text in each
 backend, queries for relevant context and publishes `MEMORY_RETRIEVED`. Downstream

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -6,7 +6,6 @@
 services:
   - discord_gateway
   - cognitive_core
-  # Optional services (enable as needed)
   - social_graph
   - perception
   - perception_interpret
@@ -14,7 +13,6 @@ services:
   - llm_remote
   - selector
   - feedback
-  - reasoning
 
 service_bindings:
   discord_gateway:
@@ -217,7 +215,6 @@ service_bindings:
         jetstream: true
 
   social_graph:
-    optional: true
     description: Track affinity and persona context from user input.
     env:
       - NATS_URL
@@ -234,7 +231,6 @@ service_bindings:
         jetstream: true
 
   perception:
-    optional: true
     description: Multimodal perception extraction and embedding publisher.
     env:
       - NATS_URL
@@ -257,7 +253,6 @@ service_bindings:
         jetstream: true
 
   perception_interpret:
-    optional: true
     description: Convert cached perception embeddings into compact prompt interpretations.
     env:
       - NATS_URL


### PR DESCRIPTION
### Motivation
- Provide a canonical development `docker-compose.yml` that launches the actual default runtime topology operators expect instead of an infrastructure-only file.
- Avoid the host Bolt port collision between Memgraph and Neo4j so either backend can be exercised without port conflicts.
- Ensure `examples/orchestrator.yml`, `docker-compose.yml`, and `docs/architecture.md` all document and launch the same default service graph for reliable operator behavior.

### Description
- Replaced the root `docker-compose.yml` with a development-focused compose that starts `nats`, `chroma`, `memgraph` (default), and a single `app` container that runs `dtrt orchestrate examples/orchestrator.yml` and exports the environment the orchestrator-backed services expect.
- Added an optional `neo4j` profile to `docker-compose.yml` that maps Neo4j Bolt to host port `8687` while leaving Memgraph on host port `7687` to eliminate the previous port conflict.
- Updated `examples/orchestrator.yml` to make the default service list explicit and consistent: `discord_gateway`, `cognitive_core`, `social_graph`, `perception`, `perception_interpret`, `context_assembler`, `llm_remote`, `selector`, and `feedback`, and removed `optional: true` markers for those services in the default topology.
- Updated `docs/architecture.md` to describe the same default runtime topology and to document the Memgraph-default / Neo4j-alternative graph backend mapping and ports used by Compose.

### Testing
- Parsed `docker-compose.yml` and `examples/orchestrator.yml` with `yaml.safe_load()` successfully to validate syntax.
- Installed a test dependency with `python -m pip install aiosqlite` to satisfy test imports.
- Ran `pytest tests/unit/orchestrator/test_orchestrator_extra.py` and received `4 passed` (one DeprecationWarning only).
- Attempted `docker compose config` to validate the combined compose output but the environment lacks the `docker` CLI, so that validation was skipped with a warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c15037b8c083269a95d11e82154f45)