### PR TITLE
Introduce typed conversational ontology and layered graph evidence retrieval

### DIFF
--- a/src/deepthought/memory/graph/__init__.py
+++ b/src/deepthought/memory/graph/__init__.py
@@ -1,14 +1,17 @@
 from .adapters import CypherGraphMemoryStore, InMemoryGraphMemoryStore
 from .migration import migrate_sqlite_memories_to_graph
-from .pipeline import ingest_conversation_turns
-from .retrieval import retrieve_topic_context, retrieve_user_context
+from .ontology import ONTOLOGY_TYPES, PREDICATE_REGISTRY, TypedPredicate
+from .pipeline import ingest_conversation_turns, ingest_graph_objects, triples_to_graph_objects
+from .retrieval import retrieve_layered_context, retrieve_topic_context, retrieve_user_context
 from .facts import CanonicalFact, canonical_fact_dedup_key, canonical_fact_id, make_canonical_fact
 from .store import (
     GraphEntity,
     GraphEvidence,
+    GraphEvidenceBundle,
     GraphFact,
     GraphMemoryStore,
     GraphRelation,
+    ConversationalGraphObject,
     Provenance,
     TemporalValidity,
 )
@@ -23,12 +26,20 @@ __all__ = [
     "GraphRelation",
     "GraphFact",
     "GraphEvidence",
+    "GraphEvidenceBundle",
+    "ConversationalGraphObject",
     "Provenance",
     "TemporalValidity",
+    "TypedPredicate",
+    "PREDICATE_REGISTRY",
+    "ONTOLOGY_TYPES",
     "CypherGraphMemoryStore",
     "InMemoryGraphMemoryStore",
     "ingest_conversation_turns",
+    "triples_to_graph_objects",
+    "ingest_graph_objects",
     "retrieve_user_context",
     "retrieve_topic_context",
+    "retrieve_layered_context",
     "migrate_sqlite_memories_to_graph",
 ]

--- a/src/deepthought/memory/graph/adapters.py
+++ b/src/deepthought/memory/graph/adapters.py
@@ -6,6 +6,7 @@ from typing import Any, Sequence
 
 from ...graph.connector import GraphConnector, Neo4jConnector
 from ...fact_schema import format_fact_snippet
+from .ontology import freshness_score
 from .store import (
     GraphEntity,
     GraphEvidence,
@@ -195,6 +196,10 @@ def _rows_to_evidence(rows: Sequence[Any]) -> list[GraphEvidence]:
                 score=_score(confidence, attrs),
                 confidence=confidence,
                 provenance=_prov_from_any(provenance),
+                freshness=freshness_score(
+                    observed_at=str(attrs.get("updated_at") or attrs.get("timestamp") or ""),
+                    ontology_type=str(attrs.get("ontology_type") or "evidence"),
+                ),
                 attributes=attrs,
             )
         )
@@ -233,6 +238,10 @@ def _fact_to_evidence(fact: GraphFact) -> GraphEvidence:
         score=_score(fact.confidence, fact.attributes),
         confidence=fact.confidence,
         provenance=_prov_from_any(fact.provenance),
+        freshness=freshness_score(
+            observed_at=str(attrs.get("updated_at") or attrs.get("timestamp") or ""),
+            ontology_type=str(attrs.get("ontology_type") or "evidence"),
+        ),
         attributes=attrs,
     )
 

--- a/src/deepthought/memory/graph/ontology.py
+++ b/src/deepthought/memory/graph/ontology.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from .store import TemporalValidity
+
+ONTOLOGY_TYPES = {
+    "user",
+    "preference",
+    "commitment",
+    "event",
+    "relationship",
+    "topic",
+    "evidence",
+}
+
+
+@dataclass(frozen=True)
+class TypedPredicate:
+    name: str
+    subject_type: str
+    object_type: str
+    ontology_type: str
+
+
+PREDICATE_REGISTRY: dict[str, TypedPredicate] = {
+    "has_nickname": TypedPredicate("has_nickname", "user", "topic", "relationship"),
+    "likes_hobby": TypedPredicate("likes_hobby", "user", "preference", "preference"),
+    "favorite": TypedPredicate("favorite", "user", "preference", "preference"),
+    "plans_event": TypedPredicate("plans_event", "user", "event", "commitment"),
+    "mentioned": TypedPredicate("mentioned", "user", "evidence", "evidence"),
+    "memory_note": TypedPredicate("memory_note", "user", "evidence", "evidence"),
+    "multimodal_summary": TypedPredicate("multimodal_summary", "user", "evidence", "evidence"),
+}
+
+HALF_LIFE_DAYS = {
+    "preference": 365.0,
+    "commitment": 14.0,
+    "event": 21.0,
+    "relationship": 90.0,
+    "topic": 120.0,
+    "evidence": 45.0,
+    "user": 720.0,
+}
+
+
+def predicate_spec(predicate: str, fallback_type: str = "evidence") -> TypedPredicate:
+    spec = PREDICATE_REGISTRY.get(predicate)
+    if spec is not None:
+        return spec
+    return TypedPredicate(predicate, "user", fallback_type, fallback_type)
+
+
+def classify_ontology_type(*, fact_type: str, predicate: str, object_type: str | None = None) -> str:
+    spec = PREDICATE_REGISTRY.get(predicate)
+    if spec is not None:
+        return spec.ontology_type
+    if fact_type in {"preference", "profile", "temporal_fact", "utterance"}:
+        return {
+            "preference": "preference",
+            "profile": "relationship",
+            "temporal_fact": "commitment",
+            "utterance": "evidence",
+        }[fact_type]
+    if object_type in ONTOLOGY_TYPES:
+        return str(object_type)
+    return "evidence"
+
+
+def confidence_with_decay(
+    confidence: float,
+    *,
+    observed_at: str | None,
+    ontology_type: str,
+    now: datetime | None = None,
+) -> float:
+    freshness = freshness_score(observed_at=observed_at, ontology_type=ontology_type, now=now)
+    return round(float(confidence) * freshness, 6)
+
+
+def freshness_score(*, observed_at: str | None, ontology_type: str, now: datetime | None = None) -> float:
+    if not observed_at:
+        return 0.75
+    try:
+        point = datetime.fromisoformat(str(observed_at).replace("Z", "+00:00"))
+        ref = now or datetime.now(timezone.utc)
+        age_days = max(0.0, (ref - point).total_seconds() / 86400.0)
+    except ValueError:
+        return 0.75
+
+    half_life = HALF_LIFE_DAYS.get(ontology_type, 60.0)
+    if half_life <= 0:
+        return 1.0
+    decay = 0.5 ** (age_days / half_life)
+    return round(max(0.05, min(1.0, decay)), 6)
+
+
+def temporal_validity(timestamp: str | None, ontology_type: str) -> TemporalValidity:
+    if ontology_type == "commitment" and timestamp:
+        return TemporalValidity(valid_from=timestamp)
+    return TemporalValidity(valid_from=timestamp)
+
+
+def relation_projection_name(ontology_type: str, predicate: str) -> str:
+    if ontology_type in {"preference", "commitment", "relationship", "topic"}:
+        return ontology_type
+    return predicate

--- a/src/deepthought/memory/graph/pipeline.py
+++ b/src/deepthought/memory/graph/pipeline.py
@@ -5,7 +5,22 @@ from typing import Any, Iterable, Sequence
 
 from ..fact_extractor import extract_typed_fact_triples_from_turn
 from ...fact_schema import make_canonical_fact
-from .store import GraphEntity, GraphFact, GraphMemoryStore, GraphRelation, Provenance, TemporalValidity, utc_now_iso
+from .ontology import (
+    classify_ontology_type,
+    confidence_with_decay,
+    predicate_spec,
+    relation_projection_name,
+    temporal_validity,
+)
+from .store import (
+    ConversationalGraphObject,
+    GraphEntity,
+    GraphFact,
+    GraphMemoryStore,
+    GraphRelation,
+    Provenance,
+    utc_now_iso,
+)
 
 
 def ingest_conversation_turns(
@@ -35,77 +50,122 @@ def ingest_fact_triples(
     timestamp: str,
     source_id: str,
 ) -> int:
-    """Write pre-extracted triples into graph entities/relations/facts."""
+    """Write pre-extracted triples by projecting typed conversational objects."""
+
+    objects = triples_to_graph_objects(triples, timestamp=timestamp, source_id=source_id)
+    return ingest_graph_objects(objects, store)
+
+
+def triples_to_graph_objects(
+    triples: Sequence[dict[str, Any]],
+    *,
+    timestamp: str,
+    source_id: str,
+) -> list[ConversationalGraphObject]:
+    objects: list[ConversationalGraphObject] = []
+    for triple in triples:
+        ontology_type = classify_ontology_type(
+            fact_type=str(triple.get("fact_type", "")),
+            predicate=str(triple.get("predicate", "")),
+            object_type=str(triple.get("object_type", "")),
+        )
+        obj_id = triple.get("object_id")
+        if not obj_id and str(triple.get("fact_type")) == "temporal_fact" and triple.get("object_value"):
+            obj_id = f"event:{_stable_id(triple['subject_id'], str(triple.get('object_value')))}"
+        confidence = float(triple.get("confidence", 0.7))
+        attributes = {
+            **dict(triple.get("attributes", {})),
+            "fact_type": triple.get("fact_type", "profile"),
+            "subject_type": triple.get("subject_type", "user"),
+            "object_type": triple.get("object_type", ontology_type),
+            "timestamp": timestamp,
+        }
+        provenance = Provenance(source="conversation_turn", source_id=source_id, observed_at=timestamp)
+        objects.append(
+            ConversationalGraphObject(
+                object_id=f"obj:{_stable_id(triple['subject_id'], str(triple.get('predicate')), str(obj_id), str(triple.get('object_value')))}",
+                ontology_type=ontology_type,
+                subject_id=triple["subject_id"],
+                predicate=triple["predicate"],
+                object_id_ref=obj_id,
+                object_value=str(triple.get("object_value")) if triple.get("object_value") is not None else None,
+                confidence=confidence_with_decay(
+                    confidence, observed_at=timestamp, ontology_type=ontology_type
+                ),
+                provenance=provenance,
+                attributes=attributes,
+                temporal=temporal_validity(timestamp, ontology_type),
+            )
+        )
+    return objects
+
+
+def ingest_graph_objects(
+    objects: Sequence[ConversationalGraphObject],
+    store: GraphMemoryStore,
+) -> int:
+    """Project typed graph objects into entities/relations/facts."""
 
     upserts = 0
-    for triple in triples:
+    for obj in objects:
+        spec = predicate_spec(obj.predicate, fallback_type=obj.ontology_type)
         subject = GraphEntity(
-            entity_id=triple["subject_id"],
-            entity_type=triple.get("subject_type", "user"),
-            label=triple.get("subject_label", triple["subject_id"]),
-            attributes={"last_seen": timestamp},
-            provenance=Provenance(source="conversation_turn", source_id=source_id, observed_at=timestamp),
-            confidence=float(triple.get("confidence", 0.7)),
+            entity_id=obj.subject_id,
+            entity_type=spec.subject_type,
+            label=obj.subject_id,
+            attributes={"last_seen": obj.provenance.observed_at, "ontology_type": "user"},
+            provenance=obj.provenance,
+            confidence=obj.confidence,
         )
         store.upsert_entity(subject)
 
-        obj_id = triple.get("object_id")
-        if not obj_id and triple.get("fact_type") == "temporal_fact" and triple.get("object_value"):
-            obj_id = f"event:{_stable_id(triple['subject_id'], str(triple.get('object_value')))}"
-
-        if obj_id:
+        if obj.object_id_ref:
             store.upsert_entity(
                 GraphEntity(
-                    entity_id=obj_id,
-                    entity_type=triple.get("object_type", "topic"),
-                    label=triple.get("object_label", obj_id),
-                    attributes=triple.get("object_attributes", {}),
+                    entity_id=obj.object_id_ref,
+                    entity_type=spec.object_type,
+                    label=obj.object_id_ref,
+                    attributes={
+                        **obj.attributes,
+                        "ontology_type": obj.ontology_type,
+                    },
                     provenance=subject.provenance,
-                    confidence=float(triple.get("confidence", 0.7)),
+                    confidence=obj.confidence,
                 )
             )
             store.upsert_relation(
                 GraphRelation(
-                    source_id=triple["subject_id"],
-                    relation_type=_typed_relation(triple.get("fact_type", "profile"), triple["predicate"]),
-                    target_id=obj_id,
-                    attributes={**triple.get("attributes", {}), "predicate": triple["predicate"]},
+                    source_id=obj.subject_id,
+                    relation_type=relation_projection_name(obj.ontology_type, obj.predicate),
+                    target_id=obj.object_id_ref,
+                    attributes={**obj.attributes, "predicate": obj.predicate, "ontology_type": obj.ontology_type},
                     provenance=subject.provenance,
-                    confidence=float(triple.get("confidence", 0.7)),
-                    temporal=TemporalValidity(valid_from=timestamp),
+                    confidence=obj.confidence,
+                    temporal=obj.temporal,
                 )
             )
 
         canonical = make_canonical_fact(
-            subject=triple["subject_id"],
-            predicate=triple["predicate"],
-            object_id=obj_id,
-            object_value=triple.get("object_value"),
+            subject=obj.subject_id,
+            predicate=obj.predicate,
+            object_id=obj.object_id_ref,
+            object_value=obj.object_value,
             provenance={
-                "source": "conversation_turn",
-                "source_id": source_id,
-                "observed_at": timestamp,
+                "source": obj.provenance.source,
+                "source_id": obj.provenance.source_id,
+                "observed_at": obj.provenance.observed_at,
             },
-            confidence=float(triple.get("confidence", 0.7)),
-            created_at=timestamp,
-            updated_at=timestamp,
+            confidence=obj.confidence,
+            created_at=obj.provenance.observed_at,
+            updated_at=obj.provenance.observed_at,
             attributes={
-                **triple.get("attributes", {}),
-                "timestamp": timestamp,
-                "fact_type": triple.get("fact_type", "profile"),
+                **obj.attributes,
+                "ontology_type": obj.ontology_type,
             },
         )
         store.upsert_fact(GraphFact(**canonical.__dict__))
         upserts += 1
     return upserts
-
-
-def _typed_relation(fact_type: str, predicate: str) -> str:
-    return {
-        "preference": "preference",
-        "profile": "profile",
-        "temporal_fact": "temporal_fact",
-    }.get(fact_type, predicate)
 
 
 def _stable_id(*parts: Iterable[str] | str) -> str:

--- a/src/deepthought/memory/graph/retrieval.py
+++ b/src/deepthought/memory/graph/retrieval.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from .store import GraphEvidence, GraphMemoryStore
+from .ontology import freshness_score
+from .store import GraphEvidence, GraphEvidenceBundle, GraphMemoryStore
 
 
 def retrieve_user_context(
@@ -15,6 +16,21 @@ def retrieve_topic_context(
     store: GraphMemoryStore, topic: str, *, limit: int = 8
 ) -> list[GraphEvidence]:
     return _rank_dedup(store.retrieve_topic_evidence(topic, limit=limit), limit)
+
+
+def retrieve_layered_context(
+    store: GraphMemoryStore,
+    *,
+    user_id: str,
+    topic: str,
+    limit: int = 8,
+) -> dict[str, GraphEvidenceBundle]:
+    user_items = _rank_dedup(store.retrieve_user_evidence(user_id, limit=limit), limit)
+    topic_items = _rank_dedup(store.retrieve_topic_evidence(topic, limit=limit), limit)
+    return {
+        "user_context": _bundle("user_context", user_items),
+        "topic_context": _bundle("topic_context", topic_items),
+    }
 
 
 def _rank_dedup(items: Sequence[GraphEvidence], limit: int) -> list[GraphEvidence]:
@@ -44,3 +60,36 @@ def _rank_dedup(items: Sequence[GraphEvidence], limit: int) -> list[GraphEvidenc
 
     ranked = sorted(dedup.values(), key=_sort_key, reverse=True)
     return ranked[:limit]
+
+
+def _bundle(layer: str, items: list[GraphEvidence]) -> GraphEvidenceBundle:
+    enriched: list[GraphEvidence] = []
+    for item in items:
+        observed_at = (
+            item.provenance.observed_at
+            or item.attributes.get("updated_at")
+            or item.attributes.get("timestamp")
+        )
+        ontology_type = str(item.attributes.get("ontology_type") or "evidence")
+        fresh = freshness_score(observed_at=observed_at, ontology_type=ontology_type)
+        enriched.append(
+            GraphEvidence(
+                evidence_id=item.evidence_id,
+                summary=item.summary,
+                entity_id=item.entity_id,
+                relation_type=item.relation_type,
+                score=round(item.score * fresh, 6),
+                confidence=item.confidence,
+                provenance=item.provenance,
+                freshness=fresh,
+                attributes=dict(item.attributes),
+            )
+        )
+    provenance = [item.provenance for item in enriched]
+    freshness = round(sum(item.freshness for item in enriched) / len(enriched), 6) if enriched else 0.0
+    return GraphEvidenceBundle(
+        layer=layer,
+        evidences=enriched,
+        provenance=provenance,
+        freshness_score=freshness,
+    )

--- a/src/deepthought/memory/graph/store.py
+++ b/src/deepthought/memory/graph/store.py
@@ -56,7 +56,30 @@ class GraphEvidence:
     score: float
     confidence: float
     provenance: Provenance
+    freshness: float = 1.0
     attributes: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GraphEvidenceBundle:
+    layer: str
+    evidences: list[GraphEvidence]
+    provenance: list[Provenance]
+    freshness_score: float
+
+
+@dataclass(frozen=True)
+class ConversationalGraphObject:
+    object_id: str
+    ontology_type: str
+    subject_id: str
+    predicate: str
+    object_id_ref: str | None
+    object_value: str | None
+    confidence: float
+    provenance: Provenance
+    attributes: dict[str, Any] = field(default_factory=dict)
+    temporal: TemporalValidity = field(default_factory=TemporalValidity)
 
 
 def utc_now_iso() -> str:

--- a/src/deepthought/services/cognitive_core_service.py
+++ b/src/deepthought/services/cognitive_core_service.py
@@ -27,11 +27,9 @@ from ..memory.fact_extractor import extract_typed_fact_triples_from_turn
 from ..memory.graph import (
     CypherGraphMemoryStore,
     InMemoryGraphMemoryStore,
-    ingest_conversation_turns,
-    retrieve_topic_context,
-    retrieve_user_context,
+    retrieve_layered_context,
 )
-from ..memory.graph.pipeline import ingest_fact_triples
+from ..memory.graph.pipeline import ingest_graph_objects, triples_to_graph_objects
 from ..fact_schema import format_fact_snippet, make_canonical_fact
 from ..memory.graph.store import utc_now_iso
 from ..memory.tiered import TieredMemory
@@ -434,7 +432,7 @@ class CognitiveCoreService(BaseService):
         except asyncio.CancelledError:
             return
 
-    def _prioritized_graph_facts(self, user_id: str, topic: str) -> list[str]:
+    def _prioritized_graph_facts(self, user_id: str, topic: str) -> tuple[list[str], dict[str, Any]]:
         summary_evidence = [
             item
             for item in self._salience_summaries
@@ -453,12 +451,14 @@ class CognitiveCoreService(BaseService):
             f"summary: {item['summary']}" for item in summary_evidence[: self._top_k]
         ]
 
-        graph_user_evidence = retrieve_user_context(
-            self._graph_memory, str(user_id), limit=self._top_k
+        bundles = retrieve_layered_context(
+            self._graph_memory,
+            user_id=str(user_id),
+            topic=topic,
+            limit=self._top_k,
         )
-        graph_topic_evidence = retrieve_topic_context(
-            self._graph_memory, topic, limit=self._top_k
-        )
+        graph_user_evidence = bundles["user_context"].evidences
+        graph_topic_evidence = bundles["topic_context"].evidences
         graph_facts = []
         for ev in [*graph_user_evidence, *graph_topic_evidence]:
             fact = make_canonical_fact(
@@ -473,7 +473,26 @@ class CognitiveCoreService(BaseService):
                 attributes=dict(ev.attributes),
             )
             graph_facts.append(format_fact_snippet(fact))
-        return summary_facts + graph_facts
+        bundle_payload = {
+            key: {
+                "layer": bundle.layer,
+                "freshness_score": bundle.freshness_score,
+                "provenance": [p.__dict__ for p in bundle.provenance],
+                "evidence": [
+                    {
+                        "id": e.evidence_id,
+                        "summary": e.summary,
+                        "score": e.score,
+                        "confidence": e.confidence,
+                        "freshness": e.freshness,
+                        "provenance": e.provenance.__dict__,
+                    }
+                    for e in bundle.evidences
+                ],
+            }
+            for key, bundle in bundles.items()
+        }
+        return summary_facts + graph_facts, bundle_payload
 
     @staticmethod
     def _normalize_fact_entries(entries: list[str], *, prefix: str | None = None) -> list[str]:
@@ -621,19 +640,6 @@ class CognitiveCoreService(BaseService):
             if multimodal_memory_payload is not None and hasattr(self._db, "store_multimodal_memory"):
                 await self._db.store_multimodal_memory(multimodal_memory_payload)
 
-            ingest_conversation_turns(
-                [
-                    {
-                        "user_id": resolved_user_id,
-                        "text": user_input,
-                        "timestamp": turn_timestamp,
-                        "input_id": input_id,
-                    }
-                ],
-                self._graph_memory,
-                default_user_id=str(resolved_user_id),
-            )
-
             extracted_triples = extract_typed_fact_triples_from_turn(
                 user_id=str(resolved_user_id),
                 message=user_input,
@@ -649,12 +655,12 @@ class CognitiveCoreService(BaseService):
                     if scored.reason_tags:
                         attrs.setdefault("salience_reasons", list(scored.reason_tags))
                     enriched_triples.append({**triple, "attributes": attrs})
-                ingest_fact_triples(
+                graph_objects = triples_to_graph_objects(
                     enriched_triples,
-                    self._graph_memory,
                     timestamp=turn_timestamp,
                     source_id=input_id,
                 )
+                ingest_graph_objects(graph_objects, self._graph_memory)
 
             memory_facts = self._memory.retrieve_context(user_input) if self._memory else []
             vector_facts: List[str] = []
@@ -676,7 +682,7 @@ class CognitiveCoreService(BaseService):
             multimodal_facts = self._normalize_fact_entries(
                 _multimodal_memory_to_fact_snippets(multimodal_memories)
             )
-            graph_facts = self._prioritized_graph_facts(
+            graph_facts, graph_evidence_bundles = self._prioritized_graph_facts(
                 str(resolved_user_id), user_input
             )
 
@@ -720,6 +726,7 @@ class CognitiveCoreService(BaseService):
                     "conversation_window": conversation_window[-self._retrieval_policy.recent_turns :],
                     "recent_turn_summary": recent_turn_summary,
                     "multimodal_memories": multimodal_memories[: self._top_k],
+                    "graph_evidence_bundles": graph_evidence_bundles,
                 },
                 user_input=user_input,
                 input_id=input_id,

--- a/src/deepthought/services/db_manager.py
+++ b/src/deepthought/services/db_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import contextlib
 from datetime import datetime, timedelta
 from typing import Any, Mapping
 
@@ -11,6 +12,8 @@ import aiosqlite
 
 from ..config import get_settings
 from ..fact_schema import make_canonical_fact
+from ..memory.graph.pipeline import triples_to_graph_objects
+from ..memory.graph.store import ConversationalGraphObject
 
 SENTIMENT_BACKEND = os.getenv("SENTIMENT_BACKEND", "textblob").lower()
 try:  # Optional dependency
@@ -530,6 +533,99 @@ class DBManager:
                     json.dumps(fact.attributes),
                 ),
             )
+
+    async def adapt_memories_to_graph_objects(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[ConversationalGraphObject]:
+        """Adapt legacy ``memories`` rows into typed conversational graph objects."""
+        await self.connect()
+        assert self._db is not None
+        query = "SELECT user_id, topic, memory, sentiment_score, timestamp FROM memories ORDER BY timestamp ASC"
+        params: list[Any] = []
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+        async with self._db.execute(query, params) as cur:
+            rows = await cur.fetchall()
+
+        objects: list[ConversationalGraphObject] = []
+        for row in rows:
+            timestamp = str(row["timestamp"] or datetime.utcnow().isoformat())
+            sentiment = row["sentiment_score"]
+            triples = [
+                {
+                    "subject_id": str(row["user_id"] or "anonymous"),
+                    "subject_type": "user",
+                    "predicate": "memory_note",
+                    "object_id": None,
+                    "object_type": "evidence",
+                    "object_value": str(row["memory"] or ""),
+                    "attributes": {
+                        "topic": str(row["topic"] or ""),
+                        "sentiment_score": float(sentiment) if isinstance(sentiment, (int, float)) else None,
+                    },
+                    "confidence": 0.6,
+                    "fact_type": "utterance",
+                }
+            ]
+            objects.extend(
+                triples_to_graph_objects(
+                    triples,
+                    timestamp=timestamp,
+                    source_id=f"db.memories:{row['user_id']}:{timestamp}",
+                )
+            )
+        return objects
+
+    async def adapt_fact_records_to_graph_objects(
+        self,
+        *,
+        limit: int | None = None,
+    ) -> list[ConversationalGraphObject]:
+        """Adapt canonical ``fact_records`` rows into typed conversational graph objects."""
+        await self.connect()
+        assert self._db is not None
+        query = (
+            "SELECT subject, predicate, object_id, object_value, confidence, "
+            "provenance, attributes, updated_at FROM fact_records ORDER BY updated_at ASC"
+        )
+        params: list[Any] = []
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(int(limit))
+        async with self._db.execute(query, params) as cur:
+            rows = await cur.fetchall()
+        objects: list[ConversationalGraphObject] = []
+        for row in rows:
+            attributes_raw = row["attributes"]
+            attributes = {}
+            if isinstance(attributes_raw, str) and attributes_raw.strip():
+                with contextlib.suppress(json.JSONDecodeError):
+                    attributes = json.loads(attributes_raw)
+            timestamp = str(row["updated_at"] or datetime.utcnow().isoformat())
+            triples = [
+                {
+                    "subject_id": str(row["subject"] or "anonymous"),
+                    "subject_type": "user",
+                    "predicate": str(row["predicate"] or "memory_note"),
+                    "object_id": str(row["object_id"]) if row["object_id"] is not None else None,
+                    "object_type": str(attributes.get("object_type") or "evidence"),
+                    "object_value": str(row["object_value"]) if row["object_value"] is not None else None,
+                    "attributes": attributes,
+                    "confidence": float(row["confidence"] or 0.6),
+                    "fact_type": str(attributes.get("fact_type") or "profile"),
+                }
+            ]
+            objects.extend(
+                triples_to_graph_objects(
+                    triples,
+                    timestamp=timestamp,
+                    source_id=f"db.fact_records:{row['subject']}:{row['predicate']}:{timestamp}",
+                )
+            )
+        return objects
 
     async def _ensure_relationship_columns(self) -> None:
         """Add new columns to the relationships table if they don't exist."""


### PR DESCRIPTION
### Motivation
- Provide a formal conversational ontology (User, Preference, Commitment, Event, Relationship, Topic, Evidence) with typed predicates and decay/freshness semantics so graph memory can represent and score different kinds of conversational facts.
- Make graph ingestion more explicit and composable by converting extraction output to typed graph objects first, then projecting those into entities/relations/facts for storage and downstream projections.
- Allow retrieval to return layer-specific evidence bundles with provenance and freshness scoring so downstream consumers can reason about source and recency.

### Description
- Added a new ontology module with ontology categories, a typed `PREDICATE_REGISTRY`, `freshness_score`/decay semantics, and helper projections in `src/deepthought/memory/graph/ontology.py`.
- Introduced `ConversationalGraphObject` and `GraphEvidenceBundle` datatypes and extended `GraphEvidence` with `freshness` in `src/deepthought/memory/graph/store.py`.
- Refactored the pipeline so triples are converted to typed `ConversationalGraphObject` via `triples_to_graph_objects()` and then written by `ingest_graph_objects()` (instead of mixing extraction+ingestion) in `src/deepthought/memory/graph/pipeline.py`.
- Implemented layered retrieval that returns `user_context` and `topic_context` bundles with per-item freshness and aggregate freshness score in `src/deepthought/memory/graph/retrieval.py` and wired freshness computation into adapters in `src/deepthought/memory/graph/adapters.py`.
- Exported the new APIs from the `memory.graph` package in `src/deepthought/memory/graph/__init__.py` and updated `CognitiveCoreService` to ingest via typed objects and include `graph_evidence_bundles` in retrieval payloads in `src/deepthought/services/cognitive_core_service.py`.
- Added DB migration adapter helpers in `src/deepthought/services/db_manager.py` to convert legacy `memories` and `fact_records` rows into typed `ConversationalGraphObject` lists for graph ingestion.

### Testing
- Ran linter and static checks with `ruff check` on the modified modules and compiled the updated modules with `python -m compileall`, both completed without errors.
- Ran unit tests for the graph backend with `pytest -q tests/unit/test_graph_backend.py` and they passed (`2 passed`).
- Attempted broader test runs including `tests/unit/test_hierarchical_memory.py` and integration lifecycle tests, which failed to import `aiosqlite` in this environment (optional runtime dependency), causing collection errors; this is environmental and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8cafe37888326adb2b7277aef8717)