### PR TITLE
Add durable persona-state transitions and continuity-aware prompt hints

### DIFF
--- a/src/deepthought/memory/__init__.py
+++ b/src/deepthought/memory/__init__.py
@@ -14,16 +14,6 @@ from .vector_store import (
     create_vector_store,
 )
 from .memory_lifecycle_policy import MemoryLifecyclePolicy, MemoryTier, ScoredMemoryEvent
-from .fact_extractor import (
-    extract_typed_fact_triples_from_turn,
-    build_user_fact_context,
-    extract_and_store_user_facts,
-    extract_user_facts,
-    format_user_facts_for_prompt,
-    get_user_fact_profile,
-    merge_user_profiles,
-)
-
 __all__ = [
     "HierarchicalMemory",
     "VectorStore",
@@ -44,6 +34,22 @@ __all__ = [
     "get_user_fact_profile",
     "merge_user_profiles",
 ]
+
+
+def __getattr__(name: str):
+    if name in {
+        "extract_typed_fact_triples_from_turn",
+        "build_user_fact_context",
+        "extract_and_store_user_facts",
+        "extract_user_facts",
+        "format_user_facts_for_prompt",
+        "get_user_fact_profile",
+        "merge_user_profiles",
+    }:
+        from . import fact_extractor as _fact_extractor
+
+        return getattr(_fact_extractor, name)
+    raise AttributeError(name)
 
 
 @dataclass

--- a/src/deepthought/memory/fact_extractor.py
+++ b/src/deepthought/memory/fact_extractor.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from ..services.db_manager import DBManager
+if TYPE_CHECKING:
+    from ..services.db_manager import DBManager
 
 NICKNAME_PATTERNS = [
     re.compile(
@@ -245,13 +246,18 @@ def merge_user_profiles(
 async def extract_and_store_user_facts(
     user_id: int,
     message: str,
-    db_manager: DBManager | None = None,
+    db_manager: "DBManager | None" = None,
 ) -> dict[str, Any]:
     """Extract facts from a message and persist them to ``user_profiles``."""
     facts = extract_user_facts(message)
     if not facts:
         return {}
-    db = db_manager or DBManager()
+    if db_manager is None:
+        from ..services.db_manager import DBManager
+
+        db = DBManager()
+    else:
+        db = db_manager
     existing = await db.get_user_profile(user_id)
     merged = merge_user_profiles(existing, facts)
     await db.set_user_profile(user_id, merged)
@@ -260,10 +266,15 @@ async def extract_and_store_user_facts(
 
 async def get_user_fact_profile(
     user_id: int,
-    db_manager: DBManager | None = None,
+    db_manager: "DBManager | None" = None,
 ) -> dict[str, Any] | None:
     """Return the stored user fact profile as a dict when possible."""
-    db = db_manager or DBManager()
+    if db_manager is None:
+        from ..services.db_manager import DBManager
+
+        db = DBManager()
+    else:
+        db = db_manager
     profile = await db.get_user_profile(user_id)
     if profile is None:
         return None
@@ -297,7 +308,7 @@ def format_user_facts_for_prompt(profile: Mapping[str, Any] | None) -> str | Non
 
 async def build_user_fact_context(
     user_id: int,
-    db_manager: DBManager | None = None,
+    db_manager: "DBManager | None" = None,
 ) -> str | None:
     """Return a formatted user-fact string for prompt building."""
     profile = await get_user_fact_profile(user_id, db_manager=db_manager)

--- a/src/deepthought/modules/llm_remote.py
+++ b/src/deepthought/modules/llm_remote.py
@@ -138,6 +138,7 @@ def _build_generation_prompt(
     *,
     user_input: str,
     facts: list[str],
+    social_signals: dict[str, object] | None = None,
     author_name: str | None = None,
     channel_context: str | None = None,
     recent_turn_summary: str | None = None,
@@ -152,6 +153,16 @@ def _build_generation_prompt(
         hints.append(f"- Channel context: {channel_context}")
     if recent_turn_summary:
         hints.append(f"- Recent turn summary: {recent_turn_summary}")
+    social = social_signals if isinstance(social_signals, dict) else {}
+    persona_state = social.get("persona_state")
+    if isinstance(persona_state, str) and persona_state.strip():
+        hints.append(f"- Persona state: {persona_state.strip()}")
+    persona_reason = social.get("persona_state_reason")
+    if isinstance(persona_reason, str) and persona_reason.strip():
+        hints.append(f"- Persona state reason: {persona_reason.strip()}")
+    policy_hints = social.get("persona_policy_hints")
+    if isinstance(policy_hints, dict) and policy_hints:
+        hints.append(f"- Persona policy hints: {json.dumps(policy_hints, sort_keys=True)}")
     hints_block = "\n".join(hints) if hints else "- None"
 
     multimodal = multimodal_interpretations if isinstance(multimodal_interpretations, dict) else {}
@@ -438,6 +449,13 @@ class RemoteLLM:
             prompt = _build_generation_prompt(
                 user_input=user_input,
                 facts=facts,
+                social_signals=(
+                    payload.social_signals
+                    if "retrieved_facts" in data and isinstance(payload.social_signals, dict)
+                    else data.get("social_signals")
+                    if isinstance(data.get("social_signals"), dict)
+                    else {}
+                ),
                 author_name=author_name,
                 channel_context=channel_context,
                 recent_turn_summary=recent_turn_summary,

--- a/src/deepthought/services/persona_manager.py
+++ b/src/deepthought/services/persona_manager.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import random
+from datetime import datetime, timezone
+from typing import Any
 
 from .db_manager import DBManager
 
@@ -42,6 +44,7 @@ class PersonaManager:
         self._persona_state: dict[str, str] = {}
         self._relationship_state: dict[str, str | None] = {}
         self._sentiment_state: dict[str, float] = {}
+        self._social_persona_state: dict[str, dict[str, Any]] = {}
 
         # Initialize the database once. If an event loop is running we
         # schedule the task and await it on first use. Otherwise we
@@ -123,6 +126,127 @@ class PersonaManager:
         if not options:
             return ""
         return random.choice(options)
+
+    async def transition_persona_state(
+        self,
+        user_id: int | str,
+        *,
+        signals: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Transition durable persona-state using social and feedback signals."""
+        await self._ensure_initialized()
+        uid = str(user_id)
+        profile = await self._db.get_user_profile(uid)
+        model = dict(profile) if isinstance(profile, dict) else {}
+
+        state_block = model.get("persona_state")
+        state_data = dict(state_block) if isinstance(state_block, dict) else {}
+        current_state = str(state_data.get("current") or "new_acquaintance")
+        current_state = self._normalize_social_state(current_state)
+        evidence_log = state_data.get("evidence")
+        evidence = list(evidence_log) if isinstance(evidence_log, list) else []
+
+        normalized = dict(signals or {})
+        next_state, reason, policy_hints = self._derive_social_state(
+            current_state,
+            normalized,
+        )
+        timestamp = datetime.now(timezone.utc).isoformat()
+        evidence_entry = {
+            "at": timestamp,
+            "state": next_state,
+            "reason": reason,
+            "signals": {
+                "delta": normalized.get("delta"),
+                "affinity": normalized.get("affinity"),
+                "trust": normalized.get("trust"),
+                "feedback": normalized.get("feedback"),
+                "perception": normalized.get("perception"),
+                "familiarity_tier": normalized.get("familiarity_tier"),
+                "relationship_status": normalized.get("relationship_status"),
+            },
+        }
+        evidence.append(evidence_entry)
+        evidence = evidence[-20:]
+
+        persona_state = {
+            "current": next_state,
+            "updated_at": timestamp,
+            "reason": reason,
+            "policy_hints": policy_hints,
+            "evidence": evidence,
+        }
+        model["persona_state"] = persona_state
+        await self._db.set_user_profile(uid, model)
+        self._social_persona_state[uid] = persona_state
+        return persona_state
+
+    @staticmethod
+    def _normalize_social_state(state: str) -> str:
+        allowed = {
+            "new_acquaintance",
+            "familiar",
+            "trusted",
+            "repair_mode",
+            "uncertain_mode",
+        }
+        return state if state in allowed else "new_acquaintance"
+
+    def _derive_social_state(
+        self,
+        current_state: str,
+        signals: dict[str, Any],
+    ) -> tuple[str, str, dict[str, Any]]:
+        perception = signals.get("perception")
+        perception_map = perception if isinstance(perception, dict) else {}
+        manipulation = float(perception_map.get("manipulation", 0.0) or 0.0)
+        avoidance = float(perception_map.get("avoidance", 0.0) or 0.0)
+        flirtation = float(perception_map.get("flirtation", 0.0) or 0.0)
+        delta = float(signals.get("delta", 0.0) or 0.0)
+        trust = float(signals.get("trust", 0.0) or 0.0)
+        affinity = float(signals.get("affinity", 0.0) or 0.0)
+        familiarity_tier = str(signals.get("familiarity_tier") or "low")
+        relationship_status = str(signals.get("relationship_status") or "neutral")
+        feedback = signals.get("feedback")
+        feedback_map = feedback if isinstance(feedback, dict) else {}
+        negative_feedback = bool(feedback_map.get("negative"))
+        positive_feedback = bool(feedback_map.get("positive"))
+        uncertain = bool(feedback_map.get("uncertain")) or bool(signals.get("low_confidence"))
+
+        if manipulation >= 0.45 or avoidance >= 0.65 or negative_feedback:
+            next_state = "repair_mode"
+            reason = "social_or_feedback_repair"
+        elif uncertain:
+            next_state = "uncertain_mode"
+            reason = "uncertainty_signal"
+        elif trust >= 6.0 or affinity >= 6.0 or relationship_status == "friend":
+            next_state = "trusted"
+            reason = "high_trust_or_affinity"
+        elif familiarity_tier in {"medium", "high"} or affinity >= 2.0:
+            next_state = "familiar"
+            reason = "growing_familiarity"
+        else:
+            next_state = "new_acquaintance"
+            reason = "limited_history"
+
+        if current_state == "repair_mode" and next_state in {"familiar", "trusted"} and not positive_feedback and delta <= 0:
+            next_state = "repair_mode"
+            reason = "repair_hold"
+
+        policy_hints = {
+            "tone": {
+                "new_acquaintance": "polite_clear",
+                "familiar": "warm_consistent",
+                "trusted": "direct_collaborative",
+                "repair_mode": "careful_empathic",
+                "uncertain_mode": "clarifying",
+            }[next_state],
+            "allow_playfulness": next_state in {"familiar", "trusted"} and flirtation > 0.2,
+            "prioritize_clarification": next_state in {"repair_mode", "uncertain_mode"},
+            "avoid_assumptions": next_state == "uncertain_mode",
+            "repair_needed": next_state == "repair_mode",
+        }
+        return next_state, reason, policy_hints
 
     async def get_description(
         self,

--- a/src/deepthought/services/social_graph_memory.py
+++ b/src/deepthought/services/social_graph_memory.py
@@ -278,6 +278,13 @@ class SocialGraphMemory:
         trust = await self._db.get_trust(source)
         affinity = await self._db.get_affinity(source)
         social_model = await self._load_social_model(source)
+        profile = await self._db.get_user_profile(source)
+        profile_map = profile if isinstance(profile, dict) else {}
+        persona_state_block = (
+            profile_map.get("persona_state")
+            if isinstance(profile_map.get("persona_state"), dict)
+            else {}
+        )
         dimensions = dict(social_model.get("dimensions") or {})
         channel_specific_norms = dict(social_model.get("channel_specific_norms") or {})
         active_channel = channel_specific_norms.get(str(channel_id) if channel_id else "default", {})
@@ -308,6 +315,12 @@ class SocialGraphMemory:
                 "ask_clarifying_on_no_safe": correction_level != "low",
                 "style_modifiers": [preferred_style, rapport_level],
                 "cadence_tolerance": float((dimensions.get("cadence_tolerance") or {}).get("score", 0.5)),
+                "persona_state": str(persona_state_block.get("current") or "new_acquaintance"),
+                "persona_policy_hints": (
+                    persona_state_block.get("policy_hints")
+                    if isinstance(persona_state_block.get("policy_hints"), dict)
+                    else {}
+                ),
                 "channel_norms": active_channel or {
                     "interaction_frequency": interaction["event_count"],
                     "reciprocity": interaction["reciprocity"],
@@ -333,6 +346,18 @@ class SocialGraphMemory:
                 "graph_evidence": [item.summary for item in evidence],
             },
             "selector_inputs": selector_inputs,
+            "persona_state": str(persona_state_block.get("current") or "new_acquaintance"),
+            "persona_state_reason": persona_state_block.get("reason"),
+            "persona_policy_hints": (
+                persona_state_block.get("policy_hints")
+                if isinstance(persona_state_block.get("policy_hints"), dict)
+                else {}
+            ),
+            "persona_state_evidence": (
+                persona_state_block.get("evidence")
+                if isinstance(persona_state_block.get("evidence"), list)
+                else []
+            ),
         }
 
     async def discover_factions(self, edge_type: str = "ally") -> list[list[str]]:

--- a/src/deepthought/services/social_graph_service.py
+++ b/src/deepthought/services/social_graph_service.py
@@ -111,6 +111,23 @@ class SocialGraphService(BaseService):
                 counterpart_id,
                 channel_id=enriched.channel_id,
             )
+            persona_state = await self._persona.transition_persona_state(
+                resolved_user_id,
+                signals={
+                    "perception": perception,
+                    "delta": delta,
+                    "affinity": affinity,
+                    "trust": trust,
+                    "familiarity_tier": social_context.get("familiarity_tier"),
+                    "relationship_status": social_context.get("relationship_status"),
+                    "feedback": (
+                        data.get("feedback_signals")
+                        if isinstance(data.get("feedback_signals"), dict)
+                        else {}
+                    ),
+                    "low_confidence": bool(data.get("low_confidence")),
+                },
+            )
 
             social_snapshot = {
                 "input_id": enriched.input_id,
@@ -125,6 +142,10 @@ class SocialGraphService(BaseService):
                     "persona": persona,
                     "durable_user_model": social_context.get("durable_user_model", {}),
                     "selector_inputs": social_context.get("selector_inputs", {}),
+                    "persona_state": persona_state.get("current", "new_acquaintance"),
+                    "persona_state_reason": persona_state.get("reason"),
+                    "persona_state_evidence": persona_state.get("evidence", []),
+                    "persona_policy_hints": persona_state.get("policy_hints", {}),
                     "relationship_status": social_context.get("relationship_status", "neutral"),
                     "familiarity_tier": social_context.get("familiarity_tier", "low"),
                     "channel_norms": social_context.get("channel_norms", {}),

--- a/tests/integration/test_context_assembler_service.py
+++ b/tests/integration/test_context_assembler_service.py
@@ -565,3 +565,47 @@ async def test_qos_profile_high_risk_requires_all_providers(monkeypatch):
     ]
     assert payload["confidence"]["missing_reasons"]["perception"] == "timeout"
     assert payload["confidence"]["quality_score"] < 1.0
+
+
+@pytest.mark.asyncio
+async def test_context_assembled_exposes_structured_persona_policy_hints(monkeypatch):
+    import deepthought.services.context_assembler_service as mod
+
+    monkeypatch.setattr(mod, "Publisher", RecordingPublisher)
+    monkeypatch.setattr(mod, "Subscriber", RecordingSubscriber)
+
+    svc = ContextAssemblerService(DummyNATS(), DummyJS(), wait_window_seconds=0.03)
+    await svc._handle_input_received(
+        DummyMsg({"input_id": "i-persona-hints", "user_input": "hello"})
+    )
+    await svc._handle_provider_response(
+        DummyMsg(
+            {
+                "input_id": "i-persona-hints",
+                "retrieved_knowledge": {"facts": ["f1"]},
+            }
+        ),
+        "memory",
+    )
+    await svc._handle_provider_response(
+        DummyMsg(
+            {
+                "input_id": "i-persona-hints",
+                "social_signals": {
+                    "persona_state": "familiar",
+                    "persona_policy_hints": {"tone": "warm_consistent"},
+                    "selector_inputs": {"interaction_policy": {"response_style": "friendly"}},
+                },
+            }
+        ),
+        "social",
+    )
+    await asyncio.sleep(0.06)
+
+    assembled = [
+        c for c in svc._publisher.calls if c[0] == EventSubjects.CONTEXT_ASSEMBLED
+    ]
+    payload = assembled[0][1]["payload"]
+    assert payload["social_signals"]["persona_state"] == "familiar"
+    assert payload["social_signals"]["persona_policy_hints"]["tone"] == "warm_consistent"
+    assert isinstance(payload["social_signals"]["selector_inputs"]["interaction_policy"], dict)

--- a/tests/test_persona_state_transitions.py
+++ b/tests/test_persona_state_transitions.py
@@ -1,0 +1,111 @@
+import pytest
+
+from deepthought.services.db_manager import DBManager
+from deepthought.services.persona_manager import PersonaManager
+
+
+@pytest.mark.asyncio
+async def test_persona_state_transitions_and_persistence_across_sessions(tmp_path):
+    db = DBManager(str(tmp_path / "persona-state.db"))
+    await db.init_db()
+    pm = PersonaManager(db)
+
+    start = await pm.transition_persona_state(
+        "u-1",
+        signals={
+            "perception": {"flirtation": 0.0, "avoidance": 0.0, "manipulation": 0.0},
+            "delta": 0.0,
+            "affinity": 0.0,
+            "trust": 0.0,
+            "familiarity_tier": "low",
+            "relationship_status": "neutral",
+        },
+    )
+    assert start["current"] == "new_acquaintance"
+
+    familiar = await pm.transition_persona_state(
+        "u-1",
+        signals={
+            "perception": {"flirtation": 0.3, "avoidance": 0.1, "manipulation": 0.0},
+            "delta": 0.5,
+            "affinity": 3.0,
+            "trust": 2.0,
+            "familiarity_tier": "medium",
+            "relationship_status": "neutral",
+            "feedback": {"positive": True},
+        },
+    )
+    assert familiar["current"] == "familiar"
+    assert familiar["policy_hints"]["tone"] == "warm_consistent"
+
+    pm2 = PersonaManager(db)
+    repair = await pm2.transition_persona_state(
+        "u-1",
+        signals={
+            "perception": {"flirtation": 0.0, "avoidance": 0.8, "manipulation": 0.5},
+            "delta": -0.5,
+            "affinity": 1.0,
+            "trust": -2.0,
+            "familiarity_tier": "medium",
+            "relationship_status": "neutral",
+            "feedback": {"negative": True},
+        },
+    )
+    assert repair["current"] == "repair_mode"
+    assert repair["policy_hints"]["repair_needed"] is True
+
+    pm3 = PersonaManager(db)
+    recovered = await pm3.transition_persona_state(
+        "u-1",
+        signals={
+            "perception": {"flirtation": 0.2, "avoidance": 0.0, "manipulation": 0.0},
+            "delta": 0.8,
+            "affinity": 7.0,
+            "trust": 8.0,
+            "familiarity_tier": "high",
+            "relationship_status": "friend",
+            "feedback": {"positive": True},
+        },
+    )
+    assert recovered["current"] == "trusted"
+    assert recovered["policy_hints"]["tone"] == "direct_collaborative"
+    assert len(recovered["evidence"]) >= 4
+
+    await db.close()
+
+
+@pytest.mark.asyncio
+async def test_acceptance_tone_continuity_across_sessions(tmp_path):
+    db = DBManager(str(tmp_path / "tone-continuity.db"))
+    await db.init_db()
+
+    session_one = PersonaManager(db)
+    state_one = await session_one.transition_persona_state(
+        "u-9",
+        signals={
+            "perception": {"flirtation": 0.25, "avoidance": 0.0, "manipulation": 0.0},
+            "delta": 0.4,
+            "affinity": 3.0,
+            "trust": 3.0,
+            "familiarity_tier": "medium",
+        },
+    )
+    assert state_one["current"] == "familiar"
+    assert state_one["policy_hints"]["tone"] == "warm_consistent"
+
+    session_two = PersonaManager(db)
+    state_two = await session_two.transition_persona_state(
+        "u-9",
+        signals={
+            "perception": {"flirtation": 0.2, "avoidance": 0.0, "manipulation": 0.0},
+            "delta": 0.2,
+            "affinity": 3.0,
+            "trust": 3.0,
+            "familiarity_tier": "medium",
+        },
+    )
+    assert state_two["current"] == "familiar"
+    assert state_two["policy_hints"]["tone"] == "warm_consistent"
+    assert len(state_two["evidence"]) >= 2
+
+    await db.close()

--- a/tests/unit/modules/test_llm_remote.py
+++ b/tests/unit/modules/test_llm_remote.py
@@ -143,6 +143,37 @@ async def test_handle_context_event_publishes(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_handle_context_event_includes_persona_state_hints_in_prompt(monkeypatch):
+    llm = create_llm(monkeypatch)
+    prompts = []
+
+    async def fake_generate_candidates(self, prompt):
+        prompts.append(prompt)
+        return [llm_remote.ResponseCandidate(text="answer", confidence=0.8, source="stub", safety_passed=True)]
+
+    monkeypatch.setattr(llm, "_generate_candidates", fake_generate_candidates.__get__(llm, type(llm)))
+
+    payload = ContextAssembledPayload(
+        input_id="42",
+        user_input="hello",
+        retrieved_facts=["f1"],
+        social_signals={
+            "persona_state": "trusted",
+            "persona_state_reason": "high_trust_or_affinity",
+            "persona_policy_hints": {"tone": "direct_collaborative", "repair_needed": False},
+        },
+    )
+    msg = DummyMsg(payload.to_json())
+
+    await llm._handle_context_event(msg)
+
+    assert msg.acked
+    assert prompts
+    assert "Persona state: trusted" in prompts[0]
+    assert "Persona policy hints:" in prompts[0]
+
+
+@pytest.mark.asyncio
 async def test_generate_timeout(monkeypatch):
     class TimeoutSession:
         async def __aenter__(self):

--- a/tests/unit/services/test_social_graph_service.py
+++ b/tests/unit/services/test_social_graph_service.py
@@ -161,6 +161,14 @@ async def test_social_contract_update_and_retrieval_semantics(tmp_path, monkeypa
     assert retrieved["payload"]["input_id"] == "in-contract"
     assert retrieved["payload"]["social_signals"]["perception"]["flirtation"] == pytest.approx(0.5)
     assert retrieved["payload"]["social_signals"]["affinity"] == updated["payload"]["affinity"]
+    assert retrieved["payload"]["social_signals"]["persona_state"] in {
+        "new_acquaintance",
+        "familiar",
+        "trusted",
+        "repair_mode",
+        "uncertain_mode",
+    }
+    assert isinstance(retrieved["payload"]["social_signals"]["persona_policy_hints"], dict)
 
     await db.close()
 
@@ -216,6 +224,13 @@ async def test_social_signals_include_summarized_context_and_channel_norms(tmp_p
     selector_inputs = retrieved["selector_inputs"]
     assert set(selector_inputs) == {"social_intent_hints", "user_history_affinity", "interaction_policy"}
     assert selector_inputs["interaction_policy"]["response_style"]
+    assert selector_inputs["interaction_policy"]["persona_state"] in {
+        "new_acquaintance",
+        "familiar",
+        "trusted",
+        "repair_mode",
+        "uncertain_mode",
+    }
     assert await db.get_edge_weight("u-1", "u-2", "interaction", channel_id="c-1") > 0
     assert await db.get_edge_weight("u-1", "u-3", "interaction", channel_id="c-1") > 0
     assert await db.get_edge_weight("u-1", "u-4", "interaction", channel_id="c-1") > 0


### PR DESCRIPTION
### Motivation

- Provide a durable persona-state model driven by social/perception and explicit feedback so responder tone can be consistent across sessions.
- Surface structured persona-state evidence and policy hints into assembled context so downstream selectors and LLMs can adapt style and clarification behavior.
- Ensure persona transitions are persisted and recoverable, and validate tone continuity with acceptance tests.

### Description

- Implemented persona-state transitions in `PersonaManager` with states `new_acquaintance`, `familiar`, `trusted`, `repair_mode`, and `uncertain_mode`, including evidence logging, transition reasons, and structured `policy_hints`, and persisted this block into `user_profiles` via `DBManager` (`src/deepthought/services/persona_manager.py`).
- Wired `social_graph_service` to call the persona transition on social updates and to publish `persona_state`, `persona_state_reason`, `persona_state_evidence`, and `persona_policy_hints` in `SOCIAL_SIGNALS_RETRIEVED` payloads (`src/deepthought/services/social_graph_service.py`).
- Extended durable social context so `SocialGraphMemory.get_social_context_summary` exposes persona-state and policy hints in both `selector_inputs.interaction_policy` and top-level fields used by the `ContextAssembler` (`src/deepthought/services/social_graph_memory.py`).
- Integrated persona hints into prompt construction in `modules/llm_remote.py` so generated prompts include `Persona state` and `Persona policy hints` under the social/perception hints block (`src/deepthought/modules/llm_remote.py`).
- Added acceptance/unit/integration tests that validate persona-state transitions, persistence across manager instances, LLM prompt inclusion, and that `CONTEXT_ASSEMBLED` exposes structured persona policy hints (`tests/test_persona_state_transitions.py`, updates to `tests/unit/...` and `tests/integration/...`).
- Fixed an import-cycle during test setup by lazily exporting fact-extractor symbols in `deepthought.memory` and deferring direct `DBManager` imports inside the fact-extractor helpers to avoid circular initialization (`src/deepthought/memory/__init__.py`, `src/deepthought/memory/fact_extractor.py`).

### Testing

- Installed test runtime dependency `aiosqlite` and ran the focused test set with `python -m pytest -q tests/test_persona_state_transitions.py tests/unit/services/test_social_graph_service.py tests/unit/modules/test_llm_remote.py tests/integration/test_context_assembler_service.py`, resulting in `38 passed` (with expected warnings about aiohttp/aiosqlite threads); all added/updated tests passed.
- Ran linting with `ruff` over the modified modules and tests and the checks completed with no issues.
- Observed and addressed an import-time circular dependency during test collection by making fact-extractor imports lazy before final test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e42414248326ad22e7459d09e22f)