### PR TITLE
Unify Discord runtime entry path around service graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,13 +456,21 @@ export DT_MG_PASSWORD=memgraph
 See [docs/graphdal.md](docs/graphdal.md) for a minimal script that starts
 the memory service and listens for `INPUT_RECEIVED` events.
 
-## Social Graph Bot Example
+## Discord Runtime (Canonical Path)
 
+The primary Discord application path is the service graph runtime:
 
-An example Discord bot demonstrating social graph logging is available at
-`examples/social_graph_bot.py`. It records user interactions in a SQLite
-database, monitors channel activity, and forwards data to a Prism endpoint
-implemented in `examples/prism_server.py`.
+`discord_gateway -> cognitive_core/social_graph/perception/perception_interpret -> context_assembler -> llm_remote -> selector -> discord_gateway`
+
+Use one of these entry points:
+
+- `dtrt run discord-gateway` (recommended canonical CLI path)
+- `dtrt-discord-gateway` (direct runtime script entry point)
+- `python bot.py` (project-root compatibility launcher that now delegates to the same runtime)
+
+The `examples/social_graph_bot.py` module is maintained as a **compatibility example**
+for legacy workflows and tests; new contributors should start from the runtime
+entry points above.
 
 ### Quick Start
 
@@ -478,39 +486,34 @@ If you choose the TextBlob backend, download its corpora:
 python -m textblob.download_corpora
 ```
 
-Set the environment variables used by the bot:
+Set the core environment variables:
 
 ```bash
 export DISCORD_BOT_TOKEN=your_token
-export MONITOR_CHANNEL=1234567890
-export SOCIAL_GRAPH_DB=/path/to/social_graph.db  # optional
-export PRISM_ENDPOINT=http://localhost:5000/receive_data  # optional
-export SENTIMENT_BACKEND=vader  # optional, defaults to textblob
-export USER_REPLY_RATE_SECONDS=3                # optional rate limit per user
-export PLAYFUL_REPLY_TIMEOUT_MINUTES=5          # bot-to-bot reply cooldown
-export MAX_BOT_SPEAKERS=2                       # ignore chatter when too many bots talk
+export NATS_URL=nats://localhost:4222
 ```
 
-`DISCORD_BOT_TOKEN` and `MONITOR_CHANNEL` are required. `NATS_URL` must also be set
-to a valid NATS server address if the default `nats://localhost:4222` is not
-appropriate. All other variables are optional. `USER_REPLY_RATE_SECONDS`
-controls how quickly the bot may respond to the same user, while
-`PLAYFUL_REPLY_TIMEOUT_MINUTES` and `MAX_BOT_SPEAKERS` regulate bot-to-bot
-conversations.
-
-Set `SENTIMENT_BACKEND` to either `textblob` or `vader` to choose the library
-used for sentiment analysis. Any other value falls back to `textblob`.
+`DISCORD_BOT_TOKEN` is required. `NATS_URL` defaults to
+`nats://localhost:4222` if unset.
 
 Run the bot:
 
 ```bash
-python examples/social_graph_bot.py
+dtrt run discord-gateway
 ```
 
-Alternatively, launch the same bot using the helper script at the project root:
+Compatibility launchers that still route to the same runtime:
 
 ```bash
+python -m deepthought.runtime.discord_gateway_app
+dtrt-discord-gateway
 python bot.py
+```
+
+Legacy compatibility example:
+
+```bash
+python examples/social_graph_bot.py
 ```
 
 ### Projects Board Plugin
@@ -919,6 +922,11 @@ The default bot architecture is:
 
 `context assembler -> llm responder -> selector -> Discord gateway`
 
+Runtime entry path for this contract:
+
+- `dtrt run discord-gateway` (primary)
+- `dtrt-discord-gateway` and `python bot.py` (compatibility wrappers over the same runtime)
+
 The canonical conversational responder consumes `EventSubjects.CONTEXT_ASSEMBLED` and publishes `EventSubjects.RESPONSE_CANDIDATES`. Every emitted `ResponseCandidate` should include grounded metadata so downstream ranking remains stable across responder types:
 
 - `source`
@@ -927,6 +935,12 @@ The canonical conversational responder consumes `EventSubjects.CONTEXT_ASSEMBLED
 - calibration metadata under `source_metadata`
 
 Heuristic responders in `src/deepthought/services/responder_service.py` are optional specialist candidate producers. They can publish extra factual, persona, or safety-oriented candidates to improve ranking, but they are not the default end-user voice anymore.
+
+Primary extension points for contributors:
+
+- Add/replace services in `src/deepthought/services/` and wire them in `examples/orchestrator.yml`.
+- Extend runtime lifecycle behavior in `src/deepthought/runtime/discord_gateway_app.py`.
+- Add optional candidate producers on `RESPONSE_CANDIDATES` while preserving the canonical contract fields above.
 
 ## DSPy Pipelines
 

--- a/bot.py
+++ b/bot.py
@@ -1,16 +1,18 @@
 import asyncio
+import os
 
-from deepthought.config import load_bot_env
-from examples.social_graph_bot import run
+from deepthought.config import load_discord_bot_token
+from deepthought.runtime.discord_gateway_app import run_discord_gateway
 
 
 def main() -> None:
-    env = load_bot_env()
+    token = load_discord_bot_token()
+    if not token:
+        raise SystemExit("DISCORD_BOT_TOKEN is required")
     asyncio.run(
-        run(
-            env.DISCORD_BOT_TOKEN,
-            env.MONITOR_CHANNEL,
-            holiday_locale=env.PROJECT_HOLIDAY_LOCALE,
+        run_discord_gateway(
+            token=token,
+            nats_url=os.getenv("NATS_URL", "nats://localhost:4222"),
         )
     )
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,7 +54,7 @@ sequenceDiagram
     Bot-->>User: Reply
 ```
 
-The example Discord bot in `bot.py` sends `INPUT_RECEIVED` events and receives the final reply on `RESPONSE_RANKED` after the canonical path `discord_gateway -> cognitive_core/social_graph/perception/perception_interpret -> context_assembler -> llm_remote -> selector -> discord_gateway` completes. Heuristic responders can be enabled as auxiliary candidate producers, but they are no longer part of the default user-facing topology.
+The canonical runtime entrypoint is `src/deepthought/runtime/discord_gateway_app.py`, exposed via `dtrt run discord-gateway` (and `dtrt-discord-gateway`). The project-root `bot.py` wrapper now delegates to this same runtime path, so all default launch modes emit `INPUT_RECEIVED` and receive final replies on `RESPONSE_RANKED` through the same graph: `discord_gateway -> cognitive_core/social_graph/perception/perception_interpret -> context_assembler -> llm_remote -> selector -> discord_gateway`. Heuristic responders can be enabled as auxiliary candidate producers, but they are no longer part of the default user-facing topology.
 
 Feedback adaptation is part of the default production DAG and should be deployed with durable subscriptions for `RESPONSE_RANKED`, `OUTCOME_SIGNAL`, and `CORRECTION_SIGNAL` as documented in [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
@@ -265,7 +265,7 @@ The Discord examples integrate several safety features that adjust the bot's res
 count, sentiment = await db.get_relationship(user_id, target_id)
 ```
 
-Launch the social graph bot with deception enabled:
+Legacy compatibility example (not the canonical runtime path):
 
 ```bash
 export ALLOW_DECEPTION=true

--- a/examples/social_graph_bot.py
+++ b/examples/social_graph_bot.py
@@ -1,3 +1,10 @@
+"""Legacy compatibility Discord bot example.
+
+New deployments should prefer the service-graph runtime entrypoint:
+``dtrt run discord-gateway`` (implemented in
+``src/deepthought/runtime/discord_gateway_app.py``).
+"""
+
 import asyncio
 import datetime
 import json
@@ -1931,8 +1938,16 @@ async def enqueue_goal(goal: str, priority: int = 1) -> None:
 
 if __name__ == "__main__":
     import argparse
+    import warnings
 
     from deepthought.config import load_bot_env
+
+    warnings.warn(
+        "examples/social_graph_bot.py is a compatibility example; "
+        "prefer 'dtrt run discord-gateway' for the canonical runtime path.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
 
     parser = argparse.ArgumentParser(description="Run the SocialGraphBot")
     parser.add_argument("--enqueue-goal", help="goal text to queue")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dynamic = ["version", "dependencies"]
 [project.scripts]
 dtrt = "deepthought.cli:main"
 dtrt-finetune = "deepthought.train:main"
+dtrt-discord-gateway = "deepthought.runtime.discord_gateway_app:cli_main"
 
 [project.entry-points."deepthought.services"]
 demo = "deepthought.services.demo.service:DemoService"

--- a/src/deepthought/runtime/discord_gateway_app.py
+++ b/src/deepthought/runtime/discord_gateway_app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
 import logging
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -101,3 +103,21 @@ async def run_discord_gateway(*, token: str, nats_url: str) -> None:
 def main(*, token: str, nats_url: str) -> int:
     asyncio.run(run_discord_gateway(token=token, nats_url=nats_url))
     return 0
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint for the canonical Discord gateway runtime."""
+
+    parser = argparse.ArgumentParser(description="Run DeepThought Discord gateway runtime")
+    parser.add_argument("--token", default=os.getenv("DISCORD_BOT_TOKEN", ""))
+    parser.add_argument("--nats-url", default=os.getenv("NATS_URL", "nats://localhost:4222"))
+    args = parser.parse_args(argv)
+
+    token = str(args.token or "").strip()
+    if not token:
+        raise SystemExit("DISCORD_BOT_TOKEN is required (use --token or set DISCORD_BOT_TOKEN)")
+    return main(token=token, nats_url=args.nats_url)
+
+
+if __name__ == "__main__":  # pragma: no cover - module execution helper
+    raise SystemExit(cli_main())


### PR DESCRIPTION
### Motivation

- Make the service-graph runtime the single canonical way to run the Discord gateway so contributors and CI exercise the same event path and extension points.
- Ensure launchers and packaging lead new contributors into the same `discord_gateway -> cognitive_core/... -> selector -> discord_gateway` topology instead of the legacy example script.
- Preserve `examples/social_graph_bot.py` for backwards compatibility and tests while clearly signaling it is not the primary runtime target.

### Description

- Added a CLI entrypoint `cli_main` to `src/deepthought/runtime/discord_gateway_app.py` so the runtime can be executed directly and via packaging entry points, and enabled module execution support with a simple guard and clear token validation using `DISCORD_BOT_TOKEN`.
- Updated the project root launcher `bot.py` to delegate into the canonical runtime via `run_discord_gateway` and to read `NATS_URL` from the environment for compatibility.
- Added `dtrt-discord-gateway` script entry point in `pyproject.toml` so packagings/installations expose the canonical runtime directly.
- Updated contributor-facing docs in `README.md` and `docs/architecture.md` to point to the service-graph runtime path, list the preferred `dtrt run discord-gateway` / `dtrt-discord-gateway` / `python bot.py` entry points, and called out primary extension points under `src/deepthought/services/` and `src/deepthought/runtime/`.
- Demoted `examples/social_graph_bot.py` by adding a module docstring and runtime `DeprecationWarning` when executed directly to mark it as a legacy compatibility example rather than the recommended entry path.

### Testing

- Ran `pytest` for targeted CLI tests with `python -m pytest tests/unit/test_cli.py::test_parse_run_discord_gateway tests/unit/test_cli.py::test_run_discord_gateway_requires_token` which passed.
- Ran broader `pytest` (`tests/unit/runtime/test_discord_gateway_app.py tests/unit/test_cli.py`) which exposed environment-related failures (async tests require a pytest async plugin and some subprocess-style CLI tests failed due to a missing `pydantic` dependency in the spawned subprocess environment), so those failures are environmental and not caused by the runtime refactor.
- Ran `ruff` lint checks: `ruff check bot.py src/deepthought/runtime/discord_gateway_app.py` passed, and `ruff check bot.py src/deepthought/runtime/discord_gateway_app.py examples/social_graph_bot.py` flagged many pre-existing lint issues in the legacy example (these are not introduced by this change).
- Attempted a focused plugin test selector which reported no collectors for the selected test in this environment, so it was skipped by the test runner.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c299db49bc832697c6bf95b5964223)