### PR TITLE
Add strict EDA subject registry and enforce registry-only subject usage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ This document provides a high level overview of how the main services in **DeepT
 
 ## Service Interactions
 
-The project follows an event driven architecture built on NATS/JetStream. Components publish and subscribe to event subjects defined in `src/deepthought/eda/events.py`.
+The project follows an event driven architecture built on NATS/JetStream. Components publish and subscribe to event subjects defined in `src/deepthought/eda/events.py`, and those names are resolved through the strict subject registry in `src/deepthought/eda/contracts/subject_registry.py` (including canonical mapping + lifecycle metadata).
 
 A canonical service-to-subject wiring reference (including durable consumers and required environment variables) is maintained in [`examples/orchestrator.yml`](../examples/orchestrator.yml). The default `docker-compose.yml` launches that same topology inside the `app` container via `dtrt orchestrate examples/orchestrator.yml`.
 
@@ -275,7 +275,7 @@ python examples/social_graph_bot.py
 ## Perception Service
 
 The project includes a dedicated service for scoring social cues in user
-messages. The service consumes `dtr.input.received` events and publishes
+messages. The service consumes `EventSubjects.INPUT_RECEIVED` events and publishes
 its analysis so other components can adjust trust or select personas. See
 [perception_service.md](perception_service.md) for the service's purpose,
 event schema and CLI usage.

--- a/docs/orchestrator_quickstart.md
+++ b/docs/orchestrator_quickstart.md
@@ -66,14 +66,14 @@ The orchestrator starts multiple services with a single NATS connection. Each se
    and environment variable references), copy from
    [`examples/orchestrator.yml`](../examples/orchestrator.yml).
 
-   The default production DAG includes feedback adaptation: keep the `feedback` service enabled with durable subscriptions on `dtr.response.ranked.v1`, `dtr.feedback.outcome_signal.v1`, and `dtr.feedback.correction_signal.v1`.
+   The default production DAG includes feedback adaptation: keep the `feedback` service enabled with durable subscriptions on `EventSubjects.RESPONSE_RANKED`, `EventSubjects.OUTCOME_SIGNAL`, and `EventSubjects.CORRECTION_SIGNAL`.
 
    Set `DT_MEMORY_DB` and `DT_SOCIAL_GRAPH_DB` so adaptation writes are persisted, and optionally set `DT_FEEDBACK_DURABLE_PREFIX` to control durable naming (defaults to `feedback_service`).
 
    `llm_remote` requires the `LLM_ENDPOINT` variable pointing to a running
    `/generate` endpoint.
 
-   When `discord_gateway` is enabled, it subscribes to `dtr.response.ranked` and forwards
+   When `discord_gateway` is enabled, it subscribes to `EventSubjects.RESPONSE_RANKED` and forwards
    final responses back to the originating Discord channel (using a durable consumer).
 
 4. **Run the orchestrator**

--- a/examples/orchestrator.yml
+++ b/examples/orchestrator.yml
@@ -21,13 +21,13 @@ service_bindings:
       - NATS_URL
       - DISCORD_BOT_TOKEN
     subscribe:
-      - subject: dtr.response.ranked.v1  # legacy alias: dtr.response.ranked
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_RANKED
         jetstream: true
         durable: discord_gateway_response_ranked
         required_reliability: true
     publish:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+      - subject_ref: registry
         event_subject: EventSubjects.INPUT_RECEIVED
         jetstream: true
 
@@ -45,38 +45,38 @@ service_bindings:
       - DT_SOCIAL_GRAPH_DB
       - DT_SEARCH_DB
     subscribe:
-      - subject: dtr.memory.retrieval.requested.v1  # legacy alias: dtr.memory.retrieval.requested
+      - subject_ref: registry
         event_subject: EventSubjects.MEMORY_RETRIEVAL_REQUESTED
         jetstream: true
         durable: cognitive_core_memory_requests
         required_reliability: true
-      - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
         jetstream: true
         durable: cognitive_core_listener_perception_fused
         required_reliability: true
-      - subject: dtr.perception.image_embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_IMAGE_EMBED
         jetstream: true
         durable: cognitive_core_listener_perception_image
         required_reliability: true
-      - subject: dtr.perception.audio_embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_AUDIO_EMBED
         jetstream: true
         durable: cognitive_core_listener_perception_audio
         required_reliability: true
-      - subject: dtr.perception.video_embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_VIDEO_EMBED
         jetstream: true
         durable: cognitive_core_listener_perception_video
         required_reliability: true
-      - subject: dtr.bdi.intention
+      - subject_ref: registry
         event_subject: EventSubjects.BDI_INTENTION
         jetstream: true
         durable: cognitive_core_listener_bdi
         required_reliability: true
     publish:
-      - subject: dtr.memory.retrieved.v1  # legacy alias: dtr.memory.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.MEMORY_RETRIEVED
         jetstream: true
 
@@ -89,13 +89,13 @@ service_bindings:
       - LLM_NUM_CANDIDATES
       - LLM_SOURCE_NAME
     subscribe:
-      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+      - subject_ref: registry
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: llm_remote_service
         required_reliability: true
     publish:
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
@@ -105,13 +105,13 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+      - subject_ref: registry
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_factual_service
         required_reliability: false
     publish:
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
@@ -121,13 +121,13 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+      - subject_ref: registry
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_persona_service
         required_reliability: false
     publish:
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
@@ -137,13 +137,13 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+      - subject_ref: registry
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
         durable: responder_safety_service
         required_reliability: false
     publish:
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
 
@@ -152,13 +152,13 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
         durable: selector_service
         required_reliability: true
     publish:
-      - subject: dtr.response.ranked.v1  # legacy alias: dtr.response.ranked
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_RANKED
         jetstream: true
 
@@ -170,23 +170,23 @@ service_bindings:
       - DT_SOCIAL_GRAPH_DB
       - DT_FEEDBACK_DURABLE_PREFIX
     subscribe:
-      - subject: dtr.response.ranked.v1  # legacy aliases: dtr.response.ranked, dtr.llm.response_generated
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_RANKED
         jetstream: true
         durable: feedback_service_ranked
         required_reliability: true
-      - subject: dtr.feedback.outcome_signal.v1  # legacy alias: dtr.feedback.outcome_signal
+      - subject_ref: registry
         event_subject: EventSubjects.OUTCOME_SIGNAL
         jetstream: true
         durable: feedback_service_outcome
         required_reliability: true
-      - subject: dtr.feedback.correction_signal.v1  # legacy alias: dtr.feedback.correction_signal
+      - subject_ref: registry
         event_subject: EventSubjects.CORRECTION_SIGNAL
         jetstream: true
         durable: feedback_service_correction
         required_reliability: true
     publish:
-      - subject: dtr.telemetry.response_feedback.v1
+      - subject_ref: registry
         event_subject: response_feedback_telemetry
         jetstream: true
 
@@ -196,21 +196,21 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.response.ranked.v1  # legacy aliases: dtr.response.ranked, dtr.llm.response_generated
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_RANKED
         jetstream: true
         durable: reasoning_service_ranked
         required_reliability: false
-      - subject: dtr.response.candidates.v1  # legacy alias: dtr.response.candidates
+      - subject_ref: registry
         event_subject: EventSubjects.RESPONSE_CANDIDATES
         jetstream: true
         durable: reasoning_service_candidates
         required_reliability: false
     publish:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+      - subject_ref: registry
         event_subject: EventSubjects.INPUT_RECEIVED
         jetstream: true
-      - subject: dtr.warning
+      - subject_ref: registry
         event_subject: EventSubjects.WARNING
         jetstream: true
 
@@ -220,13 +220,13 @@ service_bindings:
       - NATS_URL
       - DT_SOCIAL_GRAPH_DB
     subscribe:
-      - subject: dtr.social.signals.requested.v1  # legacy alias: dtr.social.signals.requested
+      - subject_ref: registry
         event_subject: EventSubjects.SOCIAL_SIGNALS_REQUESTED
         jetstream: true
         durable: social_graph_requests
         required_reliability: true
     publish:
-      - subject: dtr.social.signals.retrieved.v1  # legacy alias: dtr.social.signals.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.SOCIAL_SIGNALS_RETRIEVED
         jetstream: true
 
@@ -237,18 +237,18 @@ service_bindings:
       - PERCEPTION_REQUIRE_CONSENT
       - PERCEPTION_MODEL_PATH
     subscribe:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+      - subject_ref: registry
         event_subject: EventSubjects.INPUT_RECEIVED
         jetstream: true
         durable: perception_listener
         required_reliability: true
-      - subject: dtr.perception.extract.v1  # legacy alias: dtr.perception.extract
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_EXTRACT
         jetstream: true
         durable: perception-extract-listener
         required_reliability: true
     publish:
-      - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
         jetstream: true
 
@@ -257,18 +257,18 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.perception.interpret.requested.v1  # legacy alias: dtr.perception.interpret.requested
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_INTERPRET_REQUESTED
         jetstream: true
         durable: perception_interpret_requests
         required_reliability: true
-      - subject: dtr.perception.embeddings.v1  # legacy alias: dtr.perception.embeddings
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_EMBEDDINGS
         jetstream: true
         durable: perception_interpret_embeddings
         required_reliability: false
     publish:
-      - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
         jetstream: true
 
@@ -277,28 +277,28 @@ service_bindings:
     env:
       - NATS_URL
     subscribe:
-      - subject: dtr.input.received.v1  # legacy alias: dtr.input.received
+      - subject_ref: registry
         event_subject: EventSubjects.INPUT_RECEIVED
         jetstream: true
         durable: context_assembler_input
         required_reliability: true
-      - subject: dtr.memory.retrieved.v1  # legacy alias: dtr.memory.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.MEMORY_RETRIEVED
         jetstream: true
         durable: context_assembler_memory
         required_reliability: true
-      - subject: dtr.social.signals.retrieved.v1  # legacy alias: dtr.social.signals.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.SOCIAL_SIGNALS_RETRIEVED
         jetstream: true
         durable: context_assembler_social
         required_reliability: true
-      - subject: dtr.perception.interpret.retrieved.v1  # legacy alias: dtr.perception.interpret.retrieved
+      - subject_ref: registry
         event_subject: EventSubjects.PERCEPTION_INTERPRET_RETRIEVED
         jetstream: true
         durable: context_assembler_perception
         required_reliability: true
     publish:
-      - subject: dtr.context.assembled.v1  # legacy alias: dtr.context.assembled
+      - subject_ref: registry
         event_subject: EventSubjects.CONTEXT_ASSEMBLED
         jetstream: true
 

--- a/src/deepthought/eda/contracts/__init__.py
+++ b/src/deepthought/eda/contracts/__init__.py
@@ -7,55 +7,35 @@ from datetime import datetime, timezone
 from typing import Any, Dict
 from uuid import UUID, uuid4
 
+from .subject_registry import SubjectAliases, SubjectCanonicals, SubjectLifecycleState, get_subject_metadata, legacy_subject_map, resolve_subject
+
 
 class CanonicalSubjects:
     """Canonical, versioned subject names used by production traffic."""
 
-    INPUT_RECEIVED = "dtr.input.received.v1"
-    MEMORY_RETRIEVED = "dtr.memory.retrieved.v1"
-    MEMORY_RETRIEVAL_REQUESTED = "dtr.memory.retrieval.requested.v1"
-    SOCIAL_SIGNALS_REQUESTED = "dtr.social.signals.requested.v1"
-    PERCEPTION_INTERPRET_REQUESTED = "dtr.perception.interpret.requested.v1"
-    SOCIAL_SIGNALS_RETRIEVED = "dtr.social.signals.retrieved.v1"
-    PERCEPTION_INTERPRET_RETRIEVED = "dtr.perception.interpret.retrieved.v1"
-    CONTEXT_ASSEMBLED = "dtr.context.assembled.v1"
-    CONTEXT_UPDATED = "dtr.context.updated.v1"
-    RESPONSE_CANDIDATES = "dtr.response.candidates.v1"
-    RESPONSE_RANKED = "dtr.response.ranked.v1"
-    PERCEPTION_EMBEDDINGS = "dtr.perception.embeddings.v1"
-    PERCEPTION_EXTRACT = "dtr.perception.extract.v1"
-    PERCEPTION_EXTRACT_REQUESTED = "dtr.perception.extract.requested.v1"
-    PERCEPTION_MODALITY_RESULT = "dtr.perception.modality.result.v1"
-    SOCIAL_PERCEPTION = "dtr.social.perception.v1"
-    OUTCOME_SIGNAL = "dtr.feedback.outcome_signal.v1"
-    CORRECTION_SIGNAL = "dtr.feedback.correction_signal.v1"
-    DISCORD_FEEDBACK_SIGNAL = "dtr.feedback.discord_signal.v1"
-    USER_SUMMARY_REFRESH = "dtr.memory.user_summary.refresh.v1"
+    INPUT_RECEIVED = SubjectCanonicals.INPUT_RECEIVED
+    MEMORY_RETRIEVED = SubjectCanonicals.MEMORY_RETRIEVED
+    MEMORY_RETRIEVAL_REQUESTED = SubjectCanonicals.MEMORY_RETRIEVAL_REQUESTED
+    SOCIAL_SIGNALS_REQUESTED = SubjectCanonicals.SOCIAL_SIGNALS_REQUESTED
+    PERCEPTION_INTERPRET_REQUESTED = SubjectCanonicals.PERCEPTION_INTERPRET_REQUESTED
+    SOCIAL_SIGNALS_RETRIEVED = SubjectCanonicals.SOCIAL_SIGNALS_RETRIEVED
+    PERCEPTION_INTERPRET_RETRIEVED = SubjectCanonicals.PERCEPTION_INTERPRET_RETRIEVED
+    CONTEXT_ASSEMBLED = SubjectCanonicals.CONTEXT_ASSEMBLED
+    CONTEXT_UPDATED = SubjectCanonicals.CONTEXT_UPDATED
+    RESPONSE_CANDIDATES = SubjectCanonicals.RESPONSE_CANDIDATES
+    RESPONSE_RANKED = SubjectCanonicals.RESPONSE_RANKED
+    PERCEPTION_EMBEDDINGS = SubjectCanonicals.PERCEPTION_EMBEDDINGS
+    PERCEPTION_EXTRACT = SubjectCanonicals.PERCEPTION_EXTRACT
+    PERCEPTION_EXTRACT_REQUESTED = SubjectCanonicals.PERCEPTION_EXTRACT_REQUESTED
+    PERCEPTION_MODALITY_RESULT = SubjectCanonicals.PERCEPTION_MODALITY_RESULT
+    SOCIAL_PERCEPTION = SubjectCanonicals.SOCIAL_PERCEPTION
+    OUTCOME_SIGNAL = SubjectCanonicals.OUTCOME_SIGNAL
+    CORRECTION_SIGNAL = SubjectCanonicals.CORRECTION_SIGNAL
+    DISCORD_FEEDBACK_SIGNAL = SubjectCanonicals.DISCORD_FEEDBACK_SIGNAL
+    USER_SUMMARY_REFRESH = SubjectCanonicals.USER_SUMMARY_REFRESH
 
 
-LEGACY_SUBJECT_MAP: Dict[str, str] = {
-    "dtr.input.received": CanonicalSubjects.INPUT_RECEIVED,
-    "dtr.memory.retrieved": CanonicalSubjects.MEMORY_RETRIEVED,
-    "dtr.memory.retrieval.requested": CanonicalSubjects.MEMORY_RETRIEVAL_REQUESTED,
-    "dtr.social.signals.requested": CanonicalSubjects.SOCIAL_SIGNALS_REQUESTED,
-    "dtr.perception.interpret.requested": CanonicalSubjects.PERCEPTION_INTERPRET_REQUESTED,
-    "dtr.social.signals.retrieved": CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED,
-    "dtr.perception.interpret.retrieved": CanonicalSubjects.PERCEPTION_INTERPRET_RETRIEVED,
-    "dtr.context.assembled": CanonicalSubjects.CONTEXT_ASSEMBLED,
-    "dtr.context.updated": CanonicalSubjects.CONTEXT_UPDATED,
-    "dtr.response.candidates": CanonicalSubjects.RESPONSE_CANDIDATES,
-    "dtr.response.ranked": CanonicalSubjects.RESPONSE_RANKED,
-    "dtr.llm.response_generated": CanonicalSubjects.RESPONSE_RANKED,
-    "dtr.perception.embeddings": CanonicalSubjects.PERCEPTION_EMBEDDINGS,
-    "dtr.perception.extract": CanonicalSubjects.PERCEPTION_EXTRACT,
-    "dtr.perception.extract.requested": CanonicalSubjects.PERCEPTION_EXTRACT_REQUESTED,
-    "dtr.perception.modality.result": CanonicalSubjects.PERCEPTION_MODALITY_RESULT,
-    "dtr.social.perception": CanonicalSubjects.SOCIAL_PERCEPTION,
-    "dtr.feedback.outcome_signal": CanonicalSubjects.OUTCOME_SIGNAL,
-    "dtr.feedback.correction_signal": CanonicalSubjects.CORRECTION_SIGNAL,
-    "dtr.feedback.discord_signal": CanonicalSubjects.DISCORD_FEEDBACK_SIGNAL,
-    "dtr.memory.user_summary.refresh": CanonicalSubjects.USER_SUMMARY_REFRESH,
-}
+LEGACY_SUBJECT_MAP: Dict[str, str] = legacy_subject_map()
 
 
 @dataclass(frozen=True)
@@ -142,7 +122,7 @@ def validate_envelope(data: Dict[str, Any]) -> EventEnvelope:
 
 
 def to_canonical_subject(subject: str) -> str:
-    return LEGACY_SUBJECT_MAP.get(subject, subject)
+    return resolve_subject(subject)
 
 
 def validate_cross_service_envelope(subject: str, data: Dict[str, Any]) -> EventEnvelope:
@@ -301,3 +281,22 @@ def decode_payload_or_envelope(subject: str, data: Dict[str, Any]) -> tuple[Dict
         "created_at": None,
         "subject": to_canonical_subject(subject),
     }
+
+
+__all__ = [
+    "CanonicalSubjects",
+    "EventEnvelope",
+    "LEGACY_SUBJECT_MAP",
+    "PAYLOAD_VALIDATORS",
+    "SubjectAliases",
+    "SubjectCanonicals",
+    "SubjectLifecycleState",
+    "decode_payload",
+    "decode_payload_or_envelope",
+    "get_subject_metadata",
+    "normalize_legacy_payload",
+    "resolve_subject",
+    "to_canonical_subject",
+    "validate_cross_service_envelope",
+    "validate_envelope",
+]

--- a/src/deepthought/eda/contracts/subject_registry.py
+++ b/src/deepthought/eda/contracts/subject_registry.py
@@ -1,0 +1,192 @@
+"""Strict subject registry with lifecycle metadata for DeepThought EDA subjects."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+from enum import Enum
+from typing import Final
+
+logger = logging.getLogger(__name__)
+
+
+class SubjectLifecycleState(str, Enum):
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    REMOVE_BY_DATE = "remove-by-date"
+
+
+@dataclass(frozen=True)
+class SubjectMetadata:
+    alias: str
+    canonical: str
+    schema_id: str
+    lifecycle: SubjectLifecycleState = SubjectLifecycleState.ACTIVE
+    remove_by: str | None = None
+
+
+class SubjectAliases:
+    INPUT_RECEIVED: Final[str] = "dtr.input.received"
+    MEMORY_RETRIEVED: Final[str] = "dtr.memory.retrieved"
+    MEMORY_RETRIEVAL_REQUESTED: Final[str] = "dtr.memory.retrieval.requested"
+    SOCIAL_SIGNALS_REQUESTED: Final[str] = "dtr.social.signals.requested"
+    PERCEPTION_INTERPRET_REQUESTED: Final[str] = "dtr.perception.interpret.requested"
+    SOCIAL_SIGNALS_RETRIEVED: Final[str] = "dtr.social.signals.retrieved"
+    PERCEPTION_INTERPRET_RETRIEVED: Final[str] = "dtr.perception.interpret.retrieved"
+    CONTEXT_ASSEMBLED: Final[str] = "dtr.context.assembled"
+    CONTEXT_UPDATED: Final[str] = "dtr.context.updated"
+    RESPONSE_CANDIDATES: Final[str] = "dtr.response.candidates"
+    RESPONSE_RANKED: Final[str] = "dtr.response.ranked"
+    RESPONSE_GENERATED: Final[str] = "dtr.llm.response_generated"
+    PERCEPTION_EMBEDDINGS: Final[str] = "dtr.perception.embeddings"
+    PERCEPTION_EXTRACT: Final[str] = "dtr.perception.extract"
+    PERCEPTION_EXTRACT_REQUESTED: Final[str] = "dtr.perception.extract.requested"
+    PERCEPTION_MODALITY_RESULT: Final[str] = "dtr.perception.modality.result"
+    SOCIAL_PERCEPTION: Final[str] = "dtr.social.perception"
+    OUTCOME_SIGNAL: Final[str] = "dtr.feedback.outcome_signal"
+    CORRECTION_SIGNAL: Final[str] = "dtr.feedback.correction_signal"
+    DISCORD_FEEDBACK_SIGNAL: Final[str] = "dtr.feedback.discord_signal"
+    USER_SUMMARY_REFRESH: Final[str] = "dtr.memory.user_summary.refresh"
+
+    SOCIAL_UPDATED: Final[str] = "dtr.social.updated"
+    PERCEPTION_IMAGE_EMBED: Final[str] = "dtr.perception.image_embeddings"
+    PERCEPTION_AUDIO_EMBED: Final[str] = "dtr.perception.audio_embeddings"
+    PERCEPTION_VIDEO_EMBED: Final[str] = "dtr.perception.video_embeddings"
+    REMINDER_TRIGGERED: Final[str] = "dtr.scheduler.reminder_triggered"
+    MICRO_TICK: Final[str] = "dtr.scheduler.micro_tick"
+    DAILY_STANDUP: Final[str] = "dtr.scheduler.daily_standup"
+    WEEKLY_PLANNING: Final[str] = "dtr.scheduler.weekly_planning"
+    CODE_TEMPLATE_REQUEST: Final[str] = "dtr.codegen.template_request"
+    CODE_GENERATED: Final[str] = "dtr.codegen.generated"
+    PLAN_REQUESTED: Final[str] = "dtr.plan.requested"
+    PLAN_GENERATED: Final[str] = "dtr.plan.generated"
+    BDI_INTENTION: Final[str] = "dtr.bdi.intention"
+    WARNING: Final[str] = "dtr.warning"
+
+    TELEMETRY_SELECTOR_RANKING: Final[str] = "dtr.telemetry.selector_ranking.v1"
+    TELEMETRY_EGRESS_POLICY: Final[str] = "dtr.telemetry.egress_policy.v1"
+    TELEMETRY_RESPONSE_FEEDBACK: Final[str] = "dtr.telemetry.response_feedback.v1"
+    TRAINING_FEEDBACK_TUPLES: Final[str] = "dtr.training.feedback_tuples.v1"
+
+
+class SubjectCanonicals:
+    INPUT_RECEIVED: Final[str] = "dtr.input.received.v1"
+    MEMORY_RETRIEVED: Final[str] = "dtr.memory.retrieved.v1"
+    MEMORY_RETRIEVAL_REQUESTED: Final[str] = "dtr.memory.retrieval.requested.v1"
+    SOCIAL_SIGNALS_REQUESTED: Final[str] = "dtr.social.signals.requested.v1"
+    PERCEPTION_INTERPRET_REQUESTED: Final[str] = "dtr.perception.interpret.requested.v1"
+    SOCIAL_SIGNALS_RETRIEVED: Final[str] = "dtr.social.signals.retrieved.v1"
+    PERCEPTION_INTERPRET_RETRIEVED: Final[str] = "dtr.perception.interpret.retrieved.v1"
+    CONTEXT_ASSEMBLED: Final[str] = "dtr.context.assembled.v1"
+    CONTEXT_UPDATED: Final[str] = "dtr.context.updated.v1"
+    RESPONSE_CANDIDATES: Final[str] = "dtr.response.candidates.v1"
+    RESPONSE_RANKED: Final[str] = "dtr.response.ranked.v1"
+    PERCEPTION_EMBEDDINGS: Final[str] = "dtr.perception.embeddings.v1"
+    PERCEPTION_EXTRACT: Final[str] = "dtr.perception.extract.v1"
+    PERCEPTION_EXTRACT_REQUESTED: Final[str] = "dtr.perception.extract.requested.v1"
+    PERCEPTION_MODALITY_RESULT: Final[str] = "dtr.perception.modality.result.v1"
+    SOCIAL_PERCEPTION: Final[str] = "dtr.social.perception.v1"
+    OUTCOME_SIGNAL: Final[str] = "dtr.feedback.outcome_signal.v1"
+    CORRECTION_SIGNAL: Final[str] = "dtr.feedback.correction_signal.v1"
+    DISCORD_FEEDBACK_SIGNAL: Final[str] = "dtr.feedback.discord_signal.v1"
+    USER_SUMMARY_REFRESH: Final[str] = "dtr.memory.user_summary.refresh.v1"
+
+
+SUBJECT_REGISTRY: dict[str, SubjectMetadata] = {
+    SubjectCanonicals.INPUT_RECEIVED: SubjectMetadata(SubjectCanonicals.INPUT_RECEIVED, SubjectCanonicals.INPUT_RECEIVED, "schemas/eda/input_received.v1.json"),
+    SubjectAliases.INPUT_RECEIVED: SubjectMetadata(SubjectAliases.INPUT_RECEIVED, SubjectCanonicals.INPUT_RECEIVED, "schemas/eda/input_received.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.MEMORY_RETRIEVED: SubjectMetadata(SubjectCanonicals.MEMORY_RETRIEVED, SubjectCanonicals.MEMORY_RETRIEVED, "schemas/eda/memory_retrieved.v1.json"),
+    SubjectAliases.MEMORY_RETRIEVED: SubjectMetadata(SubjectAliases.MEMORY_RETRIEVED, SubjectCanonicals.MEMORY_RETRIEVED, "schemas/eda/memory_retrieved.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.MEMORY_RETRIEVAL_REQUESTED: SubjectMetadata(SubjectCanonicals.MEMORY_RETRIEVAL_REQUESTED, SubjectCanonicals.MEMORY_RETRIEVAL_REQUESTED, "schemas/eda/memory_retrieval_requested.v1.json"),
+    SubjectAliases.MEMORY_RETRIEVAL_REQUESTED: SubjectMetadata(SubjectAliases.MEMORY_RETRIEVAL_REQUESTED, SubjectCanonicals.MEMORY_RETRIEVAL_REQUESTED, "schemas/eda/memory_retrieval_requested.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.SOCIAL_SIGNALS_REQUESTED: SubjectMetadata(SubjectCanonicals.SOCIAL_SIGNALS_REQUESTED, SubjectCanonicals.SOCIAL_SIGNALS_REQUESTED, "schemas/eda/social_signals_requested.v1.json"),
+    SubjectAliases.SOCIAL_SIGNALS_REQUESTED: SubjectMetadata(SubjectAliases.SOCIAL_SIGNALS_REQUESTED, SubjectCanonicals.SOCIAL_SIGNALS_REQUESTED, "schemas/eda/social_signals_requested.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.PERCEPTION_INTERPRET_REQUESTED: SubjectMetadata(SubjectCanonicals.PERCEPTION_INTERPRET_REQUESTED, SubjectCanonicals.PERCEPTION_INTERPRET_REQUESTED, "schemas/eda/perception_interpret_requested.v1.json"),
+    SubjectAliases.PERCEPTION_INTERPRET_REQUESTED: SubjectMetadata(SubjectAliases.PERCEPTION_INTERPRET_REQUESTED, SubjectCanonicals.PERCEPTION_INTERPRET_REQUESTED, "schemas/eda/perception_interpret_requested.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.SOCIAL_SIGNALS_RETRIEVED: SubjectMetadata(SubjectCanonicals.SOCIAL_SIGNALS_RETRIEVED, SubjectCanonicals.SOCIAL_SIGNALS_RETRIEVED, "schemas/eda/social_signals_retrieved.v1.json"),
+    SubjectAliases.SOCIAL_SIGNALS_RETRIEVED: SubjectMetadata(SubjectAliases.SOCIAL_SIGNALS_RETRIEVED, SubjectCanonicals.SOCIAL_SIGNALS_RETRIEVED, "schemas/eda/social_signals_retrieved.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.PERCEPTION_INTERPRET_RETRIEVED: SubjectMetadata(SubjectCanonicals.PERCEPTION_INTERPRET_RETRIEVED, SubjectCanonicals.PERCEPTION_INTERPRET_RETRIEVED, "schemas/eda/perception_interpret_retrieved.v1.json"),
+    SubjectAliases.PERCEPTION_INTERPRET_RETRIEVED: SubjectMetadata(SubjectAliases.PERCEPTION_INTERPRET_RETRIEVED, SubjectCanonicals.PERCEPTION_INTERPRET_RETRIEVED, "schemas/eda/perception_interpret_retrieved.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.CONTEXT_ASSEMBLED: SubjectMetadata(SubjectCanonicals.CONTEXT_ASSEMBLED, SubjectCanonicals.CONTEXT_ASSEMBLED, "schemas/eda/context_assembled.v1.json"),
+    SubjectAliases.CONTEXT_ASSEMBLED: SubjectMetadata(SubjectAliases.CONTEXT_ASSEMBLED, SubjectCanonicals.CONTEXT_ASSEMBLED, "schemas/eda/context_assembled.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.CONTEXT_UPDATED: SubjectMetadata(SubjectCanonicals.CONTEXT_UPDATED, SubjectCanonicals.CONTEXT_UPDATED, "schemas/eda/context_updated.v1.json"),
+    SubjectAliases.CONTEXT_UPDATED: SubjectMetadata(SubjectAliases.CONTEXT_UPDATED, SubjectCanonicals.CONTEXT_UPDATED, "schemas/eda/context_updated.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.RESPONSE_CANDIDATES: SubjectMetadata(SubjectCanonicals.RESPONSE_CANDIDATES, SubjectCanonicals.RESPONSE_CANDIDATES, "schemas/eda/response_candidates.v1.json"),
+    SubjectAliases.RESPONSE_CANDIDATES: SubjectMetadata(SubjectAliases.RESPONSE_CANDIDATES, SubjectCanonicals.RESPONSE_CANDIDATES, "schemas/eda/response_candidates.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.RESPONSE_RANKED: SubjectMetadata(SubjectCanonicals.RESPONSE_RANKED, SubjectCanonicals.RESPONSE_RANKED, "schemas/eda/response_ranked.v1.json"),
+    SubjectAliases.RESPONSE_RANKED: SubjectMetadata(SubjectAliases.RESPONSE_RANKED, SubjectCanonicals.RESPONSE_RANKED, "schemas/eda/response_ranked.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectAliases.RESPONSE_GENERATED: SubjectMetadata(SubjectAliases.RESPONSE_GENERATED, SubjectCanonicals.RESPONSE_RANKED, "schemas/eda/response_ranked.v1.json", SubjectLifecycleState.REMOVE_BY_DATE, remove_by="2026-12-31"),
+    SubjectCanonicals.PERCEPTION_EMBEDDINGS: SubjectMetadata(SubjectCanonicals.PERCEPTION_EMBEDDINGS, SubjectCanonicals.PERCEPTION_EMBEDDINGS, "schemas/eda/perception_embeddings.v1.json"),
+    SubjectAliases.PERCEPTION_EMBEDDINGS: SubjectMetadata(SubjectAliases.PERCEPTION_EMBEDDINGS, SubjectCanonicals.PERCEPTION_EMBEDDINGS, "schemas/eda/perception_embeddings.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.PERCEPTION_EXTRACT: SubjectMetadata(SubjectCanonicals.PERCEPTION_EXTRACT, SubjectCanonicals.PERCEPTION_EXTRACT, "schemas/eda/perception_extract.v1.json"),
+    SubjectAliases.PERCEPTION_EXTRACT: SubjectMetadata(SubjectAliases.PERCEPTION_EXTRACT, SubjectCanonicals.PERCEPTION_EXTRACT, "schemas/eda/perception_extract.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.PERCEPTION_EXTRACT_REQUESTED: SubjectMetadata(SubjectCanonicals.PERCEPTION_EXTRACT_REQUESTED, SubjectCanonicals.PERCEPTION_EXTRACT_REQUESTED, "schemas/eda/perception_extract_requested.v1.json"),
+    SubjectAliases.PERCEPTION_EXTRACT_REQUESTED: SubjectMetadata(SubjectAliases.PERCEPTION_EXTRACT_REQUESTED, SubjectCanonicals.PERCEPTION_EXTRACT_REQUESTED, "schemas/eda/perception_extract_requested.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.PERCEPTION_MODALITY_RESULT: SubjectMetadata(SubjectCanonicals.PERCEPTION_MODALITY_RESULT, SubjectCanonicals.PERCEPTION_MODALITY_RESULT, "schemas/eda/perception_modality_result.v1.json"),
+    SubjectAliases.PERCEPTION_MODALITY_RESULT: SubjectMetadata(SubjectAliases.PERCEPTION_MODALITY_RESULT, SubjectCanonicals.PERCEPTION_MODALITY_RESULT, "schemas/eda/perception_modality_result.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.SOCIAL_PERCEPTION: SubjectMetadata(SubjectCanonicals.SOCIAL_PERCEPTION, SubjectCanonicals.SOCIAL_PERCEPTION, "schemas/eda/social_perception.v1.json"),
+    SubjectAliases.SOCIAL_PERCEPTION: SubjectMetadata(SubjectAliases.SOCIAL_PERCEPTION, SubjectCanonicals.SOCIAL_PERCEPTION, "schemas/eda/social_perception.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.OUTCOME_SIGNAL: SubjectMetadata(SubjectCanonicals.OUTCOME_SIGNAL, SubjectCanonicals.OUTCOME_SIGNAL, "schemas/eda/outcome_signal.v1.json"),
+    SubjectAliases.OUTCOME_SIGNAL: SubjectMetadata(SubjectAliases.OUTCOME_SIGNAL, SubjectCanonicals.OUTCOME_SIGNAL, "schemas/eda/outcome_signal.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.CORRECTION_SIGNAL: SubjectMetadata(SubjectCanonicals.CORRECTION_SIGNAL, SubjectCanonicals.CORRECTION_SIGNAL, "schemas/eda/correction_signal.v1.json"),
+    SubjectAliases.CORRECTION_SIGNAL: SubjectMetadata(SubjectAliases.CORRECTION_SIGNAL, SubjectCanonicals.CORRECTION_SIGNAL, "schemas/eda/correction_signal.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.DISCORD_FEEDBACK_SIGNAL: SubjectMetadata(SubjectCanonicals.DISCORD_FEEDBACK_SIGNAL, SubjectCanonicals.DISCORD_FEEDBACK_SIGNAL, "schemas/eda/discord_feedback_signal.v1.json"),
+    SubjectAliases.DISCORD_FEEDBACK_SIGNAL: SubjectMetadata(SubjectAliases.DISCORD_FEEDBACK_SIGNAL, SubjectCanonicals.DISCORD_FEEDBACK_SIGNAL, "schemas/eda/discord_feedback_signal.v1.json", SubjectLifecycleState.DEPRECATED),
+    SubjectCanonicals.USER_SUMMARY_REFRESH: SubjectMetadata(SubjectCanonicals.USER_SUMMARY_REFRESH, SubjectCanonicals.USER_SUMMARY_REFRESH, "schemas/eda/user_summary_refresh.v1.json"),
+    SubjectAliases.USER_SUMMARY_REFRESH: SubjectMetadata(SubjectAliases.USER_SUMMARY_REFRESH, SubjectCanonicals.USER_SUMMARY_REFRESH, "schemas/eda/user_summary_refresh.v1.json", SubjectLifecycleState.DEPRECATED),
+
+    SubjectAliases.SOCIAL_UPDATED: SubjectMetadata(SubjectAliases.SOCIAL_UPDATED, SubjectAliases.SOCIAL_UPDATED, "schemas/eda/social_updated.v1.json"),
+    SubjectAliases.PERCEPTION_IMAGE_EMBED: SubjectMetadata(SubjectAliases.PERCEPTION_IMAGE_EMBED, SubjectAliases.PERCEPTION_IMAGE_EMBED, "schemas/eda/perception_image_embed.v1.json"),
+    SubjectAliases.PERCEPTION_AUDIO_EMBED: SubjectMetadata(SubjectAliases.PERCEPTION_AUDIO_EMBED, SubjectAliases.PERCEPTION_AUDIO_EMBED, "schemas/eda/perception_audio_embed.v1.json"),
+    SubjectAliases.PERCEPTION_VIDEO_EMBED: SubjectMetadata(SubjectAliases.PERCEPTION_VIDEO_EMBED, SubjectAliases.PERCEPTION_VIDEO_EMBED, "schemas/eda/perception_video_embed.v1.json"),
+    SubjectAliases.REMINDER_TRIGGERED: SubjectMetadata(SubjectAliases.REMINDER_TRIGGERED, SubjectAliases.REMINDER_TRIGGERED, "schemas/eda/scheduler_reminder_triggered.v1.json"),
+    SubjectAliases.MICRO_TICK: SubjectMetadata(SubjectAliases.MICRO_TICK, SubjectAliases.MICRO_TICK, "schemas/eda/scheduler_micro_tick.v1.json"),
+    SubjectAliases.DAILY_STANDUP: SubjectMetadata(SubjectAliases.DAILY_STANDUP, SubjectAliases.DAILY_STANDUP, "schemas/eda/scheduler_daily_standup.v1.json"),
+    SubjectAliases.WEEKLY_PLANNING: SubjectMetadata(SubjectAliases.WEEKLY_PLANNING, SubjectAliases.WEEKLY_PLANNING, "schemas/eda/scheduler_weekly_planning.v1.json"),
+    SubjectAliases.CODE_TEMPLATE_REQUEST: SubjectMetadata(SubjectAliases.CODE_TEMPLATE_REQUEST, SubjectAliases.CODE_TEMPLATE_REQUEST, "schemas/eda/code_template_request.v1.json"),
+    SubjectAliases.CODE_GENERATED: SubjectMetadata(SubjectAliases.CODE_GENERATED, SubjectAliases.CODE_GENERATED, "schemas/eda/code_generated.v1.json"),
+    SubjectAliases.PLAN_REQUESTED: SubjectMetadata(SubjectAliases.PLAN_REQUESTED, SubjectAliases.PLAN_REQUESTED, "schemas/eda/plan_requested.v1.json"),
+    SubjectAliases.PLAN_GENERATED: SubjectMetadata(SubjectAliases.PLAN_GENERATED, SubjectAliases.PLAN_GENERATED, "schemas/eda/plan_generated.v1.json"),
+    SubjectAliases.BDI_INTENTION: SubjectMetadata(SubjectAliases.BDI_INTENTION, SubjectAliases.BDI_INTENTION, "schemas/eda/bdi_intention.v1.json"),
+    SubjectAliases.WARNING: SubjectMetadata(SubjectAliases.WARNING, SubjectAliases.WARNING, "schemas/eda/warning.v1.json"),
+    SubjectAliases.TELEMETRY_SELECTOR_RANKING: SubjectMetadata(SubjectAliases.TELEMETRY_SELECTOR_RANKING, SubjectAliases.TELEMETRY_SELECTOR_RANKING, "schemas/eda/telemetry_selector_ranking.v1.json"),
+    SubjectAliases.TELEMETRY_EGRESS_POLICY: SubjectMetadata(SubjectAliases.TELEMETRY_EGRESS_POLICY, SubjectAliases.TELEMETRY_EGRESS_POLICY, "schemas/eda/telemetry_egress_policy.v1.json"),
+    SubjectAliases.TELEMETRY_RESPONSE_FEEDBACK: SubjectMetadata(SubjectAliases.TELEMETRY_RESPONSE_FEEDBACK, SubjectAliases.TELEMETRY_RESPONSE_FEEDBACK, "schemas/eda/telemetry_response_feedback.v1.json"),
+    SubjectAliases.TRAINING_FEEDBACK_TUPLES: SubjectMetadata(SubjectAliases.TRAINING_FEEDBACK_TUPLES, SubjectAliases.TRAINING_FEEDBACK_TUPLES, "schemas/eda/training_feedback_tuples.v1.json"),
+}
+
+_WARNED_ALIASES: set[str] = set()
+
+
+def resolve_subject(subject: str) -> str:
+    metadata = SUBJECT_REGISTRY.get(subject)
+    if metadata is None:
+        return subject
+
+    if metadata.lifecycle in (SubjectLifecycleState.DEPRECATED, SubjectLifecycleState.REMOVE_BY_DATE):
+        if subject not in _WARNED_ALIASES:
+            _WARNED_ALIASES.add(subject)
+            extra = ""
+            if metadata.lifecycle is SubjectLifecycleState.REMOVE_BY_DATE and metadata.remove_by:
+                today = date.today().isoformat()
+                extra = f"; remove by {metadata.remove_by} (today: {today})"
+            logger.warning(
+                "Deprecated EDA subject alias '%s' used; canonical subject is '%s'%s",
+                subject,
+                metadata.canonical,
+                extra,
+            )
+    return metadata.canonical
+
+
+def get_subject_metadata(subject: str) -> SubjectMetadata | None:
+    return SUBJECT_REGISTRY.get(subject)
+
+
+def legacy_subject_map() -> dict[str, str]:
+    return {
+        subject: meta.canonical
+        for subject, meta in SUBJECT_REGISTRY.items()
+        if subject != meta.canonical
+    }

--- a/src/deepthought/eda/events.py
+++ b/src/deepthought/eda/events.py
@@ -9,10 +9,8 @@ import json
 from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Optional
 
-from .contracts import (
-    CanonicalSubjects,
-    decode_payload,
-)
+from .contracts import CanonicalSubjects, decode_payload
+from .contracts.subject_registry import SubjectAliases
 
 
 # Subject naming convention: dtr.<module>.<event_type>
@@ -32,13 +30,13 @@ class EventSubjects:
     SOCIAL_SIGNALS_REQUESTED = CanonicalSubjects.SOCIAL_SIGNALS_REQUESTED
     PERCEPTION_INTERPRET_REQUESTED = CanonicalSubjects.PERCEPTION_INTERPRET_REQUESTED
     SOCIAL_SIGNALS_RETRIEVED = CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED
-    SOCIAL_UPDATED = "dtr.social.updated"
+    SOCIAL_UPDATED = SubjectAliases.SOCIAL_UPDATED
     PERCEPTION_INTERPRET_RETRIEVED = CanonicalSubjects.PERCEPTION_INTERPRET_RETRIEVED
     CONTEXT_ASSEMBLED = CanonicalSubjects.CONTEXT_ASSEMBLED
     CONTEXT_UPDATED = CanonicalSubjects.CONTEXT_UPDATED
 
     # LLM events
-    RESPONSE_GENERATED = "dtr.llm.response_generated"
+    RESPONSE_GENERATED = SubjectAliases.RESPONSE_GENERATED
     RESPONSE_CANDIDATES = CanonicalSubjects.RESPONSE_CANDIDATES
     RESPONSE_RANKED = CanonicalSubjects.RESPONSE_RANKED
     OUTCOME_SIGNAL = CanonicalSubjects.OUTCOME_SIGNAL
@@ -48,9 +46,9 @@ class EventSubjects:
 
     # Perception events
     PERCEPTION_EMBEDDINGS = CanonicalSubjects.PERCEPTION_EMBEDDINGS
-    PERCEPTION_IMAGE_EMBED = "dtr.perception.image_embeddings"
-    PERCEPTION_AUDIO_EMBED = "dtr.perception.audio_embeddings"
-    PERCEPTION_VIDEO_EMBED = "dtr.perception.video_embeddings"
+    PERCEPTION_IMAGE_EMBED = SubjectAliases.PERCEPTION_IMAGE_EMBED
+    PERCEPTION_AUDIO_EMBED = SubjectAliases.PERCEPTION_AUDIO_EMBED
+    PERCEPTION_VIDEO_EMBED = SubjectAliases.PERCEPTION_VIDEO_EMBED
     PERCEPTION_EXTRACT = CanonicalSubjects.PERCEPTION_EXTRACT
     PERCEPTION_EXTRACT_REQUESTED = CanonicalSubjects.PERCEPTION_EXTRACT_REQUESTED
     PERCEPTION_MODALITY_RESULT = CanonicalSubjects.PERCEPTION_MODALITY_RESULT
@@ -59,24 +57,24 @@ class EventSubjects:
     CHAT_RAW = "chat.raw"
 
     # Scheduler events
-    REMINDER_TRIGGERED = "dtr.scheduler.reminder_triggered"
-    MICRO_TICK = "dtr.scheduler.micro_tick"
-    DAILY_STANDUP = "dtr.scheduler.daily_standup"
-    WEEKLY_PLANNING = "dtr.scheduler.weekly_planning"
+    REMINDER_TRIGGERED = SubjectAliases.REMINDER_TRIGGERED
+    MICRO_TICK = SubjectAliases.MICRO_TICK
+    DAILY_STANDUP = SubjectAliases.DAILY_STANDUP
+    WEEKLY_PLANNING = SubjectAliases.WEEKLY_PLANNING
 
     # Code generation events
-    CODE_TEMPLATE_REQUEST = "dtr.codegen.template_request"
-    CODE_GENERATED = "dtr.codegen.generated"
+    CODE_TEMPLATE_REQUEST = SubjectAliases.CODE_TEMPLATE_REQUEST
+    CODE_GENERATED = SubjectAliases.CODE_GENERATED
 
     # Planning events
-    PLAN_REQUESTED = "dtr.plan.requested"
-    PLAN_GENERATED = "dtr.plan.generated"
+    PLAN_REQUESTED = SubjectAliases.PLAN_REQUESTED
+    PLAN_GENERATED = SubjectAliases.PLAN_GENERATED
 
     # BDI agent events
-    BDI_INTENTION = "dtr.bdi.intention"
+    BDI_INTENTION = SubjectAliases.BDI_INTENTION
 
     # Warning events
-    WARNING = "dtr.warning"
+    WARNING = SubjectAliases.WARNING
 
     # Other potential event subjects can be added here as the system expands
     # e.g., ERROR = "dtr.error"
@@ -807,8 +805,8 @@ class PerceptionExtractPayload(EventPayload):
             video_opt_in=video_opt_in,
             retain_media=data.get("retain_media"),
             text_hop_size=data.get("text_hop_size") or data.get("tokens_hop_size"),
-            attachments=[dict(a) for a in data.get("attachments", []) if isinstance(a, dict)] or None,
-            artifacts=[dict(a) for a in data.get("artifacts", []) if isinstance(a, dict)] or None,
+            attachments=[dict(a) for a in (data.get("attachments") or []) if isinstance(a, dict)] or None,
+            artifacts=[dict(a) for a in (data.get("artifacts") or []) if isinstance(a, dict)] or None,
         )
 
 

--- a/src/deepthought/eda/publisher.py
+++ b/src/deepthought/eda/publisher.py
@@ -10,7 +10,7 @@ import nats
 from nats.aio.client import Client as NATS
 from nats.js.client import JetStreamContext
 
-from .contracts import EventEnvelope, validate_cross_service_envelope
+from .contracts import EventEnvelope, to_canonical_subject, validate_cross_service_envelope
 
 logger = logging.getLogger(__name__)
 NATS_TIMEOUT_ERROR = getattr(nats.errors, "TimeoutError", TimeoutError)
@@ -40,6 +40,8 @@ class Publisher:
         """Publish message, retrying for at-least-once semantics."""
         if retries < 1:
             raise ValueError("retries must be at least 1")
+
+        subject = to_canonical_subject(subject)
 
         # Convert payload
         if isinstance(payload, bytes):

--- a/src/deepthought/eda/subscriber.py
+++ b/src/deepthought/eda/subscriber.py
@@ -11,6 +11,8 @@ from nats.aio.client import Client as NATS
 from nats.aio.msg import Msg
 from nats.js.client import JetStreamContext
 
+from .contracts import to_canonical_subject
+
 logger = logging.getLogger(__name__)
 MessageHandlerType = Callable[[Msg], Awaitable[None]]
 
@@ -39,6 +41,7 @@ class Subscriber:
 
         Returns ``True`` on success and ``False`` if an error occurred.
         """
+        subject = to_canonical_subject(subject)
         try:
             if use_jetstream:
                 if not self._js:

--- a/tests/unit/eda/test_event_contracts.py
+++ b/tests/unit/eda/test_event_contracts.py
@@ -171,3 +171,20 @@ def test_cross_service_envelope_requires_trace_event_and_causation_ids():
 def test_cross_service_envelope_rejects_raw_non_enveloped_payloads():
     with pytest.raises(ValueError, match="Missing required key 'schema_version'"):
         validate_cross_service_envelope(CanonicalSubjects.SOCIAL_SIGNALS_RETRIEVED, {"input_id": "i-1"})
+
+
+def test_deprecated_alias_resolution_logs_warning_once(caplog):
+    caplog.set_level("WARNING")
+    first = to_canonical_subject("dtr.feedback.discord_signal")
+    second = to_canonical_subject("dtr.feedback.discord_signal")
+    assert first == CanonicalSubjects.DISCORD_FEEDBACK_SIGNAL
+    assert second == CanonicalSubjects.DISCORD_FEEDBACK_SIGNAL
+    warnings = [r.message for r in caplog.records if "Deprecated EDA subject alias" in r.message]
+    assert len(warnings) == 1
+
+
+def test_remove_by_date_alias_resolution_logs_remove_by(caplog):
+    caplog.set_level("WARNING")
+    resolved = to_canonical_subject("dtr.llm.response_generated")
+    assert resolved == CanonicalSubjects.RESPONSE_RANKED
+    assert any("remove by" in record.message for record in caplog.records)

--- a/tests/unit/eda/test_subject_registry_hardcoded_guard.py
+++ b/tests/unit/eda/test_subject_registry_hardcoded_guard.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+DTR_PATTERN = re.compile(r"\bdtr\.[a-z0-9_.>*-]+")
+
+SCAN_PATHS = (
+    Path("src/deepthought/eda"),
+    Path("examples/orchestrator.yml"),
+)
+
+ALLOWED_PATHS = {
+    Path("src/deepthought/eda/contracts/subject_registry.py"),
+}
+
+
+def _is_docstring_node(node: ast.Constant, parents: dict[ast.AST, ast.AST]) -> bool:
+    parent = parents.get(node)
+    if not isinstance(parent, ast.Expr):
+        return False
+    container = parents.get(parent)
+    if isinstance(container, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        return bool(container.body) and container.body[0] is parent
+    return False
+
+
+def _scan_python(path: Path) -> list[str]:
+    violations: list[str] = []
+    tree = ast.parse(path.read_text(), filename=str(path))
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            if _is_docstring_node(node, parents):
+                continue
+            if DTR_PATTERN.search(node.value):
+                violations.append(f"{path}:{node.lineno} -> {node.value}")
+    return violations
+
+
+def _scan_text(path: Path) -> list[str]:
+    violations: list[str] = []
+    for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+        match = DTR_PATTERN.search(line)
+        if match:
+            violations.append(f"{path}:{lineno} -> {match.group(0)}")
+    return violations
+
+
+def test_no_hardcoded_dtr_subjects_outside_registry_or_migration_map() -> None:
+    violations: list[str] = []
+
+    for scan_path in SCAN_PATHS:
+        if scan_path.is_file():
+            paths = [scan_path]
+        else:
+            paths = sorted(scan_path.rglob("*.py"))
+
+        for path in paths:
+            if path in ALLOWED_PATHS:
+                continue
+            if path.suffix == ".py":
+                violations.extend(_scan_python(path))
+            else:
+                violations.extend(_scan_text(path))
+
+    assert not violations, "Hardcoded dtr.* subject literals detected:\n" + "\n".join(violations)


### PR DESCRIPTION
### Motivation
- Centralize and strictly control `dtr.*` subject names and their canonical mappings to avoid drift and scattered hardcoded literals. 
- Provide per-alias lifecycle metadata (active / deprecated / remove-by-date) so services can warn and migrate safely. 
- Ensure all publishers and subscribers consistently resolve subjects via a single registry to preserve legacy compatibility while moving to canonical `.v1` names.

### Description
- Introduced `src/deepthought/eda/contracts/subject_registry.py` which defines typed alias/canonical constants, `SubjectMetadata`, `SubjectLifecycleState`, a `SUBJECT_REGISTRY` with schema references, and `resolve_subject`/`legacy_subject_map` helpers. 
- Wired contracts to use the registry: `src/deepthought/eda/contracts/__init__.py` now resolves subjects through the registry (`to_canonical_subject` delegates to `resolve_subject`) and exposes registry helpers via `__all__`. 
- Updated `src/deepthought/eda/events.py` so `EventSubjects` and event constants reference registry-derived names (`SubjectAliases` / `CanonicalSubjects`) instead of hardcoded `dtr.*` literals. 
- Made publisher/subscriber canonicalize subjects on every `publish` / `subscribe` path by calling `to_canonical_subject` (`src/deepthought/eda/publisher.py`, `src/deepthought/eda/subscriber.py`). 
- Reworked `examples/orchestrator.yml` and documentation (`docs/architecture.md`, `docs/orchestrator_quickstart.md`) to reference registry-backed names and `EventSubjects.*` rather than hardcoded subjects. 
- Added a CI guard test `tests/unit/eda/test_subject_registry_hardcoded_guard.py` that scans `src/deepthought/eda` and `examples/orchestrator.yml` and fails if `dtr.*` literals appear outside the allowed registry file. 
- Added lifecycle-warning tests in `tests/unit/eda/test_event_contracts.py` to ensure deprecated and remove-by-date aliases log appropriate warnings only once. 
- Fixed an edge-case in `PerceptionExtractPayload.from_dict` to handle `None` attachments/artifacts by iterating over `(data.get(... ) or [])` to avoid `TypeError` during roundtrip.

### Testing
- Ran the unit subset covering EDA contracts and guards with `pytest tests/unit/eda/test_event_contracts.py tests/unit/eda/test_events_roundtrip.py tests/unit/eda/test_dtr_publish_envelope_contract.py tests/unit/eda/test_subject_registry_hardcoded_guard.py`, and all tests passed (`39 passed`). 
- Ran the linter with `ruff check src/deepthought/eda tests/unit/eda/test_event_contracts.py tests/unit/eda/test_subject_registry_hardcoded_guard.py`, and it reported no issues.
- The changes include test coverage for deprecated alias warnings and the new hardcoded-subject detection, both of which succeeded in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ab1417088326b3eb48240b4e93a2)